### PR TITLE
fix navigation around split operations

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -9,6 +9,7 @@ class CoursesController < ApplicationController
   def show
     @course = Course.find(params[:id])
     @course_splits = @course.splits
+    session[:return_to] = course_path
   end
 
   def new

--- a/app/controllers/splits_controller.rb
+++ b/app/controllers/splits_controller.rb
@@ -10,6 +10,7 @@ class SplitsController < ApplicationController
       format.xls
       format.json { send_data @splits.to_json }
     end
+    session[:return_to] = course_path(params[:course_id]) if params[:course_id].present?
   end
 
   def show
@@ -22,6 +23,7 @@ class SplitsController < ApplicationController
       @course = Course.find(params[:course_id])
     end
     authorize @split
+    session[:return_to] ||= request.referer
   end
 
   def edit
@@ -36,7 +38,7 @@ class SplitsController < ApplicationController
     authorize @split
 
     if @split.save
-      redirect_to @split
+      redirect_to session.delete(:return_to)
     else
       render 'new'
     end
@@ -59,8 +61,7 @@ class SplitsController < ApplicationController
     authorize split
     split.destroy
 
-    redirect_url = (request.referer.include?("splits/#{split.id}") ? splits_url : :back)
-    redirect_to redirect_url
+    redirect_to session.delete(:return_to) || splits_url
   end
 
   private

--- a/app/views/splits/_form.html.erb
+++ b/app/views/splits/_form.html.erb
@@ -90,7 +90,7 @@
           </div>
         </div>
         <div class="col-xs-4 col-xs-offset-2">
-          [ <%= link_to 'Cancel', splits_path %> ]
+          [ <%= link_to 'Cancel', request.referer %> ]
         </div>
     <% end %>
   </div>


### PR DESCRIPTION
@moveson I think this fixes the odd navigation issues around split operations. There may be some scenarios that I missed.

I don't falling back to splits_url on destroy of a split is the right thing to do but it may be the best option for now.