### PR TITLE
Download test file instead of linking

### DIFF
--- a/app/views/visitors/getting_started_5.html.erb
+++ b/app/views/visitors/getting_started_5.html.erb
@@ -22,8 +22,8 @@
 </p>
 <p>
   If this seems confusing, it's pretty simple in execution. <strong>Here is a sample spreadsheet you can download
-  for easy reference:
-  <%= link_to "Hardrock 2015", 'https://github.com/SplitTime/OpenSplitTime/blob/master/hardrock2015.xlsx' %></strong>
+  for easy reference: <a href="https://github.com/SplitTime/OpenSplitTime/blob/master/hardrock2015.xlsx"
+  download="https://github.com/SplitTime/OpenSplitTime/blob/master/hardrock2015.xlsx">Hardrock 2015</a></strong>
 </p>
 <p>
   Sign in, click around, and play with the various screens and buttons. Add some things manually and import some data. If you get


### PR DESCRIPTION
Fixes #30
When clicking on the link in the getting started page 5, download the file instead of linking to the github page.

cc: @moveson for review and testing.