### PR TITLE
Live Entry screen: banner alert new times avail

### DIFF
--- a/app/assets/javascripts/live_entry.js
+++ b/app/assets/javascripts/live_entry.js
@@ -54,6 +54,7 @@
             });
             liveEntry.importLiveWarning = $('#js-import-live-warning').hide().detach();
             liveEntry.importLiveError = $('#js-import-live-error').hide().detach();
+            liveEntry.newTimesAlert = $('#js-new-times-alert').hide();
             liveEntry.PopulatingFromRow = false;
             
         },
@@ -86,7 +87,14 @@
                 });
             },
             displayNewCount: function(count) {
-                var text = count > 0 ? '(' + count + ')' : '';
+                var text = '';
+                if (count > 0) {
+                    $('#js-new-times-alert').fadeTo(500, 1);
+                    text = count;
+                }
+                else {
+                    $('#js-new-times-alert').fadeTo(500, 0, function() {$('#js-new-times-alert').hide()});
+                }
                 $('#js-pull-times-count').text(text);
             }
         },

--- a/app/views/live/events/live_entry.html.erb
+++ b/app/views/live/events/live_entry.html.erb
@@ -2,7 +2,9 @@
     <% "OpenSplitTime: Live entry - #{@event.name}" %>
 <% end %>
 <div class="row header">
-
+  <div id="js-new-times-alert" class="alert alert-info center" role="alert">
+    <a href="#js-import-live-times">New Live Times availale</a>
+  </div>
   <div class="col-xs-12 col-md-6 page-title">
     <h2></h2>
     <%= content_tag "div", id: "js-event-id", "data-event-id": params[:id] do %>
@@ -182,7 +184,7 @@
    <div class="btn-group" role="group">
       <button id="js-import-live-times" class="btn btn-primary">
         Pull Times
-        <span id="js-pull-times-count"></span>
+        <span class="badge" id="js-pull-times-count"></span>
       </button>
     </div>
     <div class="btn-group" role="group">


### PR DESCRIPTION
Display a banner at the top indicating there are new live times available whenever a notification comes in with a count > 0
hide the banner when count = 0
Also, change Pull Times (count) to a Bootstrap badge.