### PR TITLE
Reduce logging in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,6 +71,13 @@ Rails.application.configure do
   # when problems arise.
   config.log_level = :info
 
+  # Suppress ActionView render information from the logger
+  ActiveSupport::on_load :action_view do
+    %w[render_template render_partial render_collection].each do |event|
+      ActiveSupport::Notifications.unsubscribe "#{event}.action_view"
+    end
+  end
+
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 


### PR DESCRIPTION
Now that we have `paper_trail` up and running, we can reduce logging to `info` level and shouldn't miss anything critical.