### PR TITLE
Switch between adjacent efforts

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -339,9 +339,10 @@ module DropdownHelper
   def prior_next_nav_button(view_object, prior_or_next, param: :parameterized_split_name)
     icon_name = prior_or_next == :prior ? 'caret-left' : 'caret-right'
     target = view_object.send("#{prior_or_next}_#{param}")
+    merge_param = target.present? ? {param => target} : {}
 
     link_to fa_icon(icon_name, class: 'fa-lg'),
-            request.params.merge(param => target),
+            request.params.merge(merge_param),
             class: 'btn btn-outline-secondary',
             disabled: target.blank?
   end

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -336,7 +336,7 @@ module DropdownHelper
     build_dropdown_menu(nil, dropdown_items, button: true)
   end
 
-  def split_name_nav_button(view_object, prior_or_next, param: :parameterized_split_name)
+  def prior_next_nav_button(view_object, prior_or_next, param: :parameterized_split_name)
     icon_name = prior_or_next == :prior ? 'caret-left' : 'caret-right'
     target = view_object.send("#{prior_or_next}_#{param}")
 

--- a/app/view_models/effort_with_lap_split_rows.rb
+++ b/app/view_models/effort_with_lap_split_rows.rb
@@ -52,6 +52,14 @@ class EffortWithLapSplitRows
     difference(prior_lap_row&.times_from_start&.first, lap_row&.times_from_start&.first)
   end
 
+  def prior_id
+    effort.prior_effort_id
+  end
+
+  def next_id
+    effort.next_effort_id
+  end
+
   def method_missing(method)
     effort.send(method)
   end

--- a/app/view_models/place_detail_view.rb
+++ b/app/view_models/place_detail_view.rb
@@ -49,6 +49,14 @@ class PlaceDetailView
     effort.topic_resource_key.present? && !effort.stopped?
   end
 
+  def prior_id
+    effort.prior_effort_id
+  end
+
+  def next_id
+    effort.next_effort_id
+  end
+
   def method_missing(method)
     effort.send(method)
   end

--- a/app/views/efforts/_effort_header.html.erb
+++ b/app/views/efforts/_effort_header.html.erb
@@ -1,0 +1,35 @@
+<header class="ost-header">
+  <div class="container">
+    <div class="ost-heading row">
+      <div class="col">
+        <div class="ost-title">
+          <div class="btn-group btn-group-ost pull-right">
+            <%= prior_next_nav_button(view_object, :prior, param: :id) %>
+            <%= prior_next_nav_button(view_object, :next, param: :id) %>
+          </div>
+          <h1><strong>
+            <% if view_object.person %>
+              <%= link_to view_object.full_name, person_path(view_object.person) %>
+            <% else %>
+              <%= view_object.full_name %>
+            <% end %>
+          </strong></h1>
+          <%= effort_view_breadcrumbs(view_object, title) %>
+        </div>
+        <div class="ost-subtitle">
+          <%= effort_start_time_string(view_object) %>
+          <%= effort_view_status(view_object) %>
+        </div>
+      </div>
+      <% unless action_name == 'audit' %>
+        <% if view_object.photo.attached? %>
+          <div class="col-3">
+            <%= link_to image_tag(view_object.photo.variant(resize: '150x150')), {action: :show_photo} %>
+          </div>
+        <% end %>
+        <%= render 'subscription_buttons', view_object: view_object %>
+      <% end %>
+    </div>
+    <%= effort_view_tabs(view_object) %>
+  </div>
+</header>

--- a/app/views/efforts/analyze.html.erb
+++ b/app/views/efforts/analyze.html.erb
@@ -2,30 +2,7 @@
   <% "OpenSplitTime: Analyze effort - #{@presenter.full_name} - #{@presenter.event_name}" %>
 <% end %>
 
-<header class="ost-header">
-  <div class="container">
-    <div class="ost-heading row">
-      <div class="col">
-        <div class="ost-title">
-          <h1><strong>
-            <% if @presenter.person %>
-              <%= link_to @presenter.full_name, person_path(@presenter.person) %>
-            <% else %>
-              <%= @presenter.full_name %>
-            <% end %>
-          </strong></h1>
-          <%= effort_view_breadcrumbs(@presenter, 'Analyze') %>
-        </div>
-        <div class="ost-subtitle">
-          <%= effort_start_time_string(@presenter) %>
-          <%= effort_view_status(@presenter) %>
-        </div>
-      </div>
-      <%= render 'subscription_buttons', view_object: @presenter %>
-    </div>
-    <%= effort_view_tabs(@presenter) %>
-  </div>
-</header>
+<%= render 'effort_header', view_object: @presenter, title: 'Analyze' %>
 
 <article class="ost-article container">
   <% if !@presenter.started? %>

--- a/app/views/efforts/audit.html.erb
+++ b/app/views/efforts/audit.html.erb
@@ -5,32 +5,9 @@
 <% content_for(:container_type) do %>skip
 <% end %>
 
-<header class="ost-header">
-  <div class="container">
-    <div class="ost-heading row">
-      <div class="col">
-        <div class="ost-title">
-          <h1><strong>
-            <% if @presenter.person %>
-              <%= link_to @presenter.full_name, person_path(@presenter.person) %>
-            <% else %>
-              <%= @presenter.full_name %>
-            <% end %>
-          </strong></h1>
-          <%= effort_view_breadcrumbs(@presenter, 'Audit') %>
-        </div>
-        <div class="ost-subtitle">
-          <%= effort_start_time_string(@presenter) %>
-          <%= effort_view_status(@presenter) %>
-        </div>
-      </div>
-    </div>
-    <%= effort_view_tabs(@presenter) %>
-  </div>
-</header>
+<%= render 'effort_header', view_object: @presenter, title: 'Audit' %>
 
 <article class="ost-article container">
-
   <% if @presenter.lap_split_rows.present? %>
     <%= render 'split_times/audit_list', presenter: @presenter %>
   <% end %>

--- a/app/views/efforts/place.html.erb
+++ b/app/views/efforts/place.html.erb
@@ -2,31 +2,7 @@
   <% "OpenSplitTime: Place detail - #{@presenter.full_name} - #{@presenter.event_name}" %>
 <% end %>
 
-
-<header class="ost-header">
-  <div class="container">
-    <div class="ost-heading row">
-      <div class="col">
-        <div class="ost-title">
-          <h1><strong>
-            <% if @presenter.person %>
-              <%= link_to @presenter.full_name, person_path(@presenter.person) %>
-            <% else %>
-              <%= @presenter.full_name %>
-            <% end %>
-          </strong></h1>
-          <%= effort_view_breadcrumbs(@presenter, 'Place') %>
-        </div>
-        <div class="ost-subtitle">
-          <%= effort_start_time_string(@presenter) %>
-          <%= effort_view_status(@presenter) %>
-        </div>
-      </div>
-      <%= render 'subscription_buttons', view_object: @presenter %>
-    </div>
-    <%= effort_view_tabs(@presenter) %>
-  </div>
-</header>
+<%= render 'effort_header', view_object: @presenter, title: 'Place' %>
 
 <article class="ost-article container">
   <% if !@presenter.started? %>

--- a/app/views/efforts/projections.html.erb
+++ b/app/views/efforts/projections.html.erb
@@ -19,5 +19,7 @@
 
   <% if @presenter.actual_lap_split_rows.present? %>
     <%= render 'split_times/projections_list', view_object: @presenter %>
+  <% else %>
+    <h4><%= "No projections are available. The entrant has not started." %></h4>
   <% end %>
 </article>

--- a/app/views/efforts/projections.html.erb
+++ b/app/views/efforts/projections.html.erb
@@ -5,35 +5,7 @@
 <% content_for(:container_type) do %>skip
 <% end %>
 
-<header class="ost-header">
-  <div class="container">
-    <div class="ost-heading row">
-      <div class="col">
-        <div class="ost-title">
-          <h1><strong>
-            <% if @presenter.person %>
-              <%= link_to @presenter.full_name, person_path(@presenter.person) %>
-            <% else %>
-              <%= @presenter.full_name %>
-            <% end %>
-          </strong></h1>
-          <%= effort_view_breadcrumbs(@presenter, 'Projections') %>
-        </div>
-        <div class="ost-subtitle">
-          <%= effort_start_time_string(@presenter) %>
-          <%= effort_view_status(@presenter) %>
-        </div>
-      </div>
-      <% if @presenter.photo.attached? %>
-        <div class="col-3">
-          <%= image_tag(@presenter.photo.variant(resize: '150x150')) %>
-        </div>
-      <% end %>
-      <%= render 'subscription_buttons', view_object: @presenter %>
-    </div>
-    <%= effort_view_tabs(@presenter) %>
-  </div>
-</header>
+<%= render 'effort_header', view_object: @presenter, title: 'Projections' %>
 
 <aside class="ost-toolbar">
   <div class="container">

--- a/app/views/efforts/show.html.erb
+++ b/app/views/efforts/show.html.erb
@@ -5,35 +5,7 @@
 <% content_for(:container_type) do %>skip
 <% end %>
 
-<header class="ost-header">
-  <div class="container">
-    <div class="ost-heading row">
-      <div class="col">
-        <div class="ost-title">
-          <h1><strong>
-            <% if @presenter.person %>
-              <%= link_to @presenter.full_name, person_path(@presenter.person) %>
-            <% else %>
-              <%= @presenter.full_name %>
-            <% end %>
-          </strong></h1>
-          <%= effort_view_breadcrumbs(@presenter, nil) %>
-        </div>
-        <div class="ost-subtitle">
-          <%= effort_start_time_string(@presenter) %>
-          <%= effort_view_status(@presenter) %>
-        </div>
-      </div>
-      <% if @presenter.photo.attached? %>
-        <div class="col-3">
-          <%= link_to image_tag(@presenter.photo.variant(resize: '150x150')), {action: :show_photo} %>
-        </div>
-      <% end %>
-      <%= render 'subscription_buttons', view_object: @presenter %>
-    </div>
-    <%= effort_view_tabs(@presenter) %>
-  </div>
-</header>
+<%= render 'effort_header', view_object: @presenter, title: nil %>
 
 <aside class="ost-toolbar" data-controller="roster">
   <%= render 'event_groups/start_efforts_modal', resource: :effort %>

--- a/app/views/event_groups/split_raw_times.html.erb
+++ b/app/views/event_groups/split_raw_times.html.erb
@@ -31,9 +31,9 @@
       <div class="col form-inline">
         <div class="dropdown float-left-button">
           <div class="btn-group btn-group-ost pull-right">
-            <%= split_name_nav_button(@presenter, :prior) %>
+            <%= prior_next_nav_button(@presenter, :prior) %>
             <%= split_name_dropdown(@presenter) %>
-            <%= split_name_nav_button(@presenter, :next) %>
+            <%= prior_next_nav_button(@presenter, :next) %>
           </div>
           <% if @presenter.sub_split_kinds.many? %>
             <%= sub_split_kind_dropdown(@presenter) %>

--- a/app/views/event_groups/traffic.html.erb
+++ b/app/views/event_groups/traffic.html.erb
@@ -30,9 +30,9 @@
       <div class="col form-inline">
         <div class="dropdown float-left-button">
           <div class="btn-group btn-group-ost pull-right">
-            <%= split_name_nav_button(@presenter, :prior) %>
+            <%= prior_next_nav_button(@presenter, :prior) %>
             <%= split_name_dropdown(@presenter) %>
-            <%= split_name_nav_button(@presenter, :next) %>
+            <%= prior_next_nav_button(@presenter, :next) %>
           </div>
         </div>
       </div>

--- a/app/views/live/events/aid_station_detail.html.erb
+++ b/app/views/live/events/aid_station_detail.html.erb
@@ -34,9 +34,9 @@
       <!-- Navigation Widget -->
       <div class="col form-inline">
         <div class="btn-group btn-group-ost pull-right">
-          <%= split_name_nav_button(@aid_station_detail, :prior) %>
+          <%= prior_next_nav_button(@aid_station_detail, :prior) %>
           <%= split_name_dropdown(@aid_station_detail) %>
-          <%= split_name_nav_button(@aid_station_detail, :next) %>
+          <%= prior_next_nav_button(@aid_station_detail, :next) %>
         </div>
       </div>
       <!-- Filter Widget -->


### PR DESCRIPTION
This adds buttons to allow a user to switch to the prior or next effort without returning to the main spread view. This greatly speeds review, particularly in the Audit view.