### PR TITLE
Callback to touch events after event group save

### DIFF
--- a/app/models/event_group.rb
+++ b/app/models/event_group.rb
@@ -18,6 +18,7 @@ class EventGroup < ApplicationRecord
 
   after_create :notify_admin
   after_save :conform_concealed_status
+  after_save :touch_all_events
 
   validates_presence_of :name, :organization, :home_time_zone
   validates_uniqueness_of :name, case_sensitive: false
@@ -92,5 +93,9 @@ class EventGroup < ApplicationRecord
 
   def split_analyzable
     self
+  end
+
+  def touch_all_events
+    events.update_all(updated_at: Time.current)
   end
 end

--- a/spec/models/event_group_spec.rb
+++ b/spec/models/event_group_spec.rb
@@ -55,6 +55,26 @@ RSpec.describe EventGroup, type: :model do
     end
   end
 
+  describe "after_save" do
+    let(:event_group) { event_groups(:dirty_30) }
+    let(:events) { event_group.events }
+
+    it "touches all events" do
+      events.each do |event|
+        event.reload
+        expect(event.updated_at > 1.minute.ago).not_to eq(true)
+      end
+
+      expect(event_group).to be_available_live
+      event_group.update(available_live: false)
+
+      events.each do |event|
+        event.reload
+        expect(event.updated_at > 1.minute.ago).to eq(true)
+      end
+    end
+  end
+
   describe '#multiple_laps?' do
     subject { build_stubbed(:event_group, events: events) }
     let(:event_1) { build_stubbed(:event, laps_required: 1) }


### PR DESCRIPTION
This should fix the caching problem described in https://github.com/SplitTime/OpenSplitTime/issues/248

Easier than expected--just touch the events when event group is updated, and that should bust the cache.