### PR TITLE
Check for valid params before rendering docs

### DIFF
--- a/app/controllers/docs/visitors_controller.rb
+++ b/app/controllers/docs/visitors_controller.rb
@@ -25,6 +25,8 @@ class Docs::VisitorsController < ApplicationController
 
   def render_using_presenter(presenter)
     @presenter = presenter.new(params, current_user)
+    raise ActionController::RoutingError, 'Not Found' unless @presenter.valid_params?
+
     render :docs
   end
 end

--- a/app/presenters/docs/base_presenter.rb
+++ b/app/presenters/docs/base_presenter.rb
@@ -37,6 +37,10 @@ module Docs
       "#{category}_#{topic}_#{page}"
     end
 
+    def valid_params?
+      File.exists?(Rails.root.join("app/views/docs/visitors/_#{partial}.html.erb"))
+    end
+
     private
 
     def default_topic


### PR DESCRIPTION
Checks validity of params passed in to the Docs controller, and returns 404 if the documentation page is not available.

Addresses https://github.com/SplitTime/OpenSplitTime/issues/199