### PR TITLE
Handle all formats for ErrorsController#not_found

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
   before_action :set_paper_trail_whodunnit
   helper_method :prepared_params
 
+  rescue_from ActionController::UnknownFormat, with: :not_acceptable_head
+
   impersonates :user
 
   if Rails.env.development? || Rails.env.test?
@@ -68,6 +70,10 @@ class ApplicationController < ActionController::Base
 
   def internal_server_error_json
     render json: {errors: ['internal server error']}, status: :internal_server_error
+  end
+
+  def not_acceptable_head
+    head :not_acceptable
   end
 
   def record_not_found_json

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -5,6 +5,9 @@ class ErrorsController < ApplicationController
     respond_to do |format|
       format.html { render status: :not_found }
       format.json { record_not_found_json }
+      format.js { record_not_found_json }
+      format.text { record_not_found_json }
+      format.csv { record_not_found_json }
     end
   end
 

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -5,9 +5,6 @@ class ErrorsController < ApplicationController
     respond_to do |format|
       format.html { render status: :not_found }
       format.json { record_not_found_json }
-      format.js { record_not_found_json }
-      format.text { record_not_found_json }
-      format.csv { record_not_found_json }
     end
   end
 


### PR DESCRIPTION
We are seeing internal server errors resulting from the ErrorController's inability to handle formats other than html and json for the 404 page. When users randomly search for nonexistent pages using `.txt` or `.csv`, this results in an error trying to render the 404 page.

This MR adds a general rescue for ActionController::UnknownFormat and returns a head-only 406 response.