### PR TITLE
Refresh buttons on efforts views and roster

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module LinkHelper
-
   def link_to_reversing_sort_heading(column_heading, field_name, existing_sort)
     new_sort = field_name.to_s == existing_sort.to_s ? "-#{field_name}" : field_name
     link_to_sort_heading(column_heading, new_sort)

--- a/app/helpers/refresh_helper.rb
+++ b/app/helpers/refresh_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RefreshHelper
+  def link_to_refresh
+    link_to fa_icon(:redo), request.params, class: 'btn btn-primary'
+  end
+end

--- a/app/views/efforts/_effort_header.html.erb
+++ b/app/views/efforts/_effort_header.html.erb
@@ -1,12 +1,13 @@
 <header class="ost-header">
   <div class="container">
     <div class="ost-heading row">
-      <div class="col">
+      <div class="col-auto">
         <div class="ost-title">
-          <div class="btn-group btn-group-ost pull-right">
+          <div class="btn-group btn-group-ost">
             <%= prior_next_nav_button(view_object, :prior, param: :id) %>
             <%= prior_next_nav_button(view_object, :next, param: :id) %>
           </div>
+          <%= link_to_refresh %>
           <h1><strong>
             <% if view_object.person %>
               <%= link_to view_object.full_name, person_path(view_object.person) %>

--- a/app/views/event_groups/roster.html.erb
+++ b/app/views/event_groups/roster.html.erb
@@ -7,6 +7,9 @@
     <div class="ost-heading row">
       <div class="col">
         <div class="ost-title">
+          <div>
+            <%= link_to_refresh %>
+          </div>
           <h1>
             <strong><%= @presenter.name %> <%= @presenter.concealed? ? fa_icon('eye-slash') : fa_icon('eye') %></strong>
           </h1>


### PR DESCRIPTION
Adds a refresh button that allows a user to refresh with Turbolinks instead of doing a browser refresh.