### PR TITLE
Rework policy scoping

### DIFF
--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -9,7 +9,7 @@ class EffortsController < ApplicationController
   end
 
   def index
-    @efforts = Effort.order(prepared_params[:sort] || :bib_number, :last_name, :first_name)
+    @efforts = policy_scope(Effort).order(prepared_params[:sort] || :bib_number, :last_name, :first_name)
                    .where(prepared_params[:filter])
     respond_to do |format|
       format.html do
@@ -207,7 +207,7 @@ class EffortsController < ApplicationController
   end
 
   def set_effort
-    @effort = Effort.friendly.find(params[:id])
+    @effort = policy_scope(Effort).friendly.find(params[:id])
     redirect_numeric_to_friendly(@effort, params[:id])
   end
 end

--- a/app/controllers/splits_controller.rb
+++ b/app/controllers/splits_controller.rb
@@ -5,7 +5,7 @@ class SplitsController < ApplicationController
 
   def index
     order = prepared_params[:sort].presence || [:course_id, :distance_from_start]
-    @splits = Split.order(order).where(prepared_params[:filter])
+    @splits = policy_scope(Split).order(order).where(prepared_params[:filter])
 
     respond_to do |format|
       format.html do
@@ -70,7 +70,7 @@ class SplitsController < ApplicationController
   private
 
   def set_split
-    @split = Split.friendly.find(params[:id])
+    @split = policy_scope(Split).friendly.find(params[:id])
     redirect_numeric_to_friendly(@split, params[:id])
   end
 end

--- a/app/models/concerns/concealable.rb
+++ b/app/models/concerns/concealable.rb
@@ -2,15 +2,14 @@
 
 # Used for models with a 'concealed' attribute.
 
-# Not used on the Effort module, which needs custom logic entirely based on the
-# associated event's concealed status.
+# Not used on the Event or Effort models, which need custom logic based on the
+# concealed status of parent or grandparent records.
 
 module Concealable
   extend ActiveSupport::Concern
 
   included do
-    scope :concealed, -> { where(concealed: true) }
-    scope :visible, -> { where(concealed: [false, nil]) }
+    scope :visible, -> { where("#{table_name}.concealed is not true") }
   end
 
   def visible?

--- a/app/models/concerns/delegable.rb
+++ b/app/models/concerns/delegable.rb
@@ -17,6 +17,7 @@ module Delegable
   included do
     scope :with_policy_scope_attributes, ->{ all }
     scope :owned_by, ->(user) { with_policy_scope_attributes.where("#{table_name}.organization_id in (?)", user.owned_organization_ids) }
+    scope :visible, -> { with_policy_scope_attributes.where("#{table_name}.concealed is not true") }
 
     scope :delegated_to, ->(user) do
       with_policy_scope_attributes

--- a/app/models/concerns/delegable.rb
+++ b/app/models/concerns/delegable.rb
@@ -15,7 +15,6 @@ module Delegable
   extend ActiveSupport::Concern
 
   included do
-    scope :with_policy_scope_attributes, -> { all } # May be overridden by the including class
     scope :owned_by, ->(user) { with_policy_scope_attributes.where("#{table_name}.organization_id in (?)", user.owned_organization_ids) }
 
     scope :delegated_to, ->(user) do

--- a/app/models/concerns/delegable.rb
+++ b/app/models/concerns/delegable.rb
@@ -11,7 +11,7 @@ module Delegable
 
   included do
     scope :with_organization_id, -> { all }
-    scope :owned_by, -> (user) { with_organization_id.where("#{table_name}.organization_id in (?)", user.owned_organization_ids) }
+    scope :owned_by, ->(user) { with_organization_id.where("#{table_name}.organization_id in (?)", user.owned_organization_ids) }
     scope :delegated_to, ->(user) do
       with_organization_id
         .where("#{table_name}.organization_id in (?)", user.delegated_organization_ids)

--- a/app/models/concerns/delegable.rb
+++ b/app/models/concerns/delegable.rb
@@ -15,7 +15,7 @@ module Delegable
   extend ActiveSupport::Concern
 
   included do
-    scope :with_policy_scope_attributes, ->{ all }
+    scope :with_policy_scope_attributes, -> { all } # May be overridden by the including class
     scope :owned_by, ->(user) { with_policy_scope_attributes.where("#{table_name}.organization_id in (?)", user.owned_organization_ids) }
     scope :visible, -> { with_policy_scope_attributes.where("#{table_name}.concealed is not true") }
 

--- a/app/models/concerns/delegable.rb
+++ b/app/models/concerns/delegable.rb
@@ -1,24 +1,28 @@
 # frozen_string_literal: true
 
-# The including class must contain an organization_id attribute *or*
-# must override the :with_organization_id scope using joins to put an
-# organization_id attribute on returned records, for example:
+# The including class must contain an organization_id attribute and a
+# concealed attribute *or* must override the :with_policy_scope_attributes
+# scope using joins to put an organization_id attribute and a concealed
+# attribute on returned records, for example:
 #
-# scope :with_organization_id, -> { from(select('events.*, event_groups.organization_id').joins(:event_group), :events) }
+# scope :with_policy_scope_attributes, -> do
+#   from(select('events.*, event_groups.organization_id, event_groups.concealed').joins(:event_group), :events)
+# end
 #
 module Delegable
   extend ActiveSupport::Concern
 
   included do
-    scope :with_organization_id, -> { all }
-    scope :owned_by, ->(user) { with_organization_id.where("#{table_name}.organization_id in (?)", user.owned_organization_ids) }
+    scope :with_policy_scope_attributes, ->{ all }
+    scope :owned_by, ->(user) { with_policy_scope_attributes.where("#{table_name}.organization_id in (?)", user.owned_organization_ids) }
+
     scope :delegated_to, ->(user) do
-      with_organization_id
+      with_policy_scope_attributes
         .where("#{table_name}.organization_id in (?)", user.delegated_organization_ids)
     end
 
     scope :visible_or_delegated_to, ->(user) do
-      with_organization_id
+      with_policy_scope_attributes
         .where("#{table_name}.concealed is not true or #{table_name}.organization_id in (?)", user.delegated_organization_ids)
     end
   end

--- a/app/models/concerns/delegable.rb
+++ b/app/models/concerns/delegable.rb
@@ -17,7 +17,6 @@ module Delegable
   included do
     scope :with_policy_scope_attributes, -> { all } # May be overridden by the including class
     scope :owned_by, ->(user) { with_policy_scope_attributes.where("#{table_name}.organization_id in (?)", user.owned_organization_ids) }
-    scope :visible, -> { with_policy_scope_attributes.where("#{table_name}.concealed is not true") }
 
     scope :delegated_to, ->(user) do
       with_policy_scope_attributes

--- a/app/models/concerns/delegable.rb
+++ b/app/models/concerns/delegable.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-# The including class must contain an organization_id attribute and a
-# concealed attribute *or* must override the :with_policy_scope_attributes
-# scope using joins to put an organization_id attribute and a concealed
-# attribute on returned records, for example:
+# The including class must contain an `organization_id` attribute and a
+# `concealed` attribute *or* must override the :with_policy_scope_attributes
+# scope using joins to put an `organization_id` attribute and a `concealed`
+# attribute on scoped records, for example:
 #
 # scope :with_policy_scope_attributes, -> do
 #   from(select('events.*, event_groups.organization_id, event_groups.concealed').joins(:event_group), :events)
 # end
+#
+# The including class must also respond to `organization`.
 #
 module Delegable
   extend ActiveSupport::Concern

--- a/app/models/concerns/delegable.rb
+++ b/app/models/concerns/delegable.rb
@@ -1,10 +1,26 @@
 # frozen_string_literal: true
 
+# The including class must contain an organization_id attribute *or*
+# must override the :with_organization_id scope using joins to put an
+# organization_id attribute on returned records, for example:
+#
+# scope :with_organization_id, -> { from(select('events.*, event_groups.organization_id').joins(:event_group), :events) }
+#
 module Delegable
   extend ActiveSupport::Concern
 
   included do
-    scope :delegated, -> (user_id) { where('stewardships.user_id = ? OR organizations.created_by = ?', user_id, user_id) }
+    scope :with_organization_id, -> { all }
+    scope :owned_by, -> (user) { with_organization_id.where("#{table_name}.organization_id in (?)", user.owned_organization_ids) }
+    scope :delegated_to, ->(user) do
+      with_organization_id
+        .where("#{table_name}.organization_id in (?)", user.delegated_organization_ids)
+    end
+
+    scope :visible_or_delegated_to, ->(user) do
+      with_organization_id
+        .where("#{table_name}.concealed is not true or #{table_name}.organization_id in (?)", user.delegated_organization_ids)
+    end
   end
 
   delegate :stewards, to: :organization

--- a/app/models/concerns/delegated_concealable.rb
+++ b/app/models/concerns/delegated_concealable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This module is for classes that need a :visible scope but do not have
+# a `concealed` attribute directly on the table, but instead inherit
+# their `concealed` status from a parent or grandparent record.
+#
+module DelegatedConcealable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :visible, -> { with_policy_scope_attributes.where("#{table_name}.concealed is not true") }
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -17,6 +17,7 @@ class Course < ApplicationRecord
   accepts_nested_attributes_for :splits, reject_if: lambda { |s| s[:distance_from_start].blank? && s[:distance_in_preferred_units].blank? }
 
   scope :standard_includes, -> { includes(:splits) }
+  scope :with_policy_scope_attributes, -> { all }
 
   validates_presence_of :name, :organization
   validates_uniqueness_of :name, case_sensitive: false

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -7,8 +7,8 @@ class Effort < ApplicationRecord
   # See app/concerns/data_status_methods for related scopes and methods
   VALID_STATUSES = [nil, data_statuses[:good]].freeze
 
-  include Auditable, DataStatusMethods, Delegable, GuaranteedFindable, LapsRequiredMethods, PersonalInfo,
-          Searchable, Subscribable, TimeZonable, Matchable
+  include Auditable, DataStatusMethods, Delegable, DelegatedConcealable, GuaranteedFindable, LapsRequiredMethods,
+          PersonalInfo, Searchable, Subscribable, TimeZonable, Matchable
   extend FriendlyId
 
   strip_attributes collapse_spaces: true

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -51,8 +51,6 @@ class Effort < ApplicationRecord
   scope :started, -> { joins(:split_times).uniq }
   scope :unstarted, -> { includes(:split_times).where(split_times: {id: nil}) }
   scope :checked_in, -> { where(checked_in: true) }
-  scope :concealed, -> { includes(event: :event_group).where(event_groups: {concealed: true}) }
-  scope :visible, -> { includes(event: :event_group).where(event_groups: {concealed: false}) }
   scope :add_ready_to_start, -> do
     select('distinct on (efforts.id) efforts.*, coalesce(scheduled_start_time, events.start_time) as assumed_start_time, (split_times.id is null and checked_in is true and (coalesce(scheduled_start_time, events.start_time) < current_timestamp)) as ready_to_start')
         .left_joins(:event, split_times: :split)

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -58,6 +58,7 @@ class Effort < ApplicationRecord
         .left_joins(:event, split_times: :split)
         .order('efforts.id, split_times.lap, splits.distance_from_start, split_times.sub_split_bitkey')
   end
+  scope :with_organization_id, -> { from(select('efforts.*, event_groups.organization_id').joins(event: :event_group), :efforts) }
 
   def self.null_record
     @null_record ||= Effort.new(first_name: '', last_name: '')

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -58,7 +58,9 @@ class Effort < ApplicationRecord
         .left_joins(:event, split_times: :split)
         .order('efforts.id, split_times.lap, splits.distance_from_start, split_times.sub_split_bitkey')
   end
-  scope :with_organization_id, -> { from(select('efforts.*, event_groups.organization_id').joins(event: :event_group), :efforts) }
+  scope :with_policy_scope_attributes, -> do
+    from(select('efforts.*, event_groups.organization_id, event_groups.concealed').joins(event: :event_group), :efforts)
+  end
 
   def self.null_record
     @null_record ||= Effort.new(first_name: '', last_name: '')

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -41,7 +41,9 @@ class Event < ApplicationRecord
   scope :concealed, -> { includes(:event_group).where(event_groups: {concealed: true}) }
   scope :visible, -> { includes(:event_group).where(event_groups: {concealed: false}) }
   scope :standard_includes, -> { includes(:splits, :efforts, :event_group) }
-  scope :with_organization_id, -> { from(select('events.*, event_groups.organization_id').joins(:event_group), :events) }
+  scope :with_policy_scope_attributes, -> do
+    from(select('events.*, event_groups.organization_id, event_groups.concealed').joins(:event_group), :events)
+  end
 
   def self.search(search_param)
     return all if search_param.blank?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,7 +20,7 @@ class Event < ApplicationRecord
   has_many :partners, through: :event_group
 
   delegate :concealed, :concealed?, :visible?, :available_live, :available_live?,
-           :organization, :organization_id, :permit_notifications?, :home_time_zone, to: :event_group
+           :organization, :permit_notifications?, :home_time_zone, to: :event_group
 
   validates_presence_of :course_id, :start_time, :laps_required, :event_group, :results_template
   validates_uniqueness_of :short_name, case_sensitive: false, scope: :event_group_id
@@ -41,6 +41,7 @@ class Event < ApplicationRecord
   scope :concealed, -> { includes(:event_group).where(event_groups: {concealed: true}) }
   scope :visible, -> { includes(:event_group).where(event_groups: {concealed: false}) }
   scope :standard_includes, -> { includes(:splits, :efforts, :event_group) }
+  scope :with_organization_id, -> { from(select('events.*, event_groups.organization_id').joins(:event_group), :events) }
 
   def self.search(search_param)
     return all if search_param.blank?
@@ -96,6 +97,10 @@ class Event < ApplicationRecord
 
   def course_name
     course.name
+  end
+
+  def organization_id
+    attributes.key?('organization_id') ? attributes['organization_id'] : organization&.id
   end
 
   def organization_name

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -38,8 +38,6 @@ class Event < ApplicationRecord
         .left_joins(:efforts).left_joins(:event_group)
         .group('events.id, event_groups.id')
   end
-  scope :concealed, -> { includes(:event_group).where(event_groups: {concealed: true}) }
-  scope :visible, -> { includes(:event_group).where(event_groups: {concealed: false}) }
   scope :standard_includes, -> { includes(:splits, :efforts, :event_group) }
   scope :with_policy_scope_attributes, -> do
     from(select('events.*, event_groups.organization_id, event_groups.concealed').joins(:event_group), :events)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
-  include Auditable, Delegable, SplitMethods, LapsRequiredMethods, Reconcilable, TimeZonable
+  include Auditable, Delegable, DelegatedConcealable, SplitMethods, LapsRequiredMethods, Reconcilable, TimeZonable
   extend FriendlyId
 
   strip_attributes collapse_spaces: true

--- a/app/models/event_group.rb
+++ b/app/models/event_group.rb
@@ -30,6 +30,7 @@ class EventGroup < ApplicationRecord
   attr_accessor :duplicate_event_date
 
   scope :standard_includes, -> { includes(events: :splits) }
+  scope :with_policy_scope_attributes, -> { all }
   scope :by_group_start_time, -> do
     joins(:events)
         .select('event_groups.*, min(events.start_time) as group_start_time')

--- a/app/models/event_series.rb
+++ b/app/models/event_series.rb
@@ -1,5 +1,5 @@
 class EventSeries < ApplicationRecord
-  include Delegable, MultiEventable
+  include Delegable, DelegatedConcealable, MultiEventable
   extend FriendlyId
 
   enum scoring_method: [:time, :rank, :points]

--- a/app/models/event_series.rb
+++ b/app/models/event_series.rb
@@ -17,6 +17,8 @@ class EventSeries < ApplicationRecord
   validates_presence_of :name, :organization, :results_template, :scoring_method
   validate :point_system_present, if: :points?
 
+  scope :with_policy_scope_attributes, -> { from(select('event_series.*, false as concealed'), :event_series) }
+
   private
 
   def point_system_present

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -17,15 +17,16 @@ class Organization < ApplicationRecord
   has_many :event_series, dependent: :destroy
   has_many :results_templates, dependent: :destroy
 
-  scope :owned_by, ->(user) { user.present? ? where(created_by: user.id) : none }
+  scope :owned_by, ->(user) { where(created_by: user.id) }
   scope :authorized_for, ->(user) do
-    if user.present?
-      left_joins(:stewardships)
-        .where('organizations.created_by = ? or stewardships.user_id = ?', user.id, user.id)
-        .distinct
-    else
-      none
-    end
+    left_joins(:stewardships)
+      .where('organizations.created_by = ? or stewardships.user_id = ?', user.id, user.id)
+      .distinct
+  end
+  scope :visible_or_authorized_for, ->(user) do
+    left_joins(:stewardships)
+      .where('organizations.concealed is not true or organizations.created_by = ? or stewardships.user_id = ?', user.id, user.id)
+      .distinct
   end
   scope :with_visible_event_count, -> do
     left_joins(event_groups: :events).select('organizations.*, COUNT(DISTINCT events) AS event_count')

--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -4,7 +4,7 @@ class RawTime < ApplicationRecord
   enum data_status: [:bad, :questionable, :good]
   VALID_STATUSES = [nil, data_statuses[:good], data_statuses[:questionable]]
 
-  include Auditable, DataStatusMethods, Delegable, TimePointMethods, TimeRecordable, TimeZonable
+  include Auditable, DataStatusMethods, Delegable, DelegatedConcealable, TimePointMethods, TimeRecordable, TimeZonable
 
   zonable_attribute :absolute_time
   has_paper_trail

--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -32,6 +32,8 @@ class RawTime < ApplicationRecord
   validates_presence_of :event_group, :split_name, :bitkey, :bib_number, :source
   validates :bib_number, length: {maximum: 6}, format: {with: /\A[\d\*]+\z/, message: 'may contain only digits and asterisks'}
 
+  scope :with_organization_id, -> { from(select('raw_times.*, event_groups.organization_id').joins(:event_group), :raw_times) }
+
   def self.with_relation_ids(args = {})
     query = RawTimeQuery.with_relations(args)
     self.find_by_sql(query)

--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -4,12 +4,7 @@ class RawTime < ApplicationRecord
   enum data_status: [:bad, :questionable, :good]
   VALID_STATUSES = [nil, data_statuses[:good], data_statuses[:questionable]]
 
-  include Auditable
-  include DataStatusMethods
-  include Delegable
-  include TimePointMethods
-  include TimeRecordable
-  include TimeZonable
+  include Auditable, DataStatusMethods, Delegable, TimePointMethods, TimeRecordable, TimeZonable
 
   zonable_attribute :absolute_time
   has_paper_trail
@@ -32,7 +27,9 @@ class RawTime < ApplicationRecord
   validates_presence_of :event_group, :split_name, :bitkey, :bib_number, :source
   validates :bib_number, length: {maximum: 6}, format: {with: /\A[\d\*]+\z/, message: 'may contain only digits and asterisks'}
 
-  scope :with_organization_id, -> { from(select('raw_times.*, event_groups.organization_id').joins(:event_group), :raw_times) }
+  scope :with_policy_scope_attributes, -> do
+    from(select('raw_times.*, event_groups.organization_id, event_groups.concealed').joins(:event_group), :raw_times)
+  end
 
   def self.with_relation_ids(args = {})
     query = RawTimeQuery.with_relations(args)

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -3,7 +3,7 @@
 class Split < ApplicationRecord
   DISTANCE_THRESHOLD = 50 # Distance (in meters) below which split locations are deemed equivalent
 
-  include Auditable, Delegable, Locatable, GuaranteedFindable, UnitConversions
+  include Auditable, Delegable, DelegatedConcealable, Locatable, GuaranteedFindable, UnitConversions
   extend FriendlyId
 
   strip_attributes collapse_spaces: true

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -34,7 +34,9 @@ class Split < ApplicationRecord
 
   scope :ordered, -> { order(:distance_from_start) }
   scope :with_course_name, -> { from(select('splits.*, courses.name as course_name').joins(:course), :splits) }
-  scope :with_organization_id, -> { from(select('splits.*, courses.organization_id').joins(:course), :splits) }
+  scope :with_policy_scope_attributes, -> do
+    from(select('splits.*, courses.organization_id, courses.concealed').joins(:course), :splits)
+  end
   scope :location_bounded_by, -> (params) { where(latitude: params[:south]..params[:north],
                                                   longitude: params[:west]..params[:east]) }
   scope :location_bounded_across_dateline, -> (params) { where(latitude: params[:south]..params[:north])

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -33,7 +33,8 @@ class Split < ApplicationRecord
   attribute :kind, default: :intermediate
 
   scope :ordered, -> { order(:distance_from_start) }
-  scope :with_course_name, -> { select('splits.*, courses.name as course_name').joins(:course) }
+  scope :with_course_name, -> { from(select('splits.*, courses.name as course_name').joins(:course), :splits) }
+  scope :with_organization_id, -> { from(select('splits.*, courses.organization_id').joins(:course), :splits) }
   scope :location_bounded_by, -> (params) { where(latitude: params[:south]..params[:north],
                                                   longitude: params[:west]..params[:east]) }
   scope :location_bounded_across_dateline, -> (params) { where(latitude: params[:south]..params[:north])

--- a/app/models/split_time.rb
+++ b/app/models/split_time.rb
@@ -27,10 +27,16 @@ class SplitTime < ApplicationRecord
   scope :start, -> { includes(:split).where(splits: {kind: Split.kinds[:start]}) }
   scope :out, -> { where(sub_split_bitkey: SubSplit::OUT_BITKEY) }
   scope :in, -> { where(sub_split_bitkey: SubSplit::IN_BITKEY) }
+
   scope :with_time_from_start, -> do
     select('split_times.*, extract(epoch from split_times.absolute_time - sst.absolute_time) as time_from_start')
         .joins(SplitTimeQuery.starting_split_times(scope: {efforts: {id: current_scope.map(&:effort_id).uniq}}))
   end
+
+  scope :with_policy_scope_attributes, -> do
+    from(select('split_times.*, event_groups.organization_id, event_groups.concealed').joins(effort: {event: :event_group}), :split_times)
+  end
+
   scope :with_time_record_matchers, -> { joins(effort: {event: :event_group}).select("split_times.*, event_groups.home_time_zone, efforts.bib_number") }
 
   # SplitTime::recorded_at_aid functions properly only when called on split_times within an event

--- a/app/models/split_time.rb
+++ b/app/models/split_time.rb
@@ -31,7 +31,6 @@ class SplitTime < ApplicationRecord
     select('split_times.*, extract(epoch from split_times.absolute_time - sst.absolute_time) as time_from_start')
         .joins(SplitTimeQuery.starting_split_times(scope: {efforts: {id: current_scope.map(&:effort_id).uniq}}))
   end
-  scope :visible, -> { includes(effort: {event: :event_group}).where('event_groups.concealed = ?', 'f') }
   scope :with_time_record_matchers, -> { joins(effort: {event: :event_group}).select("split_times.*, event_groups.home_time_zone, efforts.bib_number") }
 
   # SplitTime::recorded_at_aid functions properly only when called on split_times within an event

--- a/app/models/split_time.rb
+++ b/app/models/split_time.rb
@@ -7,7 +7,7 @@ class SplitTime < ApplicationRecord
   # See app/concerns/data_status_methods for related scopes and methods
   VALID_STATUSES = [nil, data_statuses[:good], data_statuses[:confirmed]]
 
-  include Auditable, DataStatusMethods, Delegable, GuaranteedFindable, TimePointMethods, TimeZonable
+  include Auditable, DataStatusMethods, Delegable, DelegatedConcealable, GuaranteedFindable, TimePointMethods, TimeZonable
 
   zonable_attributes :absolute_time, :absolute_estimate_early, :absolute_estimate_late
   has_paper_trail

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,6 +94,14 @@ class User < ApplicationRecord
     resource.respond_to?(:stewards) ? resource.stewards.include?(self) : false
   end
 
+  def delegated_organization_ids
+    Organization.authorized_for(self).pluck(:id)
+  end
+
+  def owned_organization_ids
+    Organization.owned_by(self).pluck(:id)
+  end
+
   def full_name
     [first_name, last_name].join(' ')
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -16,7 +16,7 @@ class ApplicationPolicy
       elsif user.nil?
         scope.none
       else
-        scope.where(id: (created_records.ids + delegated_records.ids).uniq)
+        authorized_to_edit_records
       end
     end
     alias_method :editable, :resolve_editable
@@ -27,7 +27,7 @@ class ApplicationPolicy
       elsif user.nil?
         visible_records
       else
-        scope.where(id: (visible_records + owned_records + created_records + delegated_records).uniq)
+        authorized_to_view_records
       end
     end
     alias_method :viewable, :resolve_viewable
@@ -38,25 +38,13 @@ class ApplicationPolicy
     end
 
     # May be overridden by model policies
-    def owned_records
+    def authorized_to_edit_records
       scope.none
-    end
-
-    def created_records
-      scope.where(created_by: user.id)
     end
 
     # May be overridden by model policies
-    def delegated_records
-      scope.none
-    end
-
-    def authorized_organizations
-      Organization.authorized_for(user)
-    end
-
-    def owned_organizations
-      Organization.owned_by(user)
+    def authorized_to_view_records
+      visible_records
     end
   end
 

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -5,12 +5,12 @@ class CoursePolicy < ApplicationPolicy
     def post_initialize
     end
 
-    def delegated_records
-      scope.where(organization_id: authorized_organizations)
+    def authorized_to_edit_records
+      scope.owned_by(user)
     end
 
-    def owned_records
-      scope.where(organization_id: owned_organizations)
+    def authorized_to_view_records
+      scope.visible_or_delegated_to(user)
     end
   end
 

--- a/app/policies/effort_policy.rb
+++ b/app/policies/effort_policy.rb
@@ -5,13 +5,12 @@ class EffortPolicy < ApplicationPolicy
     def post_initialize
     end
 
-    def delegated_records
-      if user
-        scope.joins(event: {event_group: {organization: :stewardships}})
-            .includes(event: {event_group: {organization: :stewardships}}).delegated(user.id)
-      else
-        scope.none
-      end
+    def authorized_to_edit_records
+      scope.delegated_to(user)
+    end
+
+    def authorized_to_view_records
+      scope.visible_or_delegated_to(user)
     end
   end
 

--- a/app/policies/event_group_policy.rb
+++ b/app/policies/event_group_policy.rb
@@ -5,12 +5,12 @@ class EventGroupPolicy < ApplicationPolicy
     def post_initialize
     end
 
-    def delegated_records
-      if user
-        scope.joins(organization: :stewardships).includes(organization: :stewardships).delegated(user.id)
-      else
-        scope.none
-      end
+    def authorized_to_edit_records
+      scope.delegated_to(user)
+    end
+
+    def authorized_to_view_records
+      scope.visible_or_delegated_to(user)
     end
   end
 

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -5,13 +5,12 @@ class EventPolicy < ApplicationPolicy
     def post_initialize
     end
 
-    def delegated_records
-      if user
-        scope.joins(event_group: {organization: :stewardships})
-            .includes(event_group: {organization: :stewardships}).delegated(user.id)
-      else
-        scope.none
-      end
+    def authorized_to_edit_records
+      scope.delegated_to(user)
+    end
+
+    def authorized_to_view_records
+      scope.visible_or_delegated_to(user)
     end
   end
 

--- a/app/policies/event_series_policy.rb
+++ b/app/policies/event_series_policy.rb
@@ -5,12 +5,12 @@ class EventSeriesPolicy < ApplicationPolicy
     def post_initialize
     end
 
-    def delegated_records
-      if user
-        scope.joins(organization: :stewardships).includes(organization: :stewardships).delegated(user.id)
-      else
-        scope.none
-      end
+    def authorized_to_edit_records
+      scope.delegated_to(user)
+    end
+
+    def authorized_to_view_records
+      scope.visible_or_delegated_to(user)
     end
   end
 

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -2,13 +2,15 @@
 
 class OrganizationPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
-    attr_reader :user, :scope
-
     def post_initialize
     end
 
-    def delegated_records
-      user ? scope.joins(:stewardships).where(stewardships: {user_id: user.id}) : scope.none
+    def authorized_to_edit_records
+      scope.owned_by(user)
+    end
+
+    def authorized_to_view_records
+      scope.visible_or_authorized_for(user)
     end
   end
 

--- a/app/policies/split_policy.rb
+++ b/app/policies/split_policy.rb
@@ -4,6 +4,10 @@ class SplitPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def post_initialize
     end
+
+    def authorized_to_view_records
+      scope.visible_or_delegated_to(user)
+    end
   end
 
   attr_reader :split

--- a/spec/models/effort_spec.rb
+++ b/spec/models/effort_spec.rb
@@ -523,19 +523,12 @@ RSpec.describe Effort, type: :model do
     end
   end
 
-  describe '.concealed and .visible' do
+  describe '.visible' do
     let(:concealed_event_group) { event_groups(:dirty_30) }
     let(:visible_efforts) { Effort.joins(:event).where.not(events: { event_group_id: concealed_event_group.id }).first(5) }
     let(:concealed_efforts) { Effort.joins(:event).where(events: { event_group_id: concealed_event_group.id }).first(5) }
 
     before { concealed_event_group.update(concealed: true) }
-
-    describe '.concealed' do
-      it 'limits the subject scope to efforts whose event_group is concealed' do
-        visible_efforts.each { |effort| expect(Effort.concealed).not_to include(effort) }
-        concealed_efforts.each { |effort| expect(Effort.concealed).to include(effort) }
-      end
-    end
 
     describe '.visible' do
       it 'limits the subject scope to efforts whose event_group is visible' do

--- a/spec/system/visit_effort_show_spec.rb
+++ b/spec/system/visit_effort_show_spec.rb
@@ -83,8 +83,6 @@ RSpec.describe 'visit an effort show page' do
     end
 
     scenario 'The user is the owner' do
-      effort.update(created_by: owner.id)
-
       login_as owner, scope: :user
       visit effort_path(effort)
       

--- a/spec/system/visit_effort_show_spec.rb
+++ b/spec/system/visit_effort_show_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe 'visit an effort show page' do
     organization.stewards << steward
   end
 
-  let(:event) { events(:hardrock_2014) }
-  let(:organization) { event.organization }
+  let(:event) { effort.event }
+  let(:event_group) { event.event_group}
+  let(:organization) { event_group.organization }
 
   let(:completed_effort) { efforts(:hardrock_2014_finished_first) }
   let(:in_progress_effort) { efforts(:hardrock_2014_progress_sherman) }
@@ -157,6 +158,43 @@ RSpec.describe 'visit an effort show page' do
     end
   end
 
+  context 'when the effort is hidden' do
+    let(:effort) { completed_effort }
+    before { event_group.update(concealed: true) }
+
+    scenario 'The user is a visitor' do
+      verify_page_not_found
+    end
+
+    scenario 'The user is not the owner and is not a steward' do
+      login_as user, scope: :user
+      verify_page_not_found
+    end
+
+    scenario 'The user is the owner' do
+      login_as owner, scope: :user
+      visit effort_path(effort)
+
+      verify_page_content
+      verify_admin_links_present
+    end
+
+    scenario 'The user is a steward of the organization related to the event' do
+      login_as steward, scope: :user
+      visit effort_path(effort)
+
+      verify_page_content
+      verify_admin_links_present
+    end
+
+    scenario 'The user is an admin' do
+      login_as admin, scope: :user
+      visit effort_path(effort)
+
+      verify_page_content
+      verify_admin_links_present
+    end
+  end
 
   def verify_page_content
     expect(page).to have_content(effort.full_name)
@@ -207,5 +245,9 @@ RSpec.describe 'visit an effort show page' do
     expect(page).to have_content 'Set stop'
     effort.reload
     expect(effort.ordered_split_times.last).not_to be_stopped_here
+  end
+
+  def verify_page_not_found
+    expect { visit effort_path(effort) }.to raise_error ::ActiveRecord::RecordNotFound
   end
 end

--- a/spec/system/visit_event_group_settings_spec.rb
+++ b/spec/system/visit_event_group_settings_spec.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Visit an event group settings page and try various features' do
+  let(:user) { users(:third_user) }
+  let(:owner) { users(:fourth_user) }
+  let(:steward) { users(:fifth_user) }
+  let(:admin) { users(:admin_user) }
+
+  before do
+    organization.update(created_by: owner.id)
+    organization.stewards << steward
+  end
+
+  let(:organization) { organizations(:dirty_30_running) }
+  let(:event_group) { event_groups(:sum) }
+  let(:event_1) { event_group.events.first }
+  let(:event_2) { event_group.events.second }
+
+  let(:outside_event_group) { event_groups(:rufa_2017) }
+  let(:outside_event_1) { outside_event_group.events.first }
+  let(:outside_event_2) { outside_event_group.events.second }
+
+
+  context 'The event group is visible' do
+    scenario 'The user is a visitor' do
+      visit event_group_path(event_group)
+
+      verify_public_links_present
+      verify_steward_links_absent
+      verify_admin_links_absent
+      verify_outside_content_absent
+    end
+
+    scenario 'The user is not the owner and not a steward' do
+      login_as user, scope: :user
+      visit event_group_path(event_group)
+
+      verify_public_links_present
+      verify_steward_links_absent
+      verify_admin_links_absent
+      verify_outside_content_absent
+    end
+
+    scenario 'The user owns the organization' do
+      login_as owner, scope: :user
+      visit event_group_path(event_group)
+
+      verify_public_links_present
+      verify_steward_links_present
+      verify_admin_links_present
+      verify_outside_content_absent
+    end
+
+    scenario 'The user is a steward of the organization' do
+      login_as steward, scope: :user
+      visit event_group_path(event_group)
+
+      verify_public_links_present
+      verify_steward_links_present
+      verify_admin_links_absent
+      verify_outside_content_absent
+    end
+
+    scenario 'The user is an admin user' do
+      login_as admin, scope: :user
+      visit event_group_path(event_group)
+
+      verify_public_links_present
+      verify_steward_links_present
+      verify_admin_links_present
+      verify_outside_content_absent
+    end
+  end
+
+  context 'The event group is concealed' do
+    before { event_group.update(concealed: true) }
+
+    scenario 'The user is a visitor' do
+      verify_record_not_found
+    end
+
+    scenario 'The user is not the owner and not a steward' do
+      login_as user, scope: :user
+      verify_record_not_found
+    end
+
+    scenario 'The user owns the organization' do
+      login_as owner, scope: :user
+      visit event_group_path(event_group)
+
+      verify_public_links_present
+      verify_steward_links_present
+      verify_admin_links_present
+      verify_outside_content_absent
+    end
+
+    scenario 'The user is a steward of the organization' do
+      login_as steward, scope: :user
+      visit event_group_path(event_group)
+
+      verify_public_links_present
+      verify_steward_links_present
+      verify_admin_links_absent
+      verify_outside_content_absent
+    end
+
+    scenario 'The user is an admin user' do
+      login_as admin, scope: :user
+      visit event_group_path(event_group)
+
+      verify_public_links_present
+      verify_steward_links_present
+      verify_admin_links_present
+      verify_outside_content_absent
+    end
+
+    # Ensure policy scoping is working as expected, i.e., ignoring created_by
+    # and looking only at the organization owner.
+    context 'The event group has an event that was created by an admin' do
+      before { event_2.update(created_by: admin.id) }
+
+      scenario 'The user owns the organization' do
+        login_as owner, scope: :user
+        visit event_group_path(event_group)
+
+        verify_public_links_present
+        verify_steward_links_present
+        verify_admin_links_present
+        verify_outside_content_absent
+      end
+
+      scenario 'The user is a steward of the organization' do
+        login_as steward, scope: :user
+        visit event_group_path(event_group)
+
+        verify_public_links_present
+        verify_steward_links_present
+        verify_admin_links_absent
+        verify_outside_content_absent
+      end
+
+      scenario 'The user is an admin user' do
+        login_as admin, scope: :user
+        visit event_group_path(event_group)
+
+        verify_public_links_present
+        verify_steward_links_present
+        verify_admin_links_present
+        verify_outside_content_absent
+      end
+    end
+  end
+
+  scenario 'The user is a visitor that clicks an event link' do
+    visit event_group_path(event_group)
+    click_link event_1.name
+
+    expect(page).to have_content(event_1.name)
+    expect(page).to have_content('Full results')
+  end
+
+  def verify_public_links_present
+    expect(page).to have_content(organization.name)
+
+    verify_link_present(event_1)
+    verify_link_present(event_2)
+  end
+
+  def verify_outside_content_absent
+    expect(page).not_to have_content(outside_event_group.name)
+    expect(page).not_to have_content(outside_event_1.guaranteed_short_name)
+    expect(page).not_to have_content(outside_event_2.guaranteed_short_name)
+  end
+
+  def verify_steward_links_absent
+    expect(page).not_to have_content('Edit/Delete Event')
+  end
+
+  def verify_steward_links_present
+    expect(page).to have_link('Edit/Delete Event', href: edit_event_path(event_1))
+    expect(page).to have_link('Edit/Delete Event', href: edit_event_path(event_2))
+  end
+
+  def verify_admin_links_absent
+    expect(page).not_to have_content('Make private')
+    expect(page).not_to have_content('Make public')
+    expect(page).not_to have_content('Disable live')
+    expect(page).not_to have_content('Enable live')
+    expect(page).not_to have_content('Group Actions')
+  end
+
+  def verify_admin_links_present
+    if event_group.concealed?
+      expect(page).to have_link('Make public', href: event_group_path(event_group, event_group: {concealed: false}))
+    else
+      expect(page).to have_link('Make private', href: event_group_path(event_group, event_group: {concealed: true}))
+    end
+
+    if event_group.available_live?
+      expect(page).to have_link('Disable live', href: event_group_path(event_group, event_group: {available_live: false}))
+    else
+      expect(page).to have_link('Enable live', href: event_group_path(event_group, event_group: {available_live: true}))
+    end
+
+    expect(page).to have_content('Group Actions')
+  end
+
+  def verify_record_not_found
+    expect { visit event_group_path(event_group) }.to raise_error ::ActiveRecord::RecordNotFound
+  end
+end

--- a/spec/system/visit_split_show_spec.rb
+++ b/spec/system/visit_split_show_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'visit a split show page' do
+  let(:user) { users(:third_user) }
+  let(:owner) { users(:fourth_user) }
+  let(:steward) { users(:fifth_user) }
+  let(:admin) { users(:admin_user) }
+
+  before do
+    organization.update(created_by: owner.id)
+    organization.stewards << steward
+  end
+
+  let(:event) { events(:hardrock_2016) }
+  let(:event_group) { event.event_group}
+  let(:organization) { event_group.organization }
+
+  let(:course) { event.course }
+
+  let(:start_split) { course.ordered_splits.first }
+  let(:intermediate_split) { course.ordered_splits.second }
+  let(:finish_split) { course.ordered_splits.last }
+
+  context 'When the split is a start split' do
+    let(:split) { start_split }
+
+    scenario 'The user is a visitor' do
+      visit split_path(split)
+      
+      verify_page_content
+      verify_admin_links_absent
+    end
+
+    scenario 'The user is not the owner and is not a steward' do
+      login_as user, scope: :user
+      visit split_path(split)
+      
+      verify_page_content
+      verify_admin_links_absent
+    end
+
+    scenario 'The user is the owner' do
+      login_as owner, scope: :user
+      visit split_path(split)
+      
+      verify_page_content
+      verify_admin_links_present
+    end
+
+    scenario 'The user is a steward of the organization related to the event' do
+      login_as steward, scope: :user
+      visit split_path(split)
+      
+      verify_page_content
+      verify_admin_links_present
+    end
+
+    scenario 'The user is an admin' do
+      login_as admin, scope: :user
+      visit split_path(split)
+      
+      verify_page_content
+      verify_admin_links_present
+    end
+  end
+
+  context 'When the split is intermediate' do
+    let(:split) { intermediate_split }
+
+    scenario 'The user is a visitor' do
+      visit split_path(split)
+      
+      verify_page_content
+      verify_admin_links_absent
+    end
+
+    scenario 'The user is not the owner and is not a steward' do
+      login_as user, scope: :user
+      visit split_path(split)
+      
+      verify_page_content
+      verify_admin_links_absent
+    end
+
+    scenario 'The user is the owner' do
+      login_as owner, scope: :user
+      visit split_path(split)
+      
+      verify_page_content
+      verify_admin_links_present
+    end
+
+    scenario 'The user is a steward of the organization related to the event' do
+      login_as steward, scope: :user
+      visit split_path(split)
+      
+      verify_page_content
+      verify_admin_links_present
+    end
+
+    scenario 'The user is an admin' do
+      login_as admin, scope: :user
+      visit split_path(split)
+
+      verify_page_content
+      verify_admin_links_present
+    end
+  end
+
+  context 'When the split is a finish split' do
+    let(:split) { finish_split }
+
+    scenario 'The user is a visitor' do
+      visit split_path(split)
+      
+      verify_page_content
+      verify_admin_links_absent
+    end
+
+    scenario 'The user is not the owner and is not a steward' do
+      login_as user, scope: :user
+      visit split_path(split)
+      
+      verify_page_content
+      verify_admin_links_absent
+    end
+
+    scenario 'The user is the owner' do
+      login_as owner, scope: :user
+      visit split_path(split)
+
+      verify_page_content
+      verify_admin_links_present
+    end
+
+    scenario 'The user is a steward of the organization related to the event' do
+      login_as steward, scope: :user
+      visit split_path(split)
+
+      verify_page_content
+      verify_admin_links_present
+    end
+
+    scenario 'The user is an admin' do
+      login_as admin, scope: :user
+      visit split_path(split)
+
+      verify_page_content
+      verify_admin_links_present
+    end
+  end
+
+  context 'when the course is hidden' do
+    let(:split) { intermediate_split }
+    before { course.update(concealed: true) }
+
+    scenario 'The user is a visitor' do
+      verify_page_not_found
+    end
+
+    scenario 'The user is not the owner and is not a steward' do
+      login_as user, scope: :user
+      verify_page_not_found
+    end
+
+    scenario 'The user is the owner' do
+      login_as owner, scope: :user
+      visit split_path(split)
+
+      verify_page_content
+      verify_admin_links_present
+    end
+
+    scenario 'The user is a steward of the organization related to the event' do
+      login_as steward, scope: :user
+      visit split_path(split)
+
+      verify_page_content
+      verify_admin_links_present
+    end
+
+    scenario 'The user is an admin' do
+      login_as admin, scope: :user
+      visit split_path(split)
+
+      verify_page_content
+      verify_admin_links_present
+    end
+  end
+
+  def verify_page_content
+    expect(page).to have_content(split.base_name)
+    expect(page).to have_content(course.name)
+  end
+
+  def verify_admin_links_absent
+    expect(page).not_to have_content('Edit Split')
+  end
+
+  def verify_admin_links_present
+    expect(page).to have_link('Edit Split', href: edit_split_path(split))
+  end
+
+  def verify_page_not_found
+    expect { visit split_path(split) }.to raise_error ::ActiveRecord::RecordNotFound
+  end
+end


### PR DESCRIPTION
Policy scopes have been set up for some time using a conglomeration of `delegated_records`, `visible_records`, and `created_records` that has always felt a bit hacky, and has always required multiple database calls to perform, including potentially very long strings of ids being passed into `where` clauses.

This MR reworks the entire policy scope framework, simplifying it around the organization owner and stewards. 

Along with optimizations, this should address https://github.com/SplitTime/OpenSplitTime/issues/269