### PR TITLE
Remove unused method from Split Raw Times presenter

### DIFF
--- a/app/presenters/split_raw_times_presenter.rb
+++ b/app/presenters/split_raw_times_presenter.rb
@@ -46,8 +46,4 @@ class SplitRawTimesPresenter < BasePresenter
   def bitkey
     @bitkey ||= SubSplit.bitkey(sub_split_kind)
   end
-
-  def universal_bib_row_attributes
-    {single_lap: single_lap?}
-  end
 end


### PR DESCRIPTION
Removing a mystery private method.