### PR TITLE
Return a single record in response to Effort#enriched

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -268,7 +268,7 @@ class Effort < ApplicationRecord
   end
 
   def enriched
-    event.efforts.ranked_with_status.find { |e| e.id == id }
+    event.efforts.ranked_with_status(effort_id: id).first
   end
 
   def template_age

--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -4,6 +4,7 @@ class EffortQuery < BaseQuery
   def self.rank_and_status(args = {})
     select_sql = sql_select_from_string(args[:fields], permitted_column_names, '*')
     order_sql = sql_order_from_hash(args[:sort], permitted_column_names, 'event_id,overall_rank')
+    where_clause = args[:effort_id].present? ? "where id = #{args[:effort_id]}" : ''
 
     <<-SQL.squish
       with
@@ -166,6 +167,7 @@ class EffortQuery < BaseQuery
                         age desc) 
           as next_effort_id
       from main_subquery
+      #{where_clause}
       order by #{order_sql}
     SQL
   end


### PR DESCRIPTION
Currently when we want to get an enriched effort (with rank and status), we return an entire event's worth of records from the database and find the desired effort among the resulting array. 

This MR includes a simple change to the effort query that returns a single record if called with an effort id. This should result in some performance gains.