### PR TITLE
Quick optimization for best efforts view

### DIFF
--- a/app/presenters/best_efforts_display.rb
+++ b/app/presenters/best_efforts_display.rb
@@ -110,7 +110,7 @@ class BestEffortsDisplay < BasePresenter
   end
 
   def filter_ids
-    @filter_ids ||= Effort.where(filter_hash).search(search_text).ids.to_set
+    @filter_ids ||= Effort.joins(:event).where(events: {course: course}).where(filter_hash).search(search_text).ids.to_set
   end
 
   def all_efforts


### PR DESCRIPTION
The current presenter for the best efforts view grabs all effort ids that match a filter (male/female/combined) and a search string. This results in many thousands of effort ids being returned.

This PR limits the effort ids to those that are on the subject course.

Further optimizations need to come in the form of scoping before running the `over_segment` query and true pagination at the database (not Ruby/Rails) level.