### PR TITLE
Format best efforts duration in Postgres

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -251,7 +251,7 @@ module DropdownHelper
   def gender_dropdown_menu(view_object)
     dropdown_items = %w(combined male female).map do |gender|
       {name: gender.titleize,
-       link: request.params.merge(filter: {gender: gender}),
+       link: request.params.merge(filter: {gender: gender}, page: nil),
        active: view_object.gender_text == gender}
     end
     build_dropdown_menu(nil, dropdown_items, button: true)

--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -269,12 +269,13 @@ class EffortQuery < BaseQuery
                 case when laps_finished >= laps_required then true else false end 
               end
               as finished,
-              sst.absolute_time as actual_start_time
+              sst.absolute_time as actual_start_time,
+              to_char((segment_seconds || ' second')::interval, 'HH24:MI:SS') as segment_duration
       from main_subquery 
         left join start_split_times sst on sst.effort_id = main_subquery.effort_id
         left join stopped_split_times on stopped_split_times.effort_id = main_subquery.effort_id
         left join farthest_split_times on farthest_split_times.effort_id = main_subquery.effort_id
-      where event_group_concealed = 'f'
+      where event_group_concealed is false and segment_seconds > 0
       order by overall_rank)
       as efforts
     SQL

--- a/app/views/efforts/_efforts_list_segment.html.erb
+++ b/app/views/efforts/_efforts_list_segment.html.erb
@@ -27,7 +27,7 @@
         <% unless presenter.segment_ends_at_finish? %>
           <td class="text-center"><%= humanize_boolean(effort_row.finished?) %></td>
         <% end %>
-        <td class="text-right"><%= time_format_hhmmss(effort_row.segment_seconds) %></td>
+        <td class="text-right"><%= effort_row.segment_duration %></td>
       </tr>
   <% end %>
   </tbody>


### PR DESCRIPTION
Pushes a bit more work to the database by having it render segment durations as strings ready to display in the best efforts view.