### PR TITLE
Paginate to 50 records by default in best efforts view

### DIFF
--- a/app/presenters/best_efforts_display.rb
+++ b/app/presenters/best_efforts_display.rb
@@ -107,4 +107,8 @@ class BestEffortsDisplay < BasePresenter
   def all_efforts
     Effort.joins(:event).where(events: {course: course})
   end
+
+  def per_page
+    params[:per_page] || 50
+  end
 end


### PR DESCRIPTION
Best efforts is still slower than I would like to see. Limiting pagination to 50 by default instead of 200.