### PR TITLE
Specify fields to return from best efforts query

### DIFF
--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -188,9 +188,9 @@ class EffortQuery < BaseQuery
         existing_scope as (#{existing_scope_subquery}),
         
         efforts_scoped as 
-            (select efforts.*
-             from efforts
-             inner join existing_scope on existing_scope.id = efforts.id),
+            (select e.id, e.event_id, e.first_name, e.last_name, e.gender, e.birthdate, e.age, e.city, e.state_code, e.country_code, e.slug
+             from efforts e
+             inner join existing_scope on existing_scope.id = e.id),
                                        
         start_split_times as
           (select effort_id, absolute_time


### PR DESCRIPTION
Even after limiting pagination, the beats query is taking a long time. This is because the database has to perform operations on every effort-lap ever run on the course in question, which in some cases is 1500+ records. There isn't really a way to scope the query down beyond that in advance, because we need the full scope in order to rank the efforts correctly.

This MR attempts a marginal optimization by limiting the fields returned on the efforts table from the main query.