### PR TITLE
Fix breadcrumb bug in best efforts view

### DIFF
--- a/app/presenters/best_efforts_display.rb
+++ b/app/presenters/best_efforts_display.rb
@@ -2,7 +2,8 @@
 
 class BestEffortsDisplay < BasePresenter
   attr_reader :course
-  delegate :name, :simple?, :ordered_splits_without_finish, :ordered_splits_without_start, :to_param, to: :course
+  delegate :name, :simple?, :ordered_splits_without_finish, :ordered_splits_without_start, :organization,
+           :to_param, to: :course
   delegate :distance, :vert_gain, :vert_loss, :begin_lap, :end_lap,
            :begin_id, :end_id, :begin_bitkey, :end_bitkey, to: :segment
 
@@ -71,10 +72,6 @@ class BestEffortsDisplay < BasePresenter
 
   def split2
     params[:split2] || ordered_splits.last.to_param
-  end
-
-  def organization
-    events.first&.organization
   end
 
   private


### PR DESCRIPTION
Currently in production, in the Hardrock 100 Clockwise Best Efforts view, the organization that shows up in the breadcrumbs is "Testrock." That organization does have an event on that course, but it is not the course owner. The current `organization` method in the best efforts presenter is a holdover from the bad old days when courses did not belong to organizations.

This MR delegates `organization` in the best efforts presenter to the course.