### PR TITLE
Proper scoping of events in best efforts display

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -74,7 +74,7 @@ class CoursesController < ApplicationController
       flash[:danger] = 'No efforts yet run on this course'
       redirect_to course_path(@course)
     else
-      @presenter = BestEffortsDisplay.new(@course, prepared_params)
+      @presenter = BestEffortsDisplay.new(@course, prepared_params, current_user)
       session[:return_to] = best_efforts_course_path(@course)
     end
   end

--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -238,8 +238,7 @@ class EffortQuery < BaseQuery
                               split_times.lap, 
                               split_times.split_id, 
                               split_times.sub_split_bitkey,
-                              events.laps_required,
-                              event_groups.concealed as event_group_concealed
+                              events.laps_required
                       from efforts_scoped
                         inner join split_times on split_times.effort_id = efforts_scoped.id 
                         inner join events on events.id = efforts_scoped.event_id
@@ -275,7 +274,7 @@ class EffortQuery < BaseQuery
         left join start_split_times sst on sst.effort_id = main_subquery.effort_id
         left join stopped_split_times on stopped_split_times.effort_id = main_subquery.effort_id
         left join farthest_split_times on farthest_split_times.effort_id = main_subquery.effort_id
-      where event_group_concealed is false and segment_seconds > 0
+      where segment_seconds > 0
       order by overall_rank)
       as efforts
     SQL

--- a/spec/system/best_efforts_flow_spec.rb
+++ b/spec/system/best_efforts_flow_spec.rb
@@ -8,8 +8,11 @@ require 'rails_helper'
 # rails db:structure:load RAILS_ENV=test
 
 RSpec.describe 'Visit the best efforts page and search for an effort' do
-  let(:course) { courses(:hardrock_ccw) }
-  let(:event) { events(:hardrock_2015) }
+  let(:course) { courses(:hardrock_cw) }
+  let(:event) { events(:hardrock_2016) }
+  let(:event_group) { event.event_group }
+  let(:organization) { event_group.organization }
+
   let(:effort_1) { event.efforts.ranked_with_status.first }
   let(:other_efforts) { event.efforts.where.not(id: effort_1.id) }
 
@@ -27,5 +30,61 @@ RSpec.describe 'Visit the best efforts page and search for an effort' do
 
     verify_link_present(effort_1)
     other_efforts.each { |effort| verify_content_absent(effort) }
+  end
+
+  context 'when hidden efforts exist for the course' do
+    let(:hidden_event) { events(:hardrock_2014) }
+    let(:hidden_event_group) { hidden_event.event_group }
+    let(:hidden_effort_1) { hidden_event.efforts.ranked_with_status.first }
+    let(:other_hidden_efforts) { hidden_event.efforts.where.not(id: hidden_effort_1.id) }
+
+    let(:user) { users(:third_user) }
+    let(:owner) { users(:fourth_user) }
+    let(:steward) { users(:fifth_user) }
+    let(:admin) { users(:admin_user) }
+
+    before do
+      hidden_event_group.update(concealed: true)
+      organization.update(created_by: owner.id)
+      organization.stewards << steward
+    end
+
+    scenario 'The user is a visitor' do
+      visit best_efforts_course_path(course)
+      verify_link_present(effort_1)
+      verify_content_absent(hidden_effort_1)
+    end
+
+    scenario 'The user is not the owner and not a steward' do
+      login_as user, scope: :user
+
+      visit best_efforts_course_path(course)
+      verify_link_present(effort_1)
+      verify_content_absent(hidden_effort_1)
+    end
+
+    scenario 'The user owns the organization' do
+      login_as owner, scope: :user
+
+      visit best_efforts_course_path(course)
+      verify_link_present(effort_1)
+      verify_link_present(hidden_effort_1)
+    end
+
+    scenario 'The user is a steward of the organization' do
+      login_as steward, scope: :user
+
+      visit best_efforts_course_path(course)
+      verify_link_present(effort_1)
+      verify_link_present(hidden_effort_1)
+    end
+
+    scenario 'The user is an admin' do
+      login_as admin, scope: :user
+
+      visit best_efforts_course_path(course)
+      verify_link_present(effort_1)
+      verify_link_present(hidden_effort_1)
+    end
   end
 end


### PR DESCRIPTION
Currently we are seeing hidden events show up in the metadata for the best efforts display. For example, Hardrock Clockwise is indicating there is an event on March 5, 2020, which is a reference to the hidden Testrock event.

This PR passes current user into the best efforts display and properly scopes events (and by extension, efforts) ensuring no hidden information will be displayed in this view.