### PR TITLE
Redirect follow action if event group is completed

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -81,6 +81,11 @@ class EventGroupsController < ApplicationController
 
   def follow
     @presenter = EventGroupFollowPresenter.new(@event_group, prepared_params, current_user)
+
+    if @presenter.event_group_finished?
+      flash[:success] = "#{@presenter.name} is completed."
+      redirect_to event_group_path(@event_group)
+    end
   end
 
   def traffic

--- a/spec/system/follow_view_spec.rb
+++ b/spec/system/follow_view_spec.rb
@@ -25,4 +25,28 @@ RSpec.describe 'visit the follow page' do
     visit follow_event_group_path(event_group)
     expect(page).to have_content(event_group.name)
   end
+
+  context 'The event group is completed' do
+    before do
+      event_group.events.each do |event|
+        Interactors::UpdateEffortsStop.perform!(event.efforts, stop_status: true)
+      end
+    end
+
+    context 'The event group has a single event' do
+      let(:event) { event_group.events.first }
+      scenario 'A visitor views the follow page and is redirected to the spread' do
+        visit follow_event_group_path(event_group)
+        expect(current_path).to eq spread_event_path(event)
+      end
+    end
+
+    context 'The event group has multiple events' do
+      let(:event_group) { event_groups(:sum) }
+      scenario 'A visitor views the follow page and is redirected to the event group page' do
+        visit follow_event_group_path(event_group)
+        expect(current_path).to eq event_group_path(event_group)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR redirects a user trying to access a Follow page after the event group has been completed.

Addresses #297 