### PR TITLE
Restrict the course index to admin

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,7 +1,7 @@
 class CoursesController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show, :best_efforts, :plan_effort]
+  before_action :authenticate_user!, except: [:show, :best_efforts, :plan_effort]
   before_action :set_course, except: [:index, :new, :create]
-  after_action :verify_authorized, except: [:index, :show, :best_efforts, :plan_effort]
+  after_action :verify_authorized, except: [:show, :best_efforts, :plan_effort]
 
   def index
     @courses = policy_scope(Course).paginate(page: params[:page], per_page: 25).order(:name)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -6,7 +6,7 @@ class CoursesController < ApplicationController
   def index
     authorize Course
 
-    @courses = policy_scope(Course).paginate(page: params[:page], per_page: 25).order(:name)
+    @courses = policy_scope(Course).includes(:events, :splits).with_attached_gpx.order(:name).paginate(page: params[:page], per_page: 25)
     session[:return_to] = courses_path
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -4,6 +4,8 @@ class CoursesController < ApplicationController
   after_action :verify_authorized, except: [:show, :best_efforts, :plan_effort]
 
   def index
+    authorize Course
+
     @courses = policy_scope(Course).paginate(page: params[:page], per_page: 25).order(:name)
     session[:return_to] = courses_path
   end

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -20,7 +20,11 @@ class CoursePolicy < ApplicationPolicy
     @course = course
   end
 
-  # Course destruction could affect events that belong to users other than the course owner
+  # The course index is only for admin convenience
+  def index?
+    user.admin?
+  end
+
   def destroy?
     user.admin?
   end

--- a/spec/system/visit_course_index_spec.rb
+++ b/spec/system/visit_course_index_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Visit the course index' do
+  let(:user) { users(:third_user) }
+  let(:admin) { users(:admin_user) }
+
+  scenario 'The user is a visitor' do
+    visit courses_path
+    expect(current_path).to eq root_path
+  end
+
+  scenario 'The user is a non-admin user' do
+    login_as user, scope: :user
+    visit courses_path
+    expect(current_path).to eq root_path
+  end
+
+  scenario 'The user is an admin user' do
+    login_as admin, scope: :user
+    visit courses_path
+
+    verify_courses_present
+  end
+
+  def verify_courses_present
+    Course.all.each do |course|
+      expect(page).to have_content(course.name)
+    end
+  end
+end


### PR DESCRIPTION
There is no reason to have a public course index. This PR restricts the index to admin only.