### PR TITLE
Use an inexpensive query to count the filtered efforts

### DIFF
--- a/app/presenters/best_efforts_display.rb
+++ b/app/presenters/best_efforts_display.rb
@@ -16,7 +16,14 @@ class BestEffortsDisplay < BasePresenter
   def filtered_efforts
     all_efforts.over_segment(segment).unscope(:where, :joins)
       .where(filter_hash).search(search_text)
-      .paginate(page: page, per_page: per_page)
+      .paginate(page: page, per_page: per_page, total_entries: filtered_efforts_count)
+  end
+
+  # This method duplicates some code from filtered_efforts, but it allows us to do a very
+  # inexpensive count of records instead of running the expensive over_segment subquery
+  # twice, once just to get the count.
+  def filtered_efforts_count
+    @filtered_efforts_count ||= all_efforts.where(filter_hash).search(search_text).count
   end
 
   def all_efforts_count

--- a/app/views/courses/best_efforts.html.erb
+++ b/app/views/courses/best_efforts.html.erb
@@ -57,7 +57,7 @@
       from #{[@presenter.earliest_event_date, @presenter.most_recent_event_date].compact.join(' to ')}" %>
     </h5>
 
-    <% if @presenter.filtered_efforts.present? %>
+    <% if @presenter.filtered_efforts_count > 0 %>
       <%= render 'efforts/efforts_list_segment', presenter: @presenter %>
 
       <div class="row">


### PR DESCRIPTION
We have optimized the `over_segment` subquery for determining best efforts, but it is still relatively expensive, in the range of 200-300ms. Currently we are running this query twice, once to get the paginated records themselves, and once to count the total (pre-pagination) records. This is required because the pagination library wants to build out a block allowing pagination to the end of the filtered record list. But even the `count` version of the subquery takes 150+ ms to run for a course with many efforts. 

This PR further optimizes the best efforts view by using a cheaper version of the filtered query (one without the `over_segment` subquery) to count records. This cheaper query should run an order of magnitude faster than the full subquery with `over_segment`.