### PR TITLE
Eager load event groups for person show view

### DIFF
--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -11,7 +11,7 @@ class PersonPresenter < BasePresenter
   end
 
   def efforts
-    @efforts ||= EffortPolicy::Scope.new(current_user, Effort).viewable.includes(:event, split_times: :split)
+    @efforts ||= EffortPolicy::Scope.new(current_user, Effort).viewable.includes(event: :event_group, split_times: :split)
                      .where(person: person).sort_by { |effort| -effort.actual_start_time.to_i }
   end
 


### PR DESCRIPTION
We are getting N+1 queries in the person show view as a result of events needing an event_group to build the event name. 

This PR eager loads the event groups to avoid the N+1 problem.