### PR TITLE
Change rolling restarts back to 12 hours

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,7 @@ end
 before_fork do
   require 'puma_worker_killer'
 
-  PumaWorkerKiller.enable_rolling_restart(3.hours)
+  PumaWorkerKiller.enable_rolling_restart(12.hours)
 end
 
 if %w(development test).include?(ENV['RACK_ENV'])


### PR DESCRIPTION
We are using memory much more efficiently now. Let's see if we can lengthen rolling restart times and maybe eliminate them altogether eventually.