### PR TITLE
Use policy scope when setting single person

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -95,7 +95,7 @@ class PeopleController < ApplicationController
   private
 
   def set_person
-    @person = Person.friendly.find(params[:id])
+    @person = policy_scope(Person).friendly.find(params[:id])
     redirect_numeric_to_friendly(@person, params[:id])
   end
 end

--- a/spec/system/visit_person_show_spec.rb
+++ b/spec/system/visit_person_show_spec.rb
@@ -3,16 +3,37 @@
 require 'rails_helper'
 
 RSpec.describe 'visit a person show page' do
+  let(:person) { people(:finished_first_utah_us) }
+  let(:user) { users(:third_user) }
+  let(:owner) { users(:fourth_user) }
+  let(:steward) { users(:fifth_user) }
+  let(:admin) { users(:admin_user) }
 
-  context 'When the person has at least one effort' do
-    let(:person) { people(:finished_first_utah_us) }
-
+  context 'When the person is visible' do
     scenario 'Visit the page' do
       visit person_path(person)
+
       verify_page_header
       expect(person.efforts.visible.size).to eq(1)
       verify_efforts
     end
+  end
+
+  context 'When the person is hidden' do
+    before { person.update(concealed: true) }
+    scenario 'The user is a visitor and cannot see the record' do
+      expect { visit person_path(person) }.to raise_error ::ActiveRecord::RecordNotFound
+    end
+
+    scenario 'The user is an admin user' do
+      login_as admin, scope: :user
+      visit person_path(person)
+
+      verify_page_header
+      expect(person.efforts.visible.size).to eq(1)
+      verify_efforts
+    end
+
   end
 
   def verify_page_header

--- a/spec/system/visit_person_show_spec.rb
+++ b/spec/system/visit_person_show_spec.rb
@@ -5,35 +5,48 @@ require 'rails_helper'
 RSpec.describe 'visit a person show page' do
   let(:person) { people(:finished_first_utah_us) }
   let(:user) { users(:third_user) }
-  let(:owner) { users(:fourth_user) }
-  let(:steward) { users(:fifth_user) }
   let(:admin) { users(:admin_user) }
 
   context 'When the person is visible' do
     scenario 'Visit the page' do
       visit person_path(person)
 
-      verify_page_header
-      expect(person.efforts.visible.size).to eq(1)
-      verify_efforts
+      verify_content_present
     end
-  end
 
-  context 'When the person is hidden' do
-    before { person.update(concealed: true) }
-    scenario 'The user is a visitor and cannot see the record' do
-      expect { visit person_path(person) }.to raise_error ::ActiveRecord::RecordNotFound
+    scenario 'The user is a non-admin' do
+      login_as user, scope: :user
+      visit person_path(person)
+
+      verify_content_present
     end
 
     scenario 'The user is an admin user' do
       login_as admin, scope: :user
       visit person_path(person)
 
-      verify_page_header
-      expect(person.efforts.visible.size).to eq(1)
-      verify_efforts
+      verify_content_present
+    end
+  end
+
+  context 'When the person is hidden' do
+    before { person.update(concealed: true) }
+    scenario 'The user is a visitor' do
+      verify_record_not_found
     end
 
+    scenario 'The user is a non-admin' do
+      login_as user, scope: user
+
+      verify_record_not_found
+    end
+
+    scenario 'The user is an admin user' do
+      login_as admin, scope: :user
+      visit person_path(person)
+
+      verify_content_present
+    end
   end
 
   def verify_page_header
@@ -43,5 +56,15 @@ RSpec.describe 'visit a person show page' do
 
   def verify_efforts
     person.efforts.each { |effort| verify_link_present(effort, :event_name) }
+  end
+
+  def verify_content_present
+    verify_page_header
+    expect(person.efforts.visible.size).to eq(1)
+    verify_efforts
+  end
+
+  def verify_record_not_found
+    expect { visit person_path(person) }.to raise_error ::ActiveRecord::RecordNotFound
   end
 end


### PR DESCRIPTION
Proper policy scoping for the `set_person` method.