### PR TITLE
New process flow for OST Remote time import

### DIFF
--- a/app/controllers/api/v1/event_groups_controller.rb
+++ b/app/controllers/api/v1/event_groups_controller.rb
@@ -59,16 +59,14 @@ module Api
         render json: {data: {rawTimeRows: raw_time_rows.map { |row| row.serialize }}, errors: errors}, status: :ok
       end
 
+      # This endpoint searches for un-pulled raw_times belonging to the event_group,
+      # selects a batch, marks them as pulled, combines them into time_rows, and returns them
+      # to the live entry page.
+
+      # Batch size is determined by params[:page][:size]; otherwise the default number will be used.
+      # If params[:force_pull] == true, raw_times without a matching split_time will be pulled
+      # even if they are marked as already having been pulled.
       def pull_raw_times
-
-        # This endpoint searches for un-pulled raw_times belonging to the event_group,
-        # selects a batch, marks them as pulled, combines them into time_rows, and returns them
-        # to the live entry page.
-
-        # Batch size is determined by params[:page][:size]; otherwise the default number will be used.
-        # If params[:force_pull] == true, raw_times without a matching split_time will be pulled
-        # even if they are marked as already having been pulled.
-
         authorize @resource
         event_group = EventGroup.where(id: @resource.id).includes(events: :splits).first
 
@@ -93,11 +91,9 @@ module Api
         render json: {data: {rawTimeRows: raw_time_rows.map { |row| row.serialize }}}, status: :ok
       end
 
+      # This endpoint accepts a single raw_time_row and returns an identical raw_time_row
+      # with data_status, split_time_exists, lap, and other attributes set
       def enrich_raw_time_row
-
-        # This endpoint accepts a single raw_time_row and returns an identical raw_time_row
-        # with data_status, split_time_exists, lap, and other attributes set
-
         authorize @resource
         event_group = EventGroup.where(id: @resource.id).includes(:events).first
 
@@ -112,15 +108,13 @@ module Api
         end
       end
 
+      # This endpoint accepts an array of raw_time_rows, verifies them, saves raw_times and saves or updates
+      # related split_time data where appropriate, and returns the others.
+
+      # In all instances, raw_times having bad split_name or bib_number data will be returned.
+      # When params[:force_submit] is false/nil, all times having bad data status and all duplicate times will be returned.
+      # When params[:force_submit] is true, bad and duplicate times will be forced through.
       def submit_raw_time_rows
-
-        # This endpoint accepts an array of raw_time_rows, verifies them, saves raw_times and saves or updates
-        # related split_time data where appropriate, and returns the others.
-
-        # In all instances, raw_times having bad split_name or bib_number data will be returned.
-        # When params[:force_submit] is false/nil, all times having bad data status and all duplicate times will be returned.
-        # When params[:force_submit] is true, bad and duplicate times will be forced through.
-
         authorize @resource
         event_group = EventGroup.where(id: @resource.id).includes(:events).first
 

--- a/app/jobs/process_imported_raw_times_job.rb
+++ b/app/jobs/process_imported_raw_times_job.rb
@@ -6,7 +6,8 @@ class ProcessImportedRawTimesJob < ApplicationJob
   queue_as :default
 
   def perform(event_group, raw_times)
-    match_response = Interactors::MatchRawTimesToSplitTimes.perform!(event_group: event_group, raw_times: raw_times)
+    loaded_raw_times = ::RawTimes::SetAbsoluteTimeAndLap.perform(event_group, raw_times)
+    match_response = Interactors::MatchRawTimesToSplitTimes.perform!(event_group: event_group, raw_times: loaded_raw_times)
 
     if match_response.successful?
       unmatched_raw_times = match_response.resources[:unmatched]

--- a/app/jobs/process_imported_raw_times_job.rb
+++ b/app/jobs/process_imported_raw_times_job.rb
@@ -7,7 +7,7 @@ class ProcessImportedRawTimesJob < ApplicationJob
 
   def perform(event_group, raw_times)
     loaded_raw_times = ::RawTimes::SetAbsoluteTimeAndLap.perform(event_group, raw_times)
-    match_response = Interactors::MatchRawTimesToSplitTimes.perform!(event_group: event_group, raw_times: loaded_raw_times)
+    match_response = ::Interactors::MatchRawTimesToSplitTimes.perform!(event_group: event_group, raw_times: loaded_raw_times)
 
     if match_response.successful?
       unmatched_raw_times = match_response.resources[:unmatched]

--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -134,4 +134,8 @@ class RawTime < ApplicationRecord
   def home_time_zone
     @home_time_zone ||= attributes['home_time_zone'] || event_group.home_time_zone
   end
+
+  def complete?
+    effort_id && event_id && split_id && lap && absolute_time && bitkey_valid? && lap_valid?
+  end
 end

--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -16,6 +16,7 @@ class RawTime < ApplicationRecord
 
   attribute :lap, :integer
   attribute :split_time_exists, :boolean
+  attribute :split_time_replaceable, :boolean
   attribute :bitkey_valid, :boolean
   attribute :lap_valid, :boolean
   attribute :distance_from_start, :integer
@@ -118,6 +119,10 @@ class RawTime < ApplicationRecord
     absolute_time.present? || entered_time.present?
   end
 
+  def complete?
+    effort_id && event_id && split_id && lap && absolute_time && bitkey_valid? && lap_valid?
+  end
+
   private
 
   def create_sortable_bib_number
@@ -134,9 +139,5 @@ class RawTime < ApplicationRecord
 
   def home_time_zone
     @home_time_zone ||= attributes['home_time_zone'] || event_group.home_time_zone
-  end
-
-  def complete?
-    effort_id && event_id && split_id && lap && absolute_time && bitkey_valid? && lap_valid?
   end
 end

--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -17,9 +17,9 @@ class RawTime < ApplicationRecord
   attribute :lap, :integer
   attribute :split_time_exists, :boolean
   attribute :split_time_replaceable, :boolean
-  attribute :bitkey_valid, :boolean
-  attribute :lap_valid, :boolean
-  attribute :distance_from_start, :integer
+  attribute :bitkey_valid, :boolean # Set by the with_relation_ids method
+  attribute :lap_valid, :boolean # Set by the with_relation_ids method
+  attribute :distance_from_start, :integer # Set by the with_relation_ids method
 
   attr_accessor :new_split_time
   attr_writer :effort, :event, :split
@@ -119,8 +119,8 @@ class RawTime < ApplicationRecord
     absolute_time.present? || entered_time.present?
   end
 
-  def complete?
-    effort_id && event_id && split_id && lap && absolute_time && bitkey_valid? && lap_valid?
+  def time_point_complete?
+    time_point.complete?
   end
 
   private

--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -18,6 +18,7 @@ class RawTime < ApplicationRecord
   attribute :split_time_exists, :boolean
   attribute :bitkey_valid, :boolean
   attribute :lap_valid, :boolean
+  attribute :distance_from_start, :integer
 
   attr_accessor :new_split_time
   attr_writer :effort, :event, :split

--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -16,6 +16,8 @@ class RawTime < ApplicationRecord
 
   attribute :lap, :integer
   attribute :split_time_exists, :boolean
+  attribute :bitkey_valid, :boolean
+  attribute :lap_valid, :boolean
 
   attr_accessor :new_split_time
   attr_writer :effort, :event, :split

--- a/app/models/time_point.rb
+++ b/app/models/time_point.rb
@@ -11,4 +11,8 @@ TimePoint = Struct.new(:lap, :split_id, :bitkey) do
   def lap_split_key
     lap && split_id && LapSplitKey.new(lap, split_id)
   end
+
+  def complete?
+    lap && split_id && bitkey
+  end
 end

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class BaseQuery
+  def self.sql_for_existing_scope(scope)
+    scope.connection.unprepared_statement { scope.reorder(nil).select('id').to_sql }
+  end
+
   def self.sql_safe_integer_list(array)
     array.flatten.compact.map(&:to_i).join(',')
   end
@@ -21,7 +25,6 @@ class BaseQuery
   # Converts an ActiveRecord-style hash to a SQL string for a WHERE clause
   # {efforts: {event_id: 12, first_name: 'Bill'}} becomes
   # "efforts.event_id = 12 and efforts.first_name = 'Bill'"
-
   def self.where_string_from_hash(hash)
     hash.map do |table, criteria|
       criteria.map do |field, value|

--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -307,10 +307,6 @@ class EffortQuery < BaseQuery
     Effort.connection.unprepared_statement { Effort.reorder(nil).select('id').to_sql }
   end
 
-  def self.sql_for_existing_scope(scope)
-    scope.connection.unprepared_statement { scope.reorder(nil).select('id').to_sql }
-  end
-
   def self.permitted_column_names
     EffortParameters.enriched_query
   end

--- a/app/queries/raw_time_query.rb
+++ b/app/queries/raw_time_query.rb
@@ -1,7 +1,7 @@
 class RawTimeQuery < BaseQuery
 
   def self.with_relations(args = {})
-    order_sql = sql_order_from_hash(args[:sort], permitted_column_names, 'sortable_bib_number')
+    order_sql = sql_order_from_hash(args[:sort], permitted_column_names, 'sortable_bib_number, lap, distance_from_start, bitkey')
 
     query = <<-SQL
 
@@ -17,6 +17,7 @@ class RawTimeQuery < BaseQuery
      e.last_name AS effort_last_name,
      e.event_id, 
      s.split_id,
+     s.distance_from_start,
      r.bitkey & s.sub_split_bitmap > 0 as bitkey_valid,
      e.laps_required = 0 or r.entered_lap is null or r.entered_lap <= e.laps_required as lap_valid
     FROM raw_times_scoped r
@@ -28,7 +29,7 @@ class RawTimeQuery < BaseQuery
                    AND r.matchable_bib_number = e.bib_number
                    AND e.event_group_id = r.event_group_id
     LEFT JOIN LATERAL (
-                SELECT a.split_id, s.sub_split_bitmap
+                SELECT a.split_id, s.sub_split_bitmap, s.distance_from_start
                 FROM aid_stations a
                 INNER JOIN splits s ON a.split_id = s.id
                 WHERE a.event_id = e.event_id

--- a/app/queries/raw_time_query.rb
+++ b/app/queries/raw_time_query.rb
@@ -1,7 +1,7 @@
 class RawTimeQuery < BaseQuery
 
   def self.with_relations(args = {})
-    order_sql = sql_order_from_hash(args[:sort], permitted_column_names, 'sortable_bib_number, lap, distance_from_start, bitkey')
+    order_sql = sql_order_from_hash(args[:sort], permitted_column_names, 'sortable_bib_number')
 
     query = <<-SQL
 

--- a/app/queries/split_time_query.rb
+++ b/app/queries/split_time_query.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class SplitTimeQuery < BaseQuery
-
   def self.typical_segment_time(segment, effort_ids)
     # Params should all be integers, but convert them to integers
     # to protect against SQL injection
@@ -439,10 +438,6 @@ class SplitTimeQuery < BaseQuery
   def self.existing_scope_sql
     # have to do this to get the binds interpolated. remove any ordering and just grab the ID
     SplitTime.connection.unprepared_statement { SplitTime.reorder(nil).select("id").to_sql }
-  end
-
-  def self.sql_for_existing_scope(scope)
-    scope.connection.unprepared_statement { scope.reorder(nil).select('id').to_sql }
   end
 
   def self.valid_statuses_list

--- a/app/services/interactors/match_raw_times_to_split_times.rb
+++ b/app/services/interactors/match_raw_times_to_split_times.rb
@@ -14,7 +14,7 @@ module Interactors
       ArgsValidator.validate(params: args, required: [:event_group, :raw_times], exclusive: [:event_group, :raw_times, :tolerance], class: self.class)
       @event_group = args[:event_group]
       @raw_times = args[:raw_times]
-      @tolerance = args[:tolerance] || 1.minute
+      @tolerance = args[:tolerance] || RawTimes::Constants::MATCH_TOLERANCE
       @errors = []
       validate_setup
     end

--- a/app/services/interactors/match_time_records_to_split_times.rb
+++ b/app/services/interactors/match_time_records_to_split_times.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# This class matches raw times to existing split times based on
+# several matching criteria and a specified time tolerance.
+# Raw times having identical characteristics to an existing split time
+# except for the stopped_here flag should be matched later in the
+# process pipeline.
 module Interactors
   class MatchTimeRecordsToSplitTimes
     include Interactors::Errors
@@ -15,7 +20,7 @@ module Interactors
                              class: self.class)
       @time_records = args[:time_records]
       @split_times = args[:split_times]
-      @tolerance = args[:tolerance] || 1.minute
+      @tolerance = args[:tolerance] || RawTimes::Constants::MATCH_TOLERANCE
       @errors = []
       @resources = {matched: [], unmatched: []}
     end

--- a/app/services/interactors/update_efforts_from_raw_times.rb
+++ b/app/services/interactors/update_efforts_from_raw_times.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# raw_times should be previously loaded with relation ids etc.
+#
+# For each raw time having sufficient information, pass it along
+# with its effort to RawTimes::VerifyWithinEffort. Raw times are
+# passed individually because the decision whether to persist
+# a resulting split time is made individually.
+#
+# This class merely optimizes the effort lookup process;
+# the real work is performed by UpdateEffortFromRawTimes and
+# by UpsertSplitTimesFromRawTimeRow.
+module Interactors
+  class UpdateEffortsFromRawTimes
+    def self.perform!(event_group, raw_times)
+      new(event_group, raw_times).perform!
+    end
+
+    def initialize(event_group, raw_times)
+      @event_group = event_group
+      @raw_times = raw_times
+      @times_container = ::SegmentTimesContainer.new(calc_model: :stats)
+      @upserted_split_times = []
+      @errors = []
+    end
+
+    def perform!
+      verify_raw_times
+      update_raw_times
+      update_effort_and_split_times
+
+      ::Interactors::Response.new(errors, '', upserted_split_times: upserted_split_times)
+    end
+
+    private
+
+    attr_reader :event_group, :raw_times, :times_container, :upserted_split_times, :errors
+
+    def verify_raw_times
+      complete_raw_times.each do |raw_time|
+        effort = indexed_efforts[raw_time.effort_id]
+        ::RawTimes::VerifyWithinEffort.perform([raw_time], effort, times_container: times_container)
+      rescue ArgumentError => e
+        errors << e.message
+      end
+    end
+
+    def update_raw_times
+      complete_raw_times.each do |raw_time|
+        unless raw_time.save
+          errors << resource_error_object(raw_time)
+        end
+      end
+    end
+
+    def update_effort_and_split_times
+      upsertable_raw_times.each do |raw_time|
+        rtr = ::RawTimeRow.new([raw_time])
+        upsert_response = ::Interactors::UpsertSplitTimesFromRawTimeRow.perform!(event_group: event_group, raw_time_row: rtr)
+        upsert_response.resources[:upserted_split_times].each { |st| upserted_split_times << st }
+        upsert_response.errors.each { |error| errors << error }
+      end
+    end
+
+    def upsertable_raw_times
+      raw_times.reject { |rt| rt.bad? || (rt.split_time_exists? && !rt.split_time_replaceable?) }
+    end
+
+    def complete_raw_times
+      @complete_raw_times ||= raw_times.select(&:complete?)
+    end
+
+    def indexed_efforts
+      @indexed_efforts ||= ::Effort.includes(:event).where(id: effort_ids).index_by(&:id)
+    end
+
+    def effort_ids
+      raw_times.map(&:effort_id).uniq
+    end
+  end
+end

--- a/app/services/raw_times/constants.rb
+++ b/app/services/raw_times/constants.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RawTimes
+  class Constants
+    MATCH_TOLERANCE = 1.minute
+  end
+end

--- a/app/services/raw_times/set_absolute_time_and_lap.rb
+++ b/app/services/raw_times/set_absolute_time_and_lap.rb
@@ -51,7 +51,7 @@ module RawTimes
       if raw_time.entered_time =~ MILITARY_TIME_REGEX
         raw_time.absolute_time = calculated_absolute_time(raw_time)
       else
-        raw_time.absolute_time = raw_time.entered_time.in_time_zone(time_zone)
+        raw_time.absolute_time = raw_time.entered_time.in_time_zone(event_group.home_time_zone)
       end
     end
 

--- a/app/services/raw_times/set_absolute_time_and_lap.rb
+++ b/app/services/raw_times/set_absolute_time_and_lap.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module RawTimes
+  class SetAbsoluteTimeAndLap
+    MILITARY_TIME_REGEX = /\A\d{1,2}:\d{2}(:\d{2})?\z/
+
+    def self.perform(event_group, raw_times)
+      new(event_group, raw_times).perform
+    end
+
+    def initialize(event_group, raw_times)
+      @event_group = event_group
+      @raw_times = ::RawTime.where(id: raw_times).with_relation_ids
+      validate_setup
+    end
+
+    def perform
+      raw_times.each do |raw_time|
+        set_lap_simple(raw_time)
+        set_entered_from_absolute_time(raw_time) if raw_time.absolute_time.present? # See note below
+        set_absolute_from_entered_time(raw_time) unless raw_time.absolute_time.present?
+        set_lap_using_time(raw_time) unless raw_time.lap.present?
+      end
+
+      raw_times
+    end
+
+    private
+
+    attr_reader :event_group, :raw_times
+
+    def set_lap_simple(raw_time)
+      if raw_time.entered_lap
+        raw_time.lap = raw_time.entered_lap
+      elsif single_lap_event_group? || single_lap_event?(raw_time)
+        raw_time.lap = 1
+      end
+    end
+
+    # OST Remote currently sets absolute_time directly, so we need to
+    # copy absolute_time to entered_time if absolute_time exists.
+    #
+    # This method can be removed once OST Remote sets entered_time
+    # instead of absolute_time (and there has been plenty of time for
+    # users to upgrade).
+    def set_entered_from_absolute_time(raw_time)
+      raw_time.entered_time = raw_time.absolute_time
+    end
+
+    def set_absolute_from_entered_time(raw_time)
+      if raw_time.entered_time =~ MILITARY_TIME_REGEX
+        raw_time.absolute_time = calculated_absolute_time(raw_time)
+      else
+        raw_time.absolute_time = raw_time.entered_time.in_time_zone(time_zone)
+      end
+    end
+
+    def set_lap_using_time(raw_time)
+      if raw_time.absolute_time
+        raw_time.lap = expected_lap(raw_time, :absolute_time_local, raw_time.absolute_time)
+      elsif raw_time.military_time
+        raw_time.lap = expected_lap(raw_time, :military_time, raw_time.military_time)
+      else
+        raw_time.lap = nil
+      end
+    end
+
+    def expected_lap(raw_time, subject_attribute, subject_value)
+      ::FindExpectedLap.perform(effort: indexed_efforts[raw_time.effort_id],
+                                subject_attribute: subject_attribute,
+                                subject_value: subject_value,
+                                split_id: raw_time.split_id,
+                                bitkey: raw_time.bitkey)
+    end
+
+    def calculated_absolute_time(raw_time)
+      return unless raw_time.effort_id && raw_time.split_id
+
+      ::IntendedTimeCalculator.absolute_time_local(military_time: raw_time.entered_time,
+                                                   effort: indexed_efforts[raw_time.effort_id],
+                                                   time_point: raw_time.time_point)
+    end
+
+    def single_lap_event_group?
+      @single_lap_event_group ||= event_group.single_lap?
+    end
+
+    def single_lap_event?(raw_time)
+      indexed_events[raw_time.event_id]&.single_lap?
+    end
+
+    def indexed_events
+      @indexed_events ||= event_group.events.index_by(&:id)
+    end
+
+    def indexed_efforts
+      @indexed_efforts ||= ::Effort.where(id: raw_times.map(&:effort_id)).index_by(&:id)
+    end
+
+    def validate_setup
+      raise ArgumentError, 'All raw_times must match the provided event_group' unless raw_times.all? { |rt| rt.event_group_id == event_group.id }
+    end
+  end
+end

--- a/app/services/raw_times/verify_within_effort.rb
+++ b/app/services/raw_times/verify_within_effort.rb
@@ -19,6 +19,8 @@ module RawTimes
       set_split_time_exists
       append_split_times
       set_data_status
+
+      raw_times
     end
 
     private
@@ -44,10 +46,13 @@ module RawTimes
     end
 
     def set_data_status
+      return unless new_split_times.present?
+
       ::Interactors::SetEffortStatus.perform(effort,
                                              ordered_split_times: combined_split_times,
                                              lap_splits: effort_lap_splits,
                                              times_container: times_container)
+      raw_times.select(&:new_split_time).each { |rt| rt.data_status = rt.new_split_time.data_status }
     end
 
     def combined_split_times
@@ -62,7 +67,7 @@ module RawTimes
     end
 
     def existing_split_times
-      effort.ordered_split_times.map(&:dup)
+      @existing_split_times ||= effort.ordered_split_times.map(&:dup)
     end
 
     def new_split_times

--- a/app/services/raw_times/verify_within_effort.rb
+++ b/app/services/raw_times/verify_within_effort.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# raw_times must be complete with relation ids, lap, and absolute_time
+module RawTimes
+  class VerifyWithinEffort
+    def self.perform(raw_times, effort, options = {})
+      new(raw_times, effort, options).perform
+    end
+
+    def initialize(raw_times, effort, options = {})
+      @raw_times = raw_times
+      @effort = effort
+      @times_container = options[:times_container] || SegmentTimesContainer.new(calc_model: :stats)
+      @errors = []
+      validate_setup
+    end
+
+    def perform
+      set_split_time_exists
+      append_split_times
+      set_data_status
+    end
+
+    private
+
+    attr_reader :raw_times, :effort, :times_container, :errors
+
+    def set_split_time_exists
+      raw_times.each do |raw_time|
+        raw_time.split_time_exists = existing_split_times.any? { |st| st.time_point == raw_time.time_point }
+      end
+    end
+
+    def append_split_times
+      raw_times.each do |raw_time|
+        raw_time.new_split_time = ::SplitTimeFromRawTime.build(raw_time, effort: effort, event: event)
+      end
+    end
+
+    def set_data_status
+      ::Interactors::SetEffortStatus.perform(effort, ordered_split_times: combined_split_times, lap_splits: effort_lap_splits, times_container: times_container)
+    end
+
+    def combined_split_times
+      existing_split_times.each { |st| st.data_status = :confirmed if st.good? }
+      indexed_existing_split_times = existing_split_times.index_by(&:time_point)
+      indexed_new_split_times = new_split_times.index_by(&:time_point)
+      indexed_split_times = indexed_existing_split_times.merge(indexed_new_split_times)
+      indexed_split_times.values_at(*effort_time_points)
+    end
+
+    def existing_split_times
+      effort.ordered_split_times.map(&:dup)
+    end
+
+    def new_split_times
+      raw_times.map(&:new_split_time).compact
+    end
+
+    def event
+      effort.event
+    end
+
+    def effort_time_points
+      @effort_time_points ||= effort_lap_splits.flat_map(&:time_points)
+    end
+
+    def effort_lap_splits
+      @effort_lap_splits ||= event.required_lap_splits.presence || event.lap_splits_through(max_raw_time_lap)
+    end
+
+    def max_raw_time_lap
+      raw_times.max_by(&:lap).lap
+    end
+
+    def validate_setup
+      raw_times.each do |raw_time|
+        raise ArgumentError, "#{raw_time} is incomplete" unless raw_time.complete?
+        raise ArgumentError, "#{raw_time} does not match the provided effort #{effort}" unless raw_time.effort_id == effort.id
+      end
+    end
+  end
+end

--- a/app/services/raw_times/verify_within_effort.rb
+++ b/app/services/raw_times/verify_within_effort.rb
@@ -38,6 +38,7 @@ module RawTimes
 
     def append_split_times
       raw_times.each do |raw_time|
+        next unless raw_time.time_point_complete?
         raw_time.new_split_time = ::SplitTimeFromRawTime.build(raw_time, effort: effort, event: event)
       end
     end
@@ -86,7 +87,6 @@ module RawTimes
 
     def validate_setup
       raw_times.each do |raw_time|
-        raise ArgumentError, "#{raw_time} is incomplete" unless raw_time.complete?
         raise ArgumentError, "#{raw_time} does not match the provided effort #{effort}" unless raw_time.effort_id == effort.id
       end
     end

--- a/app/services/split_time_from_raw_time.rb
+++ b/app/services/split_time_from_raw_time.rb
@@ -1,4 +1,8 @@
 class SplitTimeFromRawTime
+  # TODO: This method should be called only when a the raw time is complete, meaning
+  # among other things that it has an absolute_time. But currently this method is called
+  # by VerifyRawTimeRow, which does not guarantee presence of an absolute_time. Once that
+  # is changed, the conditional `if raw_time.absolute_time?` should be removed.
   def self.build(raw_time, args)
     effort = args[:effort]
     event = args[:event]

--- a/lib/tasks/database_fixtures.rake
+++ b/lib/tasks/database_fixtures.rake
@@ -5,7 +5,18 @@
 namespace :db do
   desc 'Convert development database to Rails test fixtures'
   task to_fixtures: :environment do
-    TABLES_TO_SKIP = %w[ar_internal_metadata delayed_jobs schema_info schema_migrations friendly_id_slugs locations active_storage_blobs active_storage_attachments].freeze
+    TABLES_TO_SKIP = [
+      "active_storage_attachments",
+      "active_storage_blobs",
+      "ar_internal_metadata",
+      "delayed_jobs",
+      "friendly_id_slugs",
+      "locations",
+      "schema_info",
+      "schema_migrations",
+      "shortened_urls",
+      "versions",
+    ]
 
     begin
       ActiveRecord::Base.establish_connection
@@ -51,7 +62,18 @@ namespace :db do
   task from_fixtures: :environment do
     process_start_time = Time.current
 
-    TABLES_TO_SKIP = %w[ar_internal_metadata delayed_jobs schema_info schema_migrations friendly_id_slugs locations active_storage_blobs active_storage_attachments versions].freeze
+    TABLES_TO_SKIP = [
+      "active_storage_attachments",
+      "active_storage_blobs",
+      "ar_internal_metadata",
+      "delayed_jobs",
+      "friendly_id_slugs",
+      "locations",
+      "schema_info",
+      "schema_migrations",
+      "shortened_urls",
+      "versions",
+    ]
 
     begin
       ActiveRecord::Base.establish_connection

--- a/spec/controllers/api/v1/event_groups_controller_spec.rb
+++ b/spec/controllers/api/v1/event_groups_controller_spec.rb
@@ -943,7 +943,7 @@ RSpec.describe Api::V1::EventGroupsController do
     let(:event_group) { event.event_group }
     let(:request_params) { {id: event_group.id} }
     before do
-      create_list(:raw_time, 3, event_group: event_group, split_name: split.base_name)
+      create_list(:raw_time, 3, :with_absolute_time, event_group: event_group, split_name: split.base_name)
     end
 
     via_login_and_jwt do

--- a/spec/factories/raw_time.rb
+++ b/spec/factories/raw_time.rb
@@ -4,8 +4,13 @@ FactoryBot.define do
     split_name { "#{FFaker::Name.first_name} #{FFaker::Name.first_name}".parameterize }
     bitkey { [SubSplit::IN_BITKEY, SubSplit::OUT_BITKEY].sample }
     bib_number { rand(1..999).to_s }
-    absolute_time { FFaker::Time.datetime }
+    entered_time { FFaker::Time.datetime }
     source { 'ost-test' }
+
+    trait :with_absolute_time do
+      entered_time { nil }
+      absolute_time { FFaker::Time.datetime }
+    end
 
     after(:build, :stub) do |raw_time|
       raw_time.run_callbacks(:validation)

--- a/spec/fixtures/courses.yml
+++ b/spec/fixtures/courses.yml
@@ -11,6 +11,7 @@ hardrock_ccw:
   next_start_time: '2019-07-19 06:00:00'
   slug: hardrock-ccw
   organization_id: 4
+  concealed: 
 ramble_even_course:
   id: 9
   name: Ramble Even Course
@@ -22,6 +23,7 @@ ramble_even_course:
   next_start_time: 
   slug: ramble-even-course
   organization_id: 6
+  concealed: 
 hardrock_cw:
   id: 12
   name: Hardrock CW
@@ -33,6 +35,7 @@ hardrock_cw:
   next_start_time: '2016-07-15 12:00:00'
   slug: hardrock-cw
   organization_id: 4
+  concealed: 
 rufa_course:
   id: 20
   name: RUFA Course
@@ -44,6 +47,7 @@ rufa_course:
   next_start_time: '2019-02-09 14:00:00'
   slug: rufa-course
   organization_id: 14
+  concealed: 
 d30_50k_course:
   id: 26
   name: D30 50K Course
@@ -55,6 +59,7 @@ d30_50k_course:
   next_start_time: '2017-11-06 06:00:00'
   slug: d30-50k-course
   organization_id: 15
+  concealed: 
 d30_12m_course:
   id: 27
   name: D30 12M Course
@@ -66,6 +71,7 @@ d30_12m_course:
   next_start_time: 
   slug: d30-12m-course
   organization_id: 15
+  concealed: 
 sum_100k_course:
   id: 31
   name: SUM 100K Course
@@ -77,6 +83,7 @@ sum_100k_course:
   next_start_time: 
   slug: sum-100k-course
   organization_id: 15
+  concealed: 
 sum_55k_course:
   id: 32
   name: SUM 55K Course
@@ -88,3 +95,4 @@ sum_55k_course:
   next_start_time: 
   slug: sum-55k-course
   organization_id: 15
+  concealed: 

--- a/spec/fixtures/raw_times.yml
+++ b/spec/fixtures/raw_times.yml
@@ -3,10 +3,10 @@ raw_time_49:
   id: 49
   event_group_id: 17
   split_time_id: 
-  split_name: Pole Creek
+  split_name: Sherman
   bitkey: 1
-  bib_number: '102'
-  absolute_time: '2017-07-07 16:31:00'
+  bib_number: '103'
+  absolute_time: '2015-07-10 22:10:00'
   entered_time: 
   with_pacer: 
   stopped_here: 
@@ -16,20 +16,22 @@ raw_time_49:
   created_by: 1
   updated_by: 1
   created_at: '2018-06-11 10:56:14.732619'
-  updated_at: '2020-02-14 08:08:54.171286'
-  parameterized_split_name: pole-creek
+  updated_at: '2020-04-07 13:23:20.698946'
+  parameterized_split_name: sherman
   remarks: 
-  sortable_bib_number: 102
+  sortable_bib_number: 103
   data_status: 
-  matchable_bib_number: 102
+  matchable_bib_number: 103
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_50:
   id: 50
   event_group_id: 17
   split_time_id: 
-  split_name: Pole Creek
+  split_name: Sherman
   bitkey: 64
   bib_number: '103'
-  absolute_time: '2017-07-07 20:20:00'
+  absolute_time: '2015-07-10 22:20:00'
   entered_time: 
   with_pacer: 
   stopped_here: 
@@ -39,12 +41,14 @@ raw_time_50:
   created_by: 1
   updated_by: 1
   created_at: '2018-06-11 10:56:14.735995'
-  updated_at: '2020-02-14 08:08:54.176666'
-  parameterized_split_name: pole-creek
+  updated_at: '2020-04-07 13:23:20.707143'
+  parameterized_split_name: sherman
   remarks: 
   sortable_bib_number: 103
   data_status: 
   matchable_bib_number: 103
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_67:
   id: 67
   event_group_id: 32
@@ -68,6 +72,8 @@ raw_time_67:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_68:
   id: 68
   event_group_id: 32
@@ -91,6 +97,8 @@ raw_time_68:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_69:
   id: 69
   event_group_id: 32
@@ -114,6 +122,8 @@ raw_time_69:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_70:
   id: 70
   event_group_id: 32
@@ -137,6 +147,8 @@ raw_time_70:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_73:
   id: 73
   event_group_id: 32
@@ -160,6 +172,8 @@ raw_time_73:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_74:
   id: 74
   event_group_id: 32
@@ -183,6 +197,8 @@ raw_time_74:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_75:
   id: 75
   event_group_id: 32
@@ -206,6 +222,8 @@ raw_time_75:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_76:
   id: 76
   event_group_id: 32
@@ -229,6 +247,8 @@ raw_time_76:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_77:
   id: 77
   event_group_id: 32
@@ -252,6 +272,8 @@ raw_time_77:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_78:
   id: 78
   event_group_id: 32
@@ -275,6 +297,8 @@ raw_time_78:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_79:
   id: 79
   event_group_id: 32
@@ -298,6 +322,8 @@ raw_time_79:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_80:
   id: 80
   event_group_id: 32
@@ -321,6 +347,8 @@ raw_time_80:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_81:
   id: 81
   event_group_id: 32
@@ -344,6 +372,8 @@ raw_time_81:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_82:
   id: 82
   event_group_id: 32
@@ -367,6 +397,8 @@ raw_time_82:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_83:
   id: 83
   event_group_id: 32
@@ -390,6 +422,8 @@ raw_time_83:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_84:
   id: 84
   event_group_id: 32
@@ -413,6 +447,8 @@ raw_time_84:
   sortable_bib_number: 101
   data_status: 
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_85:
   id: 85
   event_group_id: 32
@@ -436,6 +472,8 @@ raw_time_85:
   sortable_bib_number: 101
   data_status: 
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_86:
   id: 86
   event_group_id: 32
@@ -459,6 +497,8 @@ raw_time_86:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_87:
   id: 87
   event_group_id: 32
@@ -482,6 +522,8 @@ raw_time_87:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_88:
   id: 88
   event_group_id: 32
@@ -505,6 +547,8 @@ raw_time_88:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_89:
   id: 89
   event_group_id: 32
@@ -528,6 +572,8 @@ raw_time_89:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_91:
   id: 91
   event_group_id: 32
@@ -551,6 +597,8 @@ raw_time_91:
   sortable_bib_number: 777
   data_status: 
   matchable_bib_number: 777
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_92:
   id: 92
   event_group_id: 32
@@ -574,6 +622,8 @@ raw_time_92:
   sortable_bib_number: 777
   data_status: 
   matchable_bib_number: 777
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_176:
   id: 176
   event_group_id: 32
@@ -597,6 +647,8 @@ raw_time_176:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_177:
   id: 177
   event_group_id: 32
@@ -620,6 +672,8 @@ raw_time_177:
   sortable_bib_number: 130
   data_status: 0
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_178:
   id: 178
   event_group_id: 32
@@ -643,6 +697,8 @@ raw_time_178:
   sortable_bib_number: 130
   data_status: 0
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1100:
   id: 1100
   event_group_id: 32
@@ -666,6 +722,8 @@ raw_time_1100:
   sortable_bib_number: 130
   data_status: 2
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1106:
   id: 1106
   event_group_id: 32
@@ -689,6 +747,8 @@ raw_time_1106:
   sortable_bib_number: 103
   data_status: 2
   matchable_bib_number: 103
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1110:
   id: 1110
   event_group_id: 32
@@ -712,6 +772,8 @@ raw_time_1110:
   sortable_bib_number: 103
   data_status: 2
   matchable_bib_number: 103
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1111:
   id: 1111
   event_group_id: 32
@@ -735,6 +797,8 @@ raw_time_1111:
   sortable_bib_number: 103
   data_status: 2
   matchable_bib_number: 103
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1117:
   id: 1117
   event_group_id: 32
@@ -758,6 +822,8 @@ raw_time_1117:
   sortable_bib_number: 103
   data_status: 2
   matchable_bib_number: 103
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1122:
   id: 1122
   event_group_id: 32
@@ -781,6 +847,8 @@ raw_time_1122:
   sortable_bib_number: 101
   data_status: 2
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1123:
   id: 1123
   event_group_id: 32
@@ -804,6 +872,8 @@ raw_time_1123:
   sortable_bib_number: 101
   data_status: 2
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1124:
   id: 1124
   event_group_id: 32
@@ -827,6 +897,8 @@ raw_time_1124:
   sortable_bib_number: 101
   data_status: 2
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1125:
   id: 1125
   event_group_id: 32
@@ -850,6 +922,8 @@ raw_time_1125:
   sortable_bib_number: 101
   data_status: 2
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1126:
   id: 1126
   event_group_id: 32
@@ -873,3 +947,5 @@ raw_time_1126:
   sortable_bib_number: 114
   data_status: 2
   matchable_bib_number: 114
+  disassociated_from_effort: 
+  entered_lap: 

--- a/spec/jobs/process_imported_raw_times_job_spec.rb
+++ b/spec/jobs/process_imported_raw_times_job_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 include BitkeyDefinitions
 
 RSpec.describe ProcessImportedRawTimesJob do
-  subject { ProcessImportedRawTimesJob.new }
+  subject { described_class.new }
   let(:perform_process) { subject.perform(event_group, raw_times) }
 
   let(:course) { courses(:hardrock_cw) }

--- a/spec/jobs/process_imported_raw_times_job_spec.rb
+++ b/spec/jobs/process_imported_raw_times_job_spec.rb
@@ -23,38 +23,161 @@ RSpec.describe ProcessImportedRawTimesJob do
                             absolute_time: absolute_time_in, with_pacer: 'true', stopped_here: 'false', source: source) }
   let(:raw_time_2) { create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: 'out',
                             absolute_time: absolute_time_out, with_pacer: 'true', stopped_here: 'true', source: source) }
-  let(:raw_times) { [raw_time_1, raw_time_2] }
+  let(:raw_times) { [raw_time_1] }
 
   describe '#perform' do
-    context 'when there is a matching split_time in the database' do
-      let(:split) { ordered_splits.second }
-      let!(:split_time) { create(:split_time, effort: effort, split: split, bitkey: in_bitkey, absolute_time_local: absolute_time_in, pacer: true, stopped_here: false) }
+    context 'when there is an existing split_time at the time point' do
+      let!(:split_time) { create(:split_time, effort: effort, split: existing_split, bitkey: existing_bitkey, absolute_time_local: existing_time_in, pacer: false, stopped_here: true) }
+      let(:existing_split) { ordered_splits.second }
+      let(:existing_bitkey) { in_bitkey }
+      let(:raw_time) { raw_times.first }
 
-      it 'saves the raw_times to the database, matches the duplicate raw_time with the existing split_time, and creates a new split_time' do
-        expect { perform_process }.to change { SplitTime.count }.by(1)
-        new_split_time = SplitTime.last
-        raw_times.each(&:reload)
+      shared_examples 'matches the raw time' do
+        it 'does not create a new split time' do
+          expect { perform_process }.not_to change { SplitTime.count }
+        end
 
-        expect(raw_times.map(&:split_time_id)).to match_array([split_time.id, new_split_time.id])
+        it 'matches the raw time with the existing split time' do
+          perform_process
+          raw_time.reload
+          expect(raw_time.split_time_id).to eq(split_time.id)
+        end
+
+        it 'sets stop and pacer flags to the new values' do
+          expect(split_time.pacer).to eq(false)
+          expect(split_time.stopped_here).to eq(true)
+
+          perform_process
+          split_time.reload
+
+          expect(split_time.pacer).to eq(true)
+          expect(split_time.stopped_here).to eq(false)
+        end
+      end
+
+      context 'when the existing absolute time is identical to the raw time' do
+        let(:existing_time_in) { absolute_time_in }
+
+        include_examples 'matches the raw time'
+      end
+
+      context 'when the existing absolute time is close to the raw time' do
+        let(:existing_time_in) { absolute_time_in + 5.seconds }
+
+        include_examples 'matches the raw time'
+      end
+
+      context 'when the existing absolute time is not close to the raw time' do
+        let(:existing_time_in) { absolute_time_in + 5.minutes }
+        it 'does not create a new split time' do
+          expect { perform_process }.not_to change { SplitTime.count }
+        end
+
+        it 'does not match the raw time with the existing split time' do
+          perform_process
+          raw_time.reload
+          expect(raw_time.split_time_id).to be_nil
+        end
+
+        it 'does not set stop and pacer flags to the new values' do
+          expect(split_time.pacer).to eq(false)
+          expect(split_time.stopped_here).to eq(true)
+
+          perform_process
+          split_time.reload
+
+          expect(split_time.pacer).to eq(false)
+          expect(split_time.stopped_here).to eq(true)
+        end
       end
     end
 
-    context 'when there is a non-duplicate split_time in the database' do
-      let(:effort) { create(:effort, bib_number: 333, event: event) }
-      let(:split) { ordered_splits.first }
-      let(:absolute_time_local) { time_zone.parse(absolute_time_in) }
-      let!(:split_time) { create(:split_time, effort: effort, split: split, bitkey: in_bitkey, absolute_time_local: absolute_time_in + 2.minutes, pacer: true, stopped_here: false) }
+    context 'when there is no split time at the time point' do
+      let(:existing_time_in) { absolute_time_in }
+      let(:existing_split) { ordered_splits.second }
+      let(:existing_bitkey) { out_bitkey }
+      let(:raw_time) { raw_times.first }
 
-      it 'does not match any raw_time with the existing split_time' do
-        expect { perform_process }.to change { SplitTime.count }.by(0)
-        raw_times.each(&:reload)
+      it 'creates a new split time' do
+        expect { perform_process }.to change { SplitTime.count }.by(1)
+      end
 
-        expect(raw_times.map(&:split_time_id)).to all be_nil
+      it 'matches the raw time to the new split time' do
+        perform_process
+        new_split_time = SplitTime.last
+        raw_time.reload
+        expect(raw_time.split_time_id).to eq(new_split_time.id)
+      end
+    end
+
+    context 'when multiple raw times are imported' do
+      let(:raw_times) { [raw_time_1, raw_time_2] }
+      let!(:split_time_1) { create(:split_time, effort: effort, split: existing_split_1, bitkey: existing_bitkey_1,
+                                   absolute_time_local: existing_time_in, pacer: false, stopped_here: true) }
+      let!(:split_time_2) { create(:split_time, effort: effort, split: existing_split_2, bitkey: existing_bitkey_2,
+                                   absolute_time_local: existing_time_out, pacer: false, stopped_here: false) }
+      let(:split_times) { [split_time_1, split_time_2] }
+
+      let(:existing_split_1) { ordered_splits.second }
+      let(:existing_split_2) { ordered_splits.second }
+      let(:existing_bitkey_1) { in_bitkey }
+      let(:existing_bitkey_2) { out_bitkey }
+      let(:existing_time_in) { absolute_time_in }
+      let(:existing_time_out) { absolute_time_out }
+
+      shared_examples 'matches both raw times' do
+        it 'does not create a new split time' do
+          expect { perform_process }.not_to change { SplitTime.count }
+        end
+
+        it 'matches the raw times with the existing split times' do
+          perform_process
+          raw_times.each(&:reload)
+          expect(raw_times.map(&:split_time_id)).to match_array([split_time_1.id, split_time_2.id])
+        end
+
+        it 'sets stops to the new values' do
+          expect(split_time_1.stopped_here).to eq(true)
+          expect(split_time_2.stopped_here).to eq(false)
+
+          perform_process
+          split_times.each(&:reload)
+
+          expect(split_time_1.stopped_here).to eq(false)
+          expect(split_time_2.stopped_here).to eq(true)
+        end
+      end
+
+      context 'when exact matches for both are present' do
+        include_examples 'matches both raw times'
+      end
+
+      context 'when both times are within tolerance' do
+        let(:existing_time_in) { absolute_time_in + 5.seconds }
+        let(:existing_time_out) { absolute_time_out + 5.seconds }
+
+        include_examples 'matches both raw times'
+      end
+
+      context 'when only one time point is taken' do
+        let(:existing_split_1) { ordered_splits.third }
+
+        it 'creates one new split time' do
+          expect { perform_process }.to change { SplitTime.count }.by(1)
+        end
+
+        it 'matches the other split time' do
+          perform_process
+          raw_times.each(&:reload)
+          new_split_time = SplitTime.last
+          expect(raw_times.map(&:split_time_id)).to match_array([new_split_time.id, split_time_2.id])
+        end
       end
     end
 
     context 'when push notifications are permitted and raw_times do not create new split_times' do
       let(:bib_number) { '*' } # Invalid bib numbers never automatically create split_times
+      let(:raw_times) { [raw_time_1, raw_time_2] }
 
       before { event_group.update(available_live: true, concealed: false) }
 
@@ -70,6 +193,7 @@ RSpec.describe ProcessImportedRawTimesJob do
     context 'when event_group.permit_notifications? is true' do
       before { event_group.update(available_live: true, concealed: false) }
       let!(:person) { effort.person }
+      let(:raw_times) { [raw_time_1, raw_time_2] }
 
       it 'creates new split_times matching the raw_times' do
         expect { perform_process }.to change { SplitTime.count }.by(2)
@@ -83,16 +207,14 @@ RSpec.describe ProcessImportedRawTimesJob do
       end
 
       it 'sends a message to NotifyProgressJob with relevant person and split_time data' do
-        allow(NotifyProgressJob).to receive(:perform_later) do |_, split_time_ids|
-          split_time_ids.sort!
-        end
+        allow(NotifyProgressJob).to receive(:perform_later)
 
         perform_process
         split_times = SplitTime.last(2)
         split_time_ids = split_times.map(&:id)
         effort_id = split_times.first.effort_id
 
-        expect(NotifyProgressJob).to have_received(:perform_later).with(effort_id, split_time_ids.sort)
+        expect(NotifyProgressJob).to have_received(:perform_later).with(effort_id, array_including(split_time_ids))
       end
 
       it 'sends messages to Interactors::SetEffortStatus with the efforts associated with the modified split_times' do

--- a/spec/models/time_point_spec.rb
+++ b/spec/models/time_point_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TimePoint, type: :model do
       end
     end
 
-    context 'with a nil arguments' do
+    context 'with nil arguments' do
       let(:lap) { nil }
       let(:split_id) { nil }
       let(:bitkey) { nil }

--- a/spec/services/enrich_raw_time_row_spec.rb
+++ b/spec/services/enrich_raw_time_row_spec.rb
@@ -159,8 +159,8 @@ RSpec.describe EnrichRawTimeRow do
       let(:split) { course.splits.find_by(base_name: 'Finish') }
 
       context 'when raw_times do not have a lap attached' do
-        let(:raw_time_1) { build_stubbed(:raw_time, event_group: event_group, bib_number: bib_number, split_name: base_name, sub_split_kind: 'in', stopped_here: false) }
-        let(:raw_time_2) { build_stubbed(:raw_time, event_group: event_group, bib_number: bib_number, split_name: base_name, sub_split_kind: 'out', stopped_here: true) }
+        let(:raw_time_1) { build_stubbed(:raw_time, :with_absolute_time, event_group: event_group, bib_number: bib_number, split_name: base_name, sub_split_kind: 'in', stopped_here: false) }
+        let(:raw_time_2) { build_stubbed(:raw_time, :with_absolute_time, event_group: event_group, bib_number: bib_number, split_name: base_name, sub_split_kind: 'out', stopped_here: true) }
 
         it 'calls FindExpectedLap, and verifies raw_times' do
           result_row = subject.perform

--- a/spec/services/raw_times/set_absolute_time_and_lap_spec.rb
+++ b/spec/services/raw_times/set_absolute_time_and_lap_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::RawTimes::SetAbsoluteTimeAndLap do
+  subject { described_class.new(event_group, subject_raw_times) }
+  let(:event_group) { event.event_group }
+  let(:subject_raw_times) { [raw_time] }
+
+  let!(:raw_time) do
+    create(:raw_time,
+           event_group: event_group,
+           entered_lap: entered_lap,
+           entered_time: entered_time,
+           absolute_time: absolute_time,
+           bib_number: bib_number,
+           split_name: split_name,
+           bitkey: 1,
+           stopped_here: false)
+  end
+
+  let(:entered_lap) { nil }
+  let(:entered_time) { nil }
+  let(:absolute_time) { nil }
+  let(:effort) { event.efforts.order(:bib_number).first }
+  let(:bib_number) { effort.bib_number.to_s }
+  let(:split_name) { event.ordered_splits.second.base_name }
+
+  before do
+    allow(::FindExpectedLap).to receive(:perform)
+    allow(::IntendedTimeCalculator).to receive(:absolute_time_local)
+  end
+
+  describe '#perform' do
+    let(:resulting_raw_times) { subject.perform }
+    let(:resulting_raw_time) { resulting_raw_times.first }
+    context 'for a single-lap event group' do
+      let(:event) { events(:sum_100k) }
+
+      shared_examples 'sets lap and time for a single-lap event' do
+        context 'when absolute time is present' do
+          let(:absolute_time) { '2020-04-04 07:30:00-0600' }
+          it 'sets entered time and lap' do
+            expect(resulting_raw_time.entered_time.to_datetime).to eq(absolute_time.to_datetime)
+            expect(resulting_raw_time.lap).to eq(1)
+          end
+        end
+
+        context 'when entered time is a datetime with time zone' do
+          let(:entered_time) { '2020-04-04 07:30:00-0600' }
+          it 'sets absolute time and lap' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.to_datetime)
+            expect(resulting_raw_time.lap).to eq(1)
+          end
+        end
+
+        context 'when entered time is a datetime without a time zone' do
+          let(:entered_time) { '2020-04-04 07:30:00' }
+          it 'sets absolute time and lap using the event group home time zone' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.in_time_zone(event_group.home_time_zone))
+            expect(resulting_raw_time.lap).to eq(1)
+          end
+        end
+
+        context 'when entered time is a military time' do
+          let(:entered_time) { '07:30:00' }
+          it 'sets lap' do
+            expect(resulting_raw_time.lap).to eq(1)
+          end
+
+          it 'calls IntendedTimeCalculator to determine absolute time' do
+            expect(::IntendedTimeCalculator).to receive(:absolute_time_local)
+            resulting_raw_time
+          end
+        end
+      end
+
+      context 'when entered lap is nil' do
+        include_examples 'sets lap and time for a single-lap event'
+      end
+
+      context 'when entered lap is provided' do
+        let(:entered_lap) { 1 }
+
+        include_examples 'sets lap and time for a single-lap event'
+      end
+    end
+
+    context 'for a multi-lap event group' do
+      let(:event) { events(:rufa_2017_24h) }
+      let(:effort) { efforts(:rufa_2017_24h_progress_lap1) }
+      context 'when entered lap is nil' do
+
+        shared_examples 'uses FindExpectedLap to set the lap' do
+          it 'calls FindExpectedLap to set the lap' do
+            expect(::FindExpectedLap).to receive(:perform)
+            resulting_raw_time
+          end
+        end
+
+        context 'when absolute time is present' do
+          let(:absolute_time) { '2017-02-11 11:55:00-0600' }
+          it 'sets entered time' do
+            expect(resulting_raw_time.entered_time.to_datetime).to eq(absolute_time.to_datetime)
+          end
+
+          include_examples 'uses FindExpectedLap to set the lap'
+        end
+
+        context 'when entered time is a datetime with time zone' do
+          let(:entered_time) { '2017-02-11 11:55:00-0600' }
+          it 'sets absolute time' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.to_datetime)
+          end
+
+          include_examples 'uses FindExpectedLap to set the lap'
+        end
+
+        context 'when entered time is a datetime without a time zone' do
+          let(:entered_time) { '2017-02-11 11:55:00' }
+          it 'sets absolute time using the event group home time zone' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.in_time_zone(event_group.home_time_zone))
+          end
+
+          include_examples 'uses FindExpectedLap to set the lap'
+        end
+
+        context 'when entered time is a military time' do
+          let(:entered_time) { '07:30:00' }
+          it 'calls IntendedTimeCalculator to determine absolute time' do
+            expect(::IntendedTimeCalculator).to receive(:absolute_time_local)
+            resulting_raw_time
+          end
+
+          include_examples 'uses FindExpectedLap to set the lap'
+        end
+      end
+
+      context 'when entered lap is provided' do
+        let(:entered_lap) { 2 }
+
+        shared_examples 'uses entered lap to set the lap' do
+          it 'sets lap to the entered lap' do
+            expect(resulting_raw_time.lap).to eq(entered_lap)
+          end
+        end
+
+        context 'when absolute time is present' do
+          let(:absolute_time) { '2017-02-11 11:55:00-0600' }
+          it 'sets entered time' do
+            expect(resulting_raw_time.entered_time.to_datetime).to eq(absolute_time.to_datetime)
+          end
+
+          include_examples 'uses entered lap to set the lap'
+        end
+
+        context 'when entered time is a datetime with time zone' do
+          let(:entered_time) { '2017-02-11 11:55:00-0600' }
+          it 'sets absolute time' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.to_datetime)
+          end
+
+          include_examples 'uses entered lap to set the lap'
+        end
+
+        context 'when entered time is a datetime without a time zone' do
+          let(:entered_time) { '2017-02-11 11:55:00' }
+          it 'sets absolute time using the event group home time zone' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.in_time_zone(event_group.home_time_zone))
+          end
+
+          include_examples 'uses entered lap to set the lap'
+        end
+
+        context 'when entered time is a military time' do
+          let(:entered_time) { '07:30:00' }
+          it 'calls IntendedTimeCalculator to determine absolute time' do
+            expect(::IntendedTimeCalculator).to receive(:absolute_time_local)
+            resulting_raw_time
+          end
+
+          include_examples 'uses entered lap to set the lap'
+        end
+      end
+    end
+  end
+end

--- a/spec/services/raw_times/verify_within_effort_spec.rb
+++ b/spec/services/raw_times/verify_within_effort_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::RawTimes::VerifyWithinEffort do
+  subject { described_class.new(subject_raw_times, effort) }
+  let(:subject_raw_times) { [raw_time] }
+  let(:effort) { event_group.efforts.find_by(bib_number: bib_number) }
+
+  let(:event_group) { event_groups(:hardrock_2015) }
+  let(:event) { effort.event }
+  let(:split) { event.splits.find_by(base_name: split_name) }
+  let(:bib_number) { '171' }
+
+  let(:raw_time) do
+    build(:raw_time,
+          event_group: event_group,
+          effort: effort,
+          lap: lap,
+          split: split,
+          bitkey: bitkey,
+          absolute_time_local: absolute_time_local,
+          with_pacer: with_pacer,
+          stopped_here: stopped_here)
+  end
+
+  let(:lap) { 1 }
+  let(:absolute_time) { nil }
+  let(:with_pacer) { false }
+  let(:stopped_here) { false }
+
+  describe '#perform' do
+    let(:verify_raw_times) { subject.perform }
+    context 'for a single raw time' do
+      context 'when no existing time is present' do
+        let(:split_name) { 'Putnam' }
+        let(:bitkey) { in_bitkey }
+
+        expected_results = [
+          {time: '2015-07-12 02:30:00', status: 'good'},
+          {time: '2015-07-11 20:30:00', status: 'questionable'},
+          {time: '2015-07-11 16:30:00', status: 'bad'},
+        ]
+
+        expected_results.each do |row|
+          context "when the time is #{row[:time]}" do
+            let(:absolute_time_local) { row[:time] }
+            it 'sets attributes as expected' do
+              verify_raw_times
+              expect(raw_time.split_time_exists).to eq(false)
+              expect(raw_time.data_status).to eq(row[:status])
+            end
+          end
+        end
+      end
+
+      context 'when an existing time is present' do
+        let(:split_name) { 'Grouse' }
+        let(:bitkey) { in_bitkey }
+
+        expected_results = [
+          {time: '2015-07-10 23:00:00', status: 'good'},
+          {time: '2015-07-10 20:00:00', status: 'questionable'},
+          {time: '2015-07-10 18:00:00', status: 'bad'},
+        ]
+
+        expected_results.each do |row|
+          context "when the time is #{row[:time]}" do
+            let(:absolute_time_local) { row[:time] }
+            it 'sets attributes as expected' do
+              verify_raw_times
+              expect(raw_time.split_time_exists).to eq(true)
+              expect(raw_time.data_status).to eq(row[:status])
+            end
+          end
+        end
+      end
+    end
+
+    context 'for in and out raw times' do
+      let(:subject_raw_times) { [in_raw_time, out_raw_time] }
+
+      let(:in_raw_time) do
+        build(:raw_time,
+              event_group: event_group,
+              effort: effort,
+              lap: lap,
+              split: split,
+              bitkey: in_bitkey,
+              absolute_time_local: absolute_time_local_in,
+              with_pacer: with_pacer,
+              stopped_here: stopped_here)
+      end
+
+      let(:out_raw_time) do
+        build(:raw_time,
+              event_group: event_group,
+              effort: effort,
+              lap: lap,
+              split: split,
+              bitkey: out_bitkey,
+              absolute_time_local: absolute_time_local_out,
+              with_pacer: with_pacer,
+              stopped_here: stopped_here)
+      end
+
+      let(:split_name) { 'Putnam' }
+
+      expected_results = [
+        {in_time: '2015-07-12 02:30:00', out_time: '2015-07-12 02:40:00', in_status: 'good', out_status: 'good'},
+        {in_time: '2015-07-12 02:30:00', out_time: '2015-07-12 02:20:00', in_status: 'good', out_status: 'bad'},
+        {in_time: '2015-07-11 20:30:00', out_time: '2015-07-11 20:40:00', in_status: 'questionable', out_status: 'questionable'},
+        {in_time: '2015-07-11 20:30:00', out_time: '2015-07-12 02:40:00', in_status: 'questionable', out_status: 'good'},
+        {in_time: '2015-07-11 16:30:00', out_time: '2015-07-11 16:40:00', in_status: 'bad', out_status: 'bad'},
+        {in_time: '2015-07-11 16:30:00', out_time: '2015-07-12 02:40:00', in_status: 'bad', out_status: 'good'},
+      ]
+
+      expected_results.each do |row|
+        context "when the in time is #{row[:in_time]} and the out time is #{row[:out_time]}" do
+          let(:absolute_time_local_in) { row[:in_time] }
+          let(:absolute_time_local_out) { row[:out_time] }
+          it 'sets attributes as expected' do
+            verify_raw_times
+            expect(in_raw_time.split_time_exists).to eq(false)
+            expect(out_raw_time.split_time_exists).to eq(false)
+            expect(in_raw_time.data_status).to eq(row[:in_status])
+            expect(out_raw_time.data_status).to eq(row[:out_status])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/rowify_raw_times_spec.rb
+++ b/spec/services/rowify_raw_times_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe RowifyRawTimes do
   let(:split_name_1) { event_1.ordered_splits.second.base_name }
   let(:split_name_2) { event_2.ordered_splits.third.base_name }
 
-  let!(:raw_time_1) { create(:raw_time, event_group: event_group, bib_number: bib_number_1, split_name: split_name_1, bitkey: 1, stopped_here: false) }
-  let!(:raw_time_2) { create(:raw_time, event_group: event_group, bib_number: bib_number_1, split_name: split_name_1, bitkey: 64, stopped_here: true) }
-  let!(:raw_time_3) { create(:raw_time, event_group: event_group, bib_number: bib_number_2, split_name: split_name_1, bitkey: 1, with_pacer: true) }
-  let!(:raw_time_4) { create(:raw_time, event_group: event_group, bib_number: bib_number_2, split_name: split_name_1, bitkey: 64, with_pacer: true) }
-  let!(:raw_time_5) { create(:raw_time, event_group: event_group, bib_number: bib_number_1, split_name: split_name_2, bitkey: 1) }
-  let!(:raw_time_6) { create(:raw_time, event_group: event_group, bib_number: bib_number_1, split_name: split_name_2, bitkey: 64) }
-  let!(:raw_time_7) { create(:raw_time, event_group: event_group, bib_number: bib_number_1, split_name: split_name_1, bitkey: 64) }
-  let!(:raw_time_8) { create(:raw_time, event_group: event_group, bib_number: '55', split_name: split_name_1, bitkey: 64) }
+  let!(:raw_time_1) { create(:raw_time, :with_absolute_time, event_group: event_group, bib_number: bib_number_1, split_name: split_name_1, bitkey: 1, stopped_here: false) }
+  let!(:raw_time_2) { create(:raw_time, :with_absolute_time, event_group: event_group, bib_number: bib_number_1, split_name: split_name_1, bitkey: 64, stopped_here: true) }
+  let!(:raw_time_3) { create(:raw_time, :with_absolute_time, event_group: event_group, bib_number: bib_number_2, split_name: split_name_1, bitkey: 1, with_pacer: true) }
+  let!(:raw_time_4) { create(:raw_time, :with_absolute_time, event_group: event_group, bib_number: bib_number_2, split_name: split_name_1, bitkey: 64, with_pacer: true) }
+  let!(:raw_time_5) { create(:raw_time, :with_absolute_time, event_group: event_group, bib_number: bib_number_1, split_name: split_name_2, bitkey: 1) }
+  let!(:raw_time_6) { create(:raw_time, :with_absolute_time, event_group: event_group, bib_number: bib_number_1, split_name: split_name_2, bitkey: 64) }
+  let!(:raw_time_7) { create(:raw_time, :with_absolute_time, event_group: event_group, bib_number: bib_number_1, split_name: split_name_1, bitkey: 64) }
+  let!(:raw_time_8) { create(:raw_time, :with_absolute_time, event_group: event_group, bib_number: '55', split_name: split_name_1, bitkey: 64) }
 
   let(:raw_time_rows) { subject.build }
   let(:raw_time_pairs) { raw_time_rows.map(&:raw_times) }


### PR DESCRIPTION
This is a full rework of the post-import processing flow for raw times coming in through the `Api::V1::EventGroupsController#import` endpoint.

Begins to address #311

Should also address https://github.com/SplitTime/OpenSplitTime/issues/274 and https://github.com/SplitTime/OpenSplitTime/issues/265