### PR TITLE
Improve RaceRite non-API import

### DIFF
--- a/app/services/etl/importer.rb
+++ b/app/services/etl/importer.rb
@@ -24,8 +24,6 @@ module ETL
         import_with(source_data, Extractors::RaceResultStrategy, Transformers::RaceResultSplitTimesStrategy, Loaders::InsertStrategy, {delete_blank_times: true}.merge(options))
       when :race_result_entrants
         import_with(source_data, Extractors::RaceResultStrategy, Transformers::RaceResultEntrantsStrategy, Loaders::UpsertStrategy, {delete_blank_times: false, unique_key: [:event_id, :bib_number]}.merge(options))
-      when :race_result_times
-        import_with(source_data, Extractors::RaceResultStrategy, Transformers::RaceResultSplitTimesStrategy, Loaders::SplitTimeUpsertStrategy, {delete_blank_times: false}.merge(options))
       when :race_result_api_times
         import_with(source_data, Extractors::RaceResultApiStrategy, Transformers::RaceResultApiSplitTimesStrategy, Loaders::SplitTimeUpsertStrategy, {delete_blank_times: false}.merge(options))
       when :adilas_bear_times

--- a/lib/tasks/pull_event_data.rake
+++ b/lib/tasks/pull_event_data.rake
@@ -16,14 +16,6 @@ namespace :pull_event do
 
 
   desc 'Pulls and imports time data from my.raceresult.com into an event having existing efforts'
-  task :race_result_times, [:event_id, :rr_event_id, :rr_contest_id, :rr_format] => :environment do |_, args|
-    source_uri = ETL::Helpers::RaceResultUriBuilder
-                     .new(args[:rr_event_id], args[:rr_contest_id], args[:rr_format]).full_uri
-    Rake::Task['pull_event:from_uri'].invoke(args[:event_id], source_uri, :race_result_times)
-  end
-
-
-  desc 'Pulls and imports time data from my.raceresult.com into an event having existing efforts'
   task :race_result_api_times, [:event_id, :rr_event_id, :rr_api_key] => :environment do |_, args|
     source_uri = ETL::Helpers::RaceResultApiUriBuilder
                      .new(args[:rr_event_id], args[:rr_api_key]).full_uri


### PR DESCRIPTION
This PR uses absolute time instead of time from start within the RaceRite non-API transformer. It also removes the obsolete `race_result_times` data format.