### PR TITLE
Fix maps controller

### DIFF
--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
         const splitId = this.mapInfoTarget.dataset.splitId;
 
         Rails.ajax({
-            url: "/courses/" + courseId + '.json',
+            url: "/api/v1/courses/" + courseId,
             type: "GET",
             success: function (data) {
                 const attributes = data.data.attributes;

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -11,8 +11,8 @@ export default class extends Controller {
         Rails.ajax({
             url: "/api/v1/courses/" + courseId,
             type: "GET",
-            success: function (data) {
-                const attributes = data.data.attributes;
+            success: function (response) {
+                const attributes = response.data.attributes;
 
                 var locations = null;
                 if(splitId === undefined) {

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -14,7 +14,7 @@ export default class extends Controller {
             success: function (response) {
                 const attributes = response.data.attributes;
 
-                var locations = null;
+                let locations = null;
                 if(splitId === undefined) {
                     locations = attributes.locations;
                 } else {


### PR DESCRIPTION
Fixes the bug in the Stimulus maps controller. The AJAX request as currently written was hitting the non-API `/courses` endpoint, which does not provide location or track point data.

This MR changes the AJAX request to use the API.

Addresses #338