### PR TITLE
Parse GPX files for tracks, routes, and waypoints

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -51,11 +51,15 @@ class Course < ApplicationRecord
 
   def track_points
     return [] unless gpx.attached?
-    return @track_points if defined?(@track_points)
-    file = gpx.download
-    gpx_file = GPX::GPXFile.new(gpx_data: file)
-    points = gpx_file.tracks.flat_map(&:points)
-    @track_points = points.map { |track_point| {lat: track_point.lat, lon: track_point.lon} }
+
+    @track_points ||=
+      begin
+        file = gpx.download
+        gpx_file = GPX::GPXFile.new(gpx_data: file)
+        points = gpx_file.tracks.flat_map(&:points).presence || gpx_file.routes.flat_map(&:points).presence || gpx_file.waypoints
+
+        points.map { |point| {lat: point.lat, lon: point.lon} }
+      end
   end
 
   def vert_gain

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -56,7 +56,9 @@ class Course < ApplicationRecord
       begin
         file = gpx.download
         gpx_file = GPX::GPXFile.new(gpx_data: file)
-        points = gpx_file.tracks.flat_map(&:points).presence || gpx_file.routes.flat_map(&:points).presence || gpx_file.waypoints
+        points = gpx_file.tracks.flat_map(&:points).presence ||
+          gpx_file.routes.flat_map(&:points).presence ||
+          gpx_file.waypoints
 
         points.map { |point| {lat: point.lat, lon: point.lon} }
       end


### PR DESCRIPTION
Currently, `Course#track_points` parses GPX files looking only for tracks. This MR changes the logic to look for, in order of preference, tracks, then routes, then waypoints.