### PR TITLE
Handle entered_time instead of absolute_time from OST Remote

### DIFF
--- a/app/jobs/process_imported_raw_times_job.rb
+++ b/app/jobs/process_imported_raw_times_job.rb
@@ -6,7 +6,9 @@ class ProcessImportedRawTimesJob < ApplicationJob
   queue_as :default
 
   def perform(event_group, raw_times)
-    match_response = Interactors::MatchRawTimesToSplitTimes.perform!(event_group: event_group, raw_times: raw_times)
+    updated_raw_times = ::RawTimes::SetAbsoluteTimeAndLap.perform(event_group, raw_times)
+    updated_raw_times.each(&:save)
+    match_response = Interactors::MatchRawTimesToSplitTimes.perform!(event_group: event_group, raw_times: updated_raw_times)
 
     if match_response.successful?
       unmatched_raw_times = match_response.resources[:unmatched]

--- a/app/services/raw_times/set_absolute_time_and_lap.rb
+++ b/app/services/raw_times/set_absolute_time_and_lap.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module RawTimes
+  class SetAbsoluteTimeAndLap
+    MILITARY_TIME_REGEX = /\A\d{1,2}:\d{2}(:\d{2})?\z/
+
+    def self.perform(event_group, raw_times)
+      new(event_group, raw_times).perform
+    end
+
+    def initialize(event_group, raw_times)
+      @event_group = event_group
+      @raw_times = ::RawTime.where(id: raw_times).with_relation_ids
+      validate_setup
+    end
+
+    def perform
+      raw_times.each do |raw_time|
+        set_lap_simple(raw_time)
+        set_entered_from_absolute_time(raw_time) if raw_time.absolute_time.present? # See note below
+        set_absolute_from_entered_time(raw_time) unless raw_time.absolute_time.present?
+        set_lap_using_time(raw_time) unless raw_time.lap.present?
+      end
+
+      raw_times
+    end
+
+    private
+
+    attr_reader :event_group, :raw_times
+
+    def set_lap_simple(raw_time)
+      if raw_time.entered_lap
+        raw_time.lap = raw_time.entered_lap
+      elsif single_lap_event_group? || single_lap_event?(raw_time)
+        raw_time.lap = 1
+      end
+    end
+
+    # OST Remote currently sets absolute_time directly, so we need to
+    # copy absolute_time to entered_time if absolute_time exists.
+    #
+    # This method can be removed once OST Remote sets entered_time
+    # instead of absolute_time (and there has been plenty of time for
+    # users to upgrade).
+    def set_entered_from_absolute_time(raw_time)
+      raw_time.entered_time = raw_time.absolute_time
+    end
+
+    def set_absolute_from_entered_time(raw_time)
+      if raw_time.entered_time =~ MILITARY_TIME_REGEX
+        raw_time.absolute_time = calculated_absolute_time(raw_time)
+      else
+        raw_time.absolute_time = raw_time.entered_time.in_time_zone(event_group.home_time_zone)
+      end
+    end
+
+    def set_lap_using_time(raw_time)
+      if raw_time.absolute_time
+        raw_time.lap = expected_lap(raw_time, :absolute_time_local, raw_time.absolute_time)
+      elsif raw_time.military_time
+        raw_time.lap = expected_lap(raw_time, :military_time, raw_time.military_time)
+      else
+        raw_time.lap = nil
+      end
+    end
+
+    def expected_lap(raw_time, subject_attribute, subject_value)
+      ::FindExpectedLap.perform(effort: indexed_efforts[raw_time.effort_id],
+                                subject_attribute: subject_attribute,
+                                subject_value: subject_value,
+                                split_id: raw_time.split_id,
+                                bitkey: raw_time.bitkey)
+    end
+
+    def calculated_absolute_time(raw_time)
+      return unless raw_time.effort_id && raw_time.split_id
+
+      ::IntendedTimeCalculator.absolute_time_local(military_time: raw_time.entered_time,
+                                                   effort: indexed_efforts[raw_time.effort_id],
+                                                   time_point: raw_time.time_point)
+    end
+
+    def single_lap_event_group?
+      @single_lap_event_group ||= event_group.single_lap?
+    end
+
+    def single_lap_event?(raw_time)
+      indexed_events[raw_time.event_id]&.single_lap?
+    end
+
+    def indexed_events
+      @indexed_events ||= event_group.events.index_by(&:id)
+    end
+
+    def indexed_efforts
+      @indexed_efforts ||= ::Effort.where(id: raw_times.map(&:effort_id)).index_by(&:id)
+    end
+
+    def validate_setup
+      raise ArgumentError, 'All raw_times must match the provided event_group' unless raw_times.all? { |rt| rt.event_group_id == event_group.id }
+    end
+  end
+end

--- a/spec/controllers/api/v1/event_groups_controller_spec.rb
+++ b/spec/controllers/api/v1/event_groups_controller_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe Api::V1::EventGroupsController do
       ] }
       let(:source) { 'ost-remote-1234' }
 
-      context 'when raw_time data is valid' do
+      shared_examples 'creates and processes raw times' do |time_attribute|
         via_login_and_jwt do
           it 'creates raw_times' do
             expect { make_request }.to change { RawTime.count }.by(2)
@@ -322,7 +322,7 @@ RSpec.describe Api::V1::EventGroupsController do
             expect(parsed_response['data'].map { |record| record['type'] }).to all eq('rawTimes')
             expect(raw_times.map(&:bib_number)).to all eq(bib_number)
             expect(raw_times.map(&:bitkey)).to eq([in_bitkey, out_bitkey])
-            expect(raw_times.map(&:absolute_time)).to eq([absolute_time_in, absolute_time_out])
+            expect(raw_times.map(&time_attribute).map(&:to_datetime)).to eq([absolute_time_in, absolute_time_out])
             expect(raw_times.map(&:event_group_id)).to all eq(event_group.id)
           end
 
@@ -337,6 +337,23 @@ RSpec.describe Api::V1::EventGroupsController do
             expect(ProcessImportedRawTimesJob).to have_received(:perform_later).with(event_group, raw_times.sort_by(&:id))
           end
         end
+      end
+
+      context 'when raw_time data is valid' do
+        include_examples 'creates and processes raw times', :absolute_time
+      end
+
+      context 'when raw_times use enteredTime instead of absoluteTime' do
+        let(:data) { [
+          {type: 'raw_time',
+           attributes: {bibNumber: bib_number, splitName: split_name, subSplitKind: 'in', enteredTime: absolute_time_in,
+                        withPacer: 'true', stoppedHere: 'false', source: source}},
+          {type: 'raw_time',
+           attributes: {bibNumber: bib_number, splitName: split_name, subSplitKind: 'out', enteredTime: absolute_time_out,
+                        withPacer: 'true', stoppedHere: 'true', source: source}}
+        ] }
+
+        include_examples 'creates and processes raw times', :entered_time
       end
 
       context 'when raw_times include leading zeros' do

--- a/spec/jobs/process_imported_raw_times_job_spec.rb
+++ b/spec/jobs/process_imported_raw_times_job_spec.rb
@@ -101,20 +101,20 @@ RSpec.describe ProcessImportedRawTimesJob do
       end
     end
 
-    context 'when raw times have absolute times' do
+    context 'when raw times have absolute times but no entered times' do
       let(:raw_time_1) { create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: 'in',
-                                absolute_time: absolute_time_in, with_pacer: 'true', stopped_here: 'false', source: source) }
+                                absolute_time: absolute_time_in, entered_time: nil, with_pacer: 'true', stopped_here: 'false', source: source) }
       let(:raw_time_2) { create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: 'out',
-                                absolute_time: absolute_time_out, with_pacer: 'true', stopped_here: 'true', source: source) }
+                                absolute_time: absolute_time_out, entered_time: nil, with_pacer: 'true', stopped_here: 'true', source: source) }
 
       include_examples 'processes raw times as expected'
     end
 
-    context 'when raw times have entered times' do
+    context 'when raw times have entered times but no absolute times' do
       let(:raw_time_1) { create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: 'in',
-                                entered_time: absolute_time_in, with_pacer: 'true', stopped_here: 'false', source: source) }
+                                absolute_time: nil, entered_time: absolute_time_in, with_pacer: 'true', stopped_here: 'false', source: source) }
       let(:raw_time_2) { create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: 'out',
-                                entered_time: absolute_time_out, with_pacer: 'true', stopped_here: 'true', source: source) }
+                                absolute_time: nil, entered_time: absolute_time_out, with_pacer: 'true', stopped_here: 'true', source: source) }
 
       include_examples 'processes raw times as expected'
     end

--- a/spec/jobs/process_imported_raw_times_job_spec.rb
+++ b/spec/jobs/process_imported_raw_times_job_spec.rb
@@ -19,88 +19,104 @@ RSpec.describe ProcessImportedRawTimesJob do
   let(:split_name) { ordered_splits.second.base_name }
   let(:source) { 'ost-remote-1234' }
 
-  let(:raw_time_1) { create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: 'in',
-                            absolute_time: absolute_time_in, with_pacer: 'true', stopped_here: 'false', source: source) }
-  let(:raw_time_2) { create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: 'out',
-                            absolute_time: absolute_time_out, with_pacer: 'true', stopped_here: 'true', source: source) }
   let(:raw_times) { [raw_time_1, raw_time_2] }
 
   describe '#perform' do
-    context 'when there is a matching split_time in the database' do
-      let(:split) { ordered_splits.second }
-      let!(:split_time) { create(:split_time, effort: effort, split: split, bitkey: in_bitkey, absolute_time_local: absolute_time_in, pacer: true, stopped_here: false) }
+    shared_examples 'processes raw times as expected' do
+      context 'when there is a matching split_time in the database' do
+        let(:split) { ordered_splits.second }
+        let!(:split_time) { create(:split_time, effort: effort, split: split, bitkey: in_bitkey, absolute_time_local: absolute_time_in, pacer: true, stopped_here: false) }
 
-      it 'saves the raw_times to the database, matches the duplicate raw_time with the existing split_time, and creates a new split_time' do
-        expect { perform_process }.to change { SplitTime.count }.by(1)
-        new_split_time = SplitTime.last
-        raw_times.each(&:reload)
+        it 'saves the raw_times to the database, matches the duplicate raw_time with the existing split_time, and creates a new split_time' do
+          expect { perform_process }.to change { SplitTime.count }.by(1)
+          new_split_time = SplitTime.last
+          raw_times.each(&:reload)
 
-        expect(raw_times.map(&:split_time_id)).to match_array([split_time.id, new_split_time.id])
-      end
-    end
-
-    context 'when there is a non-duplicate split_time in the database' do
-      let(:effort) { create(:effort, bib_number: 333, event: event) }
-      let(:split) { ordered_splits.first }
-      let(:absolute_time_local) { time_zone.parse(absolute_time_in) }
-      let!(:split_time) { create(:split_time, effort: effort, split: split, bitkey: in_bitkey, absolute_time_local: absolute_time_in + 2.minutes, pacer: true, stopped_here: false) }
-
-      it 'does not match any raw_time with the existing split_time' do
-        expect { perform_process }.to change { SplitTime.count }.by(0)
-        raw_times.each(&:reload)
-
-        expect(raw_times.map(&:split_time_id)).to all be_nil
-      end
-    end
-
-    context 'when push notifications are permitted and raw_times do not create new split_times' do
-      let(:bib_number) { '*' } # Invalid bib numbers never automatically create split_times
-
-      before { event_group.update(available_live: true, concealed: false) }
-
-      it 'sends a push notification that includes the count of available raw times' do
-        expect(event.permit_notifications?).to be(true)
-        allow(Pusher).to receive(:trigger)
-        perform_process
-        expected_args = ["raw-times-available.event_group.#{event_group.id}", 'update', {unconsidered: 2, unmatched: 2}]
-        expect(Pusher).to have_received(:trigger).with(*expected_args)
-      end
-    end
-
-    context 'when event_group.permit_notifications? is true' do
-      before { event_group.update(available_live: true, concealed: false) }
-      let!(:person) { effort.person }
-
-      it 'creates new split_times matching the raw_times' do
-        expect { perform_process }.to change { SplitTime.count }.by(2)
-        split_times = SplitTime.last(2)
-        raw_times.each(&:reload)
-
-        expect(split_times.map(&:absolute_time_local)).to match_array([absolute_time_in, absolute_time_out])
-        expect(split_times.map(&:bitkey)).to match_array([in_bitkey, out_bitkey])
-
-        expect(raw_times.map(&:split_time_id)).to match_array(split_times.map(&:id))
+          expect(raw_times.map(&:split_time_id)).to match_array([split_time.id, new_split_time.id])
+        end
       end
 
-      it 'sends a message to NotifyProgressJob with relevant person and split_time data' do
-        allow(NotifyProgressJob).to receive(:perform_later) do |_, split_time_ids|
-          split_time_ids.sort!
+      context 'when there is a non-duplicate split_time in the database' do
+        let(:effort) { create(:effort, bib_number: 333, event: event) }
+        let(:split) { ordered_splits.first }
+        let(:absolute_time_local) { time_zone.parse(absolute_time_in) }
+        let!(:split_time) { create(:split_time, effort: effort, split: split, bitkey: in_bitkey, absolute_time_local: absolute_time_in + 2.minutes, pacer: true, stopped_here: false) }
+
+        it 'does not match any raw_time with the existing split_time' do
+          expect { perform_process }.to change { SplitTime.count }.by(0)
+          raw_times.each(&:reload)
+
+          expect(raw_times.map(&:split_time_id)).to all be_nil
+        end
+      end
+
+      context 'when push notifications are permitted and raw_times do not create new split_times' do
+        let(:bib_number) { '*' } # Invalid bib numbers never automatically create split_times
+
+        before { event_group.update(available_live: true, concealed: false) }
+
+        it 'sends a push notification that includes the count of available raw times' do
+          expect(event.permit_notifications?).to be(true)
+          allow(Pusher).to receive(:trigger)
+          perform_process
+          expected_args = ["raw-times-available.event_group.#{event_group.id}", 'update', {unconsidered: 2, unmatched: 2}]
+          expect(Pusher).to have_received(:trigger).with(*expected_args)
+        end
+      end
+
+      context 'when event_group.permit_notifications? is true' do
+        before { event_group.update(available_live: true, concealed: false) }
+        let!(:person) { effort.person }
+
+        it 'creates new split_times matching the raw_times' do
+          expect { perform_process }.to change { SplitTime.count }.by(2)
+          split_times = SplitTime.last(2)
+          raw_times.each(&:reload)
+
+          expect(split_times.map(&:absolute_time_local)).to match_array([absolute_time_in, absolute_time_out])
+          expect(split_times.map(&:bitkey)).to match_array([in_bitkey, out_bitkey])
+
+          expect(raw_times.map(&:split_time_id)).to match_array(split_times.map(&:id))
         end
 
-        perform_process
-        split_times = SplitTime.last(2)
-        split_time_ids = split_times.map(&:id)
-        effort_id = split_times.first.effort_id
+        it 'sends a message to NotifyProgressJob with relevant person and split_time data' do
+          allow(NotifyProgressJob).to receive(:perform_later) do |_, split_time_ids|
+            split_time_ids.sort!
+          end
 
-        expect(NotifyProgressJob).to have_received(:perform_later).with(effort_id, split_time_ids.sort)
+          perform_process
+          split_times = SplitTime.last(2)
+          split_time_ids = split_times.map(&:id)
+          effort_id = split_times.first.effort_id
+
+          expect(NotifyProgressJob).to have_received(:perform_later).with(effort_id, split_time_ids.sort)
+        end
+
+        it 'sends messages to Interactors::SetEffortStatus with the efforts associated with the modified split_times' do
+          allow(Interactors::SetEffortStatus).to receive(:perform).and_return(Interactors::Response.new([], '', {}))
+          perform_process
+
+          expect(Interactors::SetEffortStatus).to have_received(:perform).at_least(2).times
+        end
       end
+    end
 
-      it 'sends messages to Interactors::SetEffortStatus with the efforts associated with the modified split_times' do
-        allow(Interactors::SetEffortStatus).to receive(:perform).and_return(Interactors::Response.new([], '', {}))
-        perform_process
+    context 'when raw times have absolute times' do
+      let(:raw_time_1) { create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: 'in',
+                                absolute_time: absolute_time_in, with_pacer: 'true', stopped_here: 'false', source: source) }
+      let(:raw_time_2) { create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: 'out',
+                                absolute_time: absolute_time_out, with_pacer: 'true', stopped_here: 'true', source: source) }
 
-        expect(Interactors::SetEffortStatus).to have_received(:perform).at_least(2).times
-      end
+      include_examples 'processes raw times as expected'
+    end
+
+    context 'when raw times have entered times' do
+      let(:raw_time_1) { create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: 'in',
+                                entered_time: absolute_time_in, with_pacer: 'true', stopped_here: 'false', source: source) }
+      let(:raw_time_2) { create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: 'out',
+                                entered_time: absolute_time_out, with_pacer: 'true', stopped_here: 'true', source: source) }
+
+      include_examples 'processes raw times as expected'
     end
   end
 end

--- a/spec/services/raw_times/set_absolute_time_and_lap_spec.rb
+++ b/spec/services/raw_times/set_absolute_time_and_lap_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::RawTimes::SetAbsoluteTimeAndLap do
+  subject { described_class.new(event_group, subject_raw_times) }
+  let(:event_group) { event.event_group }
+  let(:subject_raw_times) { [raw_time] }
+
+  let!(:raw_time) do
+    create(:raw_time,
+           event_group: event_group,
+           entered_lap: entered_lap,
+           entered_time: entered_time,
+           absolute_time: absolute_time,
+           bib_number: bib_number,
+           split_name: split_name,
+           bitkey: 1,
+           stopped_here: false)
+  end
+
+  let(:entered_lap) { nil }
+  let(:entered_time) { nil }
+  let(:absolute_time) { nil }
+  let(:effort) { event.efforts.order(:bib_number).first }
+  let(:bib_number) { effort.bib_number.to_s }
+  let(:split_name) { event.ordered_splits.second.base_name }
+
+  before do
+    allow(::FindExpectedLap).to receive(:perform)
+    allow(::IntendedTimeCalculator).to receive(:absolute_time_local)
+  end
+
+  describe '#perform' do
+    let(:resulting_raw_times) { subject.perform }
+    let(:resulting_raw_time) { resulting_raw_times.first }
+    context 'for a single-lap event group' do
+      let(:event) { events(:sum_100k) }
+
+      shared_examples 'sets lap and time for a single-lap event' do
+        context 'when absolute time is present' do
+          let(:absolute_time) { '2020-04-04 07:30:00-0600' }
+          it 'sets entered time and lap' do
+            expect(resulting_raw_time.entered_time.to_datetime).to eq(absolute_time.to_datetime)
+            expect(resulting_raw_time.lap).to eq(1)
+          end
+        end
+
+        context 'when entered time is a datetime with time zone' do
+          let(:entered_time) { '2020-04-04 07:30:00-0600' }
+          it 'sets absolute time and lap' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.to_datetime)
+            expect(resulting_raw_time.lap).to eq(1)
+          end
+        end
+
+        context 'when entered time is a datetime without a time zone' do
+          let(:entered_time) { '2020-04-04 07:30:00' }
+          it 'sets absolute time and lap using the event group home time zone' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.in_time_zone(event_group.home_time_zone))
+            expect(resulting_raw_time.lap).to eq(1)
+          end
+        end
+
+        context 'when entered time is a military time' do
+          let(:entered_time) { '07:30:00' }
+          it 'sets lap' do
+            expect(resulting_raw_time.lap).to eq(1)
+          end
+
+          it 'calls IntendedTimeCalculator to determine absolute time' do
+            expect(::IntendedTimeCalculator).to receive(:absolute_time_local)
+            resulting_raw_time
+          end
+        end
+      end
+
+      context 'when entered lap is nil' do
+        include_examples 'sets lap and time for a single-lap event'
+      end
+
+      context 'when entered lap is provided' do
+        let(:entered_lap) { 1 }
+
+        include_examples 'sets lap and time for a single-lap event'
+      end
+    end
+
+    context 'for a multi-lap event group' do
+      let(:event) { events(:rufa_2017_24h) }
+      let(:effort) { efforts(:rufa_2017_24h_progress_lap1) }
+      context 'when entered lap is nil' do
+
+        shared_examples 'uses FindExpectedLap to set the lap' do
+          it 'calls FindExpectedLap to set the lap' do
+            expect(::FindExpectedLap).to receive(:perform)
+            resulting_raw_time
+          end
+        end
+
+        context 'when absolute time is present' do
+          let(:absolute_time) { '2017-02-11 11:55:00-0600' }
+          it 'sets entered time' do
+            expect(resulting_raw_time.entered_time.to_datetime).to eq(absolute_time.to_datetime)
+          end
+
+          include_examples 'uses FindExpectedLap to set the lap'
+        end
+
+        context 'when entered time is a datetime with time zone' do
+          let(:entered_time) { '2017-02-11 11:55:00-0600' }
+          it 'sets absolute time' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.to_datetime)
+          end
+
+          include_examples 'uses FindExpectedLap to set the lap'
+        end
+
+        context 'when entered time is a datetime without a time zone' do
+          let(:entered_time) { '2017-02-11 11:55:00' }
+          it 'sets absolute time using the event group home time zone' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.in_time_zone(event_group.home_time_zone))
+          end
+
+          include_examples 'uses FindExpectedLap to set the lap'
+        end
+
+        context 'when entered time is a military time' do
+          let(:entered_time) { '07:30:00' }
+          it 'calls IntendedTimeCalculator to determine absolute time' do
+            expect(::IntendedTimeCalculator).to receive(:absolute_time_local)
+            resulting_raw_time
+          end
+
+          include_examples 'uses FindExpectedLap to set the lap'
+        end
+      end
+
+      context 'when entered lap is provided' do
+        let(:entered_lap) { 2 }
+
+        shared_examples 'uses entered lap to set the lap' do
+          it 'sets lap to the entered lap' do
+            expect(resulting_raw_time.lap).to eq(entered_lap)
+          end
+        end
+
+        context 'when absolute time is present' do
+          let(:absolute_time) { '2017-02-11 11:55:00-0600' }
+          it 'sets entered time' do
+            expect(resulting_raw_time.entered_time.to_datetime).to eq(absolute_time.to_datetime)
+          end
+
+          include_examples 'uses entered lap to set the lap'
+        end
+
+        context 'when entered time is a datetime with time zone' do
+          let(:entered_time) { '2017-02-11 11:55:00-0600' }
+          it 'sets absolute time' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.to_datetime)
+          end
+
+          include_examples 'uses entered lap to set the lap'
+        end
+
+        context 'when entered time is a datetime without a time zone' do
+          let(:entered_time) { '2017-02-11 11:55:00' }
+          it 'sets absolute time using the event group home time zone' do
+            expect(resulting_raw_time.absolute_time.to_datetime).to eq(entered_time.in_time_zone(event_group.home_time_zone))
+          end
+
+          include_examples 'uses entered lap to set the lap'
+        end
+
+        context 'when entered time is a military time' do
+          let(:entered_time) { '07:30:00' }
+          it 'calls IntendedTimeCalculator to determine absolute time' do
+            expect(::IntendedTimeCalculator).to receive(:absolute_time_local)
+            resulting_raw_time
+          end
+
+          include_examples 'uses entered lap to set the lap'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This takes care of a portion of https://github.com/SplitTime/OpenSplitTime/issues/265