### PR TITLE
Fix breadcrumbs in Stats view

### DIFF
--- a/app/views/event_groups/stats.html.erb
+++ b/app/views/event_groups/stats.html.erb
@@ -14,7 +14,7 @@
             <li class="breadcrumb-item"><%= link_to 'Organizations', organizations_path %></li>
             <li class="breadcrumb-item"><%= link_to @presenter.organization.name, organization_path(@presenter.organization) %></li>
             <li class="breadcrumb-item"><%= link_to @presenter.event_group.name, event_group_path(@presenter.event_group) %></li>
-            <li class="breadcrumb-item active">Roster</li>
+            <li class="breadcrumb-item active">Stats</li>
           </ul>
         </div>
         <%= render 'events/time_and_course_info' %>


### PR DESCRIPTION
The breadcrumbs in the Stats view say "Roster" at the end. This PR changes it to "Stats."