### PR TITLE
Throw mismatch error only if split times belong to another effort

### DIFF
--- a/app/services/interactors/destroy_effort_split_times.rb
+++ b/app/services/interactors/destroy_effort_split_times.rb
@@ -54,7 +54,7 @@ module Interactors
     end
 
     def mismatched_split_time_ids
-      split_time_ids - effort.split_times.map(&:id)
+      SplitTime.where(id: split_time_ids).where.not(effort_id: effort.id).ids
     end
   end
 end

--- a/spec/services/interactors/destroy_effort_split_times_spec.rb
+++ b/spec/services/interactors/destroy_effort_split_times_spec.rb
@@ -48,11 +48,12 @@ RSpec.describe Interactors::DestroyEffortSplitTimes do
       end
     end
 
-    context 'when split_time_ids are not included in effort.split_time ids' do
-      let(:split_time_ids) { %w[0, 1] }
+    context 'when split_time_ids belong to another effort' do
+      let(:other_effort) { efforts(:hardrock_2015_tuan_jacobs) }
+      let(:split_time_ids) { other_effort.ordered_split_times.first(2).map(&:id) }
 
       it 'raises an error' do
-        expect { subject }.to raise_error(/split_time ids 0, 1 do not correspond to effort/)
+        expect { subject }.to raise_error(/do not correspond to effort/)
       end
     end
   end


### PR DESCRIPTION
We are getting errors where users are attempting to delete split times that have already been deleted. The problem is that `Interactors::DestroyEffortSplitTimes` is flagging missing split time ids as mismatched. 

This PR changes the mismatch method to look up the referenced split times and only throw a mismatch if the references split times exist and belong to an effort other than the subject effort.

Addresses https://github.com/SplitTime/OpenSplitTime/issues/356