### PR TITLE
Sync elapsed seconds

### DIFF
--- a/lib/tasks/temp/sync_effort_elapsed_times.rake
+++ b/lib/tasks/temp/sync_effort_elapsed_times.rake
@@ -1,0 +1,26 @@
+# This is a temporary rake task that should be deleted
+# once it has been run in all environments.
+
+require 'active_record'
+
+namespace :temp do
+  desc "calculates elapsed_seconds for all split times"
+  task :initialize_elapsed_seconds => :environment do
+    puts "Initializing the elapsed_seconds column"
+
+    starting_split_times = ::SplitTime.joins(:split).where(lap: 1, bitkey: ::SubSplit::IN_BITKEY, splits: {kind: :start})
+    starting_split_times_count = starting_split_times.count
+
+    puts "Found #{starting_split_times_count} starting split times"
+
+    progress_bar = ::ProgressBar.new(starting_split_times_count)
+
+    starting_split_times.find_each do |sst|
+      progress_bar.increment!
+      sst.send(:sync_effort_elapsed_seconds)
+    rescue ActiveRecordError => e
+      puts "Could not initialize for effort #{sst.effort_id}:"
+      puts e
+    end
+  end
+end

--- a/spec/models/split_time_spec.rb
+++ b/spec/models/split_time_spec.rb
@@ -198,7 +198,10 @@ RSpec.describe SplitTime, kind: :model do
       end
 
       context "if elapsed seconds is already set" do
-        before { subject.update(elapsed_seconds: 11.hours) }
+        before do
+          subject.write_attribute(:elapsed_seconds, 11.hours)
+          subject.save!
+        end
         it "sets elapsed seconds based on absolute time" do
           expect(subject.elapsed_seconds).to eq(11.hours)
           subject.update!(absolute_time: "2016-07-15 22:00:00")


### PR DESCRIPTION
This MR synchronizes `elapsed_seconds` for all split time records. On create and update events, `absolute_time` is analyzed and `elapsed_seconds` are calculated. When a starting split time is created or updated, `elapsed_seconds` are calculated for all split times for the effort.

The goal is to improve query speed by avoiding joins whenever elapsed time data is required.