### PR TITLE
Sync elapsed seconds using pure SQL

### DIFF
--- a/lib/tasks/temp/sync_effort_elapsed_times.rake
+++ b/lib/tasks/temp/sync_effort_elapsed_times.rake
@@ -8,19 +8,18 @@ namespace :temp do
   task :initialize_elapsed_seconds => :environment do
     puts "Initializing the elapsed_seconds column"
 
-    starting_split_times = ::SplitTime.joins(:split).where(lap: 1, bitkey: ::SubSplit::IN_BITKEY, splits: {kind: :start})
-    starting_split_times_count = starting_split_times.count
+    efforts = Effort.all
+    efforts_count = efforts.count
 
-    puts "Found #{starting_split_times_count} starting split times"
+    puts "Found #{efforts_count} efforts"
 
-    progress_bar = ::ProgressBar.new(starting_split_times_count)
+    progress_bar = ::ProgressBar.new(efforts_count)
 
-    starting_split_times.find_each do |sst|
+    efforts.find_each do |effort|
       progress_bar.increment!
-      sst.send(:sync_effort_elapsed_seconds)
-      sst.save!
+      effort.split_times.first&.send(:sync_elapsed_seconds)
     rescue ActiveRecordError => e
-      puts "Could not initialize for effort #{sst.effort_id}:"
+      puts "Could not initialize for effort #{effort.id}:"
       puts e
     end
   end

--- a/spec/models/split_time_spec.rb
+++ b/spec/models/split_time_spec.rb
@@ -192,7 +192,9 @@ RSpec.describe SplitTime, kind: :model do
       context "if elapsed seconds is not already set" do
         it "sets elapsed seconds based on absolute time" do
           expect(subject.elapsed_seconds).to be_nil
+
           subject.update!(absolute_time: "2016-07-15 22:00:00")
+          subject.reload
           expect(subject.elapsed_seconds).to eq(10.hours)
         end
       end
@@ -204,7 +206,9 @@ RSpec.describe SplitTime, kind: :model do
         end
         it "sets elapsed seconds based on absolute time" do
           expect(subject.elapsed_seconds).to eq(11.hours)
+
           subject.update!(absolute_time: "2016-07-15 22:00:00")
+          subject.reload
           expect(subject.elapsed_seconds).to eq(10.hours)
         end
       end
@@ -216,7 +220,9 @@ RSpec.describe SplitTime, kind: :model do
       let(:split) { splits(:hardrock_cw_sherman) }
       it "sets elapsed seconds based on absolute time" do
         expect(subject.elapsed_seconds).to be_nil
+
         subject.save
+        subject.reload
         expect(subject.elapsed_seconds).to eq(33.hours)
       end
     end


### PR DESCRIPTION
We are currently syncing split time elapsed seconds using a callback that invokes potentially several ActiveRecord calls to the database. This ends up taking nearly a full second per record to run in production.

This MR changes the update over to pure SQL, skipping callbacks and validations. This is appropriate because the `elapsed_seconds` column is read-only in any case, and changes to that column should not result in (for example) the `updated_at` column being updated except in the case of the exact split_time for which the column was updated.

Running the rake task using this new query results in updates at the rate of approximately 400 efforts per second.

The SQL query used in this MR updates *all* `elapsed_time` attributes for an effort when *any* split time of that effort is updated. This may seem like overkill, but it allows us to use a single update regardless of whether the split time being updated is a start time or not, and regardless of whether a starting split time is destroyed. The query takes about 1ms to run locally and should perform much faster in production than the current solution does.