### PR TITLE
Complete Finish Line View

### DIFF
--- a/app/assets/stylesheets/pages/_finish_line.scss
+++ b/app/assets/stylesheets/pages/_finish_line.scss
@@ -1,0 +1,9 @@
+body.event_groups.finish_line {
+    .input-xl {
+        height: 3rem;
+        width: 10rem;
+        padding-left: 10px;
+        font-size: 2em;
+        font-weight: bold;
+    }
+}

--- a/app/models/projected_arrivals_at_split.rb
+++ b/app/models/projected_arrivals_at_split.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+class ProjectedArrivalsAtSplit
+  include ::ActiveModel::Model
+  include ::ActiveModel::Attributes
+
+  attribute :effort_id, :integer
+  attribute :first_name, :string
+  attribute :last_name, :string
+  attribute :bib_number, :integer
+  attribute :projected_time, :datetime
+  attribute :completed, :boolean
+  attribute :stopped, :boolean
+
+  alias_attribute :completed?, :completed
+  alias_attribute :stopped?, :stopped
+
+  def self.execute_query(*args)
+    query = sql(*args)
+    result = ::ActiveRecord::Base.connection.execute(query)
+    result.map { |row| new(row) }
+  end
+
+  def self.sql(event_group_id, parameterized_split_name)
+    <<~SQL.squish
+      with event_ids as
+               (select id as event_id
+                from events
+                where events.event_group_id = #{event_group_id}),
+
+           completed_segments as
+               (select distinct on (ast.effort_id) ast.effort_id,
+                                                   course_id,
+                                                   lap                  as completed_lap,
+                                                   ast.split_id         as completed_split_id,
+                                                   ast.sub_split_bitkey as completed_bitkey,
+                                                   ast.elapsed_seconds  as elapsed_seconds,
+                                                   absolute_time        as completed_time
+                from split_times ast
+                         join efforts on efforts.id = ast.effort_id
+                         join splits on splits.id = ast.split_id
+                where efforts.event_id in (select event_id from event_ids)
+                order by ast.effort_id, lap desc, distance_from_start desc, sub_split_bitkey desc),
+
+           completed_time_points as
+               (select distinct on (completed_lap, completed_split_id, completed_bitkey) course_id,
+                                                                                         completed_lap,
+                                                                                         completed_split_id,
+                                                                                         completed_bitkey
+                from completed_segments),
+
+           projected_time_points as
+               (select ctp.*,
+                       1             as started_lap,
+                       ss.id         as started_split_id,
+                       1             as started_bitkey,
+                       completed_lap as projected_lap,
+                       ps.id         as projected_split_id,
+                       1             as projected_bitkey
+                from completed_time_points ctp
+                         join splits ps on ps.course_id = ctp.course_id and ps.parameterized_base_name = '#{parameterized_split_name}'
+                         join splits ss on ss.course_id = ctp.course_id and ss.kind = 0),
+
+           projected_seconds as
+               (select ptp.*,
+                       cst.elapsed_seconds - sst.elapsed_seconds as completed_seconds,
+                       pst.elapsed_seconds - cst.elapsed_seconds as projected_seconds
+                from projected_time_points ptp
+                         join split_times sst on sst.lap = started_lap and sst.split_id = started_split_id and
+                                                 sst.sub_split_bitkey = started_bitkey
+                         join split_times cst on cst.lap = completed_lap and cst.split_id = completed_split_id and
+                                                 cst.sub_split_bitkey = completed_bitkey and cst.effort_id = sst.effort_id
+                         join split_times pst on pst.lap = projected_lap and pst.split_id = projected_split_id and
+                                                 pst.sub_split_bitkey = projected_bitkey and pst.effort_id = sst.effort_id),
+
+           projected_percentages as
+               (select completed_lap,
+                       completed_split_id,
+                       completed_bitkey,
+                       case
+                           when completed_seconds = 0 then 0
+                           else projected_seconds / completed_seconds end as projected_percentage
+                from projected_seconds),
+
+           grouped_projected_percentages as
+               (select completed_lap, completed_split_id, completed_bitkey, avg(projected_percentage) as projected_percentage
+                from projected_percentages
+                group by completed_lap, completed_split_id, completed_bitkey),
+
+           projected_times as
+               (select distinct on (cs.effort_id) cs.effort_id,
+                                                  completed_time +
+                                                  ((cs.elapsed_seconds * projected_percentage)::int * interval '1 second') as projected_time,
+                                                  projected_percentage <= 0                                                as completed,
+                                                  st.id is not null                                                        as stopped
+                from completed_segments cs
+                         left join grouped_projected_percentages using (completed_lap, completed_split_id, completed_bitkey)
+                         left join split_times st on st.effort_id = cs.effort_id and st.stopped_here = true
+                order by cs.effort_id)
+
+      select efforts.id as effort_id, first_name, last_name, bib_number, projected_time, completed, stopped
+      from efforts
+               join projected_times on projected_times.effort_id = efforts.id
+      order by projected_time desc
+    SQL
+  end
+
+  def expected?
+    !completed? && !stopped?
+  end
+
+  def full_name
+    "#{first_name} #{last_name}"
+  end
+end

--- a/app/models/projected_arrivals_at_split.rb
+++ b/app/models/projected_arrivals_at_split.rb
@@ -101,7 +101,7 @@ class ProjectedArrivalsAtSplit
       select efforts.id as effort_id, first_name, last_name, bib_number, projected_time, completed, stopped
       from efforts
                join projected_times on projected_times.effort_id = efforts.id
-      order by projected_time desc
+      order by projected_time desc nulls last
     SQL
   end
 

--- a/app/views/event_groups/_effort_button_card.html.erb
+++ b/app/views/event_groups/_effort_button_card.html.erb
@@ -4,11 +4,12 @@
   <h3 class="card-header"><strong><%= title %></strong></h3>
   <div class="card">
     <div class="card-body">
-      <% if efforts.present? %>
-        <% efforts.each do |effort| %>
+      <% if arrivals.present? %>
+        <% arrivals.each do |arrival| %>
           <div class="card">
-            <button class="btn btn-primary btn-lg text-lg-left" data-action="click->finish-line#lookup keyup->finish-line#lookup" data-bib-number="<%= effort.bib_number %>">
-              <%= "##{effort.bib_number} #{effort.full_name}" %>
+            <button class="btn btn-primary btn-lg text-lg-left" data-action="click->finish-line#lookup keyup->finish-line#lookup" data-bib-number="<%= arrival.bib_number %>">
+              <%= "##{arrival.bib_number} #{arrival.full_name}
+              (#{(arrival.projected_time.present? ? l(arrival.projected_time.in_time_zone(time_zone), format: :day_and_military) : 'Time not known')})" %>
             </button>
           </div>
         <% end %>

--- a/app/views/event_groups/finish_line.html.erb
+++ b/app/views/event_groups/finish_line.html.erb
@@ -40,6 +40,7 @@
     <div data-target="finish-line.result"></div>
     <hr/>
 
-    <%= render "effort_button_card", efforts: @presenter.recently_finished_efforts, title: "Recently Finished" %>
+    <%= render "effort_button_card", efforts: @presenter.recent_arrivals_at_finish, title: "Recently Finished" %>
+    <%= render "effort_button_card", efforts: @presenter.expected_arrivals_at_finish, title: "Next Expected" %>
   </div>
 </article>

--- a/app/views/event_groups/finish_line.html.erb
+++ b/app/views/event_groups/finish_line.html.erb
@@ -41,7 +41,7 @@
     <div data-target="finish-line.result"></div>
     <hr/>
 
-    <%= render "effort_button_card", efforts: @presenter.recent_arrivals_at_finish, title: "Recently Finished" %>
-    <%= render "effort_button_card", efforts: @presenter.expected_arrivals_at_finish, title: "Next Expected" %>
+    <%= render "effort_button_card", arrivals: @presenter.recent_arrivals_at_finish, title: "Recently Finished (Finish Time)", time_zone: @presenter.home_time_zone %>
+    <%= render "effort_button_card", arrivals: @presenter.expected_arrivals_at_finish, title: "Next Expected (Projected Time)", time_zone: @presenter.home_time_zone %>
   </div>
 </article>

--- a/app/views/event_groups/finish_line.html.erb
+++ b/app/views/event_groups/finish_line.html.erb
@@ -29,7 +29,8 @@
   <div data-controller="finish-line" data-finish-line-event-group-id="<%= @presenter.id %>">
     <div class="row">
       <div class="col">
-        <input inputmode="numeric" pattern="[0-9]*" type="text" placeholder="Bib #" style="height: 3rem; width: 10rem; font-size: 2em; font-weight: bold" data-target="finish-line.search" data-action="blur->finish-line#checkInput keyup->finish-line#checkInput">
+        <input class="input-xl" inputmode="numeric" pattern="[0-9]*" type="text" placeholder="Bib #"
+               data-target="finish-line.search" data-action="blur->finish-line#checkInput keyup->finish-line#checkInput">
       </div>
       <div class="col">
         <button class="btn btn-lg btn-primary" data-action="finish-line#checkInput">Go</button>


### PR DESCRIPTION
This MR adds a new query model called Projected Arrivals At Split, which takes an event group id and split name and returns the projected or actual arrival time for each entrant in the event group.

Using the new query model, we quickly determine most recent finishers and next expected arrivals, and populate the buttons so the user can quickly pull up information for those runners.

This addresses the remainder of #351