### PR TITLE
Default "Enter Bib Number" card for finish line view

### DIFF
--- a/app/views/event_groups/_finish_line_effort.html.erb
+++ b/app/views/event_groups/_finish_line_effort.html.erb
@@ -1,5 +1,11 @@
 <div class="card">
-  <% if @efforts.present? %>
+  <% if @efforts.nil? %>
+    <div class="card">
+      <h3 class="card-header"><strong><%= "Enter a bib number" %></strong></h3>
+      <div class="card-body">
+      </div>
+    </div>
+  <% elsif @efforts.present? %>
     <% effort = ::EffortRow.new(@efforts.first.enriched) %>
     <div class="card">
       <h3 class="card-header"><strong><%= "##{effort.bib_number} #{effort.full_name}" %></strong></h3>

--- a/app/views/event_groups/_finish_line_effort.html.erb
+++ b/app/views/event_groups/_finish_line_effort.html.erb
@@ -1,5 +1,5 @@
 <div class="card">
-  <% if @efforts.nil? %>
+  <% if @efforts.nil? # No search was performed %>
     <div class="card">
       <h3 class="card-header"><strong><%= "Enter a bib number" %></strong></h3>
       <div class="card-body">
@@ -25,7 +25,7 @@
         <h4 class="card-text"><%= effort.comments %></h4>
       </div>
     </div>
-  <% else %>
+  <% else # @efforts == []; Empty search result %>
     <div class="card">
       <h3 class="card-header"><strong><%= "Not Found" %></strong></h3>
       <div class="card-body">

--- a/app/views/event_groups/finish_line.html.erb
+++ b/app/views/event_groups/finish_line.html.erb
@@ -38,7 +38,9 @@
     </div>
     <hr/>
 
-    <div data-target="finish-line.result"></div>
+    <div data-target="finish-line.result">
+      <%= render "finish_line_effort" %>
+    </div>
     <hr/>
 
     <%= render "effort_button_card", arrivals: @presenter.recent_arrivals_at_finish, title: "Recently Finished (Finish Time)", time_zone: @presenter.home_time_zone %>


### PR DESCRIPTION
Currently, when a user first visits the Finish Line view, before entering a bib number or tapping on a button, there is nothing where the runner's result card will eventually go. 

This MR changes this and instead shows a blank card that says, "Enter Bib Number."