### PR TITLE
Use elapsed seconds in rank and status query

### DIFF
--- a/app/helpers/efforts_helper.rb
+++ b/app/helpers/efforts_helper.rb
@@ -29,7 +29,7 @@ module EffortsHelper
 
   def last_reported_elapsed_time(effort_row)
     if effort_row.started?
-      "#{time_format_hhmmss(effort_row.final_time_from_start)}"
+      "#{time_format_hhmmss(effort_row.final_elapsed_seconds)}"
     else
       '--'
     end

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -214,7 +214,7 @@ class Effort < ApplicationRecord
     when dropped?
       'DNF'
     when finished?
-      return TimeConversion.seconds_to_hms(attributes['final_time_from_start']) if attributes.has_key?('final_time_from_start')
+      return TimeConversion.seconds_to_hms(attributes['final_elapsed_seconds']) if attributes.has_key?('final_elapsed_seconds')
       finish_split_time.formatted_time_hhmmss
     else
       'In progress'

--- a/app/parameters/effort_parameters.rb
+++ b/app/parameters/effort_parameters.rb
@@ -13,7 +13,7 @@ class EffortParameters < BaseParameters
     [:id, :slug, :event_id, :person_id, :participant_id, :wave, :bib_number, :city, :state_code, :age,
      :created_at, :updated_at, :created_by, :updated_by, :first_name, :last_name, :gender,
      :country_code, :birthdate, :data_status, :beacon_url, :report_url, :photo, :laps_required, :event_start_time,
-     :final_split_name, :final_lap_distance, :final_lap, :final_split_id, :final_bitkey, :final_time_from_start,
+     :final_split_name, :final_lap_distance, :final_lap, :final_split_id, :final_bitkey, :final_elapsed_seconds,
      :final_split_time_id, :stopped_split_time_id, :stopped_lap, :stopped_split_id, :stopped_bitkey,
      :stopped_time, :final_lap_complete, :course_distance, :started, :laps_started, :laps_finished,
      :final_distance, :finished, :stopped, :dropped, :overall_rank, :gender_rank, :full_name, :bio_historic,

--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -7,167 +7,173 @@ class EffortQuery < BaseQuery
     where_clause = args[:effort_id].present? ? "where id = #{args[:effort_id]}" : ''
 
     <<-SQL.squish
-      with
-        existing_scope as (#{existing_scope_sql}),
+      with existing_scope as
+               (#{existing_scope_sql}),
 
-        efforts_scoped as
-          (select efforts.*
-           from efforts
-           inner join existing_scope on existing_scope.id = efforts.id),
+           efforts_scoped as
+               (select efforts.*
+                from efforts
+                         inner join existing_scope on existing_scope.id = efforts.id),
 
-        start_split_times as
-          (select effort_id, absolute_time
-           from split_times
-           inner join splits on splits.id = split_times.split_id
-           where lap = 1 and kind = 0 and effort_id in (select id from efforts_scoped)
-           order by effort_id),
+           start_split_times as
+               (select effort_id, absolute_time
+                from split_times
+                         inner join splits on splits.id = split_times.split_id
+                where lap = 1
+                  and kind = 0
+                  and effort_id in (select id from efforts_scoped)
+                order by effort_id),
 
-        stopped_split_times as
-          (select  split_times.id as stopped_split_time_id,
-                   split_times.lap as stopped_lap,
-                   split_times.split_id as stopped_split_id,
-                   split_times.sub_split_bitkey as stopped_bitkey,
-                   split_times.absolute_time as stopped_absolute_time,
-                   split_times.effort_id
-           from split_times
-           where effort_id in (select id from efforts_scoped) and stopped_here = true),
+           stopped_split_times as
+               (select split_times.id               as stopped_split_time_id,
+                       split_times.lap              as stopped_lap,
+                       split_times.split_id         as stopped_split_id,
+                       split_times.sub_split_bitkey as stopped_bitkey,
+                       split_times.absolute_time    as stopped_absolute_time,
+                       split_times.effort_id
+                from split_times
+                where effort_id in (select id from efforts_scoped)
+                  and stopped_here = true),
 
-        course_subquery as
-          (select courses.id as course_id,
-                  splits.distance_from_start as course_distance,
-                  splits.vert_gain_from_start as course_vert_gain
-           from courses
-           inner join splits on splits.course_id = courses.id
-           where splits.kind = 1),
+           course_subquery as
+               (select courses.id                  as course_id,
+                       splits.distance_from_start  as course_distance,
+                       splits.vert_gain_from_start as course_vert_gain
+                from courses
+                         inner join splits on splits.course_id = courses.id
+                where splits.kind = 1),
 
-        base_subquery as
-          (select distinct on(efforts_scoped.id)
-              efforts_scoped.*,
-              events.laps_required,
-              events.start_time as event_start_time,
-              event_groups.home_time_zone,
-              splits.base_name as final_split_name,
-              splits.distance_from_start as final_lap_distance,
-              splits.vert_gain_from_start as final_lap_vert_gain,
-              split_times.lap as final_lap,
-              split_times.split_id as final_split_id,
-              split_times.sub_split_bitkey as final_bitkey,
-              split_times.absolute_time as final_absolute_time,
-              sst.absolute_time as actual_start_time,
-              extract(epoch from(sst.absolute_time - events.start_time)) as start_offset,
-              extract(epoch from (split_times.absolute_time - sst.absolute_time)) as final_time_from_start,
-              split_times.id as final_split_time_id,
-              stopped_split_time_id,
-              stopped_lap,
-              stopped_split_id,
-              stopped_bitkey,
-              stopped_absolute_time,
-              course_distance,
-              course_vert_gain,
-              case when splits.kind = 1 then true else false end as final_lap_complete,
-              case when split_times.lap > 1 or splits.kind in (1, 2) then true else false end as beyond_start
-           from efforts_scoped
-              left join split_times on split_times.effort_id = efforts_scoped.id
-              left join splits on splits.id = split_times.split_id
-              left join events on events.id = efforts_scoped.event_id
-              inner join event_groups on event_groups.id = events.event_group_id
-              left join course_subquery on events.course_id = course_subquery.course_id
-              left join stopped_split_times stop_st on split_times.effort_id = stop_st.effort_id
-              left join start_split_times sst on split_times.effort_id = sst.effort_id
-           order by efforts_scoped.id,
-                    final_lap desc,
-                    final_lap_distance desc,
-                    final_bitkey desc),
+           base_subquery as
+               (select distinct on (efforts_scoped.id) 
+                           efforts_scoped.*,
+                           events.laps_required,
+                           events.start_time                                           as event_start_time,
+                           event_groups.home_time_zone,
+                           splits.base_name                                            as final_split_name,
+                           splits.distance_from_start                                  as final_lap_distance,
+                           splits.vert_gain_from_start                                 as final_lap_vert_gain,
+                           split_times.lap                                             as final_lap,
+                           split_times.split_id                                        as final_split_id,
+                           split_times.sub_split_bitkey                                as final_bitkey,
+                           split_times.absolute_time                                   as final_absolute_time,
+                           sst.absolute_time                                           as actual_start_time,
+                           extract(epoch from (sst.absolute_time - events.start_time)) as start_offset,
+                           extract(epoch from (split_times.absolute_time - sst.absolute_time)) as final_time_from_start,
+                           split_times.id                                              as final_split_time_id,
+                           stopped_split_time_id,
+                           stopped_lap,
+                           stopped_split_id,
+                           stopped_bitkey,
+                           stopped_absolute_time,
+                           course_distance,
+                           course_vert_gain,
+                           case when splits.kind = 1 then true else false end          as final_lap_complete,
+                           case
+                               when split_times.lap > 1 or splits.kind in (1, 2) then true
+                               else false end                                          as beyond_start
+                from efforts_scoped
+                         left join split_times on split_times.effort_id = efforts_scoped.id
+                         left join splits on splits.id = split_times.split_id
+                         left join events on events.id = efforts_scoped.event_id
+                         inner join event_groups on event_groups.id = events.event_group_id
+                         left join course_subquery on events.course_id = course_subquery.course_id
+                         left join stopped_split_times stop_st on split_times.effort_id = stop_st.effort_id
+                         left join start_split_times sst on split_times.effort_id = sst.effort_id
+                order by efforts_scoped.id,
+                         final_lap desc,
+                         final_lap_distance desc,
+                         final_bitkey desc),
 
-        distance_subquery as
-          (select *,
-              coalesce(scheduled_start_time, event_start_time) as assumed_start_time,
-              case when final_lap is null then false else true end as started,
-              final_lap as laps_started,
-              case when final_lap_complete is true then final_lap else final_lap - 1 end as laps_finished,
-              (final_lap - 1) * course_distance + final_lap_distance as final_distance,
-              (final_lap - 1) * course_vert_gain + final_lap_vert_gain as final_vert_gain
-           from base_subquery),
+           distance_subquery as
+               (select *,
+                       coalesce(scheduled_start_time, event_start_time)                           as assumed_start_time,
+                       case when final_lap is null then false else true end                       as started,
+                       final_lap                                                                  as laps_started,
+                       case when final_lap_complete is true then final_lap else final_lap - 1 end as laps_finished,
+                       (final_lap - 1) * course_distance + final_lap_distance                     as final_distance,
+                       (final_lap - 1) * course_vert_gain + final_lap_vert_gain                   as final_vert_gain
+                from base_subquery),
 
-        finished_subquery as
-          (select *,
-              case
-              when laps_required = 0 then
-                case when stopped_split_time_id is null then false else true end
-              else
-                case when laps_finished >= laps_required then true else false end
-              end
-              as finished,
-              case
-                when checked_in and actual_start_time is null and (assumed_start_time < current_timestamp) then true else false
-              end
-              as ready_to_start
-           from distance_subquery),
+           finished_subquery as
+               (select *,
+                       case
+                           when laps_required = 0 then
+                               case when stopped_split_time_id is null then false else true end
+                           else
+                               case when laps_finished >= laps_required then true else false end
+                           end
+                           as finished,
+                       case
+                           when checked_in and actual_start_time is null and (assumed_start_time < current_timestamp)
+                               then true
+                           else false
+                           end
+                           as ready_to_start
+                from distance_subquery),
 
-        stopped_subquery as
-          (select *,
-              case when finished or stopped_split_time_id is not null then true else false end as stopped
-           from finished_subquery),
+           stopped_subquery as
+               (select *,
+                       case when finished or stopped_split_time_id is not null then true else false end as stopped
+                from finished_subquery),
 
-        main_subquery as
-          (select *,
-              case when stopped and not finished then true else false end as dropped
-           from stopped_subquery),
+           main_subquery as
+               (select *,
+                       case when stopped and not finished then true else false end as dropped
+                from stopped_subquery),
 
-        ranking_subquery as
-          (select #{select_sql},
-              case when started then
-                rank() over
-                  (partition by event_id
-                   order by started desc,
-                            dropped,
-                            final_lap desc nulls last,
-                            final_lap_distance desc,
-                            final_bitkey desc,
-                            final_time_from_start,
-                            gender desc,
-                            age desc)
-                else null end
-              as overall_rank,
-
-              case when started then
-                rank() over
-                  (partition by event_id, gender
-                   order by started desc,
-                            dropped,
-                            final_lap desc nulls last,
-                            final_lap_distance desc,
-                            final_bitkey desc,
-                            final_time_from_start,
-                            gender desc,
-                            age desc)
-                else null end
-              as gender_rank,
-
-              lag(id) over
-                  (partition by event_id
-                   order by started desc,
-                            dropped,
-                            final_lap desc nulls last,
-                            final_lap_distance desc,
-                            final_bitkey desc,
-                            final_time_from_start,
-                            gender desc,
-                            age desc)
-              as prior_effort_id,
-
-              lead(id) over
-                  (partition by event_id
-                   order by started desc,
-                            dropped,
-                            final_lap desc nulls last,
-                            final_lap_distance desc,
-                            final_bitkey desc,
-                            final_time_from_start,
-                            gender desc,
-                            age desc)
-              as next_effort_id
-          from main_subquery)
+           ranking_subquery as
+               (select #{select_sql},
+                       case
+                           when started then
+                                       rank() over
+                                   (partition by event_id
+                                   order by started desc,
+                                       dropped,
+                                       final_lap desc nulls last,
+                                       final_lap_distance desc,
+                                       final_bitkey desc,
+                                       final_time_from_start,
+                                       gender desc,
+                                       age desc)
+                           else null end
+                           as overall_rank,
+                       case
+                           when started then
+                                       rank() over
+                                   (partition by event_id, gender
+                                   order by started desc,
+                                       dropped,
+                                       final_lap desc nulls last,
+                                       final_lap_distance desc,
+                                       final_bitkey desc,
+                                       final_time_from_start,
+                                       gender desc,
+                                       age desc)
+                           else null end
+                           as gender_rank,
+                       lag(id) over
+                           (partition by event_id
+                           order by started desc,
+                               dropped,
+                               final_lap desc nulls last,
+                               final_lap_distance desc,
+                               final_bitkey desc,
+                               final_time_from_start,
+                               gender desc,
+                               age desc)
+                           as prior_effort_id,
+                       lead(id) over
+                           (partition by event_id
+                           order by started desc,
+                               dropped,
+                               final_lap desc nulls last,
+                               final_lap_distance desc,
+                               final_bitkey desc,
+                               final_time_from_start,
+                               gender desc,
+                               age desc)
+                           as next_effort_id
+                from main_subquery)
 
       select *
       from ranking_subquery

--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -58,7 +58,7 @@ class EffortQuery < BaseQuery
                            split_times.absolute_time                                   as final_absolute_time,
                            sst.absolute_time                                           as actual_start_time,
                            extract(epoch from (sst.absolute_time - events.start_time)) as start_offset,
-                           extract(epoch from (split_times.absolute_time - sst.absolute_time)) as final_time_from_start,
+                           split_times.elapsed_seconds                                 as final_elapsed_seconds,
                            split_times.id                                              as final_split_time_id,
                            stopped_split_time_id,
                            stopped_lap,
@@ -132,7 +132,7 @@ class EffortQuery < BaseQuery
                                        final_lap desc nulls last,
                                        final_lap_distance desc,
                                        final_bitkey desc,
-                                       final_time_from_start,
+                                       final_elapsed_seconds,
                                        gender desc,
                                        age desc)
                            else null end
@@ -146,7 +146,7 @@ class EffortQuery < BaseQuery
                                        final_lap desc nulls last,
                                        final_lap_distance desc,
                                        final_bitkey desc,
-                                       final_time_from_start,
+                                       final_elapsed_seconds,
                                        gender desc,
                                        age desc)
                            else null end
@@ -158,7 +158,7 @@ class EffortQuery < BaseQuery
                                final_lap desc nulls last,
                                final_lap_distance desc,
                                final_bitkey desc,
-                               final_time_from_start,
+                               final_elapsed_seconds,
                                gender desc,
                                age desc)
                            as prior_effort_id,
@@ -169,7 +169,7 @@ class EffortQuery < BaseQuery
                                final_lap desc nulls last,
                                final_lap_distance desc,
                                final_bitkey desc,
-                               final_time_from_start,
+                               final_elapsed_seconds,
                                gender desc,
                                age desc)
                            as next_effort_id

--- a/app/services/results/series_effort.rb
+++ b/app/services/results/series_effort.rb
@@ -54,7 +54,7 @@ module Results
     end
 
     def indexed_times_from_start
-      indexed_efforts.transform_values { |effort| effort.final_time_from_start.to_i }
+      indexed_efforts.transform_values { |effort| effort.final_elapsed_seconds.to_i }
     end
 
     def total_time_from_start

--- a/app/view_models/effort_analysis_view.rb
+++ b/app/view_models/effort_analysis_view.rb
@@ -56,7 +56,7 @@ class EffortAnalysisView < EffortWithLapSplitRows
   end
 
   def farthest_recorded_time
-    effort.final_time_from_start
+    effort.final_elapsed_seconds
   end
 
   def farthest_recorded_split_name

--- a/app/views/efforts/_efforts_dropped_list.html.erb
+++ b/app/views/efforts/_efforts_dropped_list.html.erb
@@ -9,7 +9,7 @@
     <th>Category</th>
     <th>From</th>
     <th><%= link_to_reversing_sort_heading('Dropped where', :final_distance, @presenter.existing_sort) %></th>
-    <th class="text-right"><%= link_to_reversing_sort_heading('Dropped when', :final_time_from_start, @presenter.existing_sort) %></th>
+    <th class="text-right"><%= link_to_reversing_sort_heading('Dropped when', :final_elapsed_seconds, @presenter.existing_sort) %></th>
   </tr>
   </thead>
 

--- a/app/views/events/_finishers.csv.ruby
+++ b/app/views/events/_finishers.csv.ruby
@@ -5,7 +5,7 @@ if records.present?
         csv << %w(place time first last age gender city state bib)
         records.each do |record|
             csv << [record.overall_rank,
-                    record.final_time_from_start && time_format_hhmmss(record.final_time_from_start),
+                    record.final_elapsed_seconds && time_format_hhmmss(record.final_elapsed_seconds),
                     record.first_name,
                     record.last_name,
                     record.age,

--- a/app/views/events/_podium_category.html.erb
+++ b/app/views/events/_podium_category.html.erb
@@ -22,7 +22,7 @@
       <% if @presenter.multiple_laps? %>
         <td><%= effort.laps_finished %></td>
       <% end %>
-      <td><%= time_format_hhmmss(effort.final_time_from_start) %></td>
+      <td><%= time_format_hhmmss(effort.final_elapsed_seconds) %></td>
       <td><%= effort.full_name %></td>
       <td><%= effort.bio_historic %></td>
       <td><%= effort.flexible_geolocation %></td>

--- a/app/views/events/_ultrasignup.csv.ruby
+++ b/app/views/events/_ultrasignup.csv.ruby
@@ -4,7 +4,7 @@ if records.present?
             csv << %w(place time first last age gender city state dob bib status)
             records.each do |row|
                 csv << [row.overall_rank,
-                        row.final_time_from_start && time_format_hhmmss(row.final_time_from_start),
+                        row.final_elapsed_seconds && time_format_hhmmss(row.final_elapsed_seconds),
                         row.first_name,
                         row.last_name,
                         row.age,

--- a/lib/tasks/database_fixtures.rake
+++ b/lib/tasks/database_fixtures.rake
@@ -5,7 +5,18 @@
 namespace :db do
   desc 'Convert development database to Rails test fixtures'
   task to_fixtures: :environment do
-    TABLES_TO_SKIP = %w[ar_internal_metadata delayed_jobs schema_info schema_migrations friendly_id_slugs locations active_storage_blobs active_storage_attachments].freeze
+    TABLES_TO_SKIP = [
+      "active_storage_attachments",
+      "active_storage_blobs",
+      "ar_internal_metadata",
+      "delayed_jobs",
+      "friendly_id_slugs",
+      "locations",
+      "schema_info",
+      "schema_migrations",
+      "shortened_urls",
+      "versions",
+    ].freeze
 
     begin
       ActiveRecord::Base.establish_connection
@@ -51,7 +62,18 @@ namespace :db do
   task from_fixtures: :environment do
     process_start_time = Time.current
 
-    TABLES_TO_SKIP = %w[ar_internal_metadata delayed_jobs schema_info schema_migrations friendly_id_slugs locations active_storage_blobs active_storage_attachments versions].freeze
+    TABLES_TO_SKIP = [
+      "active_storage_attachments",
+      "active_storage_blobs",
+      "ar_internal_metadata",
+      "delayed_jobs",
+      "friendly_id_slugs",
+      "locations",
+      "schema_info",
+      "schema_migrations",
+      "shortened_urls",
+      "versions",
+    ].freeze
 
     begin
       ActiveRecord::Base.establish_connection

--- a/spec/fixtures/courses.yml
+++ b/spec/fixtures/courses.yml
@@ -11,6 +11,7 @@ hardrock_ccw:
   next_start_time: '2019-07-19 06:00:00'
   slug: hardrock-ccw
   organization_id: 4
+  concealed: 
 ramble_even_course:
   id: 9
   name: Ramble Even Course
@@ -22,6 +23,7 @@ ramble_even_course:
   next_start_time: 
   slug: ramble-even-course
   organization_id: 6
+  concealed: 
 hardrock_cw:
   id: 12
   name: Hardrock CW
@@ -33,6 +35,7 @@ hardrock_cw:
   next_start_time: '2016-07-15 12:00:00'
   slug: hardrock-cw
   organization_id: 4
+  concealed: 
 rufa_course:
   id: 20
   name: RUFA Course
@@ -44,6 +47,7 @@ rufa_course:
   next_start_time: '2019-02-09 14:00:00'
   slug: rufa-course
   organization_id: 14
+  concealed: 
 d30_50k_course:
   id: 26
   name: D30 50K Course
@@ -55,6 +59,7 @@ d30_50k_course:
   next_start_time: '2017-11-06 06:00:00'
   slug: d30-50k-course
   organization_id: 15
+  concealed: 
 d30_12m_course:
   id: 27
   name: D30 12M Course
@@ -66,6 +71,7 @@ d30_12m_course:
   next_start_time: 
   slug: d30-12m-course
   organization_id: 15
+  concealed: 
 sum_100k_course:
   id: 31
   name: SUM 100K Course
@@ -77,6 +83,7 @@ sum_100k_course:
   next_start_time: 
   slug: sum-100k-course
   organization_id: 15
+  concealed: 
 sum_55k_course:
   id: 32
   name: SUM 55K Course
@@ -88,3 +95,4 @@ sum_55k_course:
   next_start_time: 
   slug: sum-55k-course
   organization_id: 15
+  concealed: 

--- a/spec/fixtures/efforts.yml
+++ b/spec/fixtures/efforts.yml
@@ -28,6 +28,7 @@ hardrock_2015_tuan_jacobs:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_erich_larson:
   id: 8
   event_id: 4
@@ -57,6 +58,7 @@ hardrock_2015_erich_larson:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_leif_carter:
   id: 15
   event_id: 4
@@ -86,6 +88,7 @@ hardrock_2015_leif_carter:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_carmine_adams:
   id: 20
   event_id: 4
@@ -115,6 +118,7 @@ hardrock_2015_carmine_adams:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_garry_kuhlman:
   id: 24
   event_id: 4
@@ -144,6 +148,7 @@ hardrock_2015_garry_kuhlman:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_darius_jacobson:
   id: 25
   event_id: 4
@@ -173,6 +178,7 @@ hardrock_2015_darius_jacobson:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_santa_green:
   id: 29
   event_id: 4
@@ -202,6 +208,7 @@ hardrock_2015_santa_green:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_gilberto_mckenzie:
   id: 31
   event_id: 4
@@ -231,6 +238,7 @@ hardrock_2015_gilberto_mckenzie:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_vince_willms:
   id: 47
   event_id: 4
@@ -260,6 +268,7 @@ hardrock_2015_vince_willms:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_cedric_windler:
   id: 50
   event_id: 4
@@ -289,6 +298,7 @@ hardrock_2015_cedric_windler:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_chris_rempel:
   id: 56
   event_id: 4
@@ -318,6 +328,7 @@ hardrock_2015_chris_rempel:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_robby_gerlach:
   id: 57
   event_id: 4
@@ -347,6 +358,7 @@ hardrock_2015_robby_gerlach:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_rachelle_eichmann:
   id: 59
   event_id: 4
@@ -376,6 +388,7 @@ hardrock_2015_rachelle_eichmann:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_elden_morissette:
   id: 61
   event_id: 4
@@ -405,6 +418,7 @@ hardrock_2015_elden_morissette:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_leroy_leffler:
   id: 63
   event_id: 4
@@ -434,6 +448,7 @@ hardrock_2015_leroy_leffler:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_samara_vandervort:
   id: 73
   event_id: 4
@@ -463,6 +478,7 @@ hardrock_2015_samara_vandervort:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_robt_wintheiser:
   id: 94
   event_id: 4
@@ -492,6 +508,7 @@ hardrock_2015_robt_wintheiser:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_demetrius_moen:
   id: 96
   event_id: 4
@@ -521,6 +538,7 @@ hardrock_2015_demetrius_moen:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_vern_buckridge:
   id: 105
   event_id: 4
@@ -550,6 +568,7 @@ hardrock_2015_vern_buckridge:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_donte_spencer:
   id: 112
   event_id: 4
@@ -579,6 +598,7 @@ hardrock_2015_donte_spencer:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_bruno_fadel:
   id: 116
   event_id: 4
@@ -608,6 +628,7 @@ hardrock_2015_bruno_fadel:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_gus_walker:
   id: 117
   event_id: 4
@@ -637,6 +658,7 @@ hardrock_2015_gus_walker:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_susanna_abshire:
   id: 121
   event_id: 4
@@ -666,6 +688,7 @@ hardrock_2015_susanna_abshire:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_leandro_cole:
   id: 125
   event_id: 4
@@ -695,6 +718,7 @@ hardrock_2015_leandro_cole:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_benedict_davis:
   id: 129
   event_id: 4
@@ -724,6 +748,7 @@ hardrock_2015_benedict_davis:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_raphael_swift:
   id: 136
   event_id: 4
@@ -753,6 +778,7 @@ hardrock_2015_raphael_swift:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_bad_status:
   id: 138
   event_id: 4
@@ -782,6 +808,7 @@ hardrock_2015_bad_status:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_irvin_harber:
   id: 141
   event_id: 4
@@ -811,6 +838,7 @@ hardrock_2015_irvin_harber:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_cassondra_nienow:
   id: 155
   event_id: 4
@@ -840,6 +868,7 @@ hardrock_2015_cassondra_nienow:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2015_donn_mckenzie:
   id: 158
   event_id: 4
@@ -869,6 +898,7 @@ hardrock_2015_donn_mckenzie:
   emergency_phone: 
   scheduled_start_time: '2015-07-10 12:00:00'
   topic_resource_key: 
+  comments: 
 ramble_finished_first:
   id: 1040
   event_id: 14
@@ -898,6 +928,7 @@ ramble_finished_first:
   emergency_phone: 
   scheduled_start_time: '2006-09-16 14:00:00'
   topic_resource_key: 
+  comments: 
 ramble_finished_second:
   id: 1048
   event_id: 14
@@ -927,6 +958,7 @@ ramble_finished_second:
   emergency_phone: 
   scheduled_start_time: '2006-09-16 14:00:00'
   topic_resource_key: 
+  comments: 
 ramble_start_only:
   id: 1051
   event_id: 14
@@ -956,6 +988,7 @@ ramble_start_only:
   emergency_phone: 
   scheduled_start_time: '2006-09-16 14:00:00'
   topic_resource_key: 
+  comments: 
 ramble_not_started:
   id: 1061
   event_id: 14
@@ -985,6 +1018,7 @@ ramble_not_started:
   emergency_phone: 
   scheduled_start_time: '2006-09-16 14:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_finished_first:
   id: 4172
   event_id: 17
@@ -1014,6 +1048,7 @@ hardrock_2014_finished_first:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_finished_with_stop:
   id: 4173
   event_id: 17
@@ -1043,6 +1078,7 @@ hardrock_2014_finished_with_stop:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_finished_without_stop:
   id: 4174
   event_id: 17
@@ -1072,6 +1108,7 @@ hardrock_2014_finished_without_stop:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_claudio_wunsch:
   id: 4192
   event_id: 17
@@ -1101,6 +1138,7 @@ hardrock_2014_claudio_wunsch:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_paul_predovic:
   id: 4199
   event_id: 17
@@ -1130,6 +1168,7 @@ hardrock_2014_paul_predovic:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_keith_metz:
   id: 4206
   event_id: 17
@@ -1159,6 +1198,7 @@ hardrock_2014_keith_metz:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_major_green:
   id: 4207
   event_id: 17
@@ -1188,6 +1228,7 @@ hardrock_2014_major_green:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_humberto_adams:
   id: 4221
   event_id: 17
@@ -1217,6 +1258,7 @@ hardrock_2014_humberto_adams:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_omer_yundt:
   id: 4246
   event_id: 17
@@ -1246,6 +1288,7 @@ hardrock_2014_omer_yundt:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_pat_schaden:
   id: 4247
   event_id: 17
@@ -1275,6 +1318,7 @@ hardrock_2014_pat_schaden:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_clarence_goyette:
   id: 4249
   event_id: 17
@@ -1304,6 +1348,7 @@ hardrock_2014_clarence_goyette:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_irvin_corkery:
   id: 4251
   event_id: 17
@@ -1333,6 +1378,7 @@ hardrock_2014_irvin_corkery:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_willis_murray:
   id: 4253
   event_id: 17
@@ -1362,6 +1408,7 @@ hardrock_2014_willis_murray:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_ken_bradtke:
   id: 4256
   event_id: 17
@@ -1391,6 +1438,7 @@ hardrock_2014_ken_bradtke:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_progress_sherman:
   id: 4277
   event_id: 17
@@ -1420,6 +1468,7 @@ hardrock_2014_progress_sherman:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_multiple_stops:
   id: 4293
   event_id: 17
@@ -1449,6 +1498,7 @@ hardrock_2014_multiple_stops:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_without_start:
   id: 4294
   event_id: 17
@@ -1478,6 +1528,7 @@ hardrock_2014_without_start:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_drop_ouray:
   id: 4295
   event_id: 17
@@ -1507,6 +1558,7 @@ hardrock_2014_drop_ouray:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2014_not_started:
   id: 4302
   event_id: 17
@@ -1536,6 +1588,7 @@ hardrock_2014_not_started:
   emergency_phone: 
   scheduled_start_time: '2014-07-11 12:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2016_finished_first:
   id: 6518
   event_id: 34
@@ -1565,6 +1618,7 @@ rufa_2016_finished_first:
   emergency_phone: 
   scheduled_start_time: '2016-02-13 13:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2016_finished_second:
   id: 6520
   event_id: 34
@@ -1594,6 +1648,7 @@ rufa_2016_finished_second:
   emergency_phone: 
   scheduled_start_time: '2016-02-13 13:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2016_progress_lap1:
   id: 6560
   event_id: 34
@@ -1623,6 +1678,7 @@ rufa_2016_progress_lap1:
   emergency_phone: 
   scheduled_start_time: '2016-02-13 13:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2016_not_started:
   id: 6561
   event_id: 34
@@ -1652,6 +1708,7 @@ rufa_2016_not_started:
   emergency_phone: 
   scheduled_start_time: '2016-02-13 15:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2017_24h_finished_first:
   id: 6693
   event_id: 36
@@ -1681,6 +1738,7 @@ rufa_2017_24h_finished_first:
   emergency_phone: 
   scheduled_start_time: '2017-02-11 13:10:00'
   topic_resource_key: 
+  comments: 
 rufa_2017_24h_progress_lap6:
   id: 6695
   event_id: 36
@@ -1710,6 +1768,7 @@ rufa_2017_24h_progress_lap6:
   emergency_phone: 
   scheduled_start_time: '2017-02-11 15:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2017_24h_multiple_stops:
   id: 6756
   event_id: 36
@@ -1739,6 +1798,7 @@ rufa_2017_24h_multiple_stops:
   emergency_phone: 
   scheduled_start_time: '2017-02-11 15:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2017_24h_finished_last:
   id: 6780
   event_id: 36
@@ -1768,6 +1828,7 @@ rufa_2017_24h_finished_last:
   emergency_phone: 
   scheduled_start_time: '2017-02-11 15:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2017_24h_not_started:
   id: 6782
   event_id: 36
@@ -1797,6 +1858,7 @@ rufa_2017_24h_not_started:
   emergency_phone: 
   scheduled_start_time: '2017-02-12 01:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2017_24h_progress_lap1:
   id: 6805
   event_id: 36
@@ -1826,6 +1888,7 @@ rufa_2017_24h_progress_lap1:
   emergency_phone: 
   scheduled_start_time: '2017-02-11 16:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_lavon_paucek:
   id: 7270
   event_id: 37
@@ -1855,6 +1918,7 @@ hardrock_2016_lavon_paucek:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_vesta_borer:
   id: 7284
   event_id: 37
@@ -1884,6 +1948,7 @@ hardrock_2016_vesta_borer:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_kory_kulas:
   id: 7289
   event_id: 37
@@ -1913,6 +1978,7 @@ hardrock_2016_kory_kulas:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_shad_hirthe:
   id: 7297
   event_id: 37
@@ -1942,6 +2008,7 @@ hardrock_2016_shad_hirthe:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_douglas_vandervort:
   id: 7302
   event_id: 37
@@ -1971,6 +2038,7 @@ hardrock_2016_douglas_vandervort:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_missing_telluride_out:
   id: 7308
   event_id: 37
@@ -2000,6 +2068,7 @@ hardrock_2016_missing_telluride_out:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_junior_lesch:
   id: 7311
   event_id: 37
@@ -2029,6 +2098,7 @@ hardrock_2016_junior_lesch:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_eddy_goldner:
   id: 7315
   event_id: 37
@@ -2058,6 +2128,7 @@ hardrock_2016_eddy_goldner:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_progress_sherman:
   id: 7328
   event_id: 37
@@ -2087,6 +2158,7 @@ hardrock_2016_progress_sherman:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_benito_moen:
   id: 7337
   event_id: 37
@@ -2116,6 +2188,7 @@ hardrock_2016_benito_moen:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_kendall_koch:
   id: 7340
   event_id: 37
@@ -2145,6 +2218,7 @@ hardrock_2016_kendall_koch:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_charlie_mueller:
   id: 7343
   event_id: 37
@@ -2174,6 +2248,7 @@ hardrock_2016_charlie_mueller:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_brinda_fisher:
   id: 7376
   event_id: 37
@@ -2203,6 +2278,7 @@ hardrock_2016_brinda_fisher:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_rene_mclaughlin:
   id: 7380
   event_id: 37
@@ -2232,6 +2308,7 @@ hardrock_2016_rene_mclaughlin:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_dropped_grouse:
   id: 7396
   event_id: 37
@@ -2261,6 +2338,7 @@ hardrock_2016_dropped_grouse:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_mervin_smitham:
   id: 7400
   event_id: 37
@@ -2290,6 +2368,7 @@ hardrock_2016_mervin_smitham:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_rhett_auer:
   id: 7404
   event_id: 37
@@ -2319,6 +2398,7 @@ hardrock_2016_rhett_auer:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_hoyt_macejkovic:
   id: 7407
   event_id: 37
@@ -2348,6 +2428,7 @@ hardrock_2016_hoyt_macejkovic:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 hardrock_2016_start_only:
   id: 7411
   event_id: 37
@@ -2377,6 +2458,7 @@ hardrock_2016_start_only:
   emergency_phone: 
   scheduled_start_time: '2016-07-15 12:00:00'
   topic_resource_key: 
+  comments: 
 ggd30_50k_finished_first:
   id: 15626
   event_id: 48
@@ -2406,6 +2488,7 @@ ggd30_50k_finished_first:
   emergency_phone: 
   scheduled_start_time: '2017-06-03 13:00:00'
   topic_resource_key: 
+  comments: 
 ggd30_50k_bad_finish:
   id: 15664
   event_id: 48
@@ -2435,6 +2518,7 @@ ggd30_50k_bad_finish:
   emergency_phone: 
   scheduled_start_time: '2017-06-03 13:00:00'
   topic_resource_key: 
+  comments: 
 ggd30_50k_progress_aid4:
   id: 15891
   event_id: 48
@@ -2464,6 +2548,7 @@ ggd30_50k_progress_aid4:
   emergency_phone: 
   scheduled_start_time: '2017-06-03 13:00:00'
   topic_resource_key: 
+  comments: 
 ggd30_50k_progress_aid3:
   id: 15901
   event_id: 48
@@ -2493,6 +2578,7 @@ ggd30_50k_progress_aid3:
   emergency_phone: 
   scheduled_start_time: '2017-06-03 13:00:00'
   topic_resource_key: 
+  comments: 
 ggd30_50k_drop_aid4:
   id: 15931
   event_id: 48
@@ -2522,6 +2608,7 @@ ggd30_50k_drop_aid4:
   emergency_phone: 
   scheduled_start_time: '2017-06-03 13:00:00'
   topic_resource_key: 
+  comments: 
 ggd30_50k_start_only:
   id: 16023
   event_id: 48
@@ -2551,6 +2638,7 @@ ggd30_50k_start_only:
   emergency_phone: 
   scheduled_start_time: '2017-06-03 13:00:00'
   topic_resource_key: 
+  comments: 
 ggd30_50k_not_started:
   id: 16032
   event_id: 48
@@ -2580,6 +2668,7 @@ ggd30_50k_not_started:
   emergency_phone: 
   scheduled_start_time: '2017-06-03 13:00:00'
   topic_resource_key: 
+  comments: 
 ggd30_12m_start_only:
   id: 16094
   event_id: 49
@@ -2609,6 +2698,7 @@ ggd30_12m_start_only:
   emergency_phone: 
   scheduled_start_time: '2017-06-03 16:00:00'
   topic_resource_key: 
+  comments: 
 ggd30_12m_finished_second:
   id: 16107
   event_id: 49
@@ -2638,6 +2728,7 @@ ggd30_12m_finished_second:
   emergency_phone: 
   scheduled_start_time: '2017-06-03 16:00:00'
   topic_resource_key: 
+  comments: 
 ggd30_12m_finished_first:
   id: 16173
   event_id: 49
@@ -2667,6 +2758,7 @@ ggd30_12m_finished_first:
   emergency_phone: 
   scheduled_start_time: '2017-06-03 16:00:00'
   topic_resource_key: 
+  comments: 
 ggd30_12m_not_started:
   id: 16209
   event_id: 49
@@ -2696,6 +2788,7 @@ ggd30_12m_not_started:
   emergency_phone: 
   scheduled_start_time: '2017-06-03 16:00:00'
   topic_resource_key: 
+  comments: 
 sum_55k_finished_first:
   id: 16227
   event_id: 57
@@ -2725,6 +2818,7 @@ sum_55k_finished_first:
   emergency_phone: 
   scheduled_start_time: '2017-10-07 15:00:00'
   topic_resource_key: 
+  comments: 
 sum_55k_finished_second:
   id: 16229
   event_id: 57
@@ -2754,6 +2848,7 @@ sum_55k_finished_second:
   emergency_phone: 
   scheduled_start_time: '2017-10-07 15:00:00'
   topic_resource_key: 
+  comments: 
 sum_55k_not_started:
   id: 16242
   event_id: 57
@@ -2783,6 +2878,7 @@ sum_55k_not_started:
   emergency_phone: 
   scheduled_start_time: '2017-10-07 15:00:00'
   topic_resource_key: 
+  comments: 
 sum_55k_progress_rolling:
   id: 16244
   event_id: 57
@@ -2812,6 +2908,7 @@ sum_55k_progress_rolling:
   emergency_phone: 
   scheduled_start_time: '2017-10-07 15:00:00'
   topic_resource_key: 
+  comments: 
 sum_55k_drop_bandera:
   id: 16245
   event_id: 57
@@ -2841,6 +2938,7 @@ sum_55k_drop_bandera:
   emergency_phone: 
   scheduled_start_time: '2017-10-07 15:00:00'
   topic_resource_key: 
+  comments: 
 sum_55k_start_only:
   id: 16246
   event_id: 57
@@ -2870,6 +2968,7 @@ sum_55k_start_only:
   emergency_phone: 
   scheduled_start_time: '2017-10-07 15:00:00'
   topic_resource_key: 
+  comments: 
 sum_100k_drop_anvil:
   id: 16247
   event_id: 56
@@ -2899,6 +2998,7 @@ sum_100k_drop_anvil:
   emergency_phone: 
   scheduled_start_time: '2017-09-23 13:00:00'
   topic_resource_key: 
+  comments: 
 sum_100k_progress_cascade:
   id: 16248
   event_id: 56
@@ -2928,6 +3028,7 @@ sum_100k_progress_cascade:
   emergency_phone: 
   scheduled_start_time: 
   topic_resource_key: 
+  comments: 
 rufa_2017_12h_finished_first:
   id: 16643
   event_id: 70
@@ -2957,6 +3058,7 @@ rufa_2017_12h_finished_first:
   emergency_phone: 
   scheduled_start_time: '2017-02-11 14:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2017_12h_finished_lap6:
   id: 16648
   event_id: 70
@@ -2986,6 +3088,7 @@ rufa_2017_12h_finished_lap6:
   emergency_phone: 
   scheduled_start_time: '2017-02-11 14:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2017_12h_progress_lap5_partial:
   id: 16657
   event_id: 70
@@ -3015,6 +3118,7 @@ rufa_2017_12h_progress_lap5_partial:
   emergency_phone: 
   scheduled_start_time: '2017-02-11 14:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2017_12h_progress_lap2:
   id: 16663
   event_id: 70
@@ -3044,6 +3148,7 @@ rufa_2017_12h_progress_lap2:
   emergency_phone: 
   scheduled_start_time: '2017-02-11 14:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2017_12h_start_only:
   id: 16667
   event_id: 70
@@ -3073,6 +3178,7 @@ rufa_2017_12h_start_only:
   emergency_phone: 
   scheduled_start_time: '2017-02-11 14:00:00'
   topic_resource_key: 
+  comments: 
 rufa_2017_12h_not_started:
   id: 16673
   event_id: 70
@@ -3102,6 +3208,7 @@ rufa_2017_12h_not_started:
   emergency_phone: 
   scheduled_start_time: '2017-02-11 14:00:00'
   topic_resource_key: 
+  comments: 
 sum_100k_un_started:
   id: 16683
   event_id: 56
@@ -3131,6 +3238,7 @@ sum_100k_un_started:
   emergency_phone: 
   scheduled_start_time: '2017-09-23 13:00:00'
   topic_resource_key: 
+  comments: 
 sum_100k_on_dst_change:
   id: 16684
   event_id: 56
@@ -3160,6 +3268,7 @@ sum_100k_on_dst_change:
   emergency_phone: 
   scheduled_start_time: 
   topic_resource_key: 
+  comments: 
 sum_100k_across_dst_change:
   id: 16685
   event_id: 56
@@ -3189,6 +3298,7 @@ sum_100k_across_dst_change:
   emergency_phone: 
   scheduled_start_time: 
   topic_resource_key: 
+  comments: 
 ggd30_50k_finished_second:
   id: 16686
   event_id: 48
@@ -3218,6 +3328,7 @@ ggd30_50k_finished_second:
   emergency_phone: 
   scheduled_start_time: 
   topic_resource_key: 
+  comments: 
 ggd30_12m_series_finisher:
   id: 16687
   event_id: 49
@@ -3247,6 +3358,7 @@ ggd30_12m_series_finisher:
   emergency_phone: 
   scheduled_start_time: 
   topic_resource_key: 
+  comments: 
 sum_55k_series_finisher:
   id: 16688
   event_id: 57
@@ -3276,6 +3388,7 @@ sum_55k_series_finisher:
   emergency_phone: 
   scheduled_start_time: 
   topic_resource_key: 
+  comments: 
 sum_55k_slow_finisher:
   id: 16689
   event_id: 57
@@ -3305,6 +3418,7 @@ sum_55k_slow_finisher:
   emergency_phone: 
   scheduled_start_time: 
   topic_resource_key: 
+  comments: 
 ggd30_12m_slow_finisher:
   id: 16690
   event_id: 49
@@ -3334,3 +3448,4 @@ ggd30_12m_slow_finisher:
   emergency_phone: 
   scheduled_start_time: 
   topic_resource_key: 
+  comments: 

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -4,7 +4,7 @@ hardrock_2015:
   course_id: 4
   historical_name: Hardrock 2015
   created_at: '2016-04-16 19:25:07.717306'
-  updated_at: '2019-02-21 18:03:17.186915'
+  updated_at: '2020-08-08 19:04:59.836439'
   created_by: 1
   updated_by: 1
   start_time: '2015-07-10 12:00:00'
@@ -15,12 +15,13 @@ hardrock_2015:
   short_name: 
   results_template_id: 7
   efforts_count: 30
+  notice_text: 
 ramble:
   id: 14
   course_id: 9
   historical_name: Ramble
   created_at: '2016-05-08 07:14:16.23639'
-  updated_at: '2019-02-21 18:03:17.303974'
+  updated_at: '2020-08-08 19:04:59.844186'
   created_by: 1
   updated_by: 1
   start_time: '2006-09-16 14:00:00'
@@ -31,12 +32,13 @@ ramble:
   short_name: 
   results_template_id: 7
   efforts_count: 4
+  notice_text: 
 hardrock_2014:
   id: 17
   course_id: 12
   historical_name: Hardrock 2014
   created_at: '2016-05-23 01:05:15.602165'
-  updated_at: '2019-02-21 18:03:17.319242'
+  updated_at: '2020-08-08 19:04:59.845718'
   created_by: 1
   updated_by: 1
   start_time: '2014-07-11 12:00:00'
@@ -47,12 +49,13 @@ hardrock_2014:
   short_name: 
   results_template_id: 7
   efforts_count: 19
+  notice_text: 
 rufa_2016:
   id: 34
   course_id: 20
   historical_name: RUFA 2016
   created_at: '2017-01-28 13:22:25.985588'
-  updated_at: '2019-02-21 18:03:17.337365'
+  updated_at: '2020-08-08 19:04:59.847193'
   created_by: 1
   updated_by: 1
   start_time: '2016-02-13 13:00:00'
@@ -63,12 +66,13 @@ rufa_2016:
   short_name: 
   results_template_id: 7
   efforts_count: 4
+  notice_text: 
 rufa_2017_24h:
   id: 36
   course_id: 20
   historical_name: RUFA 2017 24H
   created_at: '2017-03-28 07:18:29.860735'
-  updated_at: '2019-02-21 18:03:17.353386'
+  updated_at: '2020-08-08 19:04:59.848674'
   created_by: 1
   updated_by: 1
   start_time: '2017-02-11 13:00:00'
@@ -79,12 +83,13 @@ rufa_2017_24h:
   short_name: 24H
   results_template_id: 7
   efforts_count: 6
+  notice_text: 
 hardrock_2016:
   id: 37
   course_id: 12
   historical_name: Hardrock 2016
   created_at: '2017-04-18 08:19:16.928331'
-  updated_at: '2019-02-21 18:03:17.374999'
+  updated_at: '2020-08-08 19:04:59.850133'
   created_by: 1
   updated_by: 1
   start_time: '2016-07-15 12:00:00'
@@ -95,12 +100,13 @@ hardrock_2016:
   short_name: 
   results_template_id: 7
   efforts_count: 19
+  notice_text: 
 ggd30_50k:
   id: 48
   course_id: 26
   historical_name: GGD30 50K
   created_at: '2017-05-28 13:58:46.392428'
-  updated_at: '2019-02-21 18:03:17.390583'
+  updated_at: '2020-08-08 19:04:59.851567'
   created_by: 1
   updated_by: 1
   start_time: '2017-06-04 01:00:00'
@@ -111,12 +117,13 @@ ggd30_50k:
   short_name: 50K
   results_template_id: 7
   efforts_count: 8
+  notice_text: 
 ggd30_12m:
   id: 49
   course_id: 27
   historical_name: GGD30 12M
   created_at: '2017-06-09 09:51:15.491594'
-  updated_at: '2019-02-21 18:03:17.407428'
+  updated_at: '2020-08-08 19:04:59.852935'
   created_by: 1
   updated_by: 1
   start_time: '2017-06-04 02:00:00'
@@ -127,12 +134,13 @@ ggd30_12m:
   short_name: 12-miler
   results_template_id: 7
   efforts_count: 6
+  notice_text: 
 sum_100k:
   id: 56
   course_id: 31
   historical_name: SUM 100K
   created_at: '2018-01-18 05:09:16.764958'
-  updated_at: '2019-02-21 18:03:17.425166'
+  updated_at: '2020-08-08 19:04:59.854183'
   created_by: 1
   updated_by: 1
   start_time: '2017-09-23 13:00:00'
@@ -143,12 +151,13 @@ sum_100k:
   short_name: 100K
   results_template_id: 7
   efforts_count: 5
+  notice_text: 
 sum_55k:
   id: 57
   course_id: 32
   historical_name: SUM 55K
   created_at: '2018-01-18 05:15:20.769855'
-  updated_at: '2019-02-21 18:03:17.46438'
+  updated_at: '2020-08-08 19:04:59.856993'
   created_by: 1
   updated_by: 1
   start_time: '2017-09-23 15:00:00'
@@ -159,12 +168,13 @@ sum_55k:
   short_name: 55K
   results_template_id: 3
   efforts_count: 8
+  notice_text: 
 rufa_2017_12h:
   id: 70
   course_id: 20
   historical_name: RUFA 2017 12H
   created_at: '2019-01-30 17:38:14.220608'
-  updated_at: '2019-02-21 18:03:17.484641'
+  updated_at: '2020-08-08 19:04:59.858665'
   created_by: 1
   updated_by: 1
   start_time: '2017-02-11 14:00:00'
@@ -175,3 +185,4 @@ rufa_2017_12h:
   short_name: 12H
   results_template_id: 7
   efforts_count: 6
+  notice_text: 

--- a/spec/fixtures/raw_times.yml
+++ b/spec/fixtures/raw_times.yml
@@ -22,6 +22,8 @@ raw_time_49:
   sortable_bib_number: 102
   data_status: 
   matchable_bib_number: 102
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_50:
   id: 50
   event_group_id: 17
@@ -45,6 +47,8 @@ raw_time_50:
   sortable_bib_number: 103
   data_status: 
   matchable_bib_number: 103
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_67:
   id: 67
   event_group_id: 32
@@ -68,6 +72,8 @@ raw_time_67:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_68:
   id: 68
   event_group_id: 32
@@ -91,6 +97,8 @@ raw_time_68:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_69:
   id: 69
   event_group_id: 32
@@ -114,6 +122,8 @@ raw_time_69:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_70:
   id: 70
   event_group_id: 32
@@ -137,6 +147,8 @@ raw_time_70:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_73:
   id: 73
   event_group_id: 32
@@ -160,6 +172,8 @@ raw_time_73:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_74:
   id: 74
   event_group_id: 32
@@ -183,6 +197,8 @@ raw_time_74:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_75:
   id: 75
   event_group_id: 32
@@ -206,6 +222,8 @@ raw_time_75:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_76:
   id: 76
   event_group_id: 32
@@ -229,6 +247,8 @@ raw_time_76:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_77:
   id: 77
   event_group_id: 32
@@ -252,6 +272,8 @@ raw_time_77:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_78:
   id: 78
   event_group_id: 32
@@ -275,6 +297,8 @@ raw_time_78:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_79:
   id: 79
   event_group_id: 32
@@ -298,6 +322,8 @@ raw_time_79:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_80:
   id: 80
   event_group_id: 32
@@ -321,6 +347,8 @@ raw_time_80:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_81:
   id: 81
   event_group_id: 32
@@ -344,6 +372,8 @@ raw_time_81:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_82:
   id: 82
   event_group_id: 32
@@ -367,6 +397,8 @@ raw_time_82:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_83:
   id: 83
   event_group_id: 32
@@ -390,6 +422,8 @@ raw_time_83:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_84:
   id: 84
   event_group_id: 32
@@ -413,6 +447,8 @@ raw_time_84:
   sortable_bib_number: 101
   data_status: 
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_85:
   id: 85
   event_group_id: 32
@@ -436,6 +472,8 @@ raw_time_85:
   sortable_bib_number: 101
   data_status: 
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_86:
   id: 86
   event_group_id: 32
@@ -459,6 +497,8 @@ raw_time_86:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_87:
   id: 87
   event_group_id: 32
@@ -482,6 +522,8 @@ raw_time_87:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_88:
   id: 88
   event_group_id: 32
@@ -505,6 +547,8 @@ raw_time_88:
   sortable_bib_number: 999
   data_status: 
   matchable_bib_number: 999
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_89:
   id: 89
   event_group_id: 32
@@ -528,6 +572,8 @@ raw_time_89:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_91:
   id: 91
   event_group_id: 32
@@ -551,6 +597,8 @@ raw_time_91:
   sortable_bib_number: 777
   data_status: 
   matchable_bib_number: 777
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_92:
   id: 92
   event_group_id: 32
@@ -574,6 +622,8 @@ raw_time_92:
   sortable_bib_number: 777
   data_status: 
   matchable_bib_number: 777
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_176:
   id: 176
   event_group_id: 32
@@ -597,6 +647,8 @@ raw_time_176:
   sortable_bib_number: 130
   data_status: 
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_177:
   id: 177
   event_group_id: 32
@@ -620,6 +672,8 @@ raw_time_177:
   sortable_bib_number: 130
   data_status: 0
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_178:
   id: 178
   event_group_id: 32
@@ -643,6 +697,8 @@ raw_time_178:
   sortable_bib_number: 130
   data_status: 0
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1100:
   id: 1100
   event_group_id: 32
@@ -666,6 +722,8 @@ raw_time_1100:
   sortable_bib_number: 130
   data_status: 2
   matchable_bib_number: 130
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1106:
   id: 1106
   event_group_id: 32
@@ -689,6 +747,8 @@ raw_time_1106:
   sortable_bib_number: 103
   data_status: 2
   matchable_bib_number: 103
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1110:
   id: 1110
   event_group_id: 32
@@ -712,6 +772,8 @@ raw_time_1110:
   sortable_bib_number: 103
   data_status: 2
   matchable_bib_number: 103
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1111:
   id: 1111
   event_group_id: 32
@@ -735,6 +797,8 @@ raw_time_1111:
   sortable_bib_number: 103
   data_status: 2
   matchable_bib_number: 103
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1117:
   id: 1117
   event_group_id: 32
@@ -758,6 +822,8 @@ raw_time_1117:
   sortable_bib_number: 103
   data_status: 2
   matchable_bib_number: 103
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1122:
   id: 1122
   event_group_id: 32
@@ -781,6 +847,8 @@ raw_time_1122:
   sortable_bib_number: 101
   data_status: 2
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1123:
   id: 1123
   event_group_id: 32
@@ -804,6 +872,8 @@ raw_time_1123:
   sortable_bib_number: 101
   data_status: 2
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1124:
   id: 1124
   event_group_id: 32
@@ -827,6 +897,8 @@ raw_time_1124:
   sortable_bib_number: 101
   data_status: 2
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1125:
   id: 1125
   event_group_id: 32
@@ -850,6 +922,8 @@ raw_time_1125:
   sortable_bib_number: 101
   data_status: 2
   matchable_bib_number: 101
+  disassociated_from_effort: 
+  entered_lap: 
 raw_time_1126:
   id: 1126
   event_group_id: 32
@@ -873,3 +947,5 @@ raw_time_1126:
   sortable_bib_number: 114
   data_status: 2
   matchable_bib_number: 114
+  disassociated_from_effort: 
+  entered_lap: 

--- a/spec/fixtures/split_times.yml
+++ b/spec/fixtures/split_times.yml
@@ -14,6 +14,7 @@ hardrock_2015_tuan_jacobs_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 13:38:00'
+  elapsed_seconds: 5880.0
 hardrock_2015_tuan_jacobs_cunningham_out_1:
   id: 15
   effort_id: 7
@@ -29,6 +30,7 @@ hardrock_2015_tuan_jacobs_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 13:38:00'
+  elapsed_seconds: 5880.0
 hardrock_2015_tuan_jacobs_sherman_in_1:
   id: 20
   effort_id: 7
@@ -44,6 +46,7 @@ hardrock_2015_tuan_jacobs_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 17:38:00'
+  elapsed_seconds: 20280.0
 hardrock_2015_tuan_jacobs_sherman_out_1:
   id: 21
   effort_id: 7
@@ -59,6 +62,7 @@ hardrock_2015_tuan_jacobs_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 17:39:00'
+  elapsed_seconds: 20340.0
 hardrock_2015_tuan_jacobs_grouse_in_1:
   id: 24
   effort_id: 7
@@ -74,6 +78,7 @@ hardrock_2015_tuan_jacobs_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:52:00'
+  elapsed_seconds: 31920.0
 hardrock_2015_tuan_jacobs_grouse_out_1:
   id: 25
   effort_id: 7
@@ -89,6 +94,7 @@ hardrock_2015_tuan_jacobs_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:57:00'
+  elapsed_seconds: 32220.0
 hardrock_2015_tuan_jacobs_ouray_in_1:
   id: 28
   effort_id: 7
@@ -104,6 +110,7 @@ hardrock_2015_tuan_jacobs_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:39:00'
+  elapsed_seconds: 41940.0
 hardrock_2015_tuan_jacobs_ouray_out_1:
   id: 29
   effort_id: 7
@@ -119,6 +126,7 @@ hardrock_2015_tuan_jacobs_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:45:00'
+  elapsed_seconds: 42300.0
 hardrock_2015_tuan_jacobs_telluride_in_1:
   id: 34
   effort_id: 7
@@ -134,6 +142,7 @@ hardrock_2015_tuan_jacobs_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 03:12:00'
+  elapsed_seconds: 54720.0
 hardrock_2015_tuan_jacobs_telluride_out_1:
   id: 35
   effort_id: 7
@@ -149,6 +158,7 @@ hardrock_2015_tuan_jacobs_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 03:22:00'
+  elapsed_seconds: 55320.0
 hardrock_2015_tuan_jacobs_putnam_in_1:
   id: 40
   effort_id: 7
@@ -164,6 +174,7 @@ hardrock_2015_tuan_jacobs_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 10:06:00'
+  elapsed_seconds: 79560.0
 hardrock_2015_tuan_jacobs_putnam_out_1:
   id: 41
   effort_id: 7
@@ -179,6 +190,7 @@ hardrock_2015_tuan_jacobs_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 10:06:00'
+  elapsed_seconds: 79560.0
 hardrock_2015_tuan_jacobs_finish_1:
   id: 42
   effort_id: 7
@@ -194,6 +206,7 @@ hardrock_2015_tuan_jacobs_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-11 11:13:00'
+  elapsed_seconds: 83580.0
 hardrock_2015_erich_larson_start_1:
   id: 43
   effort_id: 8
@@ -209,6 +222,7 @@ hardrock_2015_erich_larson_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:11'
+  elapsed_seconds: 0.0
 hardrock_2015_erich_larson_cunningham_in_1:
   id: 44
   effort_id: 8
@@ -224,6 +238,7 @@ hardrock_2015_erich_larson_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:00:22'
+  elapsed_seconds: 7211.0
 hardrock_2015_erich_larson_cunningham_out_1:
   id: 45
   effort_id: 8
@@ -239,6 +254,7 @@ hardrock_2015_erich_larson_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:01:33'
+  elapsed_seconds: 7282.0
 hardrock_2015_erich_larson_sherman_in_1:
   id: 50
   effort_id: 8
@@ -254,6 +270,7 @@ hardrock_2015_erich_larson_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 18:06:50'
+  elapsed_seconds: 21999.0
 hardrock_2015_erich_larson_sherman_out_1:
   id: 51
   effort_id: 8
@@ -269,6 +286,7 @@ hardrock_2015_erich_larson_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 18:07:00'
+  elapsed_seconds: 22009.0
 hardrock_2015_erich_larson_grouse_in_1:
   id: 54
   effort_id: 8
@@ -284,6 +302,7 @@ hardrock_2015_erich_larson_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 21:21:00'
+  elapsed_seconds: 33649.0
 hardrock_2015_erich_larson_grouse_out_1:
   id: 55
   effort_id: 8
@@ -299,6 +318,7 @@ hardrock_2015_erich_larson_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 21:24:59'
+  elapsed_seconds: 33888.0
 hardrock_2015_erich_larson_ouray_in_1:
   id: 58
   effort_id: 8
@@ -314,6 +334,7 @@ hardrock_2015_erich_larson_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:20:00'
+  elapsed_seconds: 44389.0
 hardrock_2015_erich_larson_ouray_out_1:
   id: 59
   effort_id: 8
@@ -329,6 +350,7 @@ hardrock_2015_erich_larson_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:24:00'
+  elapsed_seconds: 44629.0
 hardrock_2015_erich_larson_telluride_in_1:
   id: 64
   effort_id: 8
@@ -344,6 +366,7 @@ hardrock_2015_erich_larson_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:29:00'
+  elapsed_seconds: 59329.0
 hardrock_2015_erich_larson_telluride_out_1:
   id: 65
   effort_id: 8
@@ -359,6 +382,7 @@ hardrock_2015_erich_larson_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:33:03'
+  elapsed_seconds: 59572.0
 hardrock_2015_erich_larson_putnam_in_1:
   id: 70
   effort_id: 8
@@ -374,6 +398,7 @@ hardrock_2015_erich_larson_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 12:39:05'
+  elapsed_seconds: 88734.0
 hardrock_2015_erich_larson_putnam_out_1:
   id: 71
   effort_id: 8
@@ -389,6 +414,7 @@ hardrock_2015_erich_larson_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 12:39:07'
+  elapsed_seconds: 88736.0
 hardrock_2015_erich_larson_finish_1:
   id: 72
   effort_id: 8
@@ -404,6 +430,7 @@ hardrock_2015_erich_larson_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-11 13:45:09'
+  elapsed_seconds: 92698.0
 hardrock_2015_leif_carter_start_1:
   id: 253
   effort_id: 15
@@ -419,6 +446,7 @@ hardrock_2015_leif_carter_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_leif_carter_cunningham_in_1:
   id: 254
   effort_id: 15
@@ -434,6 +462,7 @@ hardrock_2015_leif_carter_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 13:53:00'
+  elapsed_seconds: 6780.0
 hardrock_2015_leif_carter_cunningham_out_1:
   id: 255
   effort_id: 15
@@ -449,6 +478,7 @@ hardrock_2015_leif_carter_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 13:53:00'
+  elapsed_seconds: 6780.0
 hardrock_2015_leif_carter_sherman_in_1:
   id: 260
   effort_id: 15
@@ -464,6 +494,7 @@ hardrock_2015_leif_carter_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 18:06:00'
+  elapsed_seconds: 21960.0
 hardrock_2015_leif_carter_sherman_out_1:
   id: 261
   effort_id: 15
@@ -479,6 +510,7 @@ hardrock_2015_leif_carter_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 18:08:00'
+  elapsed_seconds: 22080.0
 hardrock_2015_leif_carter_grouse_in_1:
   id: 264
   effort_id: 15
@@ -494,6 +526,7 @@ hardrock_2015_leif_carter_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 21:30:00'
+  elapsed_seconds: 34200.0
 hardrock_2015_leif_carter_grouse_out_1:
   id: 265
   effort_id: 15
@@ -509,6 +542,7 @@ hardrock_2015_leif_carter_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 21:36:00'
+  elapsed_seconds: 34560.0
 hardrock_2015_leif_carter_ouray_in_1:
   id: 268
   effort_id: 15
@@ -524,6 +558,7 @@ hardrock_2015_leif_carter_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:46:00'
+  elapsed_seconds: 45960.0
 hardrock_2015_leif_carter_ouray_out_1:
   id: 269
   effort_id: 15
@@ -539,6 +574,7 @@ hardrock_2015_leif_carter_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:46:00'
+  elapsed_seconds: 45960.0
 hardrock_2015_leif_carter_telluride_in_1:
   id: 274
   effort_id: 15
@@ -554,6 +590,7 @@ hardrock_2015_leif_carter_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:18:00'
+  elapsed_seconds: 62280.0
 hardrock_2015_leif_carter_telluride_out_1:
   id: 275
   effort_id: 15
@@ -569,6 +606,7 @@ hardrock_2015_leif_carter_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:24:00'
+  elapsed_seconds: 62640.0
 hardrock_2015_leif_carter_putnam_in_1:
   id: 280
   effort_id: 15
@@ -584,6 +622,7 @@ hardrock_2015_leif_carter_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 15:02:00'
+  elapsed_seconds: 97320.0
 hardrock_2015_leif_carter_putnam_out_1:
   id: 281
   effort_id: 15
@@ -599,6 +638,7 @@ hardrock_2015_leif_carter_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 15:06:00'
+  elapsed_seconds: 97560.0
 hardrock_2015_leif_carter_finish_1:
   id: 282
   effort_id: 15
@@ -614,6 +654,7 @@ hardrock_2015_leif_carter_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-11 16:54:00'
+  elapsed_seconds: 104040.0
 hardrock_2015_carmine_adams_start_1:
   id: 403
   effort_id: 20
@@ -629,6 +670,7 @@ hardrock_2015_carmine_adams_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_carmine_adams_cunningham_in_1:
   id: 404
   effort_id: 20
@@ -644,6 +686,7 @@ hardrock_2015_carmine_adams_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:22:00'
+  elapsed_seconds: 8520.0
 hardrock_2015_carmine_adams_cunningham_out_1:
   id: 405
   effort_id: 20
@@ -659,6 +702,7 @@ hardrock_2015_carmine_adams_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:22:00'
+  elapsed_seconds: 8520.0
 hardrock_2015_carmine_adams_sherman_in_1:
   id: 410
   effort_id: 20
@@ -674,6 +718,7 @@ hardrock_2015_carmine_adams_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:34:00'
+  elapsed_seconds: 27240.0
 hardrock_2015_carmine_adams_sherman_out_1:
   id: 411
   effort_id: 20
@@ -689,6 +734,7 @@ hardrock_2015_carmine_adams_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:40:00'
+  elapsed_seconds: 27600.0
 hardrock_2015_carmine_adams_grouse_in_1:
   id: 414
   effort_id: 20
@@ -704,6 +750,7 @@ hardrock_2015_carmine_adams_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:55:00'
+  elapsed_seconds: 42900.0
 hardrock_2015_carmine_adams_grouse_out_1:
   id: 415
   effort_id: 20
@@ -719,6 +766,7 @@ hardrock_2015_carmine_adams_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:00:00'
+  elapsed_seconds: 43200.0
 hardrock_2015_carmine_adams_ouray_in_1:
   id: 418
   effort_id: 20
@@ -734,6 +782,7 @@ hardrock_2015_carmine_adams_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 03:51:00'
+  elapsed_seconds: 57060.0
 hardrock_2015_carmine_adams_ouray_out_1:
   id: 419
   effort_id: 20
@@ -749,6 +798,7 @@ hardrock_2015_carmine_adams_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:00:00'
+  elapsed_seconds: 57600.0
 hardrock_2015_carmine_adams_telluride_in_1:
   id: 424
   effort_id: 20
@@ -764,6 +814,7 @@ hardrock_2015_carmine_adams_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 08:59:00'
+  elapsed_seconds: 75540.0
 hardrock_2015_carmine_adams_telluride_out_1:
   id: 425
   effort_id: 20
@@ -779,6 +830,7 @@ hardrock_2015_carmine_adams_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 09:09:00'
+  elapsed_seconds: 76140.0
 hardrock_2015_carmine_adams_putnam_in_1:
   id: 430
   effort_id: 20
@@ -794,6 +846,7 @@ hardrock_2015_carmine_adams_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 17:40:00'
+  elapsed_seconds: 106800.0
 hardrock_2015_carmine_adams_putnam_out_1:
   id: 431
   effort_id: 20
@@ -809,6 +862,7 @@ hardrock_2015_carmine_adams_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 17:40:00'
+  elapsed_seconds: 106800.0
 hardrock_2015_carmine_adams_finish_1:
   id: 432
   effort_id: 20
@@ -824,6 +878,7 @@ hardrock_2015_carmine_adams_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-11 18:57:00'
+  elapsed_seconds: 111420.0
 hardrock_2015_garry_kuhlman_start_1:
   id: 523
   effort_id: 24
@@ -839,6 +894,7 @@ hardrock_2015_garry_kuhlman_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_garry_kuhlman_cunningham_in_1:
   id: 524
   effort_id: 24
@@ -854,6 +910,7 @@ hardrock_2015_garry_kuhlman_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:30:00'
+  elapsed_seconds: 9000.0
 hardrock_2015_garry_kuhlman_cunningham_out_1:
   id: 525
   effort_id: 24
@@ -869,6 +926,7 @@ hardrock_2015_garry_kuhlman_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:30:00'
+  elapsed_seconds: 9000.0
 hardrock_2015_garry_kuhlman_sherman_in_1:
   id: 530
   effort_id: 24
@@ -884,6 +942,7 @@ hardrock_2015_garry_kuhlman_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:52:00'
+  elapsed_seconds: 28320.0
 hardrock_2015_garry_kuhlman_sherman_out_1:
   id: 531
   effort_id: 24
@@ -899,6 +958,7 @@ hardrock_2015_garry_kuhlman_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:58:00'
+  elapsed_seconds: 28680.0
 hardrock_2015_garry_kuhlman_grouse_in_1:
   id: 534
   effort_id: 24
@@ -914,6 +974,7 @@ hardrock_2015_garry_kuhlman_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:53:00'
+  elapsed_seconds: 42780.0
 hardrock_2015_garry_kuhlman_grouse_out_1:
   id: 535
   effort_id: 24
@@ -929,6 +990,7 @@ hardrock_2015_garry_kuhlman_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:56:00'
+  elapsed_seconds: 42960.0
 hardrock_2015_garry_kuhlman_ouray_in_1:
   id: 538
   effort_id: 24
@@ -944,6 +1006,7 @@ hardrock_2015_garry_kuhlman_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 03:42:00'
+  elapsed_seconds: 56520.0
 hardrock_2015_garry_kuhlman_ouray_out_1:
   id: 539
   effort_id: 24
@@ -959,6 +1022,7 @@ hardrock_2015_garry_kuhlman_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 03:51:00'
+  elapsed_seconds: 57060.0
 hardrock_2015_garry_kuhlman_telluride_in_1:
   id: 544
   effort_id: 24
@@ -974,6 +1038,7 @@ hardrock_2015_garry_kuhlman_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 08:59:00'
+  elapsed_seconds: 75540.0
 hardrock_2015_garry_kuhlman_telluride_out_1:
   id: 545
   effort_id: 24
@@ -989,6 +1054,7 @@ hardrock_2015_garry_kuhlman_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 09:04:00'
+  elapsed_seconds: 75840.0
 hardrock_2015_garry_kuhlman_putnam_in_1:
   id: 550
   effort_id: 24
@@ -1004,6 +1070,7 @@ hardrock_2015_garry_kuhlman_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 18:11:00'
+  elapsed_seconds: 108660.0
 hardrock_2015_garry_kuhlman_putnam_out_1:
   id: 551
   effort_id: 24
@@ -1019,6 +1086,7 @@ hardrock_2015_garry_kuhlman_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 18:11:00'
+  elapsed_seconds: 108660.0
 hardrock_2015_garry_kuhlman_finish_1:
   id: 552
   effort_id: 24
@@ -1034,6 +1102,7 @@ hardrock_2015_garry_kuhlman_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-11 19:39:00'
+  elapsed_seconds: 113940.0
 hardrock_2015_darius_jacobson_start_1:
   id: 553
   effort_id: 25
@@ -1049,6 +1118,7 @@ hardrock_2015_darius_jacobson_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_darius_jacobson_cunningham_in_1:
   id: 554
   effort_id: 25
@@ -1064,6 +1134,7 @@ hardrock_2015_darius_jacobson_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:18:00'
+  elapsed_seconds: 8280.0
 hardrock_2015_darius_jacobson_cunningham_out_1:
   id: 555
   effort_id: 25
@@ -1079,6 +1150,7 @@ hardrock_2015_darius_jacobson_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:18:00'
+  elapsed_seconds: 8280.0
 hardrock_2015_darius_jacobson_sherman_in_1:
   id: 560
   effort_id: 25
@@ -1094,6 +1166,7 @@ hardrock_2015_darius_jacobson_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:09:00'
+  elapsed_seconds: 25740.0
 hardrock_2015_darius_jacobson_sherman_out_1:
   id: 561
   effort_id: 25
@@ -1109,6 +1182,7 @@ hardrock_2015_darius_jacobson_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:18:00'
+  elapsed_seconds: 26280.0
 hardrock_2015_darius_jacobson_grouse_in_1:
   id: 564
   effort_id: 25
@@ -1124,6 +1198,7 @@ hardrock_2015_darius_jacobson_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:17:00'
+  elapsed_seconds: 40620.0
 hardrock_2015_darius_jacobson_grouse_out_1:
   id: 565
   effort_id: 25
@@ -1139,6 +1214,7 @@ hardrock_2015_darius_jacobson_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:34:00'
+  elapsed_seconds: 41640.0
 hardrock_2015_darius_jacobson_telluride_in_1:
   id: 574
   effort_id: 25
@@ -1154,6 +1230,7 @@ hardrock_2015_darius_jacobson_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 08:40:00'
+  elapsed_seconds: 74400.0
 hardrock_2015_darius_jacobson_telluride_out_1:
   id: 575
   effort_id: 25
@@ -1169,6 +1246,7 @@ hardrock_2015_darius_jacobson_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 08:54:00'
+  elapsed_seconds: 75240.0
 hardrock_2015_darius_jacobson_putnam_in_1:
   id: 580
   effort_id: 25
@@ -1184,6 +1262,7 @@ hardrock_2015_darius_jacobson_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 18:26:00'
+  elapsed_seconds: 109560.0
 hardrock_2015_darius_jacobson_putnam_out_1:
   id: 581
   effort_id: 25
@@ -1199,6 +1278,7 @@ hardrock_2015_darius_jacobson_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 18:27:00'
+  elapsed_seconds: 109620.0
 hardrock_2015_darius_jacobson_finish_1:
   id: 582
   effort_id: 25
@@ -1214,6 +1294,7 @@ hardrock_2015_darius_jacobson_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-11 19:43:00'
+  elapsed_seconds: 114180.0
 hardrock_2015_santa_green_start_1:
   id: 673
   effort_id: 29
@@ -1229,6 +1310,7 @@ hardrock_2015_santa_green_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_santa_green_cunningham_in_1:
   id: 674
   effort_id: 29
@@ -1244,6 +1326,7 @@ hardrock_2015_santa_green_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:24:00'
+  elapsed_seconds: 8640.0
 hardrock_2015_santa_green_cunningham_out_1:
   id: 675
   effort_id: 29
@@ -1259,6 +1342,7 @@ hardrock_2015_santa_green_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:24:00'
+  elapsed_seconds: 8640.0
 hardrock_2015_santa_green_sherman_in_1:
   id: 680
   effort_id: 29
@@ -1274,6 +1358,7 @@ hardrock_2015_santa_green_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:36:00'
+  elapsed_seconds: 27360.0
 hardrock_2015_santa_green_sherman_out_1:
   id: 681
   effort_id: 29
@@ -1289,6 +1374,7 @@ hardrock_2015_santa_green_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:42:00'
+  elapsed_seconds: 27720.0
 hardrock_2015_santa_green_grouse_in_1:
   id: 684
   effort_id: 29
@@ -1304,6 +1390,7 @@ hardrock_2015_santa_green_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:52:00'
+  elapsed_seconds: 42720.0
 hardrock_2015_santa_green_grouse_out_1:
   id: 685
   effort_id: 29
@@ -1319,6 +1406,7 @@ hardrock_2015_santa_green_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:52:00'
+  elapsed_seconds: 42720.0
 hardrock_2015_santa_green_ouray_in_1:
   id: 688
   effort_id: 29
@@ -1334,6 +1422,7 @@ hardrock_2015_santa_green_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:14:00'
+  elapsed_seconds: 58440.0
 hardrock_2015_santa_green_ouray_out_1:
   id: 689
   effort_id: 29
@@ -1349,6 +1438,7 @@ hardrock_2015_santa_green_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:27:00'
+  elapsed_seconds: 59220.0
 hardrock_2015_santa_green_telluride_in_1:
   id: 694
   effort_id: 29
@@ -1364,6 +1454,7 @@ hardrock_2015_santa_green_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 10:05:00'
+  elapsed_seconds: 79500.0
 hardrock_2015_santa_green_telluride_out_1:
   id: 695
   effort_id: 29
@@ -1379,6 +1470,7 @@ hardrock_2015_santa_green_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 10:14:00'
+  elapsed_seconds: 80040.0
 hardrock_2015_santa_green_putnam_in_1:
   id: 700
   effort_id: 29
@@ -1394,6 +1486,7 @@ hardrock_2015_santa_green_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 19:38:00'
+  elapsed_seconds: 113880.0
 hardrock_2015_santa_green_putnam_out_1:
   id: 701
   effort_id: 29
@@ -1409,6 +1502,7 @@ hardrock_2015_santa_green_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 19:43:00'
+  elapsed_seconds: 114180.0
 hardrock_2015_santa_green_finish_1:
   id: 702
   effort_id: 29
@@ -1424,6 +1518,7 @@ hardrock_2015_santa_green_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-11 21:22:00'
+  elapsed_seconds: 120120.0
 hardrock_2015_gilberto_mckenzie_start_1:
   id: 733
   effort_id: 31
@@ -1439,6 +1534,7 @@ hardrock_2015_gilberto_mckenzie_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_gilberto_mckenzie_cunningham_in_1:
   id: 734
   effort_id: 31
@@ -1454,6 +1550,7 @@ hardrock_2015_gilberto_mckenzie_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:24:00'
+  elapsed_seconds: 8640.0
 hardrock_2015_gilberto_mckenzie_cunningham_out_1:
   id: 735
   effort_id: 31
@@ -1469,6 +1566,7 @@ hardrock_2015_gilberto_mckenzie_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:24:00'
+  elapsed_seconds: 8640.0
 hardrock_2015_gilberto_mckenzie_sherman_in_1:
   id: 740
   effort_id: 31
@@ -1484,6 +1582,7 @@ hardrock_2015_gilberto_mckenzie_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:56:00'
+  elapsed_seconds: 28560.0
 hardrock_2015_gilberto_mckenzie_sherman_out_1:
   id: 741
   effort_id: 31
@@ -1499,6 +1598,7 @@ hardrock_2015_gilberto_mckenzie_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:02:00'
+  elapsed_seconds: 28920.0
 hardrock_2015_gilberto_mckenzie_grouse_in_1:
   id: 744
   effort_id: 31
@@ -1514,6 +1614,7 @@ hardrock_2015_gilberto_mckenzie_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:58:00'
+  elapsed_seconds: 46680.0
 hardrock_2015_gilberto_mckenzie_grouse_out_1:
   id: 745
   effort_id: 31
@@ -1529,6 +1630,7 @@ hardrock_2015_gilberto_mckenzie_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 01:12:00'
+  elapsed_seconds: 47520.0
 hardrock_2015_gilberto_mckenzie_ouray_in_1:
   id: 748
   effort_id: 31
@@ -1544,6 +1646,7 @@ hardrock_2015_gilberto_mckenzie_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:59:00'
+  elapsed_seconds: 64740.0
 hardrock_2015_gilberto_mckenzie_ouray_out_1:
   id: 749
   effort_id: 31
@@ -1559,6 +1662,7 @@ hardrock_2015_gilberto_mckenzie_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:09:00'
+  elapsed_seconds: 65340.0
 hardrock_2015_gilberto_mckenzie_telluride_in_1:
   id: 754
   effort_id: 31
@@ -1574,6 +1678,7 @@ hardrock_2015_gilberto_mckenzie_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 11:33:00'
+  elapsed_seconds: 84780.0
 hardrock_2015_gilberto_mckenzie_telluride_out_1:
   id: 755
   effort_id: 31
@@ -1589,6 +1694,7 @@ hardrock_2015_gilberto_mckenzie_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 11:45:00'
+  elapsed_seconds: 85500.0
 hardrock_2015_gilberto_mckenzie_putnam_in_1:
   id: 760
   effort_id: 31
@@ -1604,6 +1710,7 @@ hardrock_2015_gilberto_mckenzie_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 21:46:00'
+  elapsed_seconds: 121560.0
 hardrock_2015_gilberto_mckenzie_putnam_out_1:
   id: 761
   effort_id: 31
@@ -1619,6 +1726,7 @@ hardrock_2015_gilberto_mckenzie_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 21:46:00'
+  elapsed_seconds: 121560.0
 hardrock_2015_gilberto_mckenzie_finish_1:
   id: 762
   effort_id: 31
@@ -1634,6 +1742,7 @@ hardrock_2015_gilberto_mckenzie_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-11 23:18:00'
+  elapsed_seconds: 127080.0
 hardrock_2015_vince_willms_start_1:
   id: 1213
   effort_id: 47
@@ -1649,6 +1758,7 @@ hardrock_2015_vince_willms_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_vince_willms_cunningham_in_1:
   id: 1214
   effort_id: 47
@@ -1664,6 +1774,7 @@ hardrock_2015_vince_willms_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:24:00'
+  elapsed_seconds: 8640.0
 hardrock_2015_vince_willms_cunningham_out_1:
   id: 1215
   effort_id: 47
@@ -1679,6 +1790,7 @@ hardrock_2015_vince_willms_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:24:00'
+  elapsed_seconds: 8640.0
 hardrock_2015_vince_willms_sherman_in_1:
   id: 1220
   effort_id: 47
@@ -1694,6 +1806,7 @@ hardrock_2015_vince_willms_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:47:00'
+  elapsed_seconds: 28020.0
 hardrock_2015_vince_willms_sherman_out_1:
   id: 1221
   effort_id: 47
@@ -1709,6 +1822,7 @@ hardrock_2015_vince_willms_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:59:00'
+  elapsed_seconds: 28740.0
 hardrock_2015_vince_willms_grouse_in_1:
   id: 1224
   effort_id: 47
@@ -1724,6 +1838,7 @@ hardrock_2015_vince_willms_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:58:00'
+  elapsed_seconds: 43080.0
 hardrock_2015_vince_willms_grouse_out_1:
   id: 1225
   effort_id: 47
@@ -1739,6 +1854,7 @@ hardrock_2015_vince_willms_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:06:00'
+  elapsed_seconds: 43560.0
 hardrock_2015_vince_willms_ouray_in_1:
   id: 1228
   effort_id: 47
@@ -1754,6 +1870,7 @@ hardrock_2015_vince_willms_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:34:00'
+  elapsed_seconds: 59640.0
 hardrock_2015_vince_willms_ouray_out_1:
   id: 1229
   effort_id: 47
@@ -1769,6 +1886,7 @@ hardrock_2015_vince_willms_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:58:00'
+  elapsed_seconds: 61080.0
 hardrock_2015_vince_willms_telluride_in_1:
   id: 1234
   effort_id: 47
@@ -1784,6 +1902,7 @@ hardrock_2015_vince_willms_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 11:40:00'
+  elapsed_seconds: 85200.0
 hardrock_2015_vince_willms_telluride_out_1:
   id: 1235
   effort_id: 47
@@ -1799,6 +1918,7 @@ hardrock_2015_vince_willms_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 12:53:00'
+  elapsed_seconds: 89580.0
 hardrock_2015_vince_willms_putnam_in_1:
   id: 1240
   effort_id: 47
@@ -1814,6 +1934,7 @@ hardrock_2015_vince_willms_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 23:23:00'
+  elapsed_seconds: 127380.0
 hardrock_2015_vince_willms_putnam_out_1:
   id: 1241
   effort_id: 47
@@ -1829,6 +1950,7 @@ hardrock_2015_vince_willms_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 23:25:00'
+  elapsed_seconds: 127500.0
 hardrock_2015_vince_willms_finish_1:
   id: 1242
   effort_id: 47
@@ -1844,6 +1966,7 @@ hardrock_2015_vince_willms_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 00:58:00'
+  elapsed_seconds: 133080.0
 hardrock_2015_cedric_windler_cunningham_in_1:
   id: 1304
   effort_id: 50
@@ -1859,6 +1982,7 @@ hardrock_2015_cedric_windler_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:32:00'
+  elapsed_seconds: 9120.0
 hardrock_2015_cedric_windler_cunningham_out_1:
   id: 1305
   effort_id: 50
@@ -1874,6 +1998,7 @@ hardrock_2015_cedric_windler_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:32:00'
+  elapsed_seconds: 9120.0
 hardrock_2015_cedric_windler_sherman_in_1:
   id: 1310
   effort_id: 50
@@ -1889,6 +2014,7 @@ hardrock_2015_cedric_windler_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:52:00'
+  elapsed_seconds: 28320.0
 hardrock_2015_cedric_windler_sherman_out_1:
   id: 1311
   effort_id: 50
@@ -1904,6 +2030,7 @@ hardrock_2015_cedric_windler_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:59:00'
+  elapsed_seconds: 28740.0
 hardrock_2015_cedric_windler_grouse_in_1:
   id: 1314
   effort_id: 50
@@ -1919,6 +2046,7 @@ hardrock_2015_cedric_windler_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:51:00'
+  elapsed_seconds: 46260.0
 hardrock_2015_cedric_windler_grouse_out_1:
   id: 1315
   effort_id: 50
@@ -1934,6 +2062,7 @@ hardrock_2015_cedric_windler_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 01:02:00'
+  elapsed_seconds: 46920.0
 hardrock_2015_cedric_windler_ouray_in_1:
   id: 1318
   effort_id: 50
@@ -1949,6 +2078,7 @@ hardrock_2015_cedric_windler_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:06:00'
+  elapsed_seconds: 65160.0
 hardrock_2015_cedric_windler_ouray_out_1:
   id: 1319
   effort_id: 50
@@ -1964,6 +2094,7 @@ hardrock_2015_cedric_windler_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:53:00'
+  elapsed_seconds: 67980.0
 hardrock_2015_cedric_windler_telluride_in_1:
   id: 1324
   effort_id: 50
@@ -1979,6 +2110,7 @@ hardrock_2015_cedric_windler_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 13:10:00'
+  elapsed_seconds: 90600.0
 hardrock_2015_cedric_windler_telluride_out_1:
   id: 1325
   effort_id: 50
@@ -1994,6 +2126,7 @@ hardrock_2015_cedric_windler_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 13:20:00'
+  elapsed_seconds: 91200.0
 hardrock_2015_cedric_windler_putnam_in_1:
   id: 1330
   effort_id: 50
@@ -2009,6 +2142,7 @@ hardrock_2015_cedric_windler_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 23:39:00'
+  elapsed_seconds: 128340.0
 hardrock_2015_cedric_windler_putnam_out_1:
   id: 1331
   effort_id: 50
@@ -2024,6 +2158,7 @@ hardrock_2015_cedric_windler_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 23:39:00'
+  elapsed_seconds: 128340.0
 hardrock_2015_cedric_windler_finish_1:
   id: 1332
   effort_id: 50
@@ -2039,6 +2174,7 @@ hardrock_2015_cedric_windler_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 01:19:00'
+  elapsed_seconds: 134340.0
 hardrock_2015_chris_rempel_start_1:
   id: 1483
   effort_id: 56
@@ -2054,6 +2190,7 @@ hardrock_2015_chris_rempel_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_chris_rempel_cunningham_in_1:
   id: 1484
   effort_id: 56
@@ -2069,6 +2206,7 @@ hardrock_2015_chris_rempel_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:36:00'
+  elapsed_seconds: 9360.0
 hardrock_2015_chris_rempel_cunningham_out_1:
   id: 1485
   effort_id: 56
@@ -2084,6 +2222,7 @@ hardrock_2015_chris_rempel_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:36:00'
+  elapsed_seconds: 9360.0
 hardrock_2015_chris_rempel_sherman_in_1:
   id: 1490
   effort_id: 56
@@ -2099,6 +2238,7 @@ hardrock_2015_chris_rempel_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:12:00'
+  elapsed_seconds: 29520.0
 hardrock_2015_chris_rempel_sherman_out_1:
   id: 1491
   effort_id: 56
@@ -2114,6 +2254,7 @@ hardrock_2015_chris_rempel_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:23:00'
+  elapsed_seconds: 30180.0
 hardrock_2015_chris_rempel_grouse_in_1:
   id: 1494
   effort_id: 56
@@ -2129,6 +2270,7 @@ hardrock_2015_chris_rempel_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:57:00'
+  elapsed_seconds: 46620.0
 hardrock_2015_chris_rempel_grouse_out_1:
   id: 1495
   effort_id: 56
@@ -2144,6 +2286,7 @@ hardrock_2015_chris_rempel_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 01:09:00'
+  elapsed_seconds: 47340.0
 hardrock_2015_chris_rempel_ouray_in_1:
   id: 1498
   effort_id: 56
@@ -2159,6 +2302,7 @@ hardrock_2015_chris_rempel_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:05:00'
+  elapsed_seconds: 65100.0
 hardrock_2015_chris_rempel_ouray_out_1:
   id: 1499
   effort_id: 56
@@ -2174,6 +2318,7 @@ hardrock_2015_chris_rempel_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:23:00'
+  elapsed_seconds: 66180.0
 hardrock_2015_chris_rempel_telluride_in_1:
   id: 1504
   effort_id: 56
@@ -2189,6 +2334,7 @@ hardrock_2015_chris_rempel_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 12:40:00'
+  elapsed_seconds: 88800.0
 hardrock_2015_chris_rempel_telluride_out_1:
   id: 1505
   effort_id: 56
@@ -2204,6 +2350,7 @@ hardrock_2015_chris_rempel_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 13:00:00'
+  elapsed_seconds: 90000.0
 hardrock_2015_chris_rempel_putnam_in_1:
   id: 1510
   effort_id: 56
@@ -2219,6 +2366,7 @@ hardrock_2015_chris_rempel_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 00:03:00'
+  elapsed_seconds: 129780.0
 hardrock_2015_chris_rempel_putnam_out_1:
   id: 1511
   effort_id: 56
@@ -2234,6 +2382,7 @@ hardrock_2015_chris_rempel_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 00:04:00'
+  elapsed_seconds: 129840.0
 hardrock_2015_chris_rempel_finish_1:
   id: 1512
   effort_id: 56
@@ -2249,6 +2398,7 @@ hardrock_2015_chris_rempel_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 01:54:00'
+  elapsed_seconds: 136440.0
 hardrock_2015_robby_gerlach_start_1:
   id: 1513
   effort_id: 57
@@ -2264,6 +2414,7 @@ hardrock_2015_robby_gerlach_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_robby_gerlach_cunningham_in_1:
   id: 1514
   effort_id: 57
@@ -2279,6 +2430,7 @@ hardrock_2015_robby_gerlach_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:40:00'
+  elapsed_seconds: 9600.0
 hardrock_2015_robby_gerlach_cunningham_out_1:
   id: 1515
   effort_id: 57
@@ -2294,6 +2446,7 @@ hardrock_2015_robby_gerlach_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:40:00'
+  elapsed_seconds: 9600.0
 hardrock_2015_robby_gerlach_sherman_in_1:
   id: 1520
   effort_id: 57
@@ -2309,6 +2462,7 @@ hardrock_2015_robby_gerlach_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:51:00'
+  elapsed_seconds: 31860.0
 hardrock_2015_robby_gerlach_sherman_out_1:
   id: 1521
   effort_id: 57
@@ -2324,6 +2478,7 @@ hardrock_2015_robby_gerlach_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 21:03:00'
+  elapsed_seconds: 32580.0
 hardrock_2015_robby_gerlach_grouse_in_1:
   id: 1524
   effort_id: 57
@@ -2339,6 +2494,7 @@ hardrock_2015_robby_gerlach_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 01:51:00'
+  elapsed_seconds: 49860.0
 hardrock_2015_robby_gerlach_grouse_out_1:
   id: 1525
   effort_id: 57
@@ -2354,6 +2510,7 @@ hardrock_2015_robby_gerlach_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 02:08:00'
+  elapsed_seconds: 50880.0
 hardrock_2015_robby_gerlach_ouray_in_1:
   id: 1528
   effort_id: 57
@@ -2369,6 +2526,7 @@ hardrock_2015_robby_gerlach_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 07:15:00'
+  elapsed_seconds: 69300.0
 hardrock_2015_robby_gerlach_ouray_out_1:
   id: 1529
   effort_id: 57
@@ -2384,6 +2542,7 @@ hardrock_2015_robby_gerlach_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 07:32:00'
+  elapsed_seconds: 70320.0
 hardrock_2015_robby_gerlach_telluride_in_1:
   id: 1534
   effort_id: 57
@@ -2399,6 +2558,7 @@ hardrock_2015_robby_gerlach_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 13:29:00'
+  elapsed_seconds: 91740.0
 hardrock_2015_robby_gerlach_telluride_out_1:
   id: 1535
   effort_id: 57
@@ -2414,6 +2574,7 @@ hardrock_2015_robby_gerlach_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 14:44:00'
+  elapsed_seconds: 96240.0
 hardrock_2015_robby_gerlach_putnam_in_1:
   id: 1540
   effort_id: 57
@@ -2429,6 +2590,7 @@ hardrock_2015_robby_gerlach_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 00:14:00'
+  elapsed_seconds: 130440.0
 hardrock_2015_robby_gerlach_putnam_out_1:
   id: 1541
   effort_id: 57
@@ -2444,6 +2606,7 @@ hardrock_2015_robby_gerlach_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 00:14:00'
+  elapsed_seconds: 130440.0
 hardrock_2015_robby_gerlach_finish_1:
   id: 1542
   effort_id: 57
@@ -2459,6 +2622,7 @@ hardrock_2015_robby_gerlach_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 01:56:00'
+  elapsed_seconds: 136560.0
 hardrock_2015_rachelle_eichmann_start_1:
   id: 1573
   effort_id: 59
@@ -2474,6 +2638,7 @@ hardrock_2015_rachelle_eichmann_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_rachelle_eichmann_cunningham_in_1:
   id: 1574
   effort_id: 59
@@ -2489,6 +2654,7 @@ hardrock_2015_rachelle_eichmann_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:28:00'
+  elapsed_seconds: 8880.0
 hardrock_2015_rachelle_eichmann_cunningham_out_1:
   id: 1575
   effort_id: 59
@@ -2504,6 +2670,7 @@ hardrock_2015_rachelle_eichmann_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:28:00'
+  elapsed_seconds: 8880.0
 hardrock_2015_rachelle_eichmann_sherman_in_1:
   id: 1580
   effort_id: 59
@@ -2519,6 +2686,7 @@ hardrock_2015_rachelle_eichmann_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:11:00'
+  elapsed_seconds: 29460.0
 hardrock_2015_rachelle_eichmann_sherman_out_1:
   id: 1581
   effort_id: 59
@@ -2534,6 +2702,7 @@ hardrock_2015_rachelle_eichmann_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:24:00'
+  elapsed_seconds: 30240.0
 hardrock_2015_rachelle_eichmann_grouse_in_1:
   id: 1584
   effort_id: 59
@@ -2549,6 +2718,7 @@ hardrock_2015_rachelle_eichmann_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:53:00'
+  elapsed_seconds: 46380.0
 hardrock_2015_rachelle_eichmann_grouse_out_1:
   id: 1585
   effort_id: 59
@@ -2564,6 +2734,7 @@ hardrock_2015_rachelle_eichmann_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 01:10:00'
+  elapsed_seconds: 47400.0
 hardrock_2015_rachelle_eichmann_ouray_in_1:
   id: 1588
   effort_id: 59
@@ -2579,6 +2750,7 @@ hardrock_2015_rachelle_eichmann_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:30:00'
+  elapsed_seconds: 66600.0
 hardrock_2015_rachelle_eichmann_ouray_out_1:
   id: 1589
   effort_id: 59
@@ -2594,6 +2766,7 @@ hardrock_2015_rachelle_eichmann_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:40:00'
+  elapsed_seconds: 67200.0
 hardrock_2015_rachelle_eichmann_telluride_in_1:
   id: 1594
   effort_id: 59
@@ -2609,6 +2782,7 @@ hardrock_2015_rachelle_eichmann_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 13:45:00'
+  elapsed_seconds: 92700.0
 hardrock_2015_rachelle_eichmann_telluride_out_1:
   id: 1595
   effort_id: 59
@@ -2624,6 +2798,7 @@ hardrock_2015_rachelle_eichmann_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 14:05:00'
+  elapsed_seconds: 93900.0
 hardrock_2015_rachelle_eichmann_putnam_in_1:
   id: 1600
   effort_id: 59
@@ -2639,6 +2814,7 @@ hardrock_2015_rachelle_eichmann_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 01:05:00'
+  elapsed_seconds: 133500.0
 hardrock_2015_rachelle_eichmann_putnam_out_1:
   id: 1601
   effort_id: 59
@@ -2654,6 +2830,7 @@ hardrock_2015_rachelle_eichmann_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 01:05:00'
+  elapsed_seconds: 133500.0
 hardrock_2015_rachelle_eichmann_finish_1:
   id: 1602
   effort_id: 59
@@ -2669,6 +2846,7 @@ hardrock_2015_rachelle_eichmann_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 02:36:00'
+  elapsed_seconds: 138960.0
 hardrock_2015_elden_morissette_start_1:
   id: 1633
   effort_id: 61
@@ -2684,6 +2862,7 @@ hardrock_2015_elden_morissette_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_elden_morissette_cunningham_in_1:
   id: 1634
   effort_id: 61
@@ -2699,6 +2878,7 @@ hardrock_2015_elden_morissette_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:33:00'
+  elapsed_seconds: 9180.0
 hardrock_2015_elden_morissette_cunningham_out_1:
   id: 1635
   effort_id: 61
@@ -2714,6 +2894,7 @@ hardrock_2015_elden_morissette_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:33:00'
+  elapsed_seconds: 9180.0
 hardrock_2015_elden_morissette_sherman_in_1:
   id: 1640
   effort_id: 61
@@ -2729,6 +2910,7 @@ hardrock_2015_elden_morissette_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:20:00'
+  elapsed_seconds: 30000.0
 hardrock_2015_elden_morissette_sherman_out_1:
   id: 1641
   effort_id: 61
@@ -2744,6 +2926,7 @@ hardrock_2015_elden_morissette_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:38:00'
+  elapsed_seconds: 31080.0
 hardrock_2015_elden_morissette_grouse_in_1:
   id: 1644
   effort_id: 61
@@ -2759,6 +2942,7 @@ hardrock_2015_elden_morissette_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 01:24:00'
+  elapsed_seconds: 48240.0
 hardrock_2015_elden_morissette_grouse_out_1:
   id: 1645
   effort_id: 61
@@ -2774,6 +2958,7 @@ hardrock_2015_elden_morissette_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 01:50:00'
+  elapsed_seconds: 49800.0
 hardrock_2015_elden_morissette_ouray_in_1:
   id: 1648
   effort_id: 61
@@ -2789,6 +2974,7 @@ hardrock_2015_elden_morissette_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:15:00'
+  elapsed_seconds: 65700.0
 hardrock_2015_elden_morissette_ouray_out_1:
   id: 1649
   effort_id: 61
@@ -2804,6 +2990,7 @@ hardrock_2015_elden_morissette_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:59:00'
+  elapsed_seconds: 68340.0
 hardrock_2015_elden_morissette_telluride_in_1:
   id: 1654
   effort_id: 61
@@ -2819,6 +3006,7 @@ hardrock_2015_elden_morissette_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 13:08:00'
+  elapsed_seconds: 90480.0
 hardrock_2015_elden_morissette_telluride_out_1:
   id: 1655
   effort_id: 61
@@ -2834,6 +3022,7 @@ hardrock_2015_elden_morissette_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 13:33:00'
+  elapsed_seconds: 91980.0
 hardrock_2015_elden_morissette_putnam_in_1:
   id: 1660
   effort_id: 61
@@ -2849,6 +3038,7 @@ hardrock_2015_elden_morissette_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 00:48:00'
+  elapsed_seconds: 132480.0
 hardrock_2015_elden_morissette_putnam_out_1:
   id: 1661
   effort_id: 61
@@ -2864,6 +3054,7 @@ hardrock_2015_elden_morissette_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 00:53:00'
+  elapsed_seconds: 132780.0
 hardrock_2015_elden_morissette_finish_1:
   id: 1662
   effort_id: 61
@@ -2879,6 +3070,7 @@ hardrock_2015_elden_morissette_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 02:41:00'
+  elapsed_seconds: 139260.0
 hardrock_2015_leroy_leffler_start_1:
   id: 1693
   effort_id: 63
@@ -2894,6 +3086,7 @@ hardrock_2015_leroy_leffler_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_leroy_leffler_cunningham_in_1:
   id: 1694
   effort_id: 63
@@ -2909,6 +3102,7 @@ hardrock_2015_leroy_leffler_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:38:00'
+  elapsed_seconds: 9480.0
 hardrock_2015_leroy_leffler_cunningham_out_1:
   id: 1695
   effort_id: 63
@@ -2924,6 +3118,7 @@ hardrock_2015_leroy_leffler_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:38:00'
+  elapsed_seconds: 9480.0
 hardrock_2015_leroy_leffler_sherman_in_1:
   id: 1700
   effort_id: 63
@@ -2939,6 +3134,7 @@ hardrock_2015_leroy_leffler_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:22:00'
+  elapsed_seconds: 30120.0
 hardrock_2015_leroy_leffler_sherman_out_1:
   id: 1701
   effort_id: 63
@@ -2954,6 +3150,7 @@ hardrock_2015_leroy_leffler_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:38:00'
+  elapsed_seconds: 31080.0
 hardrock_2015_leroy_leffler_grouse_in_1:
   id: 1704
   effort_id: 63
@@ -2969,6 +3166,7 @@ hardrock_2015_leroy_leffler_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 01:21:00'
+  elapsed_seconds: 48060.0
 hardrock_2015_leroy_leffler_grouse_out_1:
   id: 1705
   effort_id: 63
@@ -2984,6 +3182,7 @@ hardrock_2015_leroy_leffler_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 01:38:00'
+  elapsed_seconds: 49080.0
 hardrock_2015_leroy_leffler_ouray_in_1:
   id: 1708
   effort_id: 63
@@ -2999,6 +3198,7 @@ hardrock_2015_leroy_leffler_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:32:00'
+  elapsed_seconds: 66720.0
 hardrock_2015_leroy_leffler_ouray_out_1:
   id: 1709
   effort_id: 63
@@ -3014,6 +3214,7 @@ hardrock_2015_leroy_leffler_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 07:21:00'
+  elapsed_seconds: 69660.0
 hardrock_2015_leroy_leffler_telluride_in_1:
   id: 1714
   effort_id: 63
@@ -3029,6 +3230,7 @@ hardrock_2015_leroy_leffler_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 13:07:00'
+  elapsed_seconds: 90420.0
 hardrock_2015_leroy_leffler_telluride_out_1:
   id: 1715
   effort_id: 63
@@ -3044,6 +3246,7 @@ hardrock_2015_leroy_leffler_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 13:43:00'
+  elapsed_seconds: 92580.0
 hardrock_2015_leroy_leffler_putnam_in_1:
   id: 1720
   effort_id: 63
@@ -3059,6 +3262,7 @@ hardrock_2015_leroy_leffler_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 01:15:00'
+  elapsed_seconds: 134100.0
 hardrock_2015_leroy_leffler_putnam_out_1:
   id: 1721
   effort_id: 63
@@ -3074,6 +3278,7 @@ hardrock_2015_leroy_leffler_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 01:15:00'
+  elapsed_seconds: 134100.0
 hardrock_2015_leroy_leffler_finish_1:
   id: 1722
   effort_id: 63
@@ -3089,6 +3294,7 @@ hardrock_2015_leroy_leffler_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 03:11:00'
+  elapsed_seconds: 141060.0
 hardrock_2015_samara_vandervort_start_1:
   id: 1993
   effort_id: 73
@@ -3104,6 +3310,7 @@ hardrock_2015_samara_vandervort_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_samara_vandervort_cunningham_in_1:
   id: 1994
   effort_id: 73
@@ -3119,6 +3326,7 @@ hardrock_2015_samara_vandervort_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:35:00'
+  elapsed_seconds: 9300.0
 hardrock_2015_samara_vandervort_cunningham_out_1:
   id: 1995
   effort_id: 73
@@ -3134,6 +3342,7 @@ hardrock_2015_samara_vandervort_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:35:00'
+  elapsed_seconds: 9300.0
 hardrock_2015_samara_vandervort_sherman_in_1:
   id: 2000
   effort_id: 73
@@ -3149,6 +3358,7 @@ hardrock_2015_samara_vandervort_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:28:00'
+  elapsed_seconds: 30480.0
 hardrock_2015_samara_vandervort_sherman_out_1:
   id: 2001
   effort_id: 73
@@ -3164,6 +3374,7 @@ hardrock_2015_samara_vandervort_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:42:00'
+  elapsed_seconds: 31320.0
 hardrock_2015_samara_vandervort_grouse_in_1:
   id: 2004
   effort_id: 73
@@ -3179,6 +3390,7 @@ hardrock_2015_samara_vandervort_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 01:50:00'
+  elapsed_seconds: 49800.0
 hardrock_2015_samara_vandervort_grouse_out_1:
   id: 2005
   effort_id: 73
@@ -3194,6 +3406,7 @@ hardrock_2015_samara_vandervort_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 02:03:00'
+  elapsed_seconds: 50580.0
 hardrock_2015_samara_vandervort_ouray_in_1:
   id: 2008
   effort_id: 73
@@ -3209,6 +3422,7 @@ hardrock_2015_samara_vandervort_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 07:06:00'
+  elapsed_seconds: 68760.0
 hardrock_2015_samara_vandervort_ouray_out_1:
   id: 2009
   effort_id: 73
@@ -3224,6 +3438,7 @@ hardrock_2015_samara_vandervort_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 07:20:00'
+  elapsed_seconds: 69600.0
 hardrock_2015_samara_vandervort_telluride_in_1:
   id: 2014
   effort_id: 73
@@ -3239,6 +3454,7 @@ hardrock_2015_samara_vandervort_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 14:11:00'
+  elapsed_seconds: 94260.0
 hardrock_2015_samara_vandervort_telluride_out_1:
   id: 2015
   effort_id: 73
@@ -3254,6 +3470,7 @@ hardrock_2015_samara_vandervort_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 14:29:00'
+  elapsed_seconds: 95340.0
 hardrock_2015_samara_vandervort_putnam_in_1:
   id: 2020
   effort_id: 73
@@ -3269,6 +3486,7 @@ hardrock_2015_samara_vandervort_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 01:58:00'
+  elapsed_seconds: 136680.0
 hardrock_2015_samara_vandervort_putnam_out_1:
   id: 2021
   effort_id: 73
@@ -3284,6 +3502,7 @@ hardrock_2015_samara_vandervort_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 02:04:00'
+  elapsed_seconds: 137040.0
 hardrock_2015_samara_vandervort_finish_1:
   id: 2022
   effort_id: 73
@@ -3299,6 +3518,7 @@ hardrock_2015_samara_vandervort_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 04:16:00'
+  elapsed_seconds: 144960.0
 hardrock_2015_robt_wintheiser_start_1:
   id: 2623
   effort_id: 94
@@ -3314,6 +3534,7 @@ hardrock_2015_robt_wintheiser_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_robt_wintheiser_cunningham_in_1:
   id: 2624
   effort_id: 94
@@ -3329,6 +3550,7 @@ hardrock_2015_robt_wintheiser_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:52:00'
+  elapsed_seconds: 10320.0
 hardrock_2015_robt_wintheiser_cunningham_out_1:
   id: 2625
   effort_id: 94
@@ -3344,6 +3566,7 @@ hardrock_2015_robt_wintheiser_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:52:00'
+  elapsed_seconds: 10320.0
 hardrock_2015_robt_wintheiser_sherman_in_1:
   id: 2630
   effort_id: 94
@@ -3359,6 +3582,7 @@ hardrock_2015_robt_wintheiser_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 21:10:00'
+  elapsed_seconds: 33000.0
 hardrock_2015_robt_wintheiser_sherman_out_1:
   id: 2631
   effort_id: 94
@@ -3374,6 +3598,7 @@ hardrock_2015_robt_wintheiser_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 21:27:00'
+  elapsed_seconds: 34020.0
 hardrock_2015_robt_wintheiser_grouse_in_1:
   id: 2634
   effort_id: 94
@@ -3389,6 +3614,7 @@ hardrock_2015_robt_wintheiser_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 02:37:00'
+  elapsed_seconds: 52620.0
 hardrock_2015_robt_wintheiser_grouse_out_1:
   id: 2635
   effort_id: 94
@@ -3404,6 +3630,7 @@ hardrock_2015_robt_wintheiser_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 03:00:00'
+  elapsed_seconds: 54000.0
 hardrock_2015_robt_wintheiser_ouray_in_1:
   id: 2638
   effort_id: 94
@@ -3419,6 +3646,7 @@ hardrock_2015_robt_wintheiser_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 08:24:00'
+  elapsed_seconds: 73440.0
 hardrock_2015_robt_wintheiser_ouray_out_1:
   id: 2639
   effort_id: 94
@@ -3434,6 +3662,7 @@ hardrock_2015_robt_wintheiser_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 08:27:00'
+  elapsed_seconds: 73620.0
 hardrock_2015_robt_wintheiser_telluride_in_1:
   id: 2644
   effort_id: 94
@@ -3449,6 +3678,7 @@ hardrock_2015_robt_wintheiser_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 15:34:00'
+  elapsed_seconds: 99240.0
 hardrock_2015_robt_wintheiser_telluride_out_1:
   id: 2645
   effort_id: 94
@@ -3464,6 +3694,7 @@ hardrock_2015_robt_wintheiser_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 16:34:00'
+  elapsed_seconds: 102840.0
 hardrock_2015_robt_wintheiser_putnam_in_1:
   id: 2650
   effort_id: 94
@@ -3479,6 +3710,7 @@ hardrock_2015_robt_wintheiser_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 05:22:00'
+  elapsed_seconds: 148920.0
 hardrock_2015_robt_wintheiser_putnam_out_1:
   id: 2651
   effort_id: 94
@@ -3494,6 +3726,7 @@ hardrock_2015_robt_wintheiser_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 05:33:00'
+  elapsed_seconds: 149580.0
 hardrock_2015_robt_wintheiser_finish_1:
   id: 2652
   effort_id: 94
@@ -3509,6 +3742,7 @@ hardrock_2015_robt_wintheiser_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 07:56:00'
+  elapsed_seconds: 158160.0
 hardrock_2015_demetrius_moen_start_1:
   id: 2683
   effort_id: 96
@@ -3524,6 +3758,7 @@ hardrock_2015_demetrius_moen_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_demetrius_moen_cunningham_in_1:
   id: 2684
   effort_id: 96
@@ -3539,6 +3774,7 @@ hardrock_2015_demetrius_moen_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:45:00'
+  elapsed_seconds: 9900.0
 hardrock_2015_demetrius_moen_cunningham_out_1:
   id: 2685
   effort_id: 96
@@ -3554,6 +3790,7 @@ hardrock_2015_demetrius_moen_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:45:00'
+  elapsed_seconds: 9900.0
 hardrock_2015_demetrius_moen_sherman_in_1:
   id: 2690
   effort_id: 96
@@ -3569,6 +3806,7 @@ hardrock_2015_demetrius_moen_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 21:21:00'
+  elapsed_seconds: 33660.0
 hardrock_2015_demetrius_moen_sherman_out_1:
   id: 2691
   effort_id: 96
@@ -3584,6 +3822,7 @@ hardrock_2015_demetrius_moen_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 21:36:00'
+  elapsed_seconds: 34560.0
 hardrock_2015_demetrius_moen_grouse_in_1:
   id: 2694
   effort_id: 96
@@ -3599,6 +3838,7 @@ hardrock_2015_demetrius_moen_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 03:07:00'
+  elapsed_seconds: 54420.0
 hardrock_2015_demetrius_moen_grouse_out_1:
   id: 2695
   effort_id: 96
@@ -3614,6 +3854,7 @@ hardrock_2015_demetrius_moen_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 03:27:00'
+  elapsed_seconds: 55620.0
 hardrock_2015_demetrius_moen_ouray_in_1:
   id: 2698
   effort_id: 96
@@ -3629,6 +3870,7 @@ hardrock_2015_demetrius_moen_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 08:53:00'
+  elapsed_seconds: 75180.0
 hardrock_2015_demetrius_moen_ouray_out_1:
   id: 2699
   effort_id: 96
@@ -3644,6 +3886,7 @@ hardrock_2015_demetrius_moen_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 09:15:00'
+  elapsed_seconds: 76500.0
 hardrock_2015_demetrius_moen_telluride_in_1:
   id: 2704
   effort_id: 96
@@ -3659,6 +3902,7 @@ hardrock_2015_demetrius_moen_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 15:43:00'
+  elapsed_seconds: 99780.0
 hardrock_2015_demetrius_moen_telluride_out_1:
   id: 2705
   effort_id: 96
@@ -3674,6 +3918,7 @@ hardrock_2015_demetrius_moen_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 16:02:00'
+  elapsed_seconds: 100920.0
 hardrock_2015_demetrius_moen_putnam_in_1:
   id: 2710
   effort_id: 96
@@ -3689,6 +3934,7 @@ hardrock_2015_demetrius_moen_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 05:27:00'
+  elapsed_seconds: 149220.0
 hardrock_2015_demetrius_moen_putnam_out_1:
   id: 2711
   effort_id: 96
@@ -3704,6 +3950,7 @@ hardrock_2015_demetrius_moen_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 05:36:00'
+  elapsed_seconds: 149760.0
 hardrock_2015_demetrius_moen_finish_1:
   id: 2712
   effort_id: 96
@@ -3719,6 +3966,7 @@ hardrock_2015_demetrius_moen_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 08:01:00'
+  elapsed_seconds: 158460.0
 hardrock_2015_vern_buckridge_start_1:
   id: 2953
   effort_id: 105
@@ -3734,6 +3982,7 @@ hardrock_2015_vern_buckridge_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_vern_buckridge_cunningham_in_1:
   id: 2954
   effort_id: 105
@@ -3749,6 +3998,7 @@ hardrock_2015_vern_buckridge_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:46:00'
+  elapsed_seconds: 9960.0
 hardrock_2015_vern_buckridge_cunningham_out_1:
   id: 2955
   effort_id: 105
@@ -3764,6 +4014,7 @@ hardrock_2015_vern_buckridge_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:46:00'
+  elapsed_seconds: 9960.0
 hardrock_2015_vern_buckridge_sherman_in_1:
   id: 2960
   effort_id: 105
@@ -3779,6 +4030,7 @@ hardrock_2015_vern_buckridge_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 21:45:00'
+  elapsed_seconds: 35100.0
 hardrock_2015_vern_buckridge_sherman_out_1:
   id: 2961
   effort_id: 105
@@ -3794,6 +4046,7 @@ hardrock_2015_vern_buckridge_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 22:09:00'
+  elapsed_seconds: 36540.0
 hardrock_2015_vern_buckridge_grouse_in_1:
   id: 2964
   effort_id: 105
@@ -3809,6 +4062,7 @@ hardrock_2015_vern_buckridge_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:04:00'
+  elapsed_seconds: 57840.0
 hardrock_2015_vern_buckridge_grouse_out_1:
   id: 2965
   effort_id: 105
@@ -3824,6 +4078,7 @@ hardrock_2015_vern_buckridge_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:21:00'
+  elapsed_seconds: 58860.0
 hardrock_2015_vern_buckridge_ouray_in_1:
   id: 2968
   effort_id: 105
@@ -3839,6 +4094,7 @@ hardrock_2015_vern_buckridge_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 09:48:00'
+  elapsed_seconds: 78480.0
 hardrock_2015_vern_buckridge_ouray_out_1:
   id: 2969
   effort_id: 105
@@ -3854,6 +4110,7 @@ hardrock_2015_vern_buckridge_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 10:15:00'
+  elapsed_seconds: 80100.0
 hardrock_2015_vern_buckridge_telluride_in_1:
   id: 2974
   effort_id: 105
@@ -3869,6 +4126,7 @@ hardrock_2015_vern_buckridge_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 17:08:00'
+  elapsed_seconds: 104880.0
 hardrock_2015_vern_buckridge_telluride_out_1:
   id: 2975
   effort_id: 105
@@ -3884,6 +4142,7 @@ hardrock_2015_vern_buckridge_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 17:29:00'
+  elapsed_seconds: 106140.0
 hardrock_2015_vern_buckridge_putnam_in_1:
   id: 2980
   effort_id: 105
@@ -3899,6 +4158,7 @@ hardrock_2015_vern_buckridge_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 06:54:00'
+  elapsed_seconds: 154440.0
 hardrock_2015_vern_buckridge_putnam_out_1:
   id: 2981
   effort_id: 105
@@ -3914,6 +4174,7 @@ hardrock_2015_vern_buckridge_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 07:00:00'
+  elapsed_seconds: 154800.0
 hardrock_2015_vern_buckridge_finish_1:
   id: 2982
   effort_id: 105
@@ -3929,6 +4190,7 @@ hardrock_2015_vern_buckridge_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 09:20:00'
+  elapsed_seconds: 163200.0
 hardrock_2015_donte_spencer_start_1:
   id: 3163
   effort_id: 112
@@ -3944,6 +4206,7 @@ hardrock_2015_donte_spencer_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_donte_spencer_cunningham_in_1:
   id: 3164
   effort_id: 112
@@ -3959,6 +4222,7 @@ hardrock_2015_donte_spencer_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:40:00'
+  elapsed_seconds: 9600.0
 hardrock_2015_donte_spencer_cunningham_out_1:
   id: 3165
   effort_id: 112
@@ -3974,6 +4238,7 @@ hardrock_2015_donte_spencer_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:40:00'
+  elapsed_seconds: 9600.0
 hardrock_2015_donte_spencer_sherman_in_1:
   id: 3170
   effort_id: 112
@@ -3989,6 +4254,7 @@ hardrock_2015_donte_spencer_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 20:54:00'
+  elapsed_seconds: 32040.0
 hardrock_2015_donte_spencer_sherman_out_1:
   id: 3171
   effort_id: 112
@@ -4004,6 +4270,7 @@ hardrock_2015_donte_spencer_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 21:17:00'
+  elapsed_seconds: 33420.0
 hardrock_2015_donte_spencer_grouse_in_1:
   id: 3174
   effort_id: 112
@@ -4019,6 +4286,7 @@ hardrock_2015_donte_spencer_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 02:11:00'
+  elapsed_seconds: 51060.0
 hardrock_2015_donte_spencer_grouse_out_1:
   id: 3175
   effort_id: 112
@@ -4034,6 +4302,7 @@ hardrock_2015_donte_spencer_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 02:43:00'
+  elapsed_seconds: 52980.0
 hardrock_2015_donte_spencer_ouray_in_1:
   id: 3178
   effort_id: 112
@@ -4049,6 +4318,7 @@ hardrock_2015_donte_spencer_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 09:34:00'
+  elapsed_seconds: 77640.0
 hardrock_2015_donte_spencer_ouray_out_1:
   id: 3179
   effort_id: 112
@@ -4064,6 +4334,7 @@ hardrock_2015_donte_spencer_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 11:19:00'
+  elapsed_seconds: 83940.0
 hardrock_2015_donte_spencer_telluride_in_1:
   id: 3184
   effort_id: 112
@@ -4079,6 +4350,7 @@ hardrock_2015_donte_spencer_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 17:44:00'
+  elapsed_seconds: 107040.0
 hardrock_2015_donte_spencer_telluride_out_1:
   id: 3185
   effort_id: 112
@@ -4094,6 +4366,7 @@ hardrock_2015_donte_spencer_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 17:56:00'
+  elapsed_seconds: 107760.0
 hardrock_2015_donte_spencer_putnam_in_1:
   id: 3190
   effort_id: 112
@@ -4109,6 +4382,7 @@ hardrock_2015_donte_spencer_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 07:24:00'
+  elapsed_seconds: 156240.0
 hardrock_2015_donte_spencer_putnam_out_1:
   id: 3191
   effort_id: 112
@@ -4124,6 +4398,7 @@ hardrock_2015_donte_spencer_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 08:48:00'
+  elapsed_seconds: 161280.0
 hardrock_2015_donte_spencer_finish_1:
   id: 3192
   effort_id: 112
@@ -4139,6 +4414,7 @@ hardrock_2015_donte_spencer_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 10:48:00'
+  elapsed_seconds: 168480.0
 hardrock_2015_bruno_fadel_start_1:
   id: 3283
   effort_id: 116
@@ -4154,6 +4430,7 @@ hardrock_2015_bruno_fadel_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_bruno_fadel_cunningham_in_1:
   id: 3284
   effort_id: 116
@@ -4169,6 +4446,7 @@ hardrock_2015_bruno_fadel_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:05:00'
+  elapsed_seconds: 11100.0
 hardrock_2015_bruno_fadel_cunningham_out_1:
   id: 3285
   effort_id: 116
@@ -4184,6 +4462,7 @@ hardrock_2015_bruno_fadel_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:05:00'
+  elapsed_seconds: 11100.0
 hardrock_2015_bruno_fadel_sherman_in_1:
   id: 3290
   effort_id: 116
@@ -4199,6 +4478,7 @@ hardrock_2015_bruno_fadel_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 22:10:00'
+  elapsed_seconds: 36600.0
 hardrock_2015_bruno_fadel_sherman_out_1:
   id: 3291
   effort_id: 116
@@ -4214,6 +4494,7 @@ hardrock_2015_bruno_fadel_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 22:20:00'
+  elapsed_seconds: 37200.0
 hardrock_2015_bruno_fadel_grouse_in_1:
   id: 3294
   effort_id: 116
@@ -4229,6 +4510,7 @@ hardrock_2015_bruno_fadel_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:15:00'
+  elapsed_seconds: 58500.0
 hardrock_2015_bruno_fadel_grouse_out_1:
   id: 3295
   effort_id: 116
@@ -4244,6 +4526,7 @@ hardrock_2015_bruno_fadel_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:32:00'
+  elapsed_seconds: 59520.0
 hardrock_2015_bruno_fadel_ouray_in_1:
   id: 3298
   effort_id: 116
@@ -4259,6 +4542,7 @@ hardrock_2015_bruno_fadel_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 10:13:00'
+  elapsed_seconds: 79980.0
 hardrock_2015_bruno_fadel_ouray_out_1:
   id: 3299
   effort_id: 116
@@ -4274,6 +4558,7 @@ hardrock_2015_bruno_fadel_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 10:35:00'
+  elapsed_seconds: 81300.0
 hardrock_2015_bruno_fadel_telluride_in_1:
   id: 3304
   effort_id: 116
@@ -4289,6 +4574,7 @@ hardrock_2015_bruno_fadel_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 17:18:00'
+  elapsed_seconds: 105480.0
 hardrock_2015_bruno_fadel_telluride_out_1:
   id: 3305
   effort_id: 116
@@ -4304,6 +4590,7 @@ hardrock_2015_bruno_fadel_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 17:37:00'
+  elapsed_seconds: 106620.0
 hardrock_2015_bruno_fadel_putnam_in_1:
   id: 3310
   effort_id: 116
@@ -4319,6 +4606,7 @@ hardrock_2015_bruno_fadel_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 08:22:00'
+  elapsed_seconds: 159720.0
 hardrock_2015_bruno_fadel_putnam_out_1:
   id: 3311
   effort_id: 116
@@ -4334,6 +4622,7 @@ hardrock_2015_bruno_fadel_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 08:28:00'
+  elapsed_seconds: 160080.0
 hardrock_2015_bruno_fadel_finish_1:
   id: 3312
   effort_id: 116
@@ -4349,6 +4638,7 @@ hardrock_2015_bruno_fadel_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 11:17:00'
+  elapsed_seconds: 170220.0
 hardrock_2015_gus_walker_start_1:
   id: 3313
   effort_id: 117
@@ -4364,6 +4654,7 @@ hardrock_2015_gus_walker_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_gus_walker_cunningham_in_1:
   id: 3314
   effort_id: 117
@@ -4379,6 +4670,7 @@ hardrock_2015_gus_walker_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:05:00'
+  elapsed_seconds: 11100.0
 hardrock_2015_gus_walker_cunningham_out_1:
   id: 3315
   effort_id: 117
@@ -4394,6 +4686,7 @@ hardrock_2015_gus_walker_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:05:00'
+  elapsed_seconds: 11100.0
 hardrock_2015_gus_walker_sherman_in_1:
   id: 3320
   effort_id: 117
@@ -4409,6 +4702,7 @@ hardrock_2015_gus_walker_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 22:26:00'
+  elapsed_seconds: 37560.0
 hardrock_2015_gus_walker_sherman_out_1:
   id: 3321
   effort_id: 117
@@ -4424,6 +4718,7 @@ hardrock_2015_gus_walker_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 22:46:00'
+  elapsed_seconds: 38760.0
 hardrock_2015_gus_walker_grouse_in_1:
   id: 3324
   effort_id: 117
@@ -4439,6 +4734,7 @@ hardrock_2015_gus_walker_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:05:00'
+  elapsed_seconds: 61500.0
 hardrock_2015_gus_walker_grouse_out_1:
   id: 3325
   effort_id: 117
@@ -4454,6 +4750,7 @@ hardrock_2015_gus_walker_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:09:00'
+  elapsed_seconds: 61740.0
 hardrock_2015_gus_walker_ouray_in_1:
   id: 3328
   effort_id: 117
@@ -4469,6 +4766,7 @@ hardrock_2015_gus_walker_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 09:04:00'
+  elapsed_seconds: 75840.0
 hardrock_2015_gus_walker_ouray_out_1:
   id: 3329
   effort_id: 117
@@ -4484,6 +4782,7 @@ hardrock_2015_gus_walker_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 09:16:00'
+  elapsed_seconds: 76560.0
 hardrock_2015_gus_walker_telluride_in_1:
   id: 3334
   effort_id: 117
@@ -4499,6 +4798,7 @@ hardrock_2015_gus_walker_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 18:49:00'
+  elapsed_seconds: 110940.0
 hardrock_2015_gus_walker_telluride_out_1:
   id: 3335
   effort_id: 117
@@ -4514,6 +4814,7 @@ hardrock_2015_gus_walker_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 19:08:00'
+  elapsed_seconds: 112080.0
 hardrock_2015_gus_walker_putnam_in_1:
   id: 3340
   effort_id: 117
@@ -4529,6 +4830,7 @@ hardrock_2015_gus_walker_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 09:28:00'
+  elapsed_seconds: 163680.0
 hardrock_2015_gus_walker_putnam_out_1:
   id: 3341
   effort_id: 117
@@ -4544,6 +4846,7 @@ hardrock_2015_gus_walker_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 09:30:00'
+  elapsed_seconds: 163800.0
 hardrock_2015_gus_walker_finish_1:
   id: 3342
   effort_id: 117
@@ -4559,6 +4862,7 @@ hardrock_2015_gus_walker_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 11:22:00'
+  elapsed_seconds: 170520.0
 hardrock_2015_susanna_abshire_start_1:
   id: 3433
   effort_id: 121
@@ -4574,6 +4878,7 @@ hardrock_2015_susanna_abshire_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_susanna_abshire_cunningham_in_1:
   id: 3434
   effort_id: 121
@@ -4589,6 +4894,7 @@ hardrock_2015_susanna_abshire_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:16:00'
+  elapsed_seconds: 11760.0
 hardrock_2015_susanna_abshire_cunningham_out_1:
   id: 3435
   effort_id: 121
@@ -4604,6 +4910,7 @@ hardrock_2015_susanna_abshire_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:16:00'
+  elapsed_seconds: 11760.0
 hardrock_2015_susanna_abshire_sherman_in_1:
   id: 3440
   effort_id: 121
@@ -4619,6 +4926,7 @@ hardrock_2015_susanna_abshire_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 22:50:00'
+  elapsed_seconds: 39000.0
 hardrock_2015_susanna_abshire_sherman_out_1:
   id: 3441
   effort_id: 121
@@ -4634,6 +4942,7 @@ hardrock_2015_susanna_abshire_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:02:00'
+  elapsed_seconds: 39720.0
 hardrock_2015_susanna_abshire_grouse_in_1:
   id: 3444
   effort_id: 121
@@ -4649,6 +4958,7 @@ hardrock_2015_susanna_abshire_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:25:00'
+  elapsed_seconds: 62700.0
 hardrock_2015_susanna_abshire_grouse_out_1:
   id: 3445
   effort_id: 121
@@ -4664,6 +4974,7 @@ hardrock_2015_susanna_abshire_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:38:00'
+  elapsed_seconds: 63480.0
 hardrock_2015_susanna_abshire_telluride_in_1:
   id: 3454
   effort_id: 121
@@ -4679,6 +4990,7 @@ hardrock_2015_susanna_abshire_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 19:11:00'
+  elapsed_seconds: 112260.0
 hardrock_2015_susanna_abshire_telluride_out_1:
   id: 3455
   effort_id: 121
@@ -4694,6 +5006,7 @@ hardrock_2015_susanna_abshire_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 19:21:00'
+  elapsed_seconds: 112860.0
 hardrock_2015_susanna_abshire_putnam_in_1:
   id: 3460
   effort_id: 121
@@ -4709,6 +5022,7 @@ hardrock_2015_susanna_abshire_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 09:26:00'
+  elapsed_seconds: 163560.0
 hardrock_2015_susanna_abshire_putnam_out_1:
   id: 3461
   effort_id: 121
@@ -4724,6 +5038,7 @@ hardrock_2015_susanna_abshire_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 09:26:00'
+  elapsed_seconds: 163560.0
 hardrock_2015_susanna_abshire_finish_1:
   id: 3462
   effort_id: 121
@@ -4739,6 +5054,7 @@ hardrock_2015_susanna_abshire_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 11:31:00'
+  elapsed_seconds: 171060.0
 hardrock_2015_leandro_cole_start_1:
   id: 3553
   effort_id: 125
@@ -4754,6 +5070,7 @@ hardrock_2015_leandro_cole_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_leandro_cole_cunningham_in_1:
   id: 3554
   effort_id: 125
@@ -4769,6 +5086,7 @@ hardrock_2015_leandro_cole_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:14:00'
+  elapsed_seconds: 11640.0
 hardrock_2015_leandro_cole_cunningham_out_1:
   id: 3555
   effort_id: 125
@@ -4784,6 +5102,7 @@ hardrock_2015_leandro_cole_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:14:00'
+  elapsed_seconds: 11640.0
 hardrock_2015_leandro_cole_sherman_in_1:
   id: 3560
   effort_id: 125
@@ -4799,6 +5118,7 @@ hardrock_2015_leandro_cole_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 22:15:00'
+  elapsed_seconds: 36900.0
 hardrock_2015_leandro_cole_sherman_out_1:
   id: 3561
   effort_id: 125
@@ -4814,6 +5134,7 @@ hardrock_2015_leandro_cole_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 22:35:00'
+  elapsed_seconds: 38100.0
 hardrock_2015_leandro_cole_grouse_in_1:
   id: 3564
   effort_id: 125
@@ -4829,6 +5150,7 @@ hardrock_2015_leandro_cole_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:18:00'
+  elapsed_seconds: 58680.0
 hardrock_2015_leandro_cole_grouse_out_1:
   id: 3565
   effort_id: 125
@@ -4844,6 +5166,7 @@ hardrock_2015_leandro_cole_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:53:00'
+  elapsed_seconds: 60780.0
 hardrock_2015_leandro_cole_ouray_in_1:
   id: 3568
   effort_id: 125
@@ -4859,6 +5182,7 @@ hardrock_2015_leandro_cole_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 07:39:00'
+  elapsed_seconds: 70740.0
 hardrock_2015_leandro_cole_ouray_out_1:
   id: 3569
   effort_id: 125
@@ -4874,6 +5198,7 @@ hardrock_2015_leandro_cole_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 07:47:00'
+  elapsed_seconds: 71220.0
 hardrock_2015_leandro_cole_telluride_in_1:
   id: 3574
   effort_id: 125
@@ -4889,6 +5214,7 @@ hardrock_2015_leandro_cole_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 18:49:00'
+  elapsed_seconds: 110940.0
 hardrock_2015_leandro_cole_telluride_out_1:
   id: 3575
   effort_id: 125
@@ -4904,6 +5230,7 @@ hardrock_2015_leandro_cole_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 19:14:00'
+  elapsed_seconds: 112440.0
 hardrock_2015_leandro_cole_putnam_in_1:
   id: 3580
   effort_id: 125
@@ -4919,6 +5246,7 @@ hardrock_2015_leandro_cole_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 09:30:00'
+  elapsed_seconds: 163800.0
 hardrock_2015_leandro_cole_putnam_out_1:
   id: 3581
   effort_id: 125
@@ -4934,6 +5262,7 @@ hardrock_2015_leandro_cole_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 09:32:00'
+  elapsed_seconds: 163920.0
 hardrock_2015_leandro_cole_finish_1:
   id: 3582
   effort_id: 125
@@ -4949,6 +5278,7 @@ hardrock_2015_leandro_cole_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 11:37:00'
+  elapsed_seconds: 171420.0
 hardrock_2015_benedict_davis_start_1:
   id: 3673
   effort_id: 129
@@ -4964,6 +5294,7 @@ hardrock_2015_benedict_davis_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_benedict_davis_cunningham_in_1:
   id: 3674
   effort_id: 129
@@ -4979,6 +5310,7 @@ hardrock_2015_benedict_davis_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:05:00'
+  elapsed_seconds: 11100.0
 hardrock_2015_benedict_davis_cunningham_out_1:
   id: 3675
   effort_id: 129
@@ -4994,6 +5326,7 @@ hardrock_2015_benedict_davis_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:05:00'
+  elapsed_seconds: 11100.0
 hardrock_2015_benedict_davis_sherman_in_1:
   id: 3680
   effort_id: 129
@@ -5009,6 +5342,7 @@ hardrock_2015_benedict_davis_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 22:29:00'
+  elapsed_seconds: 37740.0
 hardrock_2015_benedict_davis_sherman_out_1:
   id: 3681
   effort_id: 129
@@ -5024,6 +5358,7 @@ hardrock_2015_benedict_davis_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 22:58:00'
+  elapsed_seconds: 39480.0
 hardrock_2015_benedict_davis_grouse_in_1:
   id: 3684
   effort_id: 129
@@ -5039,6 +5374,7 @@ hardrock_2015_benedict_davis_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 04:59:00'
+  elapsed_seconds: 61140.0
 hardrock_2015_benedict_davis_grouse_out_1:
   id: 3685
   effort_id: 129
@@ -5054,6 +5390,7 @@ hardrock_2015_benedict_davis_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:36:00'
+  elapsed_seconds: 63360.0
 hardrock_2015_benedict_davis_ouray_in_1:
   id: 3688
   effort_id: 129
@@ -5069,6 +5406,7 @@ hardrock_2015_benedict_davis_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 08:24:00'
+  elapsed_seconds: 73440.0
 hardrock_2015_benedict_davis_ouray_out_1:
   id: 3689
   effort_id: 129
@@ -5084,6 +5422,7 @@ hardrock_2015_benedict_davis_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 08:30:00'
+  elapsed_seconds: 73800.0
 hardrock_2015_benedict_davis_telluride_in_1:
   id: 3694
   effort_id: 129
@@ -5099,6 +5438,7 @@ hardrock_2015_benedict_davis_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 17:55:00'
+  elapsed_seconds: 107700.0
 hardrock_2015_benedict_davis_telluride_out_1:
   id: 3695
   effort_id: 129
@@ -5114,6 +5454,7 @@ hardrock_2015_benedict_davis_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 18:27:00'
+  elapsed_seconds: 109620.0
 hardrock_2015_benedict_davis_putnam_in_1:
   id: 3700
   effort_id: 129
@@ -5129,6 +5470,7 @@ hardrock_2015_benedict_davis_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 09:58:00'
+  elapsed_seconds: 165480.0
 hardrock_2015_benedict_davis_putnam_out_1:
   id: 3701
   effort_id: 129
@@ -5144,6 +5486,7 @@ hardrock_2015_benedict_davis_putnam_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 10:00:00'
+  elapsed_seconds: 165600.0
 hardrock_2015_benedict_davis_finish_1:
   id: 3702
   effort_id: 129
@@ -5159,6 +5502,7 @@ hardrock_2015_benedict_davis_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 11:59:00'
+  elapsed_seconds: 172740.0
 hardrock_2015_raphael_swift_start_1:
   id: 3869
   effort_id: 136
@@ -5174,6 +5518,7 @@ hardrock_2015_raphael_swift_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_raphael_swift_cunningham_in_1:
   id: 3870
   effort_id: 136
@@ -5189,6 +5534,7 @@ hardrock_2015_raphael_swift_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:24:00'
+  elapsed_seconds: 12240.0
 hardrock_2015_raphael_swift_cunningham_out_1:
   id: 3871
   effort_id: 136
@@ -5204,6 +5550,7 @@ hardrock_2015_raphael_swift_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:24:00'
+  elapsed_seconds: 12240.0
 hardrock_2015_raphael_swift_sherman_in_1:
   id: 3876
   effort_id: 136
@@ -5219,6 +5566,7 @@ hardrock_2015_raphael_swift_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 22:53:00'
+  elapsed_seconds: 39180.0
 hardrock_2015_raphael_swift_sherman_out_1:
   id: 3877
   effort_id: 136
@@ -5234,6 +5582,7 @@ hardrock_2015_raphael_swift_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:02:00'
+  elapsed_seconds: 39720.0
 hardrock_2015_raphael_swift_grouse_in_1:
   id: 3880
   effort_id: 136
@@ -5249,6 +5598,7 @@ hardrock_2015_raphael_swift_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:04:00'
+  elapsed_seconds: 61440.0
 hardrock_2015_raphael_swift_grouse_out_1:
   id: 3881
   effort_id: 136
@@ -5264,6 +5614,7 @@ hardrock_2015_raphael_swift_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:13:00'
+  elapsed_seconds: 61980.0
 hardrock_2015_raphael_swift_ouray_in_1:
   id: 3884
   effort_id: 136
@@ -5279,6 +5630,7 @@ hardrock_2015_raphael_swift_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 07:59:00'
+  elapsed_seconds: 71940.0
 hardrock_2015_raphael_swift_ouray_out_1:
   id: 3885
   effort_id: 136
@@ -5294,6 +5646,7 @@ hardrock_2015_raphael_swift_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 08:06:00'
+  elapsed_seconds: 72360.0
 hardrock_2015_raphael_swift_telluride_in_1:
   id: 3890
   effort_id: 136
@@ -5309,6 +5662,7 @@ hardrock_2015_raphael_swift_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 18:22:00'
+  elapsed_seconds: 109320.0
 hardrock_2015_raphael_swift_telluride_out_1:
   id: 3891
   effort_id: 136
@@ -5324,6 +5678,7 @@ hardrock_2015_raphael_swift_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 18:44:00'
+  elapsed_seconds: 110640.0
 hardrock_2015_bad_status_start_1:
   id: 3919
   effort_id: 138
@@ -5339,6 +5694,7 @@ hardrock_2015_bad_status_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_bad_status_cunningham_in_1:
   id: 3920
   effort_id: 138
@@ -5354,6 +5710,7 @@ hardrock_2015_bad_status_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:13:00'
+  elapsed_seconds: 11580.0
 hardrock_2015_bad_status_cunningham_out_1:
   id: 3921
   effort_id: 138
@@ -5369,6 +5726,7 @@ hardrock_2015_bad_status_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:13:00'
+  elapsed_seconds: 11580.0
 hardrock_2015_bad_status_sherman_in_1:
   id: 3926
   effort_id: 138
@@ -5384,6 +5742,7 @@ hardrock_2015_bad_status_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:11:00'
+  elapsed_seconds: 40260.0
 hardrock_2015_bad_status_sherman_out_1:
   id: 3927
   effort_id: 138
@@ -5399,6 +5758,7 @@ hardrock_2015_bad_status_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 23:22:00'
+  elapsed_seconds: 40920.0
 hardrock_2015_bad_status_grouse_in_1:
   id: 3930
   effort_id: 138
@@ -5414,6 +5774,7 @@ hardrock_2015_bad_status_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:37:00'
+  elapsed_seconds: 67020.0
 hardrock_2015_bad_status_grouse_out_1:
   id: 3931
   effort_id: 138
@@ -5429,6 +5790,7 @@ hardrock_2015_bad_status_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 06:51:00'
+  elapsed_seconds: 67860.0
 hardrock_2015_bad_status_ouray_in_1:
   id: 3934
   effort_id: 138
@@ -5444,6 +5806,7 @@ hardrock_2015_bad_status_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 13:19:00'
+  elapsed_seconds: 91140.0
 hardrock_2015_bad_status_ouray_out_1:
   id: 3935
   effort_id: 138
@@ -5459,6 +5822,7 @@ hardrock_2015_bad_status_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 14:09:00'
+  elapsed_seconds: 94140.0
 hardrock_2015_irvin_harber_start_1:
   id: 3980
   effort_id: 141
@@ -5474,6 +5838,7 @@ hardrock_2015_irvin_harber_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_irvin_harber_cunningham_in_1:
   id: 3981
   effort_id: 141
@@ -5489,6 +5854,7 @@ hardrock_2015_irvin_harber_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:24:00'
+  elapsed_seconds: 8640.0
 hardrock_2015_irvin_harber_cunningham_out_1:
   id: 3982
   effort_id: 141
@@ -5504,6 +5870,7 @@ hardrock_2015_irvin_harber_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:24:00'
+  elapsed_seconds: 8640.0
 hardrock_2015_irvin_harber_sherman_in_1:
   id: 3987
   effort_id: 141
@@ -5519,6 +5886,7 @@ hardrock_2015_irvin_harber_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:39:00'
+  elapsed_seconds: 27540.0
 hardrock_2015_irvin_harber_sherman_out_1:
   id: 3988
   effort_id: 141
@@ -5534,6 +5902,7 @@ hardrock_2015_irvin_harber_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 19:45:00'
+  elapsed_seconds: 27900.0
 hardrock_2015_irvin_harber_grouse_in_1:
   id: 3991
   effort_id: 141
@@ -5549,6 +5918,7 @@ hardrock_2015_irvin_harber_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:44:00'
+  elapsed_seconds: 45840.0
 hardrock_2015_irvin_harber_grouse_out_1:
   id: 3992
   effort_id: 141
@@ -5564,6 +5934,7 @@ hardrock_2015_irvin_harber_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 01:10:00'
+  elapsed_seconds: 47400.0
 hardrock_2015_irvin_harber_ouray_in_1:
   id: 3995
   effort_id: 141
@@ -5579,6 +5950,7 @@ hardrock_2015_irvin_harber_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:46:00'
+  elapsed_seconds: 63960.0
 hardrock_2015_irvin_harber_ouray_out_1:
   id: 3996
   effort_id: 141
@@ -5594,6 +5966,7 @@ hardrock_2015_irvin_harber_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 05:46:00'
+  elapsed_seconds: 63960.0
 hardrock_2015_cassondra_nienow_start_1:
   id: 4190
   effort_id: 155
@@ -5609,6 +5982,7 @@ hardrock_2015_cassondra_nienow_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_cassondra_nienow_cunningham_in_1:
   id: 4191
   effort_id: 155
@@ -5624,6 +5998,7 @@ hardrock_2015_cassondra_nienow_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:31:00'
+  elapsed_seconds: 12660.0
 hardrock_2015_cassondra_nienow_cunningham_out_1:
   id: 4192
   effort_id: 155
@@ -5639,6 +6014,7 @@ hardrock_2015_cassondra_nienow_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 15:31:00'
+  elapsed_seconds: 12660.0
 hardrock_2015_cassondra_nienow_sherman_in_1:
   id: 4197
   effort_id: 155
@@ -5654,6 +6030,7 @@ hardrock_2015_cassondra_nienow_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 00:03:00'
+  elapsed_seconds: 43380.0
 hardrock_2015_cassondra_nienow_sherman_out_1:
   id: 4198
   effort_id: 155
@@ -5669,6 +6046,7 @@ hardrock_2015_cassondra_nienow_sherman_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-11 00:03:00'
+  elapsed_seconds: 43380.0
 hardrock_2015_donn_mckenzie_start_1:
   id: 4217
   effort_id: 158
@@ -5684,6 +6062,7 @@ hardrock_2015_donn_mckenzie_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_donn_mckenzie_cunningham_in_1:
   id: 4218
   effort_id: 158
@@ -5699,6 +6078,7 @@ hardrock_2015_donn_mckenzie_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:30:00'
+  elapsed_seconds: 9000.0
 hardrock_2015_donn_mckenzie_cunningham_out_1:
   id: 4219
   effort_id: 158
@@ -5714,6 +6094,7 @@ hardrock_2015_donn_mckenzie_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 14:30:00'
+  elapsed_seconds: 9000.0
 ramble_finished_first_start_1:
   id: 15144
   effort_id: 1040
@@ -5729,6 +6110,7 @@ ramble_finished_first_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2006-09-16 14:00:00'
+  elapsed_seconds: 0.0
 ramble_finished_first_finish_1:
   id: 15145
   effort_id: 1040
@@ -5744,6 +6126,7 @@ ramble_finished_first_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2006-09-16 14:34:22'
+  elapsed_seconds: 2062.0
 ramble_finished_second_start_1:
   id: 15160
   effort_id: 1048
@@ -5759,6 +6142,7 @@ ramble_finished_second_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2006-09-16 14:00:00'
+  elapsed_seconds: 0.0
 ramble_finished_second_finish_1:
   id: 15161
   effort_id: 1048
@@ -5774,6 +6158,7 @@ ramble_finished_second_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2006-09-16 14:37:31'
+  elapsed_seconds: 2251.0
 ramble_start_only_start_1:
   id: 15166
   effort_id: 1051
@@ -5789,6 +6174,7 @@ ramble_start_only_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2006-09-16 14:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_finished_first_start_1:
   id: 91259
   effort_id: 4172
@@ -5804,6 +6190,7 @@ hardrock_2014_finished_first_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_finished_first_telluride_in_1:
   id: 91264
   effort_id: 4172
@@ -5819,6 +6206,7 @@ hardrock_2014_finished_first_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 18:24:00'
+  elapsed_seconds: 23040.0
 hardrock_2014_finished_first_telluride_out_1:
   id: 91265
   effort_id: 4172
@@ -5834,6 +6222,7 @@ hardrock_2014_finished_first_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 18:26:00'
+  elapsed_seconds: 23160.0
 hardrock_2014_finished_first_ouray_in_1:
   id: 91270
   effort_id: 4172
@@ -5849,6 +6238,7 @@ hardrock_2014_finished_first_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 21:50:00'
+  elapsed_seconds: 35400.0
 hardrock_2014_finished_first_ouray_out_1:
   id: 91271
   effort_id: 4172
@@ -5864,6 +6254,7 @@ hardrock_2014_finished_first_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 21:52:00'
+  elapsed_seconds: 35520.0
 hardrock_2014_finished_first_grouse_in_1:
   id: 91274
   effort_id: 4172
@@ -5879,6 +6270,7 @@ hardrock_2014_finished_first_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 01:38:00'
+  elapsed_seconds: 49080.0
 hardrock_2014_finished_first_grouse_out_1:
   id: 91275
   effort_id: 4172
@@ -5894,6 +6286,7 @@ hardrock_2014_finished_first_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 01:43:00'
+  elapsed_seconds: 49380.0
 hardrock_2014_finished_first_sherman_in_1:
   id: 91278
   effort_id: 4172
@@ -5909,6 +6302,7 @@ hardrock_2014_finished_first_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 06:08:00'
+  elapsed_seconds: 65280.0
 hardrock_2014_finished_first_sherman_out_1:
   id: 91279
   effort_id: 4172
@@ -5924,6 +6318,7 @@ hardrock_2014_finished_first_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 06:17:00'
+  elapsed_seconds: 65820.0
 hardrock_2014_finished_first_cunningham_in_1:
   id: 91284
   effort_id: 4172
@@ -5939,6 +6334,7 @@ hardrock_2014_finished_first_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 13:21:00'
+  elapsed_seconds: 91260.0
 hardrock_2014_finished_first_cunningham_out_1:
   id: 91285
   effort_id: 4172
@@ -5954,6 +6350,7 @@ hardrock_2014_finished_first_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 13:27:00'
+  elapsed_seconds: 91620.0
 hardrock_2014_finished_first_finish_1:
   id: 91286
   effort_id: 4172
@@ -5969,6 +6366,7 @@ hardrock_2014_finished_first_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-12 16:07:38'
+  elapsed_seconds: 101258.0
 hardrock_2014_finished_with_stop_start_1:
   id: 91287
   effort_id: 4173
@@ -5984,6 +6382,7 @@ hardrock_2014_finished_with_stop_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_finished_with_stop_telluride_in_1:
   id: 91292
   effort_id: 4173
@@ -5999,6 +6398,7 @@ hardrock_2014_finished_with_stop_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 18:59:00'
+  elapsed_seconds: 25140.0
 hardrock_2014_finished_with_stop_telluride_out_1:
   id: 91293
   effort_id: 4173
@@ -6014,6 +6414,7 @@ hardrock_2014_finished_with_stop_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 19:03:00'
+  elapsed_seconds: 25380.0
 hardrock_2014_finished_with_stop_ouray_in_1:
   id: 91298
   effort_id: 4173
@@ -6029,6 +6430,7 @@ hardrock_2014_finished_with_stop_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:43:00'
+  elapsed_seconds: 38580.0
 hardrock_2014_finished_with_stop_ouray_out_1:
   id: 91299
   effort_id: 4173
@@ -6044,6 +6446,7 @@ hardrock_2014_finished_with_stop_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:46:00'
+  elapsed_seconds: 38760.0
 hardrock_2014_finished_with_stop_grouse_in_1:
   id: 91302
   effort_id: 4173
@@ -6059,6 +6462,7 @@ hardrock_2014_finished_with_stop_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 02:56:00'
+  elapsed_seconds: 53760.0
 hardrock_2014_finished_with_stop_grouse_out_1:
   id: 91303
   effort_id: 4173
@@ -6074,6 +6478,7 @@ hardrock_2014_finished_with_stop_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 03:06:00'
+  elapsed_seconds: 54360.0
 hardrock_2014_finished_with_stop_sherman_in_1:
   id: 91306
   effort_id: 4173
@@ -6089,6 +6494,7 @@ hardrock_2014_finished_with_stop_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 07:05:00'
+  elapsed_seconds: 68700.0
 hardrock_2014_finished_with_stop_sherman_out_1:
   id: 91307
   effort_id: 4173
@@ -6104,6 +6510,7 @@ hardrock_2014_finished_with_stop_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 07:15:00'
+  elapsed_seconds: 69300.0
 hardrock_2014_finished_with_stop_cunningham_in_1:
   id: 91312
   effort_id: 4173
@@ -6119,6 +6526,7 @@ hardrock_2014_finished_with_stop_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 13:43:00'
+  elapsed_seconds: 92580.0
 hardrock_2014_finished_with_stop_cunningham_out_1:
   id: 91313
   effort_id: 4173
@@ -6134,6 +6542,7 @@ hardrock_2014_finished_with_stop_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 13:46:00'
+  elapsed_seconds: 92760.0
 hardrock_2014_finished_with_stop_finish_1:
   id: 91314
   effort_id: 4173
@@ -6149,6 +6558,7 @@ hardrock_2014_finished_with_stop_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-12 16:23:42'
+  elapsed_seconds: 102222.0
 hardrock_2014_finished_without_stop_start_1:
   id: 91315
   effort_id: 4174
@@ -6164,6 +6574,7 @@ hardrock_2014_finished_without_stop_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_finished_without_stop_telluride_in_1:
   id: 91320
   effort_id: 4174
@@ -6179,6 +6590,7 @@ hardrock_2014_finished_without_stop_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 18:53:00'
+  elapsed_seconds: 24780.0
 hardrock_2014_finished_without_stop_telluride_out_1:
   id: 91321
   effort_id: 4174
@@ -6194,6 +6606,7 @@ hardrock_2014_finished_without_stop_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 18:56:00'
+  elapsed_seconds: 24960.0
 hardrock_2014_finished_without_stop_ouray_in_1:
   id: 91326
   effort_id: 4174
@@ -6209,6 +6622,7 @@ hardrock_2014_finished_without_stop_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:43:00'
+  elapsed_seconds: 38580.0
 hardrock_2014_finished_without_stop_ouray_out_1:
   id: 91327
   effort_id: 4174
@@ -6224,6 +6638,7 @@ hardrock_2014_finished_without_stop_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:50:00'
+  elapsed_seconds: 39000.0
 hardrock_2014_finished_without_stop_grouse_in_1:
   id: 91330
   effort_id: 4174
@@ -6239,6 +6654,7 @@ hardrock_2014_finished_without_stop_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 03:10:00'
+  elapsed_seconds: 54600.0
 hardrock_2014_finished_without_stop_grouse_out_1:
   id: 91331
   effort_id: 4174
@@ -6254,6 +6670,7 @@ hardrock_2014_finished_without_stop_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 03:15:00'
+  elapsed_seconds: 54900.0
 hardrock_2014_finished_without_stop_sherman_in_1:
   id: 91334
   effort_id: 4174
@@ -6269,6 +6686,7 @@ hardrock_2014_finished_without_stop_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 07:15:00'
+  elapsed_seconds: 69300.0
 hardrock_2014_finished_without_stop_sherman_out_1:
   id: 91335
   effort_id: 4174
@@ -6284,6 +6702,7 @@ hardrock_2014_finished_without_stop_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 07:23:59'
+  elapsed_seconds: 69839.0
 hardrock_2014_finished_without_stop_cunningham_in_1:
   id: 91340
   effort_id: 4174
@@ -6299,6 +6718,7 @@ hardrock_2014_finished_without_stop_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 14:04:00'
+  elapsed_seconds: 93840.0
 hardrock_2014_finished_without_stop_cunningham_out_1:
   id: 91341
   effort_id: 4174
@@ -6314,6 +6734,7 @@ hardrock_2014_finished_without_stop_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 14:04:00'
+  elapsed_seconds: 93840.0
 hardrock_2014_finished_without_stop_finish_1:
   id: 91342
   effort_id: 4174
@@ -6329,6 +6750,7 @@ hardrock_2014_finished_without_stop_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 16:28:54'
+  elapsed_seconds: 102534.0
 hardrock_2014_claudio_wunsch_start_1:
   id: 91819
   effort_id: 4192
@@ -6344,6 +6766,7 @@ hardrock_2014_claudio_wunsch_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_claudio_wunsch_telluride_in_1:
   id: 91824
   effort_id: 4192
@@ -6359,6 +6782,7 @@ hardrock_2014_claudio_wunsch_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 19:00:00'
+  elapsed_seconds: 25200.0
 hardrock_2014_claudio_wunsch_telluride_out_1:
   id: 91825
   effort_id: 4192
@@ -6374,6 +6798,7 @@ hardrock_2014_claudio_wunsch_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 19:07:00'
+  elapsed_seconds: 25620.0
 hardrock_2014_claudio_wunsch_ouray_in_1:
   id: 91830
   effort_id: 4192
@@ -6389,6 +6814,7 @@ hardrock_2014_claudio_wunsch_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 23:04:00'
+  elapsed_seconds: 39840.0
 hardrock_2014_claudio_wunsch_ouray_out_1:
   id: 91831
   effort_id: 4192
@@ -6404,6 +6830,7 @@ hardrock_2014_claudio_wunsch_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 23:24:00'
+  elapsed_seconds: 41040.0
 hardrock_2014_claudio_wunsch_grouse_in_1:
   id: 91834
   effort_id: 4192
@@ -6419,6 +6846,7 @@ hardrock_2014_claudio_wunsch_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 03:55:00'
+  elapsed_seconds: 57300.0
 hardrock_2014_claudio_wunsch_grouse_out_1:
   id: 91835
   effort_id: 4192
@@ -6434,6 +6862,7 @@ hardrock_2014_claudio_wunsch_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 04:37:00'
+  elapsed_seconds: 59820.0
 hardrock_2014_claudio_wunsch_sherman_in_1:
   id: 91838
   effort_id: 4192
@@ -6449,6 +6878,7 @@ hardrock_2014_claudio_wunsch_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 10:17:00'
+  elapsed_seconds: 80220.0
 hardrock_2014_claudio_wunsch_sherman_out_1:
   id: 91839
   effort_id: 4192
@@ -6464,6 +6894,7 @@ hardrock_2014_claudio_wunsch_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 10:33:00'
+  elapsed_seconds: 81180.0
 hardrock_2014_claudio_wunsch_cunningham_in_1:
   id: 91844
   effort_id: 4192
@@ -6479,6 +6910,7 @@ hardrock_2014_claudio_wunsch_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 19:19:00'
+  elapsed_seconds: 112740.0
 hardrock_2014_claudio_wunsch_cunningham_out_1:
   id: 91845
   effort_id: 4192
@@ -6494,6 +6926,7 @@ hardrock_2014_claudio_wunsch_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 19:34:00'
+  elapsed_seconds: 113640.0
 hardrock_2014_claudio_wunsch_finish_1:
   id: 91846
   effort_id: 4192
@@ -6509,6 +6942,7 @@ hardrock_2014_claudio_wunsch_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-12 23:58:21'
+  elapsed_seconds: 129501.0
 hardrock_2014_paul_predovic_start_1:
   id: 92015
   effort_id: 4199
@@ -6524,6 +6958,7 @@ hardrock_2014_paul_predovic_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_paul_predovic_telluride_in_1:
   id: 92020
   effort_id: 4199
@@ -6539,6 +6974,7 @@ hardrock_2014_paul_predovic_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 20:26:59'
+  elapsed_seconds: 30419.0
 hardrock_2014_paul_predovic_telluride_out_1:
   id: 92021
   effort_id: 4199
@@ -6554,6 +6990,7 @@ hardrock_2014_paul_predovic_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 20:39:00'
+  elapsed_seconds: 31140.0
 hardrock_2014_paul_predovic_ouray_in_1:
   id: 92026
   effort_id: 4199
@@ -6569,6 +7006,7 @@ hardrock_2014_paul_predovic_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 01:23:00'
+  elapsed_seconds: 48180.0
 hardrock_2014_paul_predovic_ouray_out_1:
   id: 92027
   effort_id: 4199
@@ -6584,6 +7022,7 @@ hardrock_2014_paul_predovic_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 01:33:00'
+  elapsed_seconds: 48780.0
 hardrock_2014_paul_predovic_grouse_in_1:
   id: 92030
   effort_id: 4199
@@ -6599,6 +7038,7 @@ hardrock_2014_paul_predovic_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 07:25:00'
+  elapsed_seconds: 69900.0
 hardrock_2014_paul_predovic_grouse_out_1:
   id: 92031
   effort_id: 4199
@@ -6614,6 +7054,7 @@ hardrock_2014_paul_predovic_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 07:49:00'
+  elapsed_seconds: 71340.0
 hardrock_2014_paul_predovic_sherman_in_1:
   id: 92034
   effort_id: 4199
@@ -6629,6 +7070,7 @@ hardrock_2014_paul_predovic_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 13:30:00'
+  elapsed_seconds: 91800.0
 hardrock_2014_paul_predovic_sherman_out_1:
   id: 92035
   effort_id: 4199
@@ -6644,6 +7086,7 @@ hardrock_2014_paul_predovic_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 13:49:00'
+  elapsed_seconds: 92940.0
 hardrock_2014_paul_predovic_cunningham_in_1:
   id: 92040
   effort_id: 4199
@@ -6659,6 +7102,7 @@ hardrock_2014_paul_predovic_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 21:53:00'
+  elapsed_seconds: 121980.0
 hardrock_2014_paul_predovic_cunningham_out_1:
   id: 92041
   effort_id: 4199
@@ -6674,6 +7118,7 @@ hardrock_2014_paul_predovic_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 21:58:00'
+  elapsed_seconds: 122280.0
 hardrock_2014_paul_predovic_finish_1:
   id: 92042
   effort_id: 4199
@@ -6689,6 +7134,7 @@ hardrock_2014_paul_predovic_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-13 01:39:17'
+  elapsed_seconds: 135557.0
 hardrock_2014_keith_metz_start_1:
   id: 92211
   effort_id: 4206
@@ -6704,6 +7150,7 @@ hardrock_2014_keith_metz_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_keith_metz_telluride_in_1:
   id: 92216
   effort_id: 4206
@@ -6719,6 +7166,7 @@ hardrock_2014_keith_metz_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 20:30:00'
+  elapsed_seconds: 30600.0
 hardrock_2014_keith_metz_telluride_out_1:
   id: 92217
   effort_id: 4206
@@ -6734,6 +7182,7 @@ hardrock_2014_keith_metz_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 20:42:00'
+  elapsed_seconds: 31320.0
 hardrock_2014_keith_metz_ouray_in_1:
   id: 92222
   effort_id: 4206
@@ -6749,6 +7198,7 @@ hardrock_2014_keith_metz_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 01:27:00'
+  elapsed_seconds: 48420.0
 hardrock_2014_keith_metz_ouray_out_1:
   id: 92223
   effort_id: 4206
@@ -6764,6 +7214,7 @@ hardrock_2014_keith_metz_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 01:43:00'
+  elapsed_seconds: 49380.0
 hardrock_2014_keith_metz_grouse_in_1:
   id: 92226
   effort_id: 4206
@@ -6779,6 +7230,7 @@ hardrock_2014_keith_metz_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 07:30:00'
+  elapsed_seconds: 70200.0
 hardrock_2014_keith_metz_grouse_out_1:
   id: 92227
   effort_id: 4206
@@ -6794,6 +7246,7 @@ hardrock_2014_keith_metz_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 07:56:00'
+  elapsed_seconds: 71760.0
 hardrock_2014_keith_metz_sherman_in_1:
   id: 92230
   effort_id: 4206
@@ -6809,6 +7262,7 @@ hardrock_2014_keith_metz_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 14:03:00'
+  elapsed_seconds: 93780.0
 hardrock_2014_keith_metz_sherman_out_1:
   id: 92231
   effort_id: 4206
@@ -6824,6 +7278,7 @@ hardrock_2014_keith_metz_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 14:22:00'
+  elapsed_seconds: 94920.0
 hardrock_2014_keith_metz_cunningham_in_1:
   id: 92236
   effort_id: 4206
@@ -6839,6 +7294,7 @@ hardrock_2014_keith_metz_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 23:19:00'
+  elapsed_seconds: 127140.0
 hardrock_2014_keith_metz_cunningham_out_1:
   id: 92237
   effort_id: 4206
@@ -6854,6 +7310,7 @@ hardrock_2014_keith_metz_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 23:30:00'
+  elapsed_seconds: 127800.0
 hardrock_2014_keith_metz_finish_1:
   id: 92238
   effort_id: 4206
@@ -6869,6 +7326,7 @@ hardrock_2014_keith_metz_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-13 02:59:02'
+  elapsed_seconds: 140342.0
 hardrock_2014_major_green_start_1:
   id: 92239
   effort_id: 4207
@@ -6884,6 +7342,7 @@ hardrock_2014_major_green_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_major_green_telluride_in_1:
   id: 92244
   effort_id: 4207
@@ -6899,6 +7358,7 @@ hardrock_2014_major_green_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 20:52:00'
+  elapsed_seconds: 31920.0
 hardrock_2014_major_green_telluride_out_1:
   id: 92245
   effort_id: 4207
@@ -6914,6 +7374,7 @@ hardrock_2014_major_green_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 20:58:00'
+  elapsed_seconds: 32280.0
 hardrock_2014_major_green_ouray_in_1:
   id: 92250
   effort_id: 4207
@@ -6929,6 +7390,7 @@ hardrock_2014_major_green_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 02:00:00'
+  elapsed_seconds: 50400.0
 hardrock_2014_major_green_ouray_out_1:
   id: 92251
   effort_id: 4207
@@ -6944,6 +7406,7 @@ hardrock_2014_major_green_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 02:12:00'
+  elapsed_seconds: 51120.0
 hardrock_2014_major_green_grouse_in_1:
   id: 92254
   effort_id: 4207
@@ -6959,6 +7422,7 @@ hardrock_2014_major_green_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 08:07:00'
+  elapsed_seconds: 72420.0
 hardrock_2014_major_green_grouse_out_1:
   id: 92255
   effort_id: 4207
@@ -6974,6 +7438,7 @@ hardrock_2014_major_green_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 08:18:00'
+  elapsed_seconds: 73080.0
 hardrock_2014_major_green_sherman_in_1:
   id: 92258
   effort_id: 4207
@@ -6989,6 +7454,7 @@ hardrock_2014_major_green_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 14:25:00'
+  elapsed_seconds: 95100.0
 hardrock_2014_major_green_sherman_out_1:
   id: 92259
   effort_id: 4207
@@ -7004,6 +7470,7 @@ hardrock_2014_major_green_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 14:40:00'
+  elapsed_seconds: 96000.0
 hardrock_2014_major_green_cunningham_in_1:
   id: 92264
   effort_id: 4207
@@ -7019,6 +7486,7 @@ hardrock_2014_major_green_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 23:13:00'
+  elapsed_seconds: 126780.0
 hardrock_2014_major_green_cunningham_out_1:
   id: 92265
   effort_id: 4207
@@ -7034,6 +7502,7 @@ hardrock_2014_major_green_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 23:23:00'
+  elapsed_seconds: 127380.0
 hardrock_2014_major_green_finish_1:
   id: 92266
   effort_id: 4207
@@ -7049,6 +7518,7 @@ hardrock_2014_major_green_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-13 03:03:41'
+  elapsed_seconds: 140621.0
 hardrock_2014_humberto_adams_start_1:
   id: 92631
   effort_id: 4221
@@ -7064,6 +7534,7 @@ hardrock_2014_humberto_adams_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_humberto_adams_telluride_in_1:
   id: 92636
   effort_id: 4221
@@ -7079,6 +7550,7 @@ hardrock_2014_humberto_adams_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 20:54:59'
+  elapsed_seconds: 32099.0
 hardrock_2014_humberto_adams_telluride_out_1:
   id: 92637
   effort_id: 4221
@@ -7094,6 +7566,7 @@ hardrock_2014_humberto_adams_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 21:58:00'
+  elapsed_seconds: 35880.0
 hardrock_2014_humberto_adams_ouray_in_1:
   id: 92642
   effort_id: 4221
@@ -7109,6 +7582,7 @@ hardrock_2014_humberto_adams_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 01:56:59'
+  elapsed_seconds: 50219.0
 hardrock_2014_humberto_adams_ouray_out_1:
   id: 92643
   effort_id: 4221
@@ -7124,6 +7598,7 @@ hardrock_2014_humberto_adams_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 02:20:00'
+  elapsed_seconds: 51600.0
 hardrock_2014_humberto_adams_grouse_in_1:
   id: 92646
   effort_id: 4221
@@ -7139,6 +7614,7 @@ hardrock_2014_humberto_adams_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 09:36:00'
+  elapsed_seconds: 77760.0
 hardrock_2014_humberto_adams_grouse_out_1:
   id: 92647
   effort_id: 4221
@@ -7154,6 +7630,7 @@ hardrock_2014_humberto_adams_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 10:22:00'
+  elapsed_seconds: 80520.0
 hardrock_2014_humberto_adams_sherman_in_1:
   id: 92650
   effort_id: 4221
@@ -7169,6 +7646,7 @@ hardrock_2014_humberto_adams_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 16:25:00'
+  elapsed_seconds: 102300.0
 hardrock_2014_humberto_adams_sherman_out_1:
   id: 92651
   effort_id: 4221
@@ -7184,6 +7662,7 @@ hardrock_2014_humberto_adams_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 16:45:00'
+  elapsed_seconds: 103500.0
 hardrock_2014_humberto_adams_cunningham_in_1:
   id: 92656
   effort_id: 4221
@@ -7199,6 +7678,7 @@ hardrock_2014_humberto_adams_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 01:18:00'
+  elapsed_seconds: 134280.0
 hardrock_2014_humberto_adams_cunningham_out_1:
   id: 92657
   effort_id: 4221
@@ -7214,6 +7694,7 @@ hardrock_2014_humberto_adams_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 01:30:00'
+  elapsed_seconds: 135000.0
 hardrock_2014_humberto_adams_finish_1:
   id: 92658
   effort_id: 4221
@@ -7229,6 +7710,7 @@ hardrock_2014_humberto_adams_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-13 05:40:21'
+  elapsed_seconds: 150021.0
 hardrock_2014_omer_yundt_start_1:
   id: 93331
   effort_id: 4246
@@ -7244,6 +7726,7 @@ hardrock_2014_omer_yundt_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_omer_yundt_telluride_in_1:
   id: 93336
   effort_id: 4246
@@ -7259,6 +7742,7 @@ hardrock_2014_omer_yundt_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 21:34:00'
+  elapsed_seconds: 34440.0
 hardrock_2014_omer_yundt_telluride_out_1:
   id: 93337
   effort_id: 4246
@@ -7274,6 +7758,7 @@ hardrock_2014_omer_yundt_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:06:00'
+  elapsed_seconds: 36360.0
 hardrock_2014_omer_yundt_ouray_in_1:
   id: 93342
   effort_id: 4246
@@ -7289,6 +7774,7 @@ hardrock_2014_omer_yundt_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 03:38:00'
+  elapsed_seconds: 56280.0
 hardrock_2014_omer_yundt_ouray_out_1:
   id: 93343
   effort_id: 4246
@@ -7304,6 +7790,7 @@ hardrock_2014_omer_yundt_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 04:26:00'
+  elapsed_seconds: 59160.0
 hardrock_2014_omer_yundt_grouse_in_1:
   id: 93346
   effort_id: 4246
@@ -7319,6 +7806,7 @@ hardrock_2014_omer_yundt_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 10:33:00'
+  elapsed_seconds: 81180.0
 hardrock_2014_omer_yundt_grouse_out_1:
   id: 93347
   effort_id: 4246
@@ -7334,6 +7822,7 @@ hardrock_2014_omer_yundt_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 11:34:00'
+  elapsed_seconds: 84840.0
 hardrock_2014_omer_yundt_sherman_in_1:
   id: 93350
   effort_id: 4246
@@ -7349,6 +7838,7 @@ hardrock_2014_omer_yundt_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 17:22:00'
+  elapsed_seconds: 105720.0
 hardrock_2014_omer_yundt_sherman_out_1:
   id: 93351
   effort_id: 4246
@@ -7364,6 +7854,7 @@ hardrock_2014_omer_yundt_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 18:00:00'
+  elapsed_seconds: 108000.0
 hardrock_2014_omer_yundt_cunningham_in_1:
   id: 93356
   effort_id: 4246
@@ -7379,6 +7870,7 @@ hardrock_2014_omer_yundt_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 02:14:00'
+  elapsed_seconds: 137640.0
 hardrock_2014_omer_yundt_cunningham_out_1:
   id: 93357
   effort_id: 4246
@@ -7394,6 +7886,7 @@ hardrock_2014_omer_yundt_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 02:33:00'
+  elapsed_seconds: 138780.0
 hardrock_2014_omer_yundt_finish_1:
   id: 93358
   effort_id: 4246
@@ -7409,6 +7902,7 @@ hardrock_2014_omer_yundt_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-13 08:48:15'
+  elapsed_seconds: 161295.0
 hardrock_2014_pat_schaden_start_1:
   id: 93359
   effort_id: 4247
@@ -7424,6 +7918,7 @@ hardrock_2014_pat_schaden_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_pat_schaden_telluride_in_1:
   id: 93364
   effort_id: 4247
@@ -7439,6 +7934,7 @@ hardrock_2014_pat_schaden_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:35:00'
+  elapsed_seconds: 38100.0
 hardrock_2014_pat_schaden_telluride_out_1:
   id: 93365
   effort_id: 4247
@@ -7454,6 +7950,7 @@ hardrock_2014_pat_schaden_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:47:00'
+  elapsed_seconds: 38820.0
 hardrock_2014_pat_schaden_ouray_in_1:
   id: 93370
   effort_id: 4247
@@ -7469,6 +7966,7 @@ hardrock_2014_pat_schaden_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 04:44:00'
+  elapsed_seconds: 60240.0
 hardrock_2014_pat_schaden_ouray_out_1:
   id: 93371
   effort_id: 4247
@@ -7484,6 +7982,7 @@ hardrock_2014_pat_schaden_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 05:16:00'
+  elapsed_seconds: 62160.0
 hardrock_2014_pat_schaden_grouse_in_1:
   id: 93374
   effort_id: 4247
@@ -7499,6 +7998,7 @@ hardrock_2014_pat_schaden_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 12:27:00'
+  elapsed_seconds: 88020.0
 hardrock_2014_pat_schaden_grouse_out_1:
   id: 93375
   effort_id: 4247
@@ -7514,6 +8014,7 @@ hardrock_2014_pat_schaden_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 12:48:00'
+  elapsed_seconds: 89280.0
 hardrock_2014_pat_schaden_sherman_in_1:
   id: 93378
   effort_id: 4247
@@ -7529,6 +8030,7 @@ hardrock_2014_pat_schaden_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 18:29:00'
+  elapsed_seconds: 109740.0
 hardrock_2014_pat_schaden_sherman_out_1:
   id: 93379
   effort_id: 4247
@@ -7544,6 +8046,7 @@ hardrock_2014_pat_schaden_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 18:52:00'
+  elapsed_seconds: 111120.0
 hardrock_2014_pat_schaden_cunningham_in_1:
   id: 93384
   effort_id: 4247
@@ -7559,6 +8062,7 @@ hardrock_2014_pat_schaden_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 04:14:00'
+  elapsed_seconds: 144840.0
 hardrock_2014_clarence_goyette_start_1:
   id: 93415
   effort_id: 4249
@@ -7574,6 +8078,7 @@ hardrock_2014_clarence_goyette_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_clarence_goyette_telluride_in_1:
   id: 93420
   effort_id: 4249
@@ -7589,6 +8094,7 @@ hardrock_2014_clarence_goyette_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:05:00'
+  elapsed_seconds: 36300.0
 hardrock_2014_clarence_goyette_telluride_out_1:
   id: 93421
   effort_id: 4249
@@ -7604,6 +8110,7 @@ hardrock_2014_clarence_goyette_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:14:00'
+  elapsed_seconds: 36840.0
 hardrock_2014_clarence_goyette_ouray_in_1:
   id: 93426
   effort_id: 4249
@@ -7619,6 +8126,7 @@ hardrock_2014_clarence_goyette_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 04:32:00'
+  elapsed_seconds: 59520.0
 hardrock_2014_clarence_goyette_ouray_out_1:
   id: 93427
   effort_id: 4249
@@ -7634,6 +8142,7 @@ hardrock_2014_clarence_goyette_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 05:02:00'
+  elapsed_seconds: 61320.0
 hardrock_2014_clarence_goyette_grouse_in_1:
   id: 93430
   effort_id: 4249
@@ -7649,6 +8158,7 @@ hardrock_2014_clarence_goyette_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 11:19:00'
+  elapsed_seconds: 83940.0
 hardrock_2014_clarence_goyette_grouse_out_1:
   id: 93431
   effort_id: 4249
@@ -7664,6 +8174,7 @@ hardrock_2014_clarence_goyette_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 11:59:00'
+  elapsed_seconds: 86340.0
 hardrock_2014_clarence_goyette_sherman_in_1:
   id: 93434
   effort_id: 4249
@@ -7679,6 +8190,7 @@ hardrock_2014_clarence_goyette_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 18:06:00'
+  elapsed_seconds: 108360.0
 hardrock_2014_clarence_goyette_sherman_out_1:
   id: 93435
   effort_id: 4249
@@ -7694,6 +8206,7 @@ hardrock_2014_clarence_goyette_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 18:32:00'
+  elapsed_seconds: 109920.0
 hardrock_2014_clarence_goyette_cunningham_in_1:
   id: 93440
   effort_id: 4249
@@ -7709,6 +8222,7 @@ hardrock_2014_clarence_goyette_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 04:02:00'
+  elapsed_seconds: 144120.0
 hardrock_2014_clarence_goyette_cunningham_out_1:
   id: 93441
   effort_id: 4249
@@ -7724,6 +8238,7 @@ hardrock_2014_clarence_goyette_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 04:32:00'
+  elapsed_seconds: 145920.0
 hardrock_2014_clarence_goyette_finish_1:
   id: 93442
   effort_id: 4249
@@ -7739,6 +8254,7 @@ hardrock_2014_clarence_goyette_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-13 09:21:28'
+  elapsed_seconds: 163288.0
 hardrock_2014_irvin_corkery_start_1:
   id: 93471
   effort_id: 4251
@@ -7754,6 +8270,7 @@ hardrock_2014_irvin_corkery_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_irvin_corkery_telluride_in_1:
   id: 93476
   effort_id: 4251
@@ -7769,6 +8286,7 @@ hardrock_2014_irvin_corkery_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 20:21:00'
+  elapsed_seconds: 30060.0
 hardrock_2014_irvin_corkery_telluride_out_1:
   id: 93477
   effort_id: 4251
@@ -7784,6 +8302,7 @@ hardrock_2014_irvin_corkery_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 20:32:00'
+  elapsed_seconds: 30720.0
 hardrock_2014_irvin_corkery_ouray_in_1:
   id: 93482
   effort_id: 4251
@@ -7799,6 +8318,7 @@ hardrock_2014_irvin_corkery_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 01:25:00'
+  elapsed_seconds: 48300.0
 hardrock_2014_irvin_corkery_ouray_out_1:
   id: 93483
   effort_id: 4251
@@ -7814,6 +8334,7 @@ hardrock_2014_irvin_corkery_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 01:45:00'
+  elapsed_seconds: 49500.0
 hardrock_2014_irvin_corkery_grouse_in_1:
   id: 93486
   effort_id: 4251
@@ -7829,6 +8350,7 @@ hardrock_2014_irvin_corkery_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 07:39:00'
+  elapsed_seconds: 70740.0
 hardrock_2014_irvin_corkery_grouse_out_1:
   id: 93487
   effort_id: 4251
@@ -7844,6 +8366,7 @@ hardrock_2014_irvin_corkery_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 08:12:59'
+  elapsed_seconds: 72779.0
 hardrock_2014_irvin_corkery_sherman_in_1:
   id: 93490
   effort_id: 4251
@@ -7859,6 +8382,7 @@ hardrock_2014_irvin_corkery_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 15:59:00'
+  elapsed_seconds: 100740.0
 hardrock_2014_irvin_corkery_sherman_out_1:
   id: 93491
   effort_id: 4251
@@ -7874,6 +8398,7 @@ hardrock_2014_irvin_corkery_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 16:35:00'
+  elapsed_seconds: 102900.0
 hardrock_2014_irvin_corkery_cunningham_in_1:
   id: 93496
   effort_id: 4251
@@ -7889,6 +8414,7 @@ hardrock_2014_irvin_corkery_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 03:38:00'
+  elapsed_seconds: 142680.0
 hardrock_2014_irvin_corkery_cunningham_out_1:
   id: 93497
   effort_id: 4251
@@ -7904,6 +8430,7 @@ hardrock_2014_irvin_corkery_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 03:54:00'
+  elapsed_seconds: 143640.0
 hardrock_2014_irvin_corkery_finish_1:
   id: 93498
   effort_id: 4251
@@ -7919,6 +8446,7 @@ hardrock_2014_irvin_corkery_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-13 09:25:16'
+  elapsed_seconds: 163516.0
 hardrock_2014_willis_murray_start_1:
   id: 93527
   effort_id: 4253
@@ -7934,6 +8462,7 @@ hardrock_2014_willis_murray_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_willis_murray_telluride_in_1:
   id: 93532
   effort_id: 4253
@@ -7949,6 +8478,7 @@ hardrock_2014_willis_murray_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:05:00'
+  elapsed_seconds: 36300.0
 hardrock_2014_willis_murray_telluride_out_1:
   id: 93533
   effort_id: 4253
@@ -7964,6 +8494,7 @@ hardrock_2014_willis_murray_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:20:00'
+  elapsed_seconds: 37200.0
 hardrock_2014_willis_murray_ouray_in_1:
   id: 93538
   effort_id: 4253
@@ -7979,6 +8510,7 @@ hardrock_2014_willis_murray_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 03:53:00'
+  elapsed_seconds: 57180.0
 hardrock_2014_willis_murray_ouray_out_1:
   id: 93539
   effort_id: 4253
@@ -7994,6 +8526,7 @@ hardrock_2014_willis_murray_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 04:31:00'
+  elapsed_seconds: 59460.0
 hardrock_2014_willis_murray_grouse_in_1:
   id: 93542
   effort_id: 4253
@@ -8009,6 +8542,7 @@ hardrock_2014_willis_murray_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 11:49:00'
+  elapsed_seconds: 85740.0
 hardrock_2014_willis_murray_grouse_out_1:
   id: 93543
   effort_id: 4253
@@ -8024,6 +8558,7 @@ hardrock_2014_willis_murray_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 12:18:00'
+  elapsed_seconds: 87480.0
 hardrock_2014_willis_murray_sherman_in_1:
   id: 93546
   effort_id: 4253
@@ -8039,6 +8574,7 @@ hardrock_2014_willis_murray_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 18:11:00'
+  elapsed_seconds: 108660.0
 hardrock_2014_willis_murray_sherman_out_1:
   id: 93547
   effort_id: 4253
@@ -8054,6 +8590,7 @@ hardrock_2014_willis_murray_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 18:46:00'
+  elapsed_seconds: 110760.0
 hardrock_2014_willis_murray_cunningham_in_1:
   id: 93552
   effort_id: 4253
@@ -8069,6 +8606,7 @@ hardrock_2014_willis_murray_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 04:11:00'
+  elapsed_seconds: 144660.0
 hardrock_2014_willis_murray_cunningham_out_1:
   id: 93553
   effort_id: 4253
@@ -8084,6 +8622,7 @@ hardrock_2014_willis_murray_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 04:38:00'
+  elapsed_seconds: 146280.0
 hardrock_2014_willis_murray_finish_1:
   id: 93554
   effort_id: 4253
@@ -8099,6 +8638,7 @@ hardrock_2014_willis_murray_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-13 09:40:40'
+  elapsed_seconds: 164440.0
 hardrock_2014_ken_bradtke_start_1:
   id: 93611
   effort_id: 4256
@@ -8114,6 +8654,7 @@ hardrock_2014_ken_bradtke_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_ken_bradtke_telluride_in_1:
   id: 93616
   effort_id: 4256
@@ -8129,6 +8670,7 @@ hardrock_2014_ken_bradtke_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 21:58:00'
+  elapsed_seconds: 35880.0
 hardrock_2014_ken_bradtke_telluride_out_1:
   id: 93617
   effort_id: 4256
@@ -8144,6 +8686,7 @@ hardrock_2014_ken_bradtke_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:11:00'
+  elapsed_seconds: 36660.0
 hardrock_2014_ken_bradtke_ouray_in_1:
   id: 93622
   effort_id: 4256
@@ -8159,6 +8702,7 @@ hardrock_2014_ken_bradtke_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 04:48:00'
+  elapsed_seconds: 60480.0
 hardrock_2014_ken_bradtke_ouray_out_1:
   id: 93623
   effort_id: 4256
@@ -8174,6 +8718,7 @@ hardrock_2014_ken_bradtke_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 05:31:00'
+  elapsed_seconds: 63060.0
 hardrock_2014_ken_bradtke_grouse_in_1:
   id: 93626
   effort_id: 4256
@@ -8189,6 +8734,7 @@ hardrock_2014_ken_bradtke_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 12:07:00'
+  elapsed_seconds: 86820.0
 hardrock_2014_ken_bradtke_grouse_out_1:
   id: 93627
   effort_id: 4256
@@ -8204,6 +8750,7 @@ hardrock_2014_ken_bradtke_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 12:24:00'
+  elapsed_seconds: 87840.0
 hardrock_2014_ken_bradtke_sherman_in_1:
   id: 93630
   effort_id: 4256
@@ -8219,6 +8766,7 @@ hardrock_2014_ken_bradtke_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 18:02:00'
+  elapsed_seconds: 108120.0
 hardrock_2014_ken_bradtke_sherman_out_1:
   id: 93631
   effort_id: 4256
@@ -8234,6 +8782,7 @@ hardrock_2014_ken_bradtke_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 18:37:00'
+  elapsed_seconds: 110220.0
 hardrock_2014_ken_bradtke_cunningham_in_1:
   id: 93636
   effort_id: 4256
@@ -8249,6 +8798,7 @@ hardrock_2014_ken_bradtke_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 04:54:00'
+  elapsed_seconds: 147240.0
 hardrock_2014_ken_bradtke_cunningham_out_1:
   id: 93637
   effort_id: 4256
@@ -8264,6 +8814,7 @@ hardrock_2014_ken_bradtke_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-13 05:08:00'
+  elapsed_seconds: 148080.0
 hardrock_2014_ken_bradtke_finish_1:
   id: 93638
   effort_id: 4256
@@ -8279,6 +8830,7 @@ hardrock_2014_ken_bradtke_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-13 10:23:44'
+  elapsed_seconds: 167024.0
 hardrock_2014_progress_sherman_start_1:
   id: 94155
   effort_id: 4277
@@ -8294,6 +8846,7 @@ hardrock_2014_progress_sherman_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_progress_sherman_telluride_in_1:
   id: 94160
   effort_id: 4277
@@ -8309,6 +8862,7 @@ hardrock_2014_progress_sherman_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 23:07:00'
+  elapsed_seconds: 40020.0
 hardrock_2014_progress_sherman_telluride_out_1:
   id: 94161
   effort_id: 4277
@@ -8324,6 +8878,7 @@ hardrock_2014_progress_sherman_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 23:16:00'
+  elapsed_seconds: 40560.0
 hardrock_2014_progress_sherman_ouray_in_1:
   id: 94166
   effort_id: 4277
@@ -8339,6 +8894,7 @@ hardrock_2014_progress_sherman_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 05:57:59'
+  elapsed_seconds: 64679.0
 hardrock_2014_progress_sherman_ouray_out_1:
   id: 94167
   effort_id: 4277
@@ -8354,6 +8910,7 @@ hardrock_2014_progress_sherman_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 06:16:00'
+  elapsed_seconds: 65760.0
 hardrock_2014_progress_sherman_grouse_in_1:
   id: 94170
   effort_id: 4277
@@ -8369,6 +8926,7 @@ hardrock_2014_progress_sherman_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 13:40:00'
+  elapsed_seconds: 92400.0
 hardrock_2014_progress_sherman_grouse_out_1:
   id: 94171
   effort_id: 4277
@@ -8384,6 +8942,7 @@ hardrock_2014_progress_sherman_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 14:06:00'
+  elapsed_seconds: 93960.0
 hardrock_2014_progress_sherman_sherman_in_1:
   id: 94174
   effort_id: 4277
@@ -8399,6 +8958,7 @@ hardrock_2014_progress_sherman_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 21:13:00'
+  elapsed_seconds: 119580.0
 hardrock_2014_progress_sherman_sherman_out_1:
   id: 94175
   effort_id: 4277
@@ -8414,6 +8974,7 @@ hardrock_2014_progress_sherman_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 21:28:00'
+  elapsed_seconds: 120480.0
 hardrock_2014_multiple_stops_start_1:
   id: 94437
   effort_id: 4293
@@ -8429,6 +8990,7 @@ hardrock_2014_multiple_stops_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_multiple_stops_telluride_in_1:
   id: 94442
   effort_id: 4293
@@ -8444,6 +9006,7 @@ hardrock_2014_multiple_stops_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:36:00'
+  elapsed_seconds: 38160.0
 hardrock_2014_multiple_stops_telluride_out_1:
   id: 94443
   effort_id: 4293
@@ -8459,6 +9022,7 @@ hardrock_2014_multiple_stops_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 22:52:00'
+  elapsed_seconds: 39120.0
 hardrock_2014_multiple_stops_ouray_in_1:
   id: 94448
   effort_id: 4293
@@ -8474,6 +9038,7 @@ hardrock_2014_multiple_stops_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 05:20:00'
+  elapsed_seconds: 62400.0
 hardrock_2014_multiple_stops_ouray_out_1:
   id: 94449
   effort_id: 4293
@@ -8489,6 +9054,7 @@ hardrock_2014_multiple_stops_ouray_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-12 05:48:00'
+  elapsed_seconds: 64080.0
 hardrock_2014_multiple_stops_grouse_in_1:
   id: 94452
   effort_id: 4293
@@ -8504,6 +9070,7 @@ hardrock_2014_multiple_stops_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 13:10:00'
+  elapsed_seconds: 90600.0
 hardrock_2014_multiple_stops_grouse_out_1:
   id: 94453
   effort_id: 4293
@@ -8519,6 +9086,7 @@ hardrock_2014_multiple_stops_grouse_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-12 13:10:00'
+  elapsed_seconds: 90600.0
 hardrock_2014_without_start_telluride_in_1:
   id: 94459
   effort_id: 4294
@@ -8534,6 +9102,7 @@ hardrock_2014_without_start_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 23:17:00'
+  elapsed_seconds: 
 hardrock_2014_without_start_telluride_out_1:
   id: 94460
   effort_id: 4294
@@ -8549,6 +9118,7 @@ hardrock_2014_without_start_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 23:27:00'
+  elapsed_seconds: 
 hardrock_2014_without_start_ouray_in_1:
   id: 94465
   effort_id: 4294
@@ -8564,6 +9134,7 @@ hardrock_2014_without_start_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 06:06:00'
+  elapsed_seconds: 
 hardrock_2014_without_start_ouray_out_1:
   id: 94466
   effort_id: 4294
@@ -8579,6 +9150,7 @@ hardrock_2014_without_start_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 06:29:00'
+  elapsed_seconds: 
 hardrock_2014_without_start_grouse_in_1:
   id: 94469
   effort_id: 4294
@@ -8594,6 +9166,7 @@ hardrock_2014_without_start_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 13:56:00'
+  elapsed_seconds: 
 hardrock_2014_without_start_grouse_out_1:
   id: 94470
   effort_id: 4294
@@ -8609,6 +9182,7 @@ hardrock_2014_without_start_grouse_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-12 13:56:00'
+  elapsed_seconds: 
 hardrock_2014_drop_ouray_start_1:
   id: 94471
   effort_id: 4295
@@ -8624,6 +9198,7 @@ hardrock_2014_drop_ouray_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2014_drop_ouray_telluride_in_1:
   id: 94476
   effort_id: 4295
@@ -8639,6 +9214,7 @@ hardrock_2014_drop_ouray_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 23:42:00'
+  elapsed_seconds: 42120.0
 hardrock_2014_drop_ouray_telluride_out_1:
   id: 94477
   effort_id: 4295
@@ -8654,6 +9230,7 @@ hardrock_2014_drop_ouray_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-11 23:54:00'
+  elapsed_seconds: 42840.0
 hardrock_2014_drop_ouray_ouray_in_1:
   id: 94482
   effort_id: 4295
@@ -8669,6 +9246,7 @@ hardrock_2014_drop_ouray_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2014-07-12 06:24:00'
+  elapsed_seconds: 66240.0
 hardrock_2014_drop_ouray_ouray_out_1:
   id: 94483
   effort_id: 4295
@@ -8684,6 +9262,7 @@ hardrock_2014_drop_ouray_ouray_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2014-07-12 06:28:00'
+  elapsed_seconds: 66480.0
 hardrock_2015_bad_status_telluride_in_1:
   id: 101536
   effort_id: 138
@@ -8699,6 +9278,7 @@ hardrock_2015_bad_status_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 21:05:00'
+  elapsed_seconds: 119100.0
 hardrock_2015_bad_status_telluride_out_1:
   id: 101537
   effort_id: 138
@@ -8714,6 +9294,7 @@ hardrock_2015_bad_status_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 21:30:00'
+  elapsed_seconds: 120600.0
 hardrock_2015_irvin_harber_telluride_in_1:
   id: 101540
   effort_id: 141
@@ -8729,6 +9310,7 @@ hardrock_2015_irvin_harber_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-11 11:00:00'
+  elapsed_seconds: 82800.0
 hardrock_2015_irvin_harber_telluride_out_1:
   id: 101541
   effort_id: 141
@@ -8744,6 +9326,7 @@ hardrock_2015_irvin_harber_telluride_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-11 12:00:00'
+  elapsed_seconds: 86400.0
 hardrock_2015_bad_status_putnam_in_1:
   id: 101555
   effort_id: 138
@@ -8759,6 +9342,7 @@ hardrock_2015_bad_status_putnam_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-12 01:00:00'
+  elapsed_seconds: 133200.0
 hardrock_2015_bad_status_putnam_out_1:
   id: 101556
   effort_id: 138
@@ -8774,6 +9358,7 @@ hardrock_2015_bad_status_putnam_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2015-07-12 01:05:00'
+  elapsed_seconds: 133500.0
 rufa_2016_finished_first_start_1:
   id: 132044
   effort_id: 6518
@@ -8789,6 +9374,7 @@ rufa_2016_finished_first_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-02-13 13:00:00'
+  elapsed_seconds: 0.0
 rufa_2016_finished_first_grandeur_peak_1:
   id: 132045
   effort_id: 6518
@@ -8804,6 +9390,7 @@ rufa_2016_finished_first_grandeur_peak_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-02-13 13:59:00'
+  elapsed_seconds: 3540.0
 rufa_2016_finished_first_grandeur_peak_2:
   id: 132046
   effort_id: 6518
@@ -8819,6 +9406,7 @@ rufa_2016_finished_first_grandeur_peak_2:
   lap: 2
   stopped_here: false
   absolute_time: '2016-02-13 15:39:00'
+  elapsed_seconds: 9540.0
 rufa_2016_finished_first_finish_2:
   id: 132047
   effort_id: 6518
@@ -8834,6 +9422,7 @@ rufa_2016_finished_first_finish_2:
   lap: 2
   stopped_here: false
   absolute_time: '2016-02-13 16:12:00'
+  elapsed_seconds: 11520.0
 rufa_2016_finished_first_grandeur_peak_3:
   id: 132048
   effort_id: 6518
@@ -8849,6 +9438,7 @@ rufa_2016_finished_first_grandeur_peak_3:
   lap: 3
   stopped_here: false
   absolute_time: '2016-02-13 17:29:00'
+  elapsed_seconds: 16140.0
 rufa_2016_finished_first_grandeur_peak_4:
   id: 132049
   effort_id: 6518
@@ -8864,6 +9454,7 @@ rufa_2016_finished_first_grandeur_peak_4:
   lap: 4
   stopped_here: false
   absolute_time: '2016-02-13 19:30:00'
+  elapsed_seconds: 23400.0
 rufa_2016_finished_first_finish_4:
   id: 132050
   effort_id: 6518
@@ -8879,6 +9470,7 @@ rufa_2016_finished_first_finish_4:
   lap: 4
   stopped_here: false
   absolute_time: '2016-02-13 20:04:00'
+  elapsed_seconds: 25440.0
 rufa_2016_finished_first_start_5:
   id: 132051
   effort_id: 6518
@@ -8894,6 +9486,7 @@ rufa_2016_finished_first_start_5:
   lap: 5
   stopped_here: false
   absolute_time: '2016-02-13 20:09:00'
+  elapsed_seconds: 25740.0
 rufa_2016_finished_first_grandeur_peak_5:
   id: 132052
   effort_id: 6518
@@ -8909,6 +9502,7 @@ rufa_2016_finished_first_grandeur_peak_5:
   lap: 5
   stopped_here: false
   absolute_time: '2016-02-13 21:22:00'
+  elapsed_seconds: 30120.0
 rufa_2016_finished_first_finish_5:
   id: 132053
   effort_id: 6518
@@ -8924,6 +9518,7 @@ rufa_2016_finished_first_finish_5:
   lap: 5
   stopped_here: false
   absolute_time: '2016-02-13 21:59:00'
+  elapsed_seconds: 32340.0
 rufa_2016_finished_first_start_6:
   id: 132054
   effort_id: 6518
@@ -8939,6 +9534,7 @@ rufa_2016_finished_first_start_6:
   lap: 6
   stopped_here: false
   absolute_time: '2016-02-13 22:07:00'
+  elapsed_seconds: 32820.0
 rufa_2016_finished_first_grandeur_peak_6:
   id: 132055
   effort_id: 6518
@@ -8954,6 +9550,7 @@ rufa_2016_finished_first_grandeur_peak_6:
   lap: 6
   stopped_here: false
   absolute_time: '2016-02-13 23:26:00'
+  elapsed_seconds: 37560.0
 rufa_2016_finished_first_finish_6:
   id: 132056
   effort_id: 6518
@@ -8969,6 +9566,7 @@ rufa_2016_finished_first_finish_6:
   lap: 6
   stopped_here: false
   absolute_time: '2016-02-14 00:07:00'
+  elapsed_seconds: 40020.0
 rufa_2016_finished_first_start_7:
   id: 132057
   effort_id: 6518
@@ -8984,6 +9582,7 @@ rufa_2016_finished_first_start_7:
   lap: 7
   stopped_here: false
   absolute_time: '2016-02-14 00:55:00'
+  elapsed_seconds: 42900.0
 rufa_2016_finished_first_grandeur_peak_7:
   id: 132058
   effort_id: 6518
@@ -8999,6 +9598,7 @@ rufa_2016_finished_first_grandeur_peak_7:
   lap: 7
   stopped_here: false
   absolute_time: '2016-02-14 02:17:00'
+  elapsed_seconds: 47820.0
 rufa_2016_finished_first_finish_7:
   id: 132059
   effort_id: 6518
@@ -9014,6 +9614,7 @@ rufa_2016_finished_first_finish_7:
   lap: 7
   stopped_here: true
   absolute_time: '2016-02-14 03:01:00'
+  elapsed_seconds: 50460.0
 rufa_2016_finished_second_start_1:
   id: 132075
   effort_id: 6520
@@ -9029,6 +9630,7 @@ rufa_2016_finished_second_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-02-13 13:00:00'
+  elapsed_seconds: 0.0
 rufa_2016_finished_second_grandeur_peak_1:
   id: 132076
   effort_id: 6520
@@ -9044,6 +9646,7 @@ rufa_2016_finished_second_grandeur_peak_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-02-13 13:47:00'
+  elapsed_seconds: 2820.0
 rufa_2016_finished_second_finish_1:
   id: 132077
   effort_id: 6520
@@ -9059,6 +9662,7 @@ rufa_2016_finished_second_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-02-13 14:13:00'
+  elapsed_seconds: 4380.0
 rufa_2016_finished_second_start_2:
   id: 132078
   effort_id: 6520
@@ -9074,6 +9678,7 @@ rufa_2016_finished_second_start_2:
   lap: 2
   stopped_here: false
   absolute_time: '2016-02-13 14:16:00'
+  elapsed_seconds: 4560.0
 rufa_2016_finished_second_grandeur_peak_2:
   id: 132079
   effort_id: 6520
@@ -9089,6 +9694,7 @@ rufa_2016_finished_second_grandeur_peak_2:
   lap: 2
   stopped_here: false
   absolute_time: '2016-02-13 15:03:00'
+  elapsed_seconds: 7380.0
 rufa_2016_finished_second_finish_2:
   id: 132080
   effort_id: 6520
@@ -9104,6 +9710,7 @@ rufa_2016_finished_second_finish_2:
   lap: 2
   stopped_here: false
   absolute_time: '2016-02-13 15:29:00'
+  elapsed_seconds: 8940.0
 rufa_2016_finished_second_grandeur_peak_3:
   id: 132081
   effort_id: 6520
@@ -9119,6 +9726,7 @@ rufa_2016_finished_second_grandeur_peak_3:
   lap: 3
   stopped_here: false
   absolute_time: '2016-02-13 16:22:00'
+  elapsed_seconds: 12120.0
 rufa_2016_finished_second_finish_3:
   id: 132082
   effort_id: 6520
@@ -9134,6 +9742,7 @@ rufa_2016_finished_second_finish_3:
   lap: 3
   stopped_here: false
   absolute_time: '2016-02-13 16:47:00'
+  elapsed_seconds: 13620.0
 rufa_2016_finished_second_start_4:
   id: 132083
   effort_id: 6520
@@ -9149,6 +9758,7 @@ rufa_2016_finished_second_start_4:
   lap: 4
   stopped_here: false
   absolute_time: '2016-02-13 16:51:00'
+  elapsed_seconds: 13860.0
 rufa_2016_finished_second_grandeur_peak_4:
   id: 132084
   effort_id: 6520
@@ -9164,6 +9774,7 @@ rufa_2016_finished_second_grandeur_peak_4:
   lap: 4
   stopped_here: false
   absolute_time: '2016-02-13 17:45:00'
+  elapsed_seconds: 17100.0
 rufa_2016_finished_second_finish_4:
   id: 132085
   effort_id: 6520
@@ -9179,6 +9790,7 @@ rufa_2016_finished_second_finish_4:
   lap: 4
   stopped_here: false
   absolute_time: '2016-02-13 18:12:00'
+  elapsed_seconds: 18720.0
 rufa_2016_finished_second_grandeur_peak_5:
   id: 132086
   effort_id: 6520
@@ -9194,6 +9806,7 @@ rufa_2016_finished_second_grandeur_peak_5:
   lap: 5
   stopped_here: false
   absolute_time: '2016-02-13 19:18:00'
+  elapsed_seconds: 22680.0
 rufa_2016_finished_second_finish_5:
   id: 132087
   effort_id: 6520
@@ -9209,6 +9822,7 @@ rufa_2016_finished_second_finish_5:
   lap: 5
   stopped_here: false
   absolute_time: '2016-02-13 19:49:00'
+  elapsed_seconds: 24540.0
 rufa_2016_finished_second_start_6:
   id: 132088
   effort_id: 6520
@@ -9224,6 +9838,7 @@ rufa_2016_finished_second_start_6:
   lap: 6
   stopped_here: false
   absolute_time: '2016-02-13 19:56:00'
+  elapsed_seconds: 24960.0
 rufa_2016_finished_second_grandeur_peak_6:
   id: 132089
   effort_id: 6520
@@ -9239,6 +9854,7 @@ rufa_2016_finished_second_grandeur_peak_6:
   lap: 6
   stopped_here: false
   absolute_time: '2016-02-13 20:58:00'
+  elapsed_seconds: 28680.0
 rufa_2016_finished_second_finish_6:
   id: 132090
   effort_id: 6520
@@ -9254,6 +9870,7 @@ rufa_2016_finished_second_finish_6:
   lap: 6
   stopped_here: true
   absolute_time: '2016-02-13 21:28:00'
+  elapsed_seconds: 30480.0
 rufa_2016_progress_lap1_start_1:
   id: 132438
   effort_id: 6560
@@ -9269,6 +9886,7 @@ rufa_2016_progress_lap1_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-02-13 13:00:00'
+  elapsed_seconds: 0.0
 rufa_2016_progress_lap1_grandeur_peak_1:
   id: 132439
   effort_id: 6560
@@ -9284,6 +9902,7 @@ rufa_2016_progress_lap1_grandeur_peak_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-02-13 14:25:00'
+  elapsed_seconds: 5100.0
 rufa_2017_24h_finished_first_start_1:
   id: 133963
   effort_id: 6693
@@ -9299,6 +9918,7 @@ rufa_2017_24h_finished_first_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 13:10:00'
+  elapsed_seconds: 0.0
 rufa_2017_24h_finished_first_grandeur_peak_1:
   id: 133964
   effort_id: 6693
@@ -9314,6 +9934,7 @@ rufa_2017_24h_finished_first_grandeur_peak_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 14:23:00'
+  elapsed_seconds: 4380.0
 rufa_2017_24h_finished_first_finish_1:
   id: 133965
   effort_id: 6693
@@ -9329,6 +9950,7 @@ rufa_2017_24h_finished_first_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 15:05:00'
+  elapsed_seconds: 6900.0
 rufa_2017_24h_finished_first_start_2:
   id: 133966
   effort_id: 6693
@@ -9344,6 +9966,7 @@ rufa_2017_24h_finished_first_start_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 15:05:00'
+  elapsed_seconds: 6900.0
 rufa_2017_24h_finished_first_grandeur_peak_2:
   id: 133967
   effort_id: 6693
@@ -9359,6 +9982,7 @@ rufa_2017_24h_finished_first_grandeur_peak_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 16:36:00'
+  elapsed_seconds: 12360.0
 rufa_2017_24h_finished_first_finish_2:
   id: 133968
   effort_id: 6693
@@ -9374,6 +9998,7 @@ rufa_2017_24h_finished_first_finish_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 17:12:00'
+  elapsed_seconds: 14520.0
 rufa_2017_24h_finished_first_start_3:
   id: 133969
   effort_id: 6693
@@ -9389,6 +10014,7 @@ rufa_2017_24h_finished_first_start_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 17:19:00'
+  elapsed_seconds: 14940.0
 rufa_2017_24h_finished_first_grandeur_peak_3:
   id: 133970
   effort_id: 6693
@@ -9404,6 +10030,7 @@ rufa_2017_24h_finished_first_grandeur_peak_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 18:47:00'
+  elapsed_seconds: 20220.0
 rufa_2017_24h_finished_first_finish_3:
   id: 133971
   effort_id: 6693
@@ -9419,6 +10046,7 @@ rufa_2017_24h_finished_first_finish_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 19:24:00'
+  elapsed_seconds: 22440.0
 rufa_2017_24h_finished_first_start_4:
   id: 133972
   effort_id: 6693
@@ -9434,6 +10062,7 @@ rufa_2017_24h_finished_first_start_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 19:31:00'
+  elapsed_seconds: 22860.0
 rufa_2017_24h_finished_first_grandeur_peak_4:
   id: 133973
   effort_id: 6693
@@ -9449,6 +10078,7 @@ rufa_2017_24h_finished_first_grandeur_peak_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 21:05:00'
+  elapsed_seconds: 28500.0
 rufa_2017_24h_finished_first_finish_4:
   id: 133974
   effort_id: 6693
@@ -9464,6 +10094,7 @@ rufa_2017_24h_finished_first_finish_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 21:46:00'
+  elapsed_seconds: 30960.0
 rufa_2017_24h_finished_first_start_5:
   id: 133975
   effort_id: 6693
@@ -9479,6 +10110,7 @@ rufa_2017_24h_finished_first_start_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 22:06:00'
+  elapsed_seconds: 32160.0
 rufa_2017_24h_finished_first_grandeur_peak_5:
   id: 133976
   effort_id: 6693
@@ -9494,6 +10126,7 @@ rufa_2017_24h_finished_first_grandeur_peak_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 23:40:00'
+  elapsed_seconds: 37800.0
 rufa_2017_24h_finished_first_finish_5:
   id: 133977
   effort_id: 6693
@@ -9509,6 +10142,7 @@ rufa_2017_24h_finished_first_finish_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-12 00:20:00'
+  elapsed_seconds: 40200.0
 rufa_2017_24h_finished_first_start_6:
   id: 133978
   effort_id: 6693
@@ -9524,6 +10158,7 @@ rufa_2017_24h_finished_first_start_6:
   lap: 6
   stopped_here: false
   absolute_time: '2017-02-12 00:50:00'
+  elapsed_seconds: 42000.0
 rufa_2017_24h_finished_first_grandeur_peak_6:
   id: 133979
   effort_id: 6693
@@ -9539,6 +10174,7 @@ rufa_2017_24h_finished_first_grandeur_peak_6:
   lap: 6
   stopped_here: false
   absolute_time: '2017-02-12 02:25:00'
+  elapsed_seconds: 47700.0
 rufa_2017_24h_finished_first_finish_6:
   id: 133980
   effort_id: 6693
@@ -9554,6 +10190,7 @@ rufa_2017_24h_finished_first_finish_6:
   lap: 6
   stopped_here: false
   absolute_time: '2017-02-12 03:15:00'
+  elapsed_seconds: 50700.0
 rufa_2017_24h_finished_first_start_7:
   id: 133981
   effort_id: 6693
@@ -9569,6 +10206,7 @@ rufa_2017_24h_finished_first_start_7:
   lap: 7
   stopped_here: false
   absolute_time: '2017-02-12 03:38:00'
+  elapsed_seconds: 52080.0
 rufa_2017_24h_finished_first_grandeur_peak_7:
   id: 133982
   effort_id: 6693
@@ -9584,6 +10222,7 @@ rufa_2017_24h_finished_first_grandeur_peak_7:
   lap: 7
   stopped_here: false
   absolute_time: '2017-02-12 05:19:00'
+  elapsed_seconds: 58140.0
 rufa_2017_24h_finished_first_finish_7:
   id: 133983
   effort_id: 6693
@@ -9599,6 +10238,7 @@ rufa_2017_24h_finished_first_finish_7:
   lap: 7
   stopped_here: true
   absolute_time: '2017-02-12 06:08:00'
+  elapsed_seconds: 61080.0
 rufa_2017_24h_progress_lap6_start_1:
   id: 134001
   effort_id: 6695
@@ -9614,6 +10254,7 @@ rufa_2017_24h_progress_lap6_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 15:00:00'
+  elapsed_seconds: 0.0
 rufa_2017_24h_progress_lap6_grandeur_peak_1:
   id: 134002
   effort_id: 6695
@@ -9629,6 +10270,7 @@ rufa_2017_24h_progress_lap6_grandeur_peak_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 15:57:00'
+  elapsed_seconds: 3420.0
 rufa_2017_24h_progress_lap6_finish_1:
   id: 134003
   effort_id: 6695
@@ -9644,6 +10286,7 @@ rufa_2017_24h_progress_lap6_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 16:28:00'
+  elapsed_seconds: 5280.0
 rufa_2017_24h_progress_lap6_start_2:
   id: 134004
   effort_id: 6695
@@ -9659,6 +10302,7 @@ rufa_2017_24h_progress_lap6_start_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 16:28:00'
+  elapsed_seconds: 5280.0
 rufa_2017_24h_progress_lap6_grandeur_peak_2:
   id: 134005
   effort_id: 6695
@@ -9674,6 +10318,7 @@ rufa_2017_24h_progress_lap6_grandeur_peak_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 17:29:00'
+  elapsed_seconds: 8940.0
 rufa_2017_24h_progress_lap6_finish_2:
   id: 134006
   effort_id: 6695
@@ -9689,6 +10334,7 @@ rufa_2017_24h_progress_lap6_finish_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 18:01:00'
+  elapsed_seconds: 10860.0
 rufa_2017_24h_progress_lap6_start_3:
   id: 134007
   effort_id: 6695
@@ -9704,6 +10350,7 @@ rufa_2017_24h_progress_lap6_start_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 18:02:00'
+  elapsed_seconds: 10920.0
 rufa_2017_24h_progress_lap6_grandeur_peak_3:
   id: 134008
   effort_id: 6695
@@ -9719,6 +10366,7 @@ rufa_2017_24h_progress_lap6_grandeur_peak_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 19:13:00'
+  elapsed_seconds: 15180.0
 rufa_2017_24h_progress_lap6_finish_3:
   id: 134009
   effort_id: 6695
@@ -9734,6 +10382,7 @@ rufa_2017_24h_progress_lap6_finish_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 19:46:00'
+  elapsed_seconds: 17160.0
 rufa_2017_24h_progress_lap6_start_4:
   id: 134010
   effort_id: 6695
@@ -9749,6 +10398,7 @@ rufa_2017_24h_progress_lap6_start_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 19:48:00'
+  elapsed_seconds: 17280.0
 rufa_2017_24h_progress_lap6_grandeur_peak_4:
   id: 134011
   effort_id: 6695
@@ -9764,6 +10414,7 @@ rufa_2017_24h_progress_lap6_grandeur_peak_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 21:01:00'
+  elapsed_seconds: 21660.0
 rufa_2017_24h_progress_lap6_finish_4:
   id: 134012
   effort_id: 6695
@@ -9779,6 +10430,7 @@ rufa_2017_24h_progress_lap6_finish_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 21:36:00'
+  elapsed_seconds: 23760.0
 rufa_2017_24h_progress_lap6_start_5:
   id: 134013
   effort_id: 6695
@@ -9794,6 +10446,7 @@ rufa_2017_24h_progress_lap6_start_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 21:39:00'
+  elapsed_seconds: 23940.0
 rufa_2017_24h_progress_lap6_grandeur_peak_5:
   id: 134014
   effort_id: 6695
@@ -9809,6 +10462,7 @@ rufa_2017_24h_progress_lap6_grandeur_peak_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 22:53:00'
+  elapsed_seconds: 28380.0
 rufa_2017_24h_progress_lap6_finish_5:
   id: 134015
   effort_id: 6695
@@ -9824,6 +10478,7 @@ rufa_2017_24h_progress_lap6_finish_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 23:27:00'
+  elapsed_seconds: 30420.0
 rufa_2017_24h_progress_lap6_start_6:
   id: 134016
   effort_id: 6695
@@ -9839,6 +10494,7 @@ rufa_2017_24h_progress_lap6_start_6:
   lap: 6
   stopped_here: false
   absolute_time: '2017-02-11 23:30:00'
+  elapsed_seconds: 30600.0
 rufa_2017_24h_progress_lap6_grandeur_peak_6:
   id: 134017
   effort_id: 6695
@@ -9854,6 +10510,7 @@ rufa_2017_24h_progress_lap6_grandeur_peak_6:
   lap: 6
   stopped_here: false
   absolute_time: '2017-02-12 00:49:00'
+  elapsed_seconds: 35340.0
 rufa_2017_24h_progress_lap6_finish_6:
   id: 134018
   effort_id: 6695
@@ -9869,6 +10526,7 @@ rufa_2017_24h_progress_lap6_finish_6:
   lap: 6
   stopped_here: false
   absolute_time: '2017-02-12 01:20:00'
+  elapsed_seconds: 37200.0
 rufa_2017_24h_multiple_stops_start_1:
   id: 134805
   effort_id: 6756
@@ -9884,6 +10542,7 @@ rufa_2017_24h_multiple_stops_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 15:00:00'
+  elapsed_seconds: 0.0
 rufa_2017_24h_multiple_stops_grandeur_peak_1:
   id: 134806
   effort_id: 6756
@@ -9899,6 +10558,7 @@ rufa_2017_24h_multiple_stops_grandeur_peak_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 16:05:00'
+  elapsed_seconds: 3900.0
 rufa_2017_24h_multiple_stops_finish_1:
   id: 134807
   effort_id: 6756
@@ -9914,6 +10574,7 @@ rufa_2017_24h_multiple_stops_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 16:40:00'
+  elapsed_seconds: 6000.0
 rufa_2017_24h_multiple_stops_start_2:
   id: 134808
   effort_id: 6756
@@ -9929,6 +10590,7 @@ rufa_2017_24h_multiple_stops_start_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 16:40:00'
+  elapsed_seconds: 6000.0
 rufa_2017_24h_multiple_stops_grandeur_peak_2:
   id: 134809
   effort_id: 6756
@@ -9944,6 +10606,7 @@ rufa_2017_24h_multiple_stops_grandeur_peak_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 17:52:00'
+  elapsed_seconds: 10320.0
 rufa_2017_24h_multiple_stops_finish_2:
   id: 134810
   effort_id: 6756
@@ -9959,6 +10622,7 @@ rufa_2017_24h_multiple_stops_finish_2:
   lap: 2
   stopped_here: true
   absolute_time: '2017-02-11 18:24:00'
+  elapsed_seconds: 12240.0
 rufa_2017_24h_multiple_stops_grandeur_peak_3:
   id: 134811
   effort_id: 6756
@@ -9974,6 +10638,7 @@ rufa_2017_24h_multiple_stops_grandeur_peak_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 19:55:00'
+  elapsed_seconds: 17700.0
 rufa_2017_24h_multiple_stops_finish_3:
   id: 134812
   effort_id: 6756
@@ -9989,6 +10654,7 @@ rufa_2017_24h_multiple_stops_finish_3:
   lap: 3
   stopped_here: true
   absolute_time: '2017-02-11 20:42:00'
+  elapsed_seconds: 20520.0
 rufa_2017_24h_finished_last_start_1:
   id: 135007
   effort_id: 6780
@@ -10004,6 +10670,7 @@ rufa_2017_24h_finished_last_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 15:00:00'
+  elapsed_seconds: 0.0
 rufa_2017_24h_finished_last_grandeur_peak_1:
   id: 135008
   effort_id: 6780
@@ -10019,6 +10686,7 @@ rufa_2017_24h_finished_last_grandeur_peak_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 16:17:00'
+  elapsed_seconds: 4620.0
 rufa_2017_24h_finished_last_finish_1:
   id: 135009
   effort_id: 6780
@@ -10034,6 +10702,7 @@ rufa_2017_24h_finished_last_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 16:54:00'
+  elapsed_seconds: 6840.0
 rufa_2017_24h_finished_last_start_2:
   id: 135010
   effort_id: 6780
@@ -10049,6 +10718,7 @@ rufa_2017_24h_finished_last_start_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 16:58:00'
+  elapsed_seconds: 7080.0
 rufa_2017_24h_finished_last_grandeur_peak_2:
   id: 135011
   effort_id: 6780
@@ -10064,6 +10734,7 @@ rufa_2017_24h_finished_last_grandeur_peak_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 18:21:00'
+  elapsed_seconds: 12060.0
 rufa_2017_24h_finished_last_finish_2:
   id: 135012
   effort_id: 6780
@@ -10079,6 +10750,7 @@ rufa_2017_24h_finished_last_finish_2:
   lap: 2
   stopped_here: true
   absolute_time: '2017-02-11 18:57:00'
+  elapsed_seconds: 14220.0
 rufa_2017_24h_progress_lap1_start_1:
   id: 135132
   effort_id: 6805
@@ -10094,6 +10766,7 @@ rufa_2017_24h_progress_lap1_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 16:00:00'
+  elapsed_seconds: 0.0
 rufa_2017_24h_progress_lap1_grandeur_peak_1:
   id: 135133
   effort_id: 6805
@@ -10109,6 +10782,7 @@ rufa_2017_24h_progress_lap1_grandeur_peak_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 17:27:00'
+  elapsed_seconds: 5220.0
 rufa_2017_24h_progress_lap1_finish_1:
   id: 135134
   effort_id: 6805
@@ -10124,6 +10798,7 @@ rufa_2017_24h_progress_lap1_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 18:53:00'
+  elapsed_seconds: 10380.0
 hardrock_2016_lavon_paucek_start_1:
   id: 146923
   effort_id: 7270
@@ -10139,6 +10814,7 @@ hardrock_2016_lavon_paucek_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_lavon_paucek_telluride_in_1:
   id: 146928
   effort_id: 7270
@@ -10154,6 +10830,7 @@ hardrock_2016_lavon_paucek_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 18:36:00'
+  elapsed_seconds: 23760.0
 hardrock_2016_lavon_paucek_telluride_out_1:
   id: 146929
   effort_id: 7270
@@ -10169,6 +10846,7 @@ hardrock_2016_lavon_paucek_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 18:38:00'
+  elapsed_seconds: 23880.0
 hardrock_2016_lavon_paucek_ouray_in_1:
   id: 146934
   effort_id: 7270
@@ -10184,6 +10862,7 @@ hardrock_2016_lavon_paucek_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 22:11:00'
+  elapsed_seconds: 36660.0
 hardrock_2016_lavon_paucek_ouray_out_1:
   id: 146935
   effort_id: 7270
@@ -10199,6 +10878,7 @@ hardrock_2016_lavon_paucek_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 22:16:00'
+  elapsed_seconds: 36960.0
 hardrock_2016_lavon_paucek_grouse_in_1:
   id: 146938
   effort_id: 7270
@@ -10214,6 +10894,7 @@ hardrock_2016_lavon_paucek_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 02:36:00'
+  elapsed_seconds: 52560.0
 hardrock_2016_lavon_paucek_grouse_out_1:
   id: 146939
   effort_id: 7270
@@ -10229,6 +10910,7 @@ hardrock_2016_lavon_paucek_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 02:36:00'
+  elapsed_seconds: 52560.0
 hardrock_2016_lavon_paucek_sherman_in_1:
   id: 146942
   effort_id: 7270
@@ -10244,6 +10926,7 @@ hardrock_2016_lavon_paucek_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 07:02:00'
+  elapsed_seconds: 68520.0
 hardrock_2016_lavon_paucek_sherman_out_1:
   id: 146943
   effort_id: 7270
@@ -10259,6 +10942,7 @@ hardrock_2016_lavon_paucek_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 07:09:00'
+  elapsed_seconds: 68940.0
 hardrock_2016_lavon_paucek_cunningham_in_1:
   id: 146948
   effort_id: 7270
@@ -10274,6 +10958,7 @@ hardrock_2016_lavon_paucek_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 14:11:00'
+  elapsed_seconds: 94260.0
 hardrock_2016_lavon_paucek_cunningham_out_1:
   id: 146949
   effort_id: 7270
@@ -10289,6 +10974,7 @@ hardrock_2016_lavon_paucek_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 14:13:00'
+  elapsed_seconds: 94380.0
 hardrock_2016_lavon_paucek_finish_1:
   id: 146950
   effort_id: 7270
@@ -10304,6 +10990,7 @@ hardrock_2016_lavon_paucek_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2016-07-16 17:02:09'
+  elapsed_seconds: 104529.0
 hardrock_2016_vesta_borer_start_1:
   id: 147315
   effort_id: 7284
@@ -10319,6 +11006,7 @@ hardrock_2016_vesta_borer_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_vesta_borer_telluride_in_1:
   id: 147320
   effort_id: 7284
@@ -10334,6 +11022,7 @@ hardrock_2016_vesta_borer_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 20:17:00'
+  elapsed_seconds: 29820.0
 hardrock_2016_vesta_borer_telluride_out_1:
   id: 147321
   effort_id: 7284
@@ -10349,6 +11038,7 @@ hardrock_2016_vesta_borer_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 20:22:00'
+  elapsed_seconds: 30120.0
 hardrock_2016_vesta_borer_ouray_in_1:
   id: 147326
   effort_id: 7284
@@ -10364,6 +11054,7 @@ hardrock_2016_vesta_borer_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 00:49:00'
+  elapsed_seconds: 46140.0
 hardrock_2016_vesta_borer_ouray_out_1:
   id: 147327
   effort_id: 7284
@@ -10379,6 +11070,7 @@ hardrock_2016_vesta_borer_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 00:58:00'
+  elapsed_seconds: 46680.0
 hardrock_2016_vesta_borer_grouse_in_1:
   id: 147330
   effort_id: 7284
@@ -10394,6 +11086,7 @@ hardrock_2016_vesta_borer_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 06:14:00'
+  elapsed_seconds: 65640.0
 hardrock_2016_vesta_borer_grouse_out_1:
   id: 147331
   effort_id: 7284
@@ -10409,6 +11102,7 @@ hardrock_2016_vesta_borer_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 06:24:00'
+  elapsed_seconds: 66240.0
 hardrock_2016_vesta_borer_sherman_in_1:
   id: 147334
   effort_id: 7284
@@ -10424,6 +11118,7 @@ hardrock_2016_vesta_borer_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 11:23:00'
+  elapsed_seconds: 84180.0
 hardrock_2016_vesta_borer_sherman_out_1:
   id: 147335
   effort_id: 7284
@@ -10439,6 +11134,7 @@ hardrock_2016_vesta_borer_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 11:41:00'
+  elapsed_seconds: 85260.0
 hardrock_2016_vesta_borer_cunningham_in_1:
   id: 147340
   effort_id: 7284
@@ -10454,6 +11150,7 @@ hardrock_2016_vesta_borer_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 19:00:00'
+  elapsed_seconds: 111600.0
 hardrock_2016_vesta_borer_cunningham_out_1:
   id: 147341
   effort_id: 7284
@@ -10469,6 +11166,7 @@ hardrock_2016_vesta_borer_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 19:05:00'
+  elapsed_seconds: 111900.0
 hardrock_2016_kory_kulas_start_1:
   id: 147455
   effort_id: 7289
@@ -10484,6 +11182,7 @@ hardrock_2016_kory_kulas_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_kory_kulas_telluride_in_1:
   id: 147460
   effort_id: 7289
@@ -10499,6 +11198,7 @@ hardrock_2016_kory_kulas_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 20:16:00'
+  elapsed_seconds: 29760.0
 hardrock_2016_kory_kulas_telluride_out_1:
   id: 147461
   effort_id: 7289
@@ -10514,6 +11214,7 @@ hardrock_2016_kory_kulas_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 20:25:00'
+  elapsed_seconds: 30300.0
 hardrock_2016_kory_kulas_ouray_in_1:
   id: 147466
   effort_id: 7289
@@ -10529,6 +11230,7 @@ hardrock_2016_kory_kulas_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 01:05:00'
+  elapsed_seconds: 47100.0
 hardrock_2016_kory_kulas_ouray_out_1:
   id: 147467
   effort_id: 7289
@@ -10544,6 +11246,7 @@ hardrock_2016_kory_kulas_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 01:16:00'
+  elapsed_seconds: 47760.0
 hardrock_2016_kory_kulas_grouse_in_1:
   id: 147470
   effort_id: 7289
@@ -10559,6 +11262,7 @@ hardrock_2016_kory_kulas_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 07:30:00'
+  elapsed_seconds: 70200.0
 hardrock_2016_kory_kulas_grouse_out_1:
   id: 147471
   effort_id: 7289
@@ -10574,6 +11278,7 @@ hardrock_2016_kory_kulas_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 07:55:00'
+  elapsed_seconds: 71700.0
 hardrock_2016_kory_kulas_sherman_in_1:
   id: 147474
   effort_id: 7289
@@ -10589,6 +11294,7 @@ hardrock_2016_kory_kulas_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 13:00:00'
+  elapsed_seconds: 90000.0
 hardrock_2016_kory_kulas_sherman_out_1:
   id: 147475
   effort_id: 7289
@@ -10604,6 +11310,7 @@ hardrock_2016_kory_kulas_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 13:08:00'
+  elapsed_seconds: 90480.0
 hardrock_2016_kory_kulas_cunningham_in_1:
   id: 147480
   effort_id: 7289
@@ -10619,6 +11326,7 @@ hardrock_2016_kory_kulas_cunningham_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 20:51:00'
+  elapsed_seconds: 118260.0
 hardrock_2016_kory_kulas_cunningham_out_1:
   id: 147481
   effort_id: 7289
@@ -10634,6 +11342,7 @@ hardrock_2016_kory_kulas_cunningham_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 20:58:00'
+  elapsed_seconds: 118680.0
 hardrock_2016_shad_hirthe_start_1:
   id: 147679
   effort_id: 7297
@@ -10649,6 +11358,7 @@ hardrock_2016_shad_hirthe_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_shad_hirthe_telluride_in_1:
   id: 147684
   effort_id: 7297
@@ -10664,6 +11374,7 @@ hardrock_2016_shad_hirthe_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 19:59:00'
+  elapsed_seconds: 28740.0
 hardrock_2016_shad_hirthe_telluride_out_1:
   id: 147685
   effort_id: 7297
@@ -10679,6 +11390,7 @@ hardrock_2016_shad_hirthe_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 20:07:00'
+  elapsed_seconds: 29220.0
 hardrock_2016_shad_hirthe_ouray_in_1:
   id: 147690
   effort_id: 7297
@@ -10694,6 +11406,7 @@ hardrock_2016_shad_hirthe_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 00:35:00'
+  elapsed_seconds: 45300.0
 hardrock_2016_shad_hirthe_ouray_out_1:
   id: 147691
   effort_id: 7297
@@ -10709,6 +11422,7 @@ hardrock_2016_shad_hirthe_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 00:47:00'
+  elapsed_seconds: 46020.0
 hardrock_2016_shad_hirthe_grouse_in_1:
   id: 147694
   effort_id: 7297
@@ -10724,6 +11438,7 @@ hardrock_2016_shad_hirthe_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 06:28:00'
+  elapsed_seconds: 66480.0
 hardrock_2016_shad_hirthe_grouse_out_1:
   id: 147695
   effort_id: 7297
@@ -10739,6 +11454,7 @@ hardrock_2016_shad_hirthe_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 06:47:00'
+  elapsed_seconds: 67620.0
 hardrock_2016_shad_hirthe_sherman_in_1:
   id: 147698
   effort_id: 7297
@@ -10754,6 +11470,7 @@ hardrock_2016_shad_hirthe_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 12:35:00'
+  elapsed_seconds: 88500.0
 hardrock_2016_shad_hirthe_sherman_out_1:
   id: 147699
   effort_id: 7297
@@ -10769,6 +11486,7 @@ hardrock_2016_shad_hirthe_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 12:59:00'
+  elapsed_seconds: 89940.0
 hardrock_2016_douglas_vandervort_start_1:
   id: 147819
   effort_id: 7302
@@ -10784,6 +11502,7 @@ hardrock_2016_douglas_vandervort_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_douglas_vandervort_telluride_in_1:
   id: 147824
   effort_id: 7302
@@ -10799,6 +11518,7 @@ hardrock_2016_douglas_vandervort_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 20:16:00'
+  elapsed_seconds: 29760.0
 hardrock_2016_douglas_vandervort_telluride_out_1:
   id: 147825
   effort_id: 7302
@@ -10814,6 +11534,7 @@ hardrock_2016_douglas_vandervort_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 20:27:00'
+  elapsed_seconds: 30420.0
 hardrock_2016_douglas_vandervort_ouray_in_1:
   id: 147830
   effort_id: 7302
@@ -10829,6 +11550,7 @@ hardrock_2016_douglas_vandervort_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 01:19:00'
+  elapsed_seconds: 47940.0
 hardrock_2016_douglas_vandervort_ouray_out_1:
   id: 147831
   effort_id: 7302
@@ -10844,6 +11566,7 @@ hardrock_2016_douglas_vandervort_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 01:46:00'
+  elapsed_seconds: 49560.0
 hardrock_2016_douglas_vandervort_grouse_in_1:
   id: 147834
   effort_id: 7302
@@ -10859,6 +11582,7 @@ hardrock_2016_douglas_vandervort_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 08:00:00'
+  elapsed_seconds: 72000.0
 hardrock_2016_douglas_vandervort_grouse_out_1:
   id: 147835
   effort_id: 7302
@@ -10874,6 +11598,7 @@ hardrock_2016_douglas_vandervort_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 08:27:00'
+  elapsed_seconds: 73620.0
 hardrock_2016_douglas_vandervort_sherman_in_1:
   id: 147838
   effort_id: 7302
@@ -10889,6 +11614,7 @@ hardrock_2016_douglas_vandervort_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 13:49:00'
+  elapsed_seconds: 92940.0
 hardrock_2016_douglas_vandervort_sherman_out_1:
   id: 147839
   effort_id: 7302
@@ -10904,6 +11630,7 @@ hardrock_2016_douglas_vandervort_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 14:19:00'
+  elapsed_seconds: 94740.0
 hardrock_2016_missing_telluride_out_start_1:
   id: 147987
   effort_id: 7308
@@ -10919,6 +11646,7 @@ hardrock_2016_missing_telluride_out_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_missing_telluride_out_telluride_in_1:
   id: 147992
   effort_id: 7308
@@ -10934,6 +11662,7 @@ hardrock_2016_missing_telluride_out_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 21:41:00'
+  elapsed_seconds: 34860.0
 hardrock_2016_missing_telluride_out_ouray_in_1:
   id: 147998
   effort_id: 7308
@@ -10949,6 +11678,7 @@ hardrock_2016_missing_telluride_out_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 02:54:00'
+  elapsed_seconds: 53640.0
 hardrock_2016_missing_telluride_out_ouray_out_1:
   id: 147999
   effort_id: 7308
@@ -10964,6 +11694,7 @@ hardrock_2016_missing_telluride_out_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 03:10:00'
+  elapsed_seconds: 54600.0
 hardrock_2016_missing_telluride_out_grouse_in_1:
   id: 148002
   effort_id: 7308
@@ -10979,6 +11710,7 @@ hardrock_2016_missing_telluride_out_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 09:04:00'
+  elapsed_seconds: 75840.0
 hardrock_2016_missing_telluride_out_grouse_out_1:
   id: 148003
   effort_id: 7308
@@ -10994,6 +11726,7 @@ hardrock_2016_missing_telluride_out_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 09:16:00'
+  elapsed_seconds: 76560.0
 hardrock_2016_missing_telluride_out_sherman_in_1:
   id: 148006
   effort_id: 7308
@@ -11009,6 +11742,7 @@ hardrock_2016_missing_telluride_out_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 14:51:00'
+  elapsed_seconds: 96660.0
 hardrock_2016_missing_telluride_out_sherman_out_1:
   id: 148007
   effort_id: 7308
@@ -11024,6 +11758,7 @@ hardrock_2016_missing_telluride_out_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 15:13:00'
+  elapsed_seconds: 97980.0
 hardrock_2016_junior_lesch_start_1:
   id: 148071
   effort_id: 7311
@@ -11039,6 +11774,7 @@ hardrock_2016_junior_lesch_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_junior_lesch_telluride_in_1:
   id: 148076
   effort_id: 7311
@@ -11054,6 +11790,7 @@ hardrock_2016_junior_lesch_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 20:10:00'
+  elapsed_seconds: 29400.0
 hardrock_2016_junior_lesch_telluride_out_1:
   id: 148077
   effort_id: 7311
@@ -11069,6 +11806,7 @@ hardrock_2016_junior_lesch_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 20:17:00'
+  elapsed_seconds: 29820.0
 hardrock_2016_junior_lesch_ouray_in_1:
   id: 148082
   effort_id: 7311
@@ -11084,6 +11822,7 @@ hardrock_2016_junior_lesch_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 00:57:00'
+  elapsed_seconds: 46620.0
 hardrock_2016_junior_lesch_ouray_out_1:
   id: 148083
   effort_id: 7311
@@ -11099,6 +11838,7 @@ hardrock_2016_junior_lesch_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 01:20:00'
+  elapsed_seconds: 48000.0
 hardrock_2016_junior_lesch_grouse_in_1:
   id: 148086
   effort_id: 7311
@@ -11114,6 +11854,7 @@ hardrock_2016_junior_lesch_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 07:31:00'
+  elapsed_seconds: 70260.0
 hardrock_2016_junior_lesch_grouse_out_1:
   id: 148087
   effort_id: 7311
@@ -11129,6 +11870,7 @@ hardrock_2016_junior_lesch_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 08:42:00'
+  elapsed_seconds: 74520.0
 hardrock_2016_junior_lesch_sherman_in_1:
   id: 148090
   effort_id: 7311
@@ -11144,6 +11886,7 @@ hardrock_2016_junior_lesch_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 15:10:00'
+  elapsed_seconds: 97800.0
 hardrock_2016_junior_lesch_sherman_out_1:
   id: 148091
   effort_id: 7311
@@ -11159,6 +11902,7 @@ hardrock_2016_junior_lesch_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 15:44:00'
+  elapsed_seconds: 99840.0
 hardrock_2016_eddy_goldner_start_1:
   id: 148183
   effort_id: 7315
@@ -11174,6 +11918,7 @@ hardrock_2016_eddy_goldner_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_eddy_goldner_telluride_in_1:
   id: 148188
   effort_id: 7315
@@ -11189,6 +11934,7 @@ hardrock_2016_eddy_goldner_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 19:41:00'
+  elapsed_seconds: 27660.0
 hardrock_2016_eddy_goldner_telluride_out_1:
   id: 148189
   effort_id: 7315
@@ -11204,6 +11950,7 @@ hardrock_2016_eddy_goldner_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 19:54:00'
+  elapsed_seconds: 28440.0
 hardrock_2016_eddy_goldner_ouray_in_1:
   id: 148194
   effort_id: 7315
@@ -11219,6 +11966,7 @@ hardrock_2016_eddy_goldner_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 00:48:00'
+  elapsed_seconds: 46080.0
 hardrock_2016_eddy_goldner_ouray_out_1:
   id: 148195
   effort_id: 7315
@@ -11234,6 +11982,7 @@ hardrock_2016_eddy_goldner_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 01:05:00'
+  elapsed_seconds: 47100.0
 hardrock_2016_eddy_goldner_grouse_in_1:
   id: 148198
   effort_id: 7315
@@ -11249,6 +11998,7 @@ hardrock_2016_eddy_goldner_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 07:42:00'
+  elapsed_seconds: 70920.0
 hardrock_2016_eddy_goldner_grouse_out_1:
   id: 148199
   effort_id: 7315
@@ -11264,6 +12014,7 @@ hardrock_2016_eddy_goldner_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 08:25:00'
+  elapsed_seconds: 73500.0
 hardrock_2016_eddy_goldner_sherman_in_1:
   id: 148202
   effort_id: 7315
@@ -11279,6 +12030,7 @@ hardrock_2016_eddy_goldner_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 14:24:00'
+  elapsed_seconds: 95040.0
 hardrock_2016_eddy_goldner_sherman_out_1:
   id: 148203
   effort_id: 7315
@@ -11294,6 +12046,7 @@ hardrock_2016_eddy_goldner_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 15:00:00'
+  elapsed_seconds: 97200.0
 hardrock_2016_progress_sherman_start_1:
   id: 148547
   effort_id: 7328
@@ -11309,6 +12062,7 @@ hardrock_2016_progress_sherman_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_progress_sherman_telluride_in_1:
   id: 148552
   effort_id: 7328
@@ -11324,6 +12078,7 @@ hardrock_2016_progress_sherman_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 19:44:00'
+  elapsed_seconds: 27840.0
 hardrock_2016_progress_sherman_telluride_out_1:
   id: 148553
   effort_id: 7328
@@ -11339,6 +12094,7 @@ hardrock_2016_progress_sherman_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 19:47:00'
+  elapsed_seconds: 28020.0
 hardrock_2016_progress_sherman_ouray_in_1:
   id: 148558
   effort_id: 7328
@@ -11354,6 +12110,7 @@ hardrock_2016_progress_sherman_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 00:03:00'
+  elapsed_seconds: 43380.0
 hardrock_2016_progress_sherman_ouray_out_1:
   id: 148559
   effort_id: 7328
@@ -11369,6 +12126,7 @@ hardrock_2016_progress_sherman_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 00:09:00'
+  elapsed_seconds: 43740.0
 hardrock_2016_progress_sherman_grouse_in_1:
   id: 148562
   effort_id: 7328
@@ -11384,6 +12142,7 @@ hardrock_2016_progress_sherman_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 05:08:00'
+  elapsed_seconds: 61680.0
 hardrock_2016_progress_sherman_grouse_out_1:
   id: 148563
   effort_id: 7328
@@ -11399,6 +12158,7 @@ hardrock_2016_progress_sherman_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 05:32:00'
+  elapsed_seconds: 63120.0
 hardrock_2016_progress_sherman_sherman_in_1:
   id: 148566
   effort_id: 7328
@@ -11414,6 +12174,7 @@ hardrock_2016_progress_sherman_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 11:27:00'
+  elapsed_seconds: 84420.0
 hardrock_2016_progress_sherman_sherman_out_1:
   id: 148567
   effort_id: 7328
@@ -11429,6 +12190,7 @@ hardrock_2016_progress_sherman_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 11:52:00'
+  elapsed_seconds: 85920.0
 hardrock_2016_benito_moen_start_1:
   id: 148799
   effort_id: 7337
@@ -11444,6 +12206,7 @@ hardrock_2016_benito_moen_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_benito_moen_telluride_in_1:
   id: 148804
   effort_id: 7337
@@ -11459,6 +12222,7 @@ hardrock_2016_benito_moen_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 20:42:00'
+  elapsed_seconds: 31320.0
 hardrock_2016_benito_moen_telluride_out_1:
   id: 148805
   effort_id: 7337
@@ -11474,6 +12238,7 @@ hardrock_2016_benito_moen_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 20:54:00'
+  elapsed_seconds: 32040.0
 hardrock_2016_benito_moen_ouray_in_1:
   id: 148810
   effort_id: 7337
@@ -11489,6 +12254,7 @@ hardrock_2016_benito_moen_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 02:32:00'
+  elapsed_seconds: 52320.0
 hardrock_2016_benito_moen_ouray_out_1:
   id: 148811
   effort_id: 7337
@@ -11504,6 +12270,7 @@ hardrock_2016_benito_moen_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 03:32:00'
+  elapsed_seconds: 55920.0
 hardrock_2016_benito_moen_grouse_in_1:
   id: 148814
   effort_id: 7337
@@ -11519,6 +12286,7 @@ hardrock_2016_benito_moen_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 10:02:00'
+  elapsed_seconds: 79320.0
 hardrock_2016_benito_moen_grouse_out_1:
   id: 148815
   effort_id: 7337
@@ -11534,6 +12302,7 @@ hardrock_2016_benito_moen_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 11:05:00'
+  elapsed_seconds: 83100.0
 hardrock_2016_benito_moen_sherman_in_1:
   id: 148818
   effort_id: 7337
@@ -11549,6 +12318,7 @@ hardrock_2016_benito_moen_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 16:45:00'
+  elapsed_seconds: 103500.0
 hardrock_2016_benito_moen_sherman_out_1:
   id: 148819
   effort_id: 7337
@@ -11564,6 +12334,7 @@ hardrock_2016_benito_moen_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 17:27:00'
+  elapsed_seconds: 106020.0
 hardrock_2016_kendall_koch_start_1:
   id: 148883
   effort_id: 7340
@@ -11579,6 +12350,7 @@ hardrock_2016_kendall_koch_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_kendall_koch_telluride_in_1:
   id: 148888
   effort_id: 7340
@@ -11594,6 +12366,7 @@ hardrock_2016_kendall_koch_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 21:44:00'
+  elapsed_seconds: 35040.0
 hardrock_2016_kendall_koch_telluride_out_1:
   id: 148889
   effort_id: 7340
@@ -11609,6 +12382,7 @@ hardrock_2016_kendall_koch_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 21:54:00'
+  elapsed_seconds: 35640.0
 hardrock_2016_kendall_koch_ouray_in_1:
   id: 148894
   effort_id: 7340
@@ -11624,6 +12398,7 @@ hardrock_2016_kendall_koch_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 03:43:00'
+  elapsed_seconds: 56580.0
 hardrock_2016_kendall_koch_ouray_out_1:
   id: 148895
   effort_id: 7340
@@ -11639,6 +12414,7 @@ hardrock_2016_kendall_koch_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 03:46:00'
+  elapsed_seconds: 56760.0
 hardrock_2016_kendall_koch_grouse_in_1:
   id: 148898
   effort_id: 7340
@@ -11654,6 +12430,7 @@ hardrock_2016_kendall_koch_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 10:18:00'
+  elapsed_seconds: 80280.0
 hardrock_2016_kendall_koch_grouse_out_1:
   id: 148899
   effort_id: 7340
@@ -11669,6 +12446,7 @@ hardrock_2016_kendall_koch_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 10:22:00'
+  elapsed_seconds: 80520.0
 hardrock_2016_kendall_koch_sherman_in_1:
   id: 148902
   effort_id: 7340
@@ -11684,6 +12462,7 @@ hardrock_2016_kendall_koch_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 17:08:00'
+  elapsed_seconds: 104880.0
 hardrock_2016_kendall_koch_sherman_out_1:
   id: 148903
   effort_id: 7340
@@ -11699,6 +12478,7 @@ hardrock_2016_kendall_koch_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 17:32:00'
+  elapsed_seconds: 106320.0
 hardrock_2016_charlie_mueller_start_1:
   id: 148967
   effort_id: 7343
@@ -11714,6 +12494,7 @@ hardrock_2016_charlie_mueller_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_charlie_mueller_telluride_in_1:
   id: 148972
   effort_id: 7343
@@ -11729,6 +12510,7 @@ hardrock_2016_charlie_mueller_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 21:45:00'
+  elapsed_seconds: 35100.0
 hardrock_2016_charlie_mueller_telluride_out_1:
   id: 148973
   effort_id: 7343
@@ -11744,6 +12526,7 @@ hardrock_2016_charlie_mueller_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 22:00:00'
+  elapsed_seconds: 36000.0
 hardrock_2016_charlie_mueller_ouray_in_1:
   id: 148978
   effort_id: 7343
@@ -11759,6 +12542,7 @@ hardrock_2016_charlie_mueller_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 03:38:00'
+  elapsed_seconds: 56280.0
 hardrock_2016_charlie_mueller_ouray_out_1:
   id: 148979
   effort_id: 7343
@@ -11774,6 +12558,7 @@ hardrock_2016_charlie_mueller_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 04:00:00'
+  elapsed_seconds: 57600.0
 hardrock_2016_charlie_mueller_grouse_in_1:
   id: 148982
   effort_id: 7343
@@ -11789,6 +12574,7 @@ hardrock_2016_charlie_mueller_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 10:15:00'
+  elapsed_seconds: 80100.0
 hardrock_2016_charlie_mueller_grouse_out_1:
   id: 148983
   effort_id: 7343
@@ -11804,6 +12590,7 @@ hardrock_2016_charlie_mueller_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 10:27:00'
+  elapsed_seconds: 80820.0
 hardrock_2016_charlie_mueller_sherman_in_1:
   id: 148986
   effort_id: 7343
@@ -11819,6 +12606,7 @@ hardrock_2016_charlie_mueller_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 16:45:00'
+  elapsed_seconds: 103500.0
 hardrock_2016_charlie_mueller_sherman_out_1:
   id: 148987
   effort_id: 7343
@@ -11834,6 +12622,7 @@ hardrock_2016_charlie_mueller_sherman_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 17:05:00'
+  elapsed_seconds: 104700.0
 hardrock_2016_brinda_fisher_start_1:
   id: 149891
   effort_id: 7376
@@ -11849,6 +12638,7 @@ hardrock_2016_brinda_fisher_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_brinda_fisher_telluride_in_1:
   id: 149896
   effort_id: 7376
@@ -11864,6 +12654,7 @@ hardrock_2016_brinda_fisher_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 22:57:00'
+  elapsed_seconds: 39420.0
 hardrock_2016_brinda_fisher_telluride_out_1:
   id: 149897
   effort_id: 7376
@@ -11879,6 +12670,7 @@ hardrock_2016_brinda_fisher_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 23:00:00'
+  elapsed_seconds: 39600.0
 hardrock_2016_brinda_fisher_ouray_in_1:
   id: 149902
   effort_id: 7376
@@ -11894,6 +12686,7 @@ hardrock_2016_brinda_fisher_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 05:56:00'
+  elapsed_seconds: 64560.0
 hardrock_2016_brinda_fisher_ouray_out_1:
   id: 149903
   effort_id: 7376
@@ -11909,6 +12702,7 @@ hardrock_2016_brinda_fisher_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 06:25:00'
+  elapsed_seconds: 66300.0
 hardrock_2016_brinda_fisher_grouse_in_1:
   id: 149906
   effort_id: 7376
@@ -11924,6 +12718,7 @@ hardrock_2016_brinda_fisher_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 14:05:00'
+  elapsed_seconds: 93900.0
 hardrock_2016_brinda_fisher_grouse_out_1:
   id: 149907
   effort_id: 7376
@@ -11939,6 +12734,7 @@ hardrock_2016_brinda_fisher_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 14:19:00'
+  elapsed_seconds: 94740.0
 hardrock_2016_rene_mclaughlin_start_1:
   id: 149997
   effort_id: 7380
@@ -11954,6 +12750,7 @@ hardrock_2016_rene_mclaughlin_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_rene_mclaughlin_telluride_in_1:
   id: 150002
   effort_id: 7380
@@ -11969,6 +12766,7 @@ hardrock_2016_rene_mclaughlin_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 22:06:00'
+  elapsed_seconds: 36360.0
 hardrock_2016_rene_mclaughlin_telluride_out_1:
   id: 150003
   effort_id: 7380
@@ -11984,6 +12782,7 @@ hardrock_2016_rene_mclaughlin_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 22:20:00'
+  elapsed_seconds: 37200.0
 hardrock_2016_rene_mclaughlin_ouray_in_1:
   id: 150008
   effort_id: 7380
@@ -11999,6 +12798,7 @@ hardrock_2016_rene_mclaughlin_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 04:34:00'
+  elapsed_seconds: 59640.0
 hardrock_2016_rene_mclaughlin_ouray_out_1:
   id: 150009
   effort_id: 7380
@@ -12014,6 +12814,7 @@ hardrock_2016_rene_mclaughlin_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 04:55:00'
+  elapsed_seconds: 60900.0
 hardrock_2016_rene_mclaughlin_grouse_in_1:
   id: 150012
   effort_id: 7380
@@ -12029,6 +12830,7 @@ hardrock_2016_rene_mclaughlin_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 12:07:00'
+  elapsed_seconds: 86820.0
 hardrock_2016_rene_mclaughlin_grouse_out_1:
   id: 150013
   effort_id: 7380
@@ -12044,6 +12846,7 @@ hardrock_2016_rene_mclaughlin_grouse_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 13:37:00'
+  elapsed_seconds: 92220.0
 hardrock_2016_rene_mclaughlin_sherman_in_1:
   id: 150016
   effort_id: 7380
@@ -12059,6 +12862,7 @@ hardrock_2016_rene_mclaughlin_sherman_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 20:41:00'
+  elapsed_seconds: 117660.0
 hardrock_2016_dropped_grouse_start_1:
   id: 150319
   effort_id: 7396
@@ -12074,6 +12878,7 @@ hardrock_2016_dropped_grouse_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_dropped_grouse_telluride_in_1:
   id: 150324
   effort_id: 7396
@@ -12089,6 +12894,7 @@ hardrock_2016_dropped_grouse_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 18:35:00'
+  elapsed_seconds: 23700.0
 hardrock_2016_dropped_grouse_telluride_out_1:
   id: 150325
   effort_id: 7396
@@ -12104,6 +12910,7 @@ hardrock_2016_dropped_grouse_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 18:39:00'
+  elapsed_seconds: 23940.0
 hardrock_2016_dropped_grouse_ouray_in_1:
   id: 150330
   effort_id: 7396
@@ -12119,6 +12926,7 @@ hardrock_2016_dropped_grouse_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 22:06:00'
+  elapsed_seconds: 36360.0
 hardrock_2016_dropped_grouse_ouray_out_1:
   id: 150331
   effort_id: 7396
@@ -12134,6 +12942,7 @@ hardrock_2016_dropped_grouse_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 22:12:00'
+  elapsed_seconds: 36720.0
 hardrock_2016_dropped_grouse_grouse_in_1:
   id: 150334
   effort_id: 7396
@@ -12149,6 +12958,7 @@ hardrock_2016_dropped_grouse_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 02:40:00'
+  elapsed_seconds: 52800.0
 hardrock_2016_dropped_grouse_grouse_out_1:
   id: 150335
   effort_id: 7396
@@ -12164,6 +12974,7 @@ hardrock_2016_dropped_grouse_grouse_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2016-07-16 02:40:00'
+  elapsed_seconds: 52800.0
 hardrock_2016_mervin_smitham_start_1:
   id: 150387
   effort_id: 7400
@@ -12179,6 +12990,7 @@ hardrock_2016_mervin_smitham_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_mervin_smitham_telluride_in_1:
   id: 150392
   effort_id: 7400
@@ -12194,6 +13006,7 @@ hardrock_2016_mervin_smitham_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 21:07:00'
+  elapsed_seconds: 32820.0
 hardrock_2016_mervin_smitham_telluride_out_1:
   id: 150393
   effort_id: 7400
@@ -12209,6 +13022,7 @@ hardrock_2016_mervin_smitham_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 21:25:00'
+  elapsed_seconds: 33900.0
 hardrock_2016_mervin_smitham_ouray_in_1:
   id: 150398
   effort_id: 7400
@@ -12224,6 +13038,7 @@ hardrock_2016_mervin_smitham_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 03:00:00'
+  elapsed_seconds: 54000.0
 hardrock_2016_mervin_smitham_ouray_out_1:
   id: 150399
   effort_id: 7400
@@ -12239,6 +13054,7 @@ hardrock_2016_mervin_smitham_ouray_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 03:59:00'
+  elapsed_seconds: 57540.0
 hardrock_2016_mervin_smitham_grouse_in_1:
   id: 150402
   effort_id: 7400
@@ -12254,6 +13070,7 @@ hardrock_2016_mervin_smitham_grouse_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 11:53:00'
+  elapsed_seconds: 85980.0
 hardrock_2016_mervin_smitham_grouse_out_1:
   id: 150403
   effort_id: 7400
@@ -12269,6 +13086,7 @@ hardrock_2016_mervin_smitham_grouse_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2016-07-16 11:53:00'
+  elapsed_seconds: 85980.0
 hardrock_2016_rhett_auer_start_1:
   id: 150455
   effort_id: 7404
@@ -12284,6 +13102,7 @@ hardrock_2016_rhett_auer_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_rhett_auer_telluride_in_1:
   id: 150460
   effort_id: 7404
@@ -12299,6 +13118,7 @@ hardrock_2016_rhett_auer_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 18:04:00'
+  elapsed_seconds: 21840.0
 hardrock_2016_rhett_auer_telluride_out_1:
   id: 150461
   effort_id: 7404
@@ -12314,6 +13134,7 @@ hardrock_2016_rhett_auer_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 18:06:00'
+  elapsed_seconds: 21960.0
 hardrock_2016_rhett_auer_ouray_in_1:
   id: 150466
   effort_id: 7404
@@ -12329,6 +13150,7 @@ hardrock_2016_rhett_auer_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 21:40:00'
+  elapsed_seconds: 34800.0
 hardrock_2016_rhett_auer_ouray_out_1:
   id: 150467
   effort_id: 7404
@@ -12344,6 +13166,7 @@ hardrock_2016_rhett_auer_ouray_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2016-07-15 21:53:00'
+  elapsed_seconds: 35580.0
 hardrock_2016_hoyt_macejkovic_start_1:
   id: 150494
   effort_id: 7407
@@ -12359,6 +13182,7 @@ hardrock_2016_hoyt_macejkovic_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2016_hoyt_macejkovic_telluride_in_1:
   id: 150499
   effort_id: 7407
@@ -12374,6 +13198,7 @@ hardrock_2016_hoyt_macejkovic_telluride_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 21:56:00'
+  elapsed_seconds: 35760.0
 hardrock_2016_hoyt_macejkovic_telluride_out_1:
   id: 150500
   effort_id: 7407
@@ -12389,6 +13214,7 @@ hardrock_2016_hoyt_macejkovic_telluride_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 22:11:00'
+  elapsed_seconds: 36660.0
 hardrock_2016_hoyt_macejkovic_ouray_in_1:
   id: 150505
   effort_id: 7407
@@ -12404,6 +13230,7 @@ hardrock_2016_hoyt_macejkovic_ouray_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-16 04:44:00'
+  elapsed_seconds: 60240.0
 hardrock_2016_hoyt_macejkovic_ouray_out_1:
   id: 150506
   effort_id: 7407
@@ -12419,6 +13246,7 @@ hardrock_2016_hoyt_macejkovic_ouray_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2016-07-16 05:46:00'
+  elapsed_seconds: 63960.0
 ggd30_50k_finished_first_start_1:
   id: 184081
   effort_id: 15626
@@ -12434,6 +13262,7 @@ ggd30_50k_finished_first_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 13:00:00'
+  elapsed_seconds: 0.0
 ggd30_50k_finished_first_aid_1_1:
   id: 184082
   effort_id: 15626
@@ -12449,6 +13278,7 @@ ggd30_50k_finished_first_aid_1_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 13:46:48.17'
+  elapsed_seconds: 2808.17
 ggd30_50k_finished_first_aid_2_1:
   id: 184083
   effort_id: 15626
@@ -12464,6 +13294,7 @@ ggd30_50k_finished_first_aid_2_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 14:54:09.71'
+  elapsed_seconds: 6849.71
 ggd30_50k_finished_first_aid_3_1:
   id: 184084
   effort_id: 15626
@@ -12479,6 +13310,7 @@ ggd30_50k_finished_first_aid_3_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 15:53:16.01'
+  elapsed_seconds: 10396.01
 ggd30_50k_bad_finish_start_1:
   id: 184337
   effort_id: 15664
@@ -12494,6 +13326,7 @@ ggd30_50k_bad_finish_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 13:00:00'
+  elapsed_seconds: 0.0
 ggd30_50k_bad_finish_aid_1_1:
   id: 184338
   effort_id: 15664
@@ -12509,6 +13342,7 @@ ggd30_50k_bad_finish_aid_1_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 13:49:00.82'
+  elapsed_seconds: 2940.82
 ggd30_50k_bad_finish_aid_2_1:
   id: 184339
   effort_id: 15664
@@ -12524,6 +13358,7 @@ ggd30_50k_bad_finish_aid_2_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 15:05:22.76'
+  elapsed_seconds: 7522.76
 ggd30_50k_bad_finish_aid_3_1:
   id: 184340
   effort_id: 15664
@@ -12539,6 +13374,7 @@ ggd30_50k_bad_finish_aid_3_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 16:15:30.09'
+  elapsed_seconds: 11730.09
 ggd30_50k_progress_aid4_start_1:
   id: 185898
   effort_id: 15891
@@ -12554,6 +13390,7 @@ ggd30_50k_progress_aid4_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 13:00:00'
+  elapsed_seconds: 0.0
 ggd30_50k_progress_aid4_aid_1_1:
   id: 185899
   effort_id: 15891
@@ -12569,6 +13406,7 @@ ggd30_50k_progress_aid4_aid_1_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 14:13:10.9'
+  elapsed_seconds: 4390.9
 ggd30_50k_progress_aid4_aid_2_1:
   id: 185900
   effort_id: 15891
@@ -12584,6 +13422,7 @@ ggd30_50k_progress_aid4_aid_2_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 15:59:30.11'
+  elapsed_seconds: 10770.11
 ggd30_50k_progress_aid3_start_1:
   id: 185965
   effort_id: 15901
@@ -12599,6 +13438,7 @@ ggd30_50k_progress_aid3_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 13:00:00'
+  elapsed_seconds: 0.0
 ggd30_50k_progress_aid3_aid_1_1:
   id: 185966
   effort_id: 15901
@@ -12614,6 +13454,7 @@ ggd30_50k_progress_aid3_aid_1_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 14:11:47'
+  elapsed_seconds: 4307.0
 ggd30_50k_progress_aid3_aid_2_1:
   id: 185967
   effort_id: 15901
@@ -12629,6 +13470,7 @@ ggd30_50k_progress_aid3_aid_2_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 15:56:58'
+  elapsed_seconds: 10618.0
 ggd30_50k_drop_aid4_start_1:
   id: 186151
   effort_id: 15931
@@ -12644,6 +13486,7 @@ ggd30_50k_drop_aid4_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 13:00:00'
+  elapsed_seconds: 0.0
 ggd30_50k_drop_aid4_aid_1_1:
   id: 186152
   effort_id: 15931
@@ -12659,6 +13502,7 @@ ggd30_50k_drop_aid4_aid_1_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 14:01:33.78'
+  elapsed_seconds: 3693.78
 ggd30_50k_drop_aid4_aid_2_1:
   id: 186153
   effort_id: 15931
@@ -12674,6 +13518,7 @@ ggd30_50k_drop_aid4_aid_2_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 15:35:56.73'
+  elapsed_seconds: 9356.73
 ggd30_50k_finished_first_aid_4_1:
   id: 188949
   effort_id: 15626
@@ -12689,6 +13534,7 @@ ggd30_50k_finished_first_aid_4_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 17:11:12.54'
+  elapsed_seconds: 15072.54
 ggd30_50k_finished_first_aid_5_1:
   id: 188950
   effort_id: 15626
@@ -12704,6 +13550,7 @@ ggd30_50k_finished_first_aid_5_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 18:09:59.14'
+  elapsed_seconds: 18599.14
 ggd30_50k_finished_first_finish_1:
   id: 188951
   effort_id: 15626
@@ -12719,6 +13566,7 @@ ggd30_50k_finished_first_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 18:29:47.41'
+  elapsed_seconds: 19787.41
 ggd30_50k_bad_finish_aid_4_1:
   id: 189053
   effort_id: 15664
@@ -12734,6 +13582,7 @@ ggd30_50k_bad_finish_aid_4_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 17:49:35.62'
+  elapsed_seconds: 17375.62
 ggd30_50k_bad_finish_aid_5_1:
   id: 189054
   effort_id: 15664
@@ -12749,6 +13598,7 @@ ggd30_50k_bad_finish_aid_5_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 19:40:01.98'
+  elapsed_seconds: 24001.98
 ggd30_50k_bad_finish_finish_1:
   id: 189055
   effort_id: 15664
@@ -12764,6 +13614,7 @@ ggd30_50k_bad_finish_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 19:24:16.59'
+  elapsed_seconds: 23056.59
 ggd30_50k_progress_aid4_aid_3_1:
   id: 189813
   effort_id: 15891
@@ -12779,6 +13630,7 @@ ggd30_50k_progress_aid4_aid_3_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 17:38:48.07'
+  elapsed_seconds: 16728.07
 ggd30_50k_progress_aid4_aid_4_1:
   id: 189814
   effort_id: 15891
@@ -12794,6 +13646,7 @@ ggd30_50k_progress_aid4_aid_4_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 19:46:07.33'
+  elapsed_seconds: 24367.33
 ggd30_50k_progress_aid3_aid_3_1:
   id: 189850
   effort_id: 15901
@@ -12809,6 +13662,7 @@ ggd30_50k_progress_aid3_aid_3_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 17:39:00'
+  elapsed_seconds: 16740.0
 ggd30_50k_drop_aid4_aid_3_1:
   id: 189951
   effort_id: 15931
@@ -12824,6 +13678,7 @@ ggd30_50k_drop_aid4_aid_3_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 17:11:07.47'
+  elapsed_seconds: 15067.47
 ggd30_50k_drop_aid4_aid_4_1:
   id: 189952
   effort_id: 15931
@@ -12839,6 +13694,7 @@ ggd30_50k_drop_aid4_aid_4_1:
   lap: 1
   stopped_here: true
   absolute_time: '2017-06-03 19:47:10.55'
+  elapsed_seconds: 24430.55
 ggd30_12m_finished_first_start_1:
   id: 190116
   effort_id: 16173
@@ -12854,6 +13710,7 @@ ggd30_12m_finished_first_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 16:00:00'
+  elapsed_seconds: 0.0
 ggd30_12m_finished_first_finish_1:
   id: 190117
   effort_id: 16173
@@ -12869,6 +13726,7 @@ ggd30_12m_finished_first_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 17:48:09.28'
+  elapsed_seconds: 6489.28
 ggd30_12m_finished_second_start_1:
   id: 190272
   effort_id: 16107
@@ -12884,6 +13742,7 @@ ggd30_12m_finished_second_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 16:00:00'
+  elapsed_seconds: 0.0
 ggd30_12m_finished_second_finish_1:
   id: 190273
   effort_id: 16107
@@ -12899,6 +13758,7 @@ ggd30_12m_finished_second_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 18:54:56.69'
+  elapsed_seconds: 10496.69
 hardrock_2015_cedric_windler_start_1:
   id: 190477
   effort_id: 50
@@ -12914,6 +13774,7 @@ hardrock_2015_cedric_windler_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 hardrock_2015_tuan_jacobs_start_1:
   id: 190478
   effort_id: 7
@@ -12929,6 +13790,7 @@ hardrock_2015_tuan_jacobs_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2015-07-10 12:00:00'
+  elapsed_seconds: 0.0
 sum_55k_finished_first_start_1:
   id: 190499
   effort_id: 16227
@@ -12944,6 +13806,7 @@ sum_55k_finished_first_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 15:00:00'
+  elapsed_seconds: 0.0
 sum_55k_finished_first_molas_pass_aid1_in_1:
   id: 190500
   effort_id: 16227
@@ -12959,6 +13822,7 @@ sum_55k_finished_first_molas_pass_aid1_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 18:20:36'
+  elapsed_seconds: 12036.0
 sum_55k_finished_first_molas_pass_aid1_out_1:
   id: 190501
   effort_id: 16227
@@ -12974,6 +13838,7 @@ sum_55k_finished_first_molas_pass_aid1_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 18:22:10'
+  elapsed_seconds: 12130.0
 sum_55k_finished_first_rolling_pass_aid2_in_1:
   id: 190502
   effort_id: 16227
@@ -12989,6 +13854,7 @@ sum_55k_finished_first_rolling_pass_aid2_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 20:48:20'
+  elapsed_seconds: 20900.0
 sum_55k_finished_first_rolling_pass_aid2_out_1:
   id: 190503
   effort_id: 16227
@@ -13004,6 +13870,7 @@ sum_55k_finished_first_rolling_pass_aid2_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 20:50:20'
+  elapsed_seconds: 21020.0
 sum_55k_finished_first_bandera_mine_aid5_in_1:
   id: 190504
   effort_id: 16227
@@ -13019,6 +13886,7 @@ sum_55k_finished_first_bandera_mine_aid5_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 21:28:20'
+  elapsed_seconds: 23300.0
 sum_55k_finished_first_bandera_mine_aid5_out_1:
   id: 190505
   effort_id: 16227
@@ -13034,6 +13902,7 @@ sum_55k_finished_first_bandera_mine_aid5_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 21:28:20'
+  elapsed_seconds: 23300.0
 sum_55k_finished_first_anvil_cg_aid6_in_1:
   id: 190506
   effort_id: 16227
@@ -13049,6 +13918,7 @@ sum_55k_finished_first_anvil_cg_aid6_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 22:43:35'
+  elapsed_seconds: 27815.0
 sum_55k_finished_first_anvil_cg_aid6_out_1:
   id: 190507
   effort_id: 16227
@@ -13064,6 +13934,7 @@ sum_55k_finished_first_anvil_cg_aid6_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 22:51:27'
+  elapsed_seconds: 28287.0
 sum_55k_finished_first_finish_1:
   id: 190508
   effort_id: 16227
@@ -13079,6 +13950,7 @@ sum_55k_finished_first_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2017-10-07 23:58:06'
+  elapsed_seconds: 32286.0
 sum_55k_finished_second_start_1:
   id: 190519
   effort_id: 16229
@@ -13094,6 +13966,7 @@ sum_55k_finished_second_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 15:00:00'
+  elapsed_seconds: 0.0
 sum_55k_finished_second_molas_pass_aid1_in_1:
   id: 190520
   effort_id: 16229
@@ -13109,6 +13982,7 @@ sum_55k_finished_second_molas_pass_aid1_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 18:30:31'
+  elapsed_seconds: 12631.0
 sum_55k_finished_second_molas_pass_aid1_out_1:
   id: 190521
   effort_id: 16229
@@ -13124,6 +13998,7 @@ sum_55k_finished_second_molas_pass_aid1_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 18:31:46'
+  elapsed_seconds: 12706.0
 sum_55k_finished_second_rolling_pass_aid2_in_1:
   id: 190522
   effort_id: 16229
@@ -13139,6 +14014,7 @@ sum_55k_finished_second_rolling_pass_aid2_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 21:13:00'
+  elapsed_seconds: 22380.0
 sum_55k_finished_second_rolling_pass_aid2_out_1:
   id: 190523
   effort_id: 16229
@@ -13154,6 +14030,7 @@ sum_55k_finished_second_rolling_pass_aid2_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 21:18:00'
+  elapsed_seconds: 22680.0
 sum_55k_finished_second_bandera_mine_aid5_in_1:
   id: 190524
   effort_id: 16229
@@ -13169,6 +14046,7 @@ sum_55k_finished_second_bandera_mine_aid5_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 22:04:20'
+  elapsed_seconds: 25460.0
 sum_55k_finished_second_bandera_mine_aid5_out_1:
   id: 190525
   effort_id: 16229
@@ -13184,6 +14062,7 @@ sum_55k_finished_second_bandera_mine_aid5_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 22:05:20'
+  elapsed_seconds: 25520.0
 sum_55k_finished_second_anvil_cg_aid6_in_1:
   id: 190526
   effort_id: 16229
@@ -13199,6 +14078,7 @@ sum_55k_finished_second_anvil_cg_aid6_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 23:13:46'
+  elapsed_seconds: 29626.0
 sum_55k_finished_second_anvil_cg_aid6_out_1:
   id: 190527
   effort_id: 16229
@@ -13214,6 +14094,7 @@ sum_55k_finished_second_anvil_cg_aid6_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 23:13:50'
+  elapsed_seconds: 29630.0
 sum_55k_finished_second_finish_1:
   id: 190528
   effort_id: 16229
@@ -13229,6 +14110,7 @@ sum_55k_finished_second_finish_1:
   lap: 1
   stopped_here: true
   absolute_time: '2017-10-08 00:07:38'
+  elapsed_seconds: 32858.0
 sum_55k_progress_rolling_start_1:
   id: 190668
   effort_id: 16244
@@ -13244,6 +14126,7 @@ sum_55k_progress_rolling_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 13:00:00'
+  elapsed_seconds: 0.0
 sum_55k_progress_rolling_molas_pass_aid1_in_1:
   id: 190669
   effort_id: 16244
@@ -13259,6 +14142,7 @@ sum_55k_progress_rolling_molas_pass_aid1_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 15:12:00'
+  elapsed_seconds: 7920.0
 sum_55k_progress_rolling_molas_pass_aid1_out_1:
   id: 190670
   effort_id: 16244
@@ -13274,6 +14158,7 @@ sum_55k_progress_rolling_molas_pass_aid1_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 15:19:00'
+  elapsed_seconds: 8340.0
 sum_55k_progress_rolling_rolling_pass_aid2_in_1:
   id: 190671
   effort_id: 16244
@@ -13289,6 +14174,7 @@ sum_55k_progress_rolling_rolling_pass_aid2_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 17:05:00'
+  elapsed_seconds: 14700.0
 sum_55k_progress_rolling_rolling_pass_aid2_out_1:
   id: 190672
   effort_id: 16244
@@ -13304,6 +14190,7 @@ sum_55k_progress_rolling_rolling_pass_aid2_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 17:15:00'
+  elapsed_seconds: 15300.0
 sum_55k_drop_bandera_start_1:
   id: 190678
   effort_id: 16245
@@ -13319,6 +14206,7 @@ sum_55k_drop_bandera_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 15:00:00'
+  elapsed_seconds: 0.0
 sum_55k_drop_bandera_molas_pass_aid1_in_1:
   id: 190679
   effort_id: 16245
@@ -13334,6 +14222,7 @@ sum_55k_drop_bandera_molas_pass_aid1_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 19:12:27'
+  elapsed_seconds: 15147.0
 sum_55k_drop_bandera_molas_pass_aid1_out_1:
   id: 190680
   effort_id: 16245
@@ -13349,6 +14238,7 @@ sum_55k_drop_bandera_molas_pass_aid1_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 19:19:02'
+  elapsed_seconds: 15542.0
 sum_55k_drop_bandera_rolling_pass_aid2_in_1:
   id: 190681
   effort_id: 16245
@@ -13364,6 +14254,7 @@ sum_55k_drop_bandera_rolling_pass_aid2_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 22:27:20'
+  elapsed_seconds: 26840.0
 sum_55k_drop_bandera_rolling_pass_aid2_out_1:
   id: 190682
   effort_id: 16245
@@ -13379,6 +14270,7 @@ sum_55k_drop_bandera_rolling_pass_aid2_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 22:54:20'
+  elapsed_seconds: 28460.0
 sum_55k_drop_bandera_bandera_mine_aid5_in_1:
   id: 190683
   effort_id: 16245
@@ -13394,6 +14286,7 @@ sum_55k_drop_bandera_bandera_mine_aid5_in_1:
   lap: 1
   stopped_here: true
   absolute_time: '2017-10-08 00:21:20'
+  elapsed_seconds: 33680.0
 sum_100k_drop_anvil_anvil_cg_aid6_in_1:
   id: 190694
   effort_id: 16247
@@ -13409,6 +14302,7 @@ sum_100k_drop_anvil_anvil_cg_aid6_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 03:11:00'
+  elapsed_seconds: 51060.0
 sum_100k_drop_anvil_anvil_cg_aid6_out_1:
   id: 190695
   effort_id: 16247
@@ -13424,6 +14318,7 @@ sum_100k_drop_anvil_anvil_cg_aid6_out_1:
   lap: 1
   stopped_here: true
   absolute_time: '2017-09-24 03:21:00'
+  elapsed_seconds: 51660.0
 sum_100k_drop_anvil_rolling_pass_aid2_in_1:
   id: 190696
   effort_id: 16247
@@ -13439,6 +14334,7 @@ sum_100k_drop_anvil_rolling_pass_aid2_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 15:09:00'
+  elapsed_seconds: 7740.0
 sum_100k_drop_anvil_rolling_pass_aid2_out_1:
   id: 190697
   effort_id: 16247
@@ -13454,6 +14350,7 @@ sum_100k_drop_anvil_rolling_pass_aid2_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 07:03:05'
+  elapsed_seconds: 64985.0
 sum_100k_drop_anvil_start_1:
   id: 190698
   effort_id: 16247
@@ -13469,6 +14366,7 @@ sum_100k_drop_anvil_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 13:00:00'
+  elapsed_seconds: 0.0
 sum_100k_drop_anvil_molas_pass_aid1_in_1:
   id: 190699
   effort_id: 16247
@@ -13484,6 +14382,7 @@ sum_100k_drop_anvil_molas_pass_aid1_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 14:30:00'
+  elapsed_seconds: 5400.0
 sum_100k_drop_anvil_molas_pass_aid1_out_1:
   id: 190700
   effort_id: 16247
@@ -13499,6 +14398,7 @@ sum_100k_drop_anvil_molas_pass_aid1_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 14:32:00'
+  elapsed_seconds: 5520.0
 sum_100k_drop_anvil_cascade_creek_rd_aid3_in_1:
   id: 190701
   effort_id: 16247
@@ -13514,6 +14414,7 @@ sum_100k_drop_anvil_cascade_creek_rd_aid3_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 07:24:00'
+  elapsed_seconds: 66240.0
 sum_100k_drop_anvil_cascade_creek_rd_aid3_out_1:
   id: 190702
   effort_id: 16247
@@ -13529,6 +14430,7 @@ sum_100k_drop_anvil_cascade_creek_rd_aid3_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 07:28:00'
+  elapsed_seconds: 66480.0
 sum_100k_drop_anvil_engineer_mtn_th_aid4_in_1:
   id: 190703
   effort_id: 16247
@@ -13544,6 +14446,7 @@ sum_100k_drop_anvil_engineer_mtn_th_aid4_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 15:09:00'
+  elapsed_seconds: 94140.0
 sum_100k_drop_anvil_engineer_mtn_th_aid4_out_1:
   id: 190704
   effort_id: 16247
@@ -13559,6 +14462,7 @@ sum_100k_drop_anvil_engineer_mtn_th_aid4_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 15:09:09'
+  elapsed_seconds: 94149.0
 ggd30_12m_start_only_start_1:
   id: 190731
   effort_id: 16094
@@ -13574,6 +14478,7 @@ ggd30_12m_start_only_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 16:00:00'
+  elapsed_seconds: 0.0
 ggd30_50k_start_only_start_1:
   id: 190761
   effort_id: 16023
@@ -13589,6 +14494,7 @@ ggd30_50k_start_only_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 13:00:00'
+  elapsed_seconds: 0.0
 sum_55k_start_only_start_1:
   id: 190816
   effort_id: 16246
@@ -13604,6 +14510,7 @@ sum_55k_start_only_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-10-07 15:00:00'
+  elapsed_seconds: 0.0
 rufa_2017_12h_finished_first_start_1:
   id: 192182
   effort_id: 16643
@@ -13619,6 +14526,7 @@ rufa_2017_12h_finished_first_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 14:00:00'
+  elapsed_seconds: 0.0
 rufa_2017_12h_finished_first_finish_1:
   id: 192183
   effort_id: 16643
@@ -13634,6 +14542,7 @@ rufa_2017_12h_finished_first_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 15:33:52'
+  elapsed_seconds: 5632.0
 rufa_2017_12h_finished_first_start_2:
   id: 192184
   effort_id: 16643
@@ -13649,6 +14558,7 @@ rufa_2017_12h_finished_first_start_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 15:40:32'
+  elapsed_seconds: 6032.0
 rufa_2017_12h_finished_first_grandeur_peak_2:
   id: 192185
   effort_id: 16643
@@ -13664,6 +14574,7 @@ rufa_2017_12h_finished_first_grandeur_peak_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 16:43:26'
+  elapsed_seconds: 9806.0
 rufa_2017_12h_finished_first_finish_2:
   id: 192186
   effort_id: 16643
@@ -13679,6 +14590,7 @@ rufa_2017_12h_finished_first_finish_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 17:10:10'
+  elapsed_seconds: 11410.0
 rufa_2017_12h_finished_first_start_3:
   id: 192187
   effort_id: 16643
@@ -13694,6 +14606,7 @@ rufa_2017_12h_finished_first_start_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 17:18:26'
+  elapsed_seconds: 11906.0
 rufa_2017_12h_finished_first_grandeur_peak_3:
   id: 192188
   effort_id: 16643
@@ -13709,6 +14622,7 @@ rufa_2017_12h_finished_first_grandeur_peak_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 18:15:00'
+  elapsed_seconds: 15300.0
 rufa_2017_12h_finished_first_finish_3:
   id: 192189
   effort_id: 16643
@@ -13724,6 +14638,7 @@ rufa_2017_12h_finished_first_finish_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 18:41:05'
+  elapsed_seconds: 16865.0
 rufa_2017_12h_finished_first_start_4:
   id: 192190
   effort_id: 16643
@@ -13739,6 +14654,7 @@ rufa_2017_12h_finished_first_start_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 18:44:57'
+  elapsed_seconds: 17097.0
 rufa_2017_12h_finished_first_grandeur_peak_4:
   id: 192191
   effort_id: 16643
@@ -13754,6 +14670,7 @@ rufa_2017_12h_finished_first_grandeur_peak_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 19:43:15'
+  elapsed_seconds: 20595.0
 rufa_2017_12h_finished_first_finish_4:
   id: 192192
   effort_id: 16643
@@ -13769,6 +14686,7 @@ rufa_2017_12h_finished_first_finish_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 20:10:39'
+  elapsed_seconds: 22239.0
 rufa_2017_12h_finished_first_start_5:
   id: 192193
   effort_id: 16643
@@ -13784,6 +14702,7 @@ rufa_2017_12h_finished_first_start_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 20:16:40'
+  elapsed_seconds: 22600.0
 rufa_2017_12h_finished_first_grandeur_peak_5:
   id: 192194
   effort_id: 16643
@@ -13799,6 +14718,7 @@ rufa_2017_12h_finished_first_grandeur_peak_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 21:19:28'
+  elapsed_seconds: 26368.0
 rufa_2017_12h_finished_first_finish_5:
   id: 192195
   effort_id: 16643
@@ -13814,6 +14734,7 @@ rufa_2017_12h_finished_first_finish_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 21:50:23'
+  elapsed_seconds: 28223.0
 rufa_2017_12h_finished_first_start_6:
   id: 192196
   effort_id: 16643
@@ -13829,6 +14750,7 @@ rufa_2017_12h_finished_first_start_6:
   lap: 6
   stopped_here: false
   absolute_time: '2017-02-11 21:59:13'
+  elapsed_seconds: 28753.0
 rufa_2017_12h_finished_first_grandeur_peak_6:
   id: 192197
   effort_id: 16643
@@ -13844,6 +14766,7 @@ rufa_2017_12h_finished_first_grandeur_peak_6:
   lap: 6
   stopped_here: false
   absolute_time: '2017-02-11 23:07:18'
+  elapsed_seconds: 32838.0
 rufa_2017_12h_finished_first_finish_6:
   id: 192198
   effort_id: 16643
@@ -13859,6 +14782,7 @@ rufa_2017_12h_finished_first_finish_6:
   lap: 6
   stopped_here: false
   absolute_time: '2017-02-11 23:38:34'
+  elapsed_seconds: 34714.0
 rufa_2017_12h_finished_first_start_7:
   id: 192199
   effort_id: 16643
@@ -13874,6 +14798,7 @@ rufa_2017_12h_finished_first_start_7:
   lap: 7
   stopped_here: false
   absolute_time: '2017-02-11 23:52:03'
+  elapsed_seconds: 35523.0
 rufa_2017_12h_finished_first_grandeur_peak_7:
   id: 192200
   effort_id: 16643
@@ -13889,6 +14814,7 @@ rufa_2017_12h_finished_first_grandeur_peak_7:
   lap: 7
   stopped_here: false
   absolute_time: '2017-02-12 01:01:00'
+  elapsed_seconds: 39660.0
 rufa_2017_12h_finished_first_finish_7:
   id: 192201
   effort_id: 16643
@@ -13904,6 +14830,7 @@ rufa_2017_12h_finished_first_finish_7:
   lap: 7
   stopped_here: true
   absolute_time: '2017-02-12 01:35:12'
+  elapsed_seconds: 41712.0
 rufa_2017_12h_finished_lap6_start_1:
   id: 192278
   effort_id: 16648
@@ -13919,6 +14846,7 @@ rufa_2017_12h_finished_lap6_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 14:00:00'
+  elapsed_seconds: 0.0
 rufa_2017_12h_finished_lap6_grandeur_peak_1:
   id: 192279
   effort_id: 16648
@@ -13934,6 +14862,7 @@ rufa_2017_12h_finished_lap6_grandeur_peak_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 14:58:53'
+  elapsed_seconds: 3533.0
 rufa_2017_12h_finished_lap6_finish_1:
   id: 192280
   effort_id: 16648
@@ -13949,6 +14878,7 @@ rufa_2017_12h_finished_lap6_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 15:30:50'
+  elapsed_seconds: 5450.0
 rufa_2017_12h_finished_lap6_start_2:
   id: 192281
   effort_id: 16648
@@ -13964,6 +14894,7 @@ rufa_2017_12h_finished_lap6_start_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 15:33:13'
+  elapsed_seconds: 5593.0
 rufa_2017_12h_finished_lap6_grandeur_peak_2:
   id: 192282
   effort_id: 16648
@@ -13979,6 +14910,7 @@ rufa_2017_12h_finished_lap6_grandeur_peak_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 16:38:35'
+  elapsed_seconds: 9515.0
 rufa_2017_12h_finished_lap6_finish_2:
   id: 192283
   effort_id: 16648
@@ -13994,6 +14926,7 @@ rufa_2017_12h_finished_lap6_finish_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 17:10:32'
+  elapsed_seconds: 11432.0
 rufa_2017_12h_finished_lap6_start_3:
   id: 192284
   effort_id: 16648
@@ -14009,6 +14942,7 @@ rufa_2017_12h_finished_lap6_start_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 17:21:18'
+  elapsed_seconds: 12078.0
 rufa_2017_12h_finished_lap6_grandeur_peak_3:
   id: 192285
   effort_id: 16648
@@ -14024,6 +14958,7 @@ rufa_2017_12h_finished_lap6_grandeur_peak_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 18:31:00'
+  elapsed_seconds: 16260.0
 rufa_2017_12h_finished_lap6_finish_3:
   id: 192286
   effort_id: 16648
@@ -14039,6 +14974,7 @@ rufa_2017_12h_finished_lap6_finish_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 19:04:24'
+  elapsed_seconds: 18264.0
 rufa_2017_12h_finished_lap6_start_4:
   id: 192287
   effort_id: 16648
@@ -14054,6 +14990,7 @@ rufa_2017_12h_finished_lap6_start_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 19:12:11'
+  elapsed_seconds: 18731.0
 rufa_2017_12h_finished_lap6_grandeur_peak_4:
   id: 192288
   effort_id: 16648
@@ -14069,6 +15006,7 @@ rufa_2017_12h_finished_lap6_grandeur_peak_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 20:23:51'
+  elapsed_seconds: 23031.0
 rufa_2017_12h_finished_lap6_finish_4:
   id: 192289
   effort_id: 16648
@@ -14084,6 +15022,7 @@ rufa_2017_12h_finished_lap6_finish_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 21:02:55'
+  elapsed_seconds: 25375.0
 rufa_2017_12h_finished_lap6_start_5:
   id: 192290
   effort_id: 16648
@@ -14099,6 +15038,7 @@ rufa_2017_12h_finished_lap6_start_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 21:25:05'
+  elapsed_seconds: 26705.0
 rufa_2017_12h_finished_lap6_grandeur_peak_5:
   id: 192291
   effort_id: 16648
@@ -14114,6 +15054,7 @@ rufa_2017_12h_finished_lap6_grandeur_peak_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 22:42:57'
+  elapsed_seconds: 31377.0
 rufa_2017_12h_finished_lap6_finish_5:
   id: 192292
   effort_id: 16648
@@ -14129,6 +15070,7 @@ rufa_2017_12h_finished_lap6_finish_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 23:20:36'
+  elapsed_seconds: 33636.0
 rufa_2017_12h_finished_lap6_start_6:
   id: 192293
   effort_id: 16648
@@ -14144,6 +15086,7 @@ rufa_2017_12h_finished_lap6_start_6:
   lap: 6
   stopped_here: false
   absolute_time: '2017-02-11 23:35:51'
+  elapsed_seconds: 34551.0
 rufa_2017_12h_finished_lap6_grandeur_peak_6:
   id: 192294
   effort_id: 16648
@@ -14159,6 +15102,7 @@ rufa_2017_12h_finished_lap6_grandeur_peak_6:
   lap: 6
   stopped_here: false
   absolute_time: '2017-02-12 00:51:18'
+  elapsed_seconds: 39078.0
 rufa_2017_12h_finished_lap6_finish_6:
   id: 192295
   effort_id: 16648
@@ -14174,6 +15118,7 @@ rufa_2017_12h_finished_lap6_finish_6:
   lap: 6
   stopped_here: true
   absolute_time: '2017-02-12 01:27:38'
+  elapsed_seconds: 41258.0
 rufa_2017_12h_progress_lap5_partial_start_1:
   id: 192420
   effort_id: 16657
@@ -14189,6 +15134,7 @@ rufa_2017_12h_progress_lap5_partial_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 14:00:00'
+  elapsed_seconds: 0.0
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_1:
   id: 192421
   effort_id: 16657
@@ -14204,6 +15150,7 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 15:08:31'
+  elapsed_seconds: 4111.0
 rufa_2017_12h_progress_lap5_partial_finish_1:
   id: 192422
   effort_id: 16657
@@ -14219,6 +15166,7 @@ rufa_2017_12h_progress_lap5_partial_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 15:44:16'
+  elapsed_seconds: 6256.0
 rufa_2017_12h_progress_lap5_partial_start_2:
   id: 192423
   effort_id: 16657
@@ -14234,6 +15182,7 @@ rufa_2017_12h_progress_lap5_partial_start_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 15:47:17'
+  elapsed_seconds: 6437.0
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_2:
   id: 192424
   effort_id: 16657
@@ -14249,6 +15198,7 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 17:07:41'
+  elapsed_seconds: 11261.0
 rufa_2017_12h_progress_lap5_partial_finish_2:
   id: 192425
   effort_id: 16657
@@ -14264,6 +15214,7 @@ rufa_2017_12h_progress_lap5_partial_finish_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 17:45:17'
+  elapsed_seconds: 13517.0
 rufa_2017_12h_progress_lap5_partial_start_3:
   id: 192426
   effort_id: 16657
@@ -14279,6 +15230,7 @@ rufa_2017_12h_progress_lap5_partial_start_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 17:51:49'
+  elapsed_seconds: 13909.0
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_3:
   id: 192427
   effort_id: 16657
@@ -14294,6 +15246,7 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 19:16:00'
+  elapsed_seconds: 18960.0
 rufa_2017_12h_progress_lap5_partial_finish_3:
   id: 192428
   effort_id: 16657
@@ -14309,6 +15262,7 @@ rufa_2017_12h_progress_lap5_partial_finish_3:
   lap: 3
   stopped_here: false
   absolute_time: '2017-02-11 19:57:00'
+  elapsed_seconds: 21420.0
 rufa_2017_12h_progress_lap5_partial_start_4:
   id: 192429
   effort_id: 16657
@@ -14324,6 +15278,7 @@ rufa_2017_12h_progress_lap5_partial_start_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 20:06:16'
+  elapsed_seconds: 21976.0
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_4:
   id: 192430
   effort_id: 16657
@@ -14339,6 +15294,7 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 21:36:13'
+  elapsed_seconds: 27373.0
 rufa_2017_12h_progress_lap5_partial_finish_4:
   id: 192431
   effort_id: 16657
@@ -14354,6 +15310,7 @@ rufa_2017_12h_progress_lap5_partial_finish_4:
   lap: 4
   stopped_here: false
   absolute_time: '2017-02-11 22:26:23'
+  elapsed_seconds: 30383.0
 rufa_2017_12h_progress_lap5_partial_start_5:
   id: 192432
   effort_id: 16657
@@ -14369,6 +15326,7 @@ rufa_2017_12h_progress_lap5_partial_start_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-11 22:47:18'
+  elapsed_seconds: 31638.0
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_5:
   id: 192433
   effort_id: 16657
@@ -14384,6 +15342,7 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_5:
   lap: 5
   stopped_here: false
   absolute_time: '2017-02-12 00:29:17'
+  elapsed_seconds: 37757.0
 rufa_2017_12h_progress_lap2_start_1:
   id: 192497
   effort_id: 16663
@@ -14399,6 +15358,7 @@ rufa_2017_12h_progress_lap2_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 14:00:00'
+  elapsed_seconds: 0.0
 rufa_2017_12h_progress_lap2_grandeur_peak_1:
   id: 192498
   effort_id: 16663
@@ -14414,6 +15374,7 @@ rufa_2017_12h_progress_lap2_grandeur_peak_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 15:13:16'
+  elapsed_seconds: 4396.0
 rufa_2017_12h_progress_lap2_finish_1:
   id: 192499
   effort_id: 16663
@@ -14429,6 +15390,7 @@ rufa_2017_12h_progress_lap2_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 16:03:44'
+  elapsed_seconds: 7424.0
 rufa_2017_12h_progress_lap2_start_2:
   id: 192500
   effort_id: 16663
@@ -14444,6 +15406,7 @@ rufa_2017_12h_progress_lap2_start_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 16:05:43'
+  elapsed_seconds: 7543.0
 rufa_2017_12h_progress_lap2_grandeur_peak_2:
   id: 192501
   effort_id: 16663
@@ -14459,6 +15422,7 @@ rufa_2017_12h_progress_lap2_grandeur_peak_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 17:25:36'
+  elapsed_seconds: 12336.0
 rufa_2017_12h_progress_lap2_finish_2:
   id: 192502
   effort_id: 16663
@@ -14474,6 +15438,7 @@ rufa_2017_12h_progress_lap2_finish_2:
   lap: 2
   stopped_here: false
   absolute_time: '2017-02-11 18:13:54'
+  elapsed_seconds: 15234.0
 rufa_2017_12h_start_only_start_1:
   id: 192542
   effort_id: 16667
@@ -14489,6 +15454,7 @@ rufa_2017_12h_start_only_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-02-11 14:00:00'
+  elapsed_seconds: 0.0
 sum_100k_progress_cascade_start_1:
   id: 192697
   effort_id: 16248
@@ -14504,6 +15470,7 @@ sum_100k_progress_cascade_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 13:00:00'
+  elapsed_seconds: 0.0
 sum_100k_progress_cascade_molas_pass_aid1_in_1:
   id: 192698
   effort_id: 16248
@@ -14519,6 +15486,7 @@ sum_100k_progress_cascade_molas_pass_aid1_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 15:20:00'
+  elapsed_seconds: 8400.0
 sum_100k_progress_cascade_molas_pass_aid1_out_1:
   id: 192699
   effort_id: 16248
@@ -14534,6 +15502,7 @@ sum_100k_progress_cascade_molas_pass_aid1_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 15:25:00'
+  elapsed_seconds: 8700.0
 sum_100k_progress_cascade_rolling_pass_aid2_in_1:
   id: 192700
   effort_id: 16248
@@ -14549,6 +15518,7 @@ sum_100k_progress_cascade_rolling_pass_aid2_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 17:11:00'
+  elapsed_seconds: 15060.0
 sum_100k_progress_cascade_rolling_pass_aid2_out_1:
   id: 192701
   effort_id: 16248
@@ -14564,6 +15534,7 @@ sum_100k_progress_cascade_rolling_pass_aid2_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 17:22:00'
+  elapsed_seconds: 15720.0
 sum_100k_progress_cascade_cascade_creek_rd_aid3_in_1:
   id: 192703
   effort_id: 16248
@@ -14579,6 +15550,7 @@ sum_100k_progress_cascade_cascade_creek_rd_aid3_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 19:50:00'
+  elapsed_seconds: 24600.0
 sum_100k_progress_cascade_cascade_creek_rd_aid3_out_1:
   id: 192704
   effort_id: 16248
@@ -14594,6 +15566,7 @@ sum_100k_progress_cascade_cascade_creek_rd_aid3_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 20:14:00'
+  elapsed_seconds: 26040.0
 hardrock_2016_start_only_start_1:
   id: 192705
   effort_id: 7411
@@ -14609,6 +15582,7 @@ hardrock_2016_start_only_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2016-07-15 12:00:00'
+  elapsed_seconds: 0.0
 sum_100k_on_dst_change_start_1:
   id: 192708
   effort_id: 16684
@@ -14624,6 +15598,7 @@ sum_100k_on_dst_change_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-11-05 14:00:00'
+  elapsed_seconds: 0.0
 sum_100k_across_dst_change_start_1:
   id: 192709
   effort_id: 16685
@@ -14639,6 +15614,7 @@ sum_100k_across_dst_change_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-11-05 06:30:00'
+  elapsed_seconds: 0.0
 sum_100k_across_dst_change_molas_pass_aid1_in_1:
   id: 192710
   effort_id: 16685
@@ -14654,6 +15630,7 @@ sum_100k_across_dst_change_molas_pass_aid1_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-11-05 09:30:00'
+  elapsed_seconds: 10800.0
 sum_100k_on_dst_change_molas_pass_aid1_in_1:
   id: 192715
   effort_id: 16684
@@ -14669,6 +15646,7 @@ sum_100k_on_dst_change_molas_pass_aid1_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-11-05 16:25:00'
+  elapsed_seconds: 8700.0
 ggd30_50k_finished_second_start_1:
   id: 192716
   effort_id: 16686
@@ -14684,6 +15662,7 @@ ggd30_50k_finished_second_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 13:00:00'
+  elapsed_seconds: 0.0
 ggd30_50k_finished_second_aid_1_1:
   id: 192717
   effort_id: 16686
@@ -14699,6 +15678,7 @@ ggd30_50k_finished_second_aid_1_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 13:52:00'
+  elapsed_seconds: 3120.0
 ggd30_50k_finished_second_aid_2_1:
   id: 192718
   effort_id: 16686
@@ -14714,6 +15694,7 @@ ggd30_50k_finished_second_aid_2_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 15:01:00'
+  elapsed_seconds: 7260.0
 ggd30_50k_finished_second_aid_3_1:
   id: 192719
   effort_id: 16686
@@ -14729,6 +15710,7 @@ ggd30_50k_finished_second_aid_3_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 16:15:00'
+  elapsed_seconds: 11700.0
 ggd30_50k_finished_second_aid_4_1:
   id: 192720
   effort_id: 16686
@@ -14744,6 +15726,7 @@ ggd30_50k_finished_second_aid_4_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 17:48:00'
+  elapsed_seconds: 17280.0
 ggd30_50k_finished_second_aid_5_1:
   id: 192721
   effort_id: 16686
@@ -14759,6 +15742,7 @@ ggd30_50k_finished_second_aid_5_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 18:50:00'
+  elapsed_seconds: 21000.0
 ggd30_50k_finished_second_finish_1:
   id: 192722
   effort_id: 16686
@@ -14774,6 +15758,7 @@ ggd30_50k_finished_second_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 19:12:00'
+  elapsed_seconds: 22320.0
 ggd30_12m_series_finisher_start_1:
   id: 192723
   effort_id: 16687
@@ -14789,6 +15774,7 @@ ggd30_12m_series_finisher_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 16:00:00'
+  elapsed_seconds: 0.0
 ggd30_12m_series_finisher_finish_1:
   id: 192724
   effort_id: 16687
@@ -14804,6 +15790,7 @@ ggd30_12m_series_finisher_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 18:55:00'
+  elapsed_seconds: 10500.0
 sum_55k_series_finisher_start_1:
   id: 192725
   effort_id: 16688
@@ -14819,6 +15806,7 @@ sum_55k_series_finisher_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 15:00:00'
+  elapsed_seconds: 0.0
 sum_55k_series_finisher_molas_pass_aid1_in_1:
   id: 192726
   effort_id: 16688
@@ -14834,6 +15822,7 @@ sum_55k_series_finisher_molas_pass_aid1_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 17:30:00'
+  elapsed_seconds: 9000.0
 sum_55k_series_finisher_molas_pass_aid1_out_1:
   id: 192727
   effort_id: 16688
@@ -14849,6 +15838,7 @@ sum_55k_series_finisher_molas_pass_aid1_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 17:35:00'
+  elapsed_seconds: 9300.0
 sum_55k_series_finisher_rolling_pass_aid2_in_1:
   id: 192728
   effort_id: 16688
@@ -14864,6 +15854,7 @@ sum_55k_series_finisher_rolling_pass_aid2_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 20:20:00'
+  elapsed_seconds: 19200.0
 sum_55k_series_finisher_rolling_pass_aid2_out_1:
   id: 192729
   effort_id: 16688
@@ -14879,6 +15870,7 @@ sum_55k_series_finisher_rolling_pass_aid2_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 20:30:00'
+  elapsed_seconds: 19800.0
 sum_55k_series_finisher_bandera_mine_aid5_in_1:
   id: 192730
   effort_id: 16688
@@ -14894,6 +15886,7 @@ sum_55k_series_finisher_bandera_mine_aid5_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 22:30:00'
+  elapsed_seconds: 27000.0
 sum_55k_series_finisher_bandera_mine_aid5_out_1:
   id: 192731
   effort_id: 16688
@@ -14909,6 +15902,7 @@ sum_55k_series_finisher_bandera_mine_aid5_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 22:44:00'
+  elapsed_seconds: 27840.0
 sum_55k_series_finisher_anvil_cg_aid6_in_1:
   id: 192732
   effort_id: 16688
@@ -14924,6 +15918,7 @@ sum_55k_series_finisher_anvil_cg_aid6_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 00:15:00'
+  elapsed_seconds: 33300.0
 sum_55k_series_finisher_anvil_cg_aid6_out_1:
   id: 192733
   effort_id: 16688
@@ -14939,6 +15934,7 @@ sum_55k_series_finisher_anvil_cg_aid6_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 00:25:00'
+  elapsed_seconds: 33900.0
 sum_55k_series_finisher_finish_1:
   id: 192734
   effort_id: 16688
@@ -14954,6 +15950,7 @@ sum_55k_series_finisher_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 01:20:00'
+  elapsed_seconds: 37200.0
 sum_55k_slow_finisher_start_1:
   id: 192735
   effort_id: 16689
@@ -14969,6 +15966,7 @@ sum_55k_slow_finisher_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 15:00:00'
+  elapsed_seconds: 0.0
 sum_55k_slow_finisher_molas_pass_aid1_in_1:
   id: 192736
   effort_id: 16689
@@ -14984,6 +15982,7 @@ sum_55k_slow_finisher_molas_pass_aid1_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 18:10:00'
+  elapsed_seconds: 11400.0
 sum_55k_slow_finisher_molas_pass_aid1_out_1:
   id: 192737
   effort_id: 16689
@@ -14999,6 +15998,7 @@ sum_55k_slow_finisher_molas_pass_aid1_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 18:20:00'
+  elapsed_seconds: 12000.0
 sum_55k_slow_finisher_rolling_pass_aid2_in_1:
   id: 192738
   effort_id: 16689
@@ -15014,6 +16014,7 @@ sum_55k_slow_finisher_rolling_pass_aid2_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 21:35:00'
+  elapsed_seconds: 23700.0
 sum_55k_slow_finisher_rolling_pass_aid2_out_1:
   id: 192739
   effort_id: 16689
@@ -15029,6 +16030,7 @@ sum_55k_slow_finisher_rolling_pass_aid2_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 21:45:00'
+  elapsed_seconds: 24300.0
 sum_55k_slow_finisher_bandera_mine_aid5_in_1:
   id: 192740
   effort_id: 16689
@@ -15044,6 +16046,7 @@ sum_55k_slow_finisher_bandera_mine_aid5_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 23:20:00'
+  elapsed_seconds: 30000.0
 sum_55k_slow_finisher_bandera_mine_aid5_out_1:
   id: 192741
   effort_id: 16689
@@ -15059,6 +16062,7 @@ sum_55k_slow_finisher_bandera_mine_aid5_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-23 23:40:00'
+  elapsed_seconds: 31200.0
 sum_55k_slow_finisher_anvil_cg_aid6_in_1:
   id: 192742
   effort_id: 16689
@@ -15074,6 +16078,7 @@ sum_55k_slow_finisher_anvil_cg_aid6_in_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 01:33:00'
+  elapsed_seconds: 37980.0
 sum_55k_slow_finisher_anvil_cg_aid6_out_1:
   id: 192743
   effort_id: 16689
@@ -15089,6 +16094,7 @@ sum_55k_slow_finisher_anvil_cg_aid6_out_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 01:55:00'
+  elapsed_seconds: 39300.0
 sum_55k_slow_finisher_finish_1:
   id: 192744
   effort_id: 16689
@@ -15104,6 +16110,7 @@ sum_55k_slow_finisher_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-09-24 03:21:21'
+  elapsed_seconds: 44481.0
 ggd30_12m_slow_finisher_start_1:
   id: 192745
   effort_id: 16690
@@ -15119,6 +16126,7 @@ ggd30_12m_slow_finisher_start_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 16:00:00'
+  elapsed_seconds: 0.0
 ggd30_12m_slow_finisher_finish_1:
   id: 192746
   effort_id: 16690
@@ -15134,3 +16142,4 @@ ggd30_12m_slow_finisher_finish_1:
   lap: 1
   stopped_here: false
   absolute_time: '2017-06-03 20:32:10'
+  elapsed_seconds: 16330.0

--- a/spec/models/split_time_spec.rb
+++ b/spec/models/split_time_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe SplitTime, kind: :model do
     context "for an existing split time" do
       subject { split_times(:hardrock_2016_brinda_fisher_telluride_out_1) }
       context "if elapsed seconds is not already set" do
+        before { subject.write_attribute(:elapsed_seconds, nil) }
         it "sets elapsed seconds based on absolute time" do
           expect(subject.elapsed_seconds).to be_nil
 
@@ -200,10 +201,6 @@ RSpec.describe SplitTime, kind: :model do
       end
 
       context "if elapsed seconds is already set" do
-        before do
-          subject.write_attribute(:elapsed_seconds, 11.hours)
-          subject.save!
-        end
         it "sets elapsed seconds based on absolute time" do
           expect(subject.elapsed_seconds).to eq(11.hours)
 
@@ -230,20 +227,12 @@ RSpec.describe SplitTime, kind: :model do
     context "for a starting split time" do
       subject { split_times(:hardrock_2016_brinda_fisher_start_1) }
       let(:effort) { subject.effort }
-      let(:effort_split_times) { effort.ordered_split_times }
       it "sets elapsed seconds for all split times for the effort" do
-        effort_split_times.each(&:reload)
-        expect(effort_split_times.map(&:elapsed_seconds)).to all be_nil
-
         subject.update(absolute_time: "2016-07-15 11:00:00")
-
-        effort_split_times.each(&:reload)
-        expect(effort_split_times.map(&:elapsed_seconds)).to eq([0.0, 43020.0, 43200.0, 68160.0, 69900.0, 97500.0, 98340.0])
+        expect(effort.split_times.pluck(:elapsed_seconds)).to match_array([0.0, 43020.0, 43200.0, 68160.0, 69900.0, 97500.0, 98340.0])
 
         subject.update(absolute_time: "2016-07-15 12:00:00")
-
-        effort_split_times.each(&:reload)
-        expect(effort_split_times.map(&:elapsed_seconds)).to eq([0.0, 39420.0, 39600.0, 64560.0, 66300.0, 93900.0, 94740.0])
+        expect(effort.split_times.pluck(:elapsed_seconds)).to match_array([0.0, 39420.0, 39600.0, 64560.0, 66300.0, 93900.0, 94740.0])
       end
     end
   end


### PR DESCRIPTION
Uses pre-computed elapsed times in the workhorse `rank_and_status` effort query.