### PR TITLE
Set and delete Effort Segments in the rollup table

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -276,6 +276,22 @@ class Effort < ApplicationRecord
     @template_age || age
   end
 
+  def destroy_effort_segments
+    query = EffortSegmentQuery.destroy_for_effort(self)
+    result = ActiveRecord::Base.connection.execute(query)
+    status = result.cmd_status
+
+    raise ::ActiveRecord::Rollback unless status.start_with?("DELETE")
+  end
+
+  def set_effort_segments
+    query = EffortSegmentQuery.set_for_effort(self)
+    result = ActiveRecord::Base.connection.execute(query)
+    status = result.cmd_status
+
+    raise ::ActiveRecord::Rollback unless status.start_with?("INSERT")
+  end
+
   # Methods related to stopped split_time
 
   # Uses a reverse sort in order to get the most recent stopped_here split_time

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -276,8 +276,8 @@ class Effort < ApplicationRecord
     @template_age || age
   end
 
-  def destroy_effort_segments
-    result = EffortSegment.destroy_for_effort(self)
+  def delete_effort_segments
+    result = EffortSegment.delete_for_effort(self)
     raise ::ActiveRecord::Rollback unless result.cmd_status.start_with?("DELETE")
   end
 

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -277,19 +277,13 @@ class Effort < ApplicationRecord
   end
 
   def destroy_effort_segments
-    query = EffortSegmentQuery.destroy_for_effort(self)
-    result = ActiveRecord::Base.connection.execute(query)
-    status = result.cmd_status
-
-    raise ::ActiveRecord::Rollback unless status.start_with?("DELETE")
+    result = EffortSegment.destroy_for_effort(self)
+    raise ::ActiveRecord::Rollback unless result.cmd_status.start_with?("DELETE")
   end
 
   def set_effort_segments
-    query = EffortSegmentQuery.set_for_effort(self)
-    result = ActiveRecord::Base.connection.execute(query)
-    status = result.cmd_status
-
-    raise ::ActiveRecord::Rollback unless status.start_with?("INSERT")
+    result = EffortSegment.set_for_effort(self)
+    raise ::ActiveRecord::Rollback unless result.cmd_status.start_with?("INSERT")
   end
 
   # Methods related to stopped split_time

--- a/app/models/effort_segment.rb
+++ b/app/models/effort_segment.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class EffortSegment < ApplicationRecord
+  readonly
+end

--- a/app/models/effort_segment.rb
+++ b/app/models/effort_segment.rb
@@ -2,4 +2,24 @@
 
 class EffortSegment < ApplicationRecord
   readonly
+
+  def self.destroy_for_effort(effort)
+    query = EffortSegmentQuery.destroy_for_effort(effort)
+    ActiveRecord::Base.connection.execute(query)
+  end
+
+  def self.destroy_for_split_time(split_time)
+    query = EffortSegmentQuery.destroy_for_split_time(split_time)
+    ActiveRecord::Base.connection.execute(query)
+  end
+
+  def self.set_for_effort(effort)
+    query = EffortSegmentQuery.set_for_effort(effort)
+    ActiveRecord::Base.connection.execute(query)
+  end
+
+  def self.set_for_split_time(split_time)
+    query = EffortSegmentQuery.set_for_split_time(split_time)
+    ActiveRecord::Base.connection.execute(query)
+  end
 end

--- a/app/models/effort_segment.rb
+++ b/app/models/effort_segment.rb
@@ -3,13 +3,13 @@
 class EffortSegment < ApplicationRecord
   readonly
 
-  def self.destroy_for_effort(effort)
-    query = EffortSegmentQuery.destroy_for_effort(effort)
+  def self.delete_for_effort(effort)
+    query = EffortSegmentQuery.delete_for_effort(effort)
     ActiveRecord::Base.connection.execute(query)
   end
 
-  def self.destroy_for_split_time(split_time)
-    query = EffortSegmentQuery.destroy_for_split_time(split_time)
+  def self.delete_for_split_time(split_time)
+    query = EffortSegmentQuery.delete_for_split_time(split_time)
     ActiveRecord::Base.connection.execute(query)
   end
 

--- a/app/models/split_time.rb
+++ b/app/models/split_time.rb
@@ -206,19 +206,13 @@ class SplitTime < ApplicationRecord
   end
 
   def destroy_effort_segments
-    query = EffortSegmentQuery.destroy_for_split_time(self)
-    result = ActiveRecord::Base.connection.execute(query)
-    status = result.cmd_status
-
-    raise ::ActiveRecord::Rollback unless status.start_with?("DELETE")
+    result = EffortSegment.destroy_for_split_time(self)
+    raise ::ActiveRecord::Rollback unless result.cmd_status.start_with?("DELETE")
   end
 
   def set_effort_segments
-    query = EffortSegmentQuery.set_for_split_time(self)
-    result = ActiveRecord::Base.connection.execute(query)
-    status = result.cmd_status
-
-    raise ::ActiveRecord::Rollback unless status.start_with?("INSERT")
+    result = EffortSegment.set_for_split_time(self)
+    raise ::ActiveRecord::Rollback unless result.cmd_status.start_with?("INSERT")
   end
 
   def set_matching_raw_time

--- a/app/models/split_time.rb
+++ b/app/models/split_time.rb
@@ -52,7 +52,7 @@ class SplitTime < ApplicationRecord
   after_save :sync_elapsed_seconds
   after_save :set_effort_segments
   after_destroy :sync_elapsed_seconds
-  after_destroy :destroy_effort_segments
+  after_destroy :delete_effort_segments
 
   validates_presence_of :effort, :split, :sub_split_bitkey, :absolute_time, :lap
   validates_uniqueness_of :split_id, scope: [:effort_id, :sub_split_bitkey, :lap],
@@ -205,8 +205,8 @@ class SplitTime < ApplicationRecord
     self.destroy if elapsed_time == ''
   end
 
-  def destroy_effort_segments
-    result = EffortSegment.destroy_for_split_time(self)
+  def delete_effort_segments
+    result = EffortSegment.delete_for_split_time(self)
     raise ::ActiveRecord::Rollback unless result.cmd_status.start_with?("DELETE")
   end
 

--- a/app/queries/effort_segment_query.rb
+++ b/app/queries/effort_segment_query.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+class EffortSegmentQuery < BaseQuery
+  def self.set_for_effort(effort)
+    set(effort.id)
+  end
+
+  def self.set_for_split_time(split_time)
+    set(split_time.effort_id, split_time.lap, split_time.split_id, split_time.bitkey)
+  end
+
+  def self.set(effort_id, lap = nil, split_id = nil, bitkey = nil)
+    scoping_sql =
+      if lap.nil? || split_id.nil? || bitkey.nil?
+        # Update all effort_segments for the entire effort
+        ""
+      else
+        # Update only the effort_segments relevant to the split time
+        "and ((ss1.lap = #{lap} and ss1.split_id = #{split_id} and ss1.sub_split_bitkey = #{bitkey})" +
+          "or (ss2.lap = #{lap} and ss2.split_id = #{split_id} and ss2.sub_split_bitkey = #{bitkey}))"
+      end
+
+    <<~SQL.squish
+      with sub_splits as
+               (select course_id,
+                       effort_id,
+                       lap,
+                       split_id,
+                       sub_split_bitkey,
+                       distance_from_start,
+                       absolute_time,
+                       elapsed_seconds
+                from split_times
+                         join splits on splits.id = split_times.split_id
+                where split_times.effort_id = #{effort_id}),
+
+           sub_split_segments as
+               (select ss1.course_id,
+                       ss1.split_id                              as begin_split_id,
+                       ss1.sub_split_bitkey                      as begin_bitkey,
+                       ss2.split_id                              as end_split_id,
+                       ss2.sub_split_bitkey                      as end_bitkey,
+                       ss1.effort_id,
+                       ss1.lap,
+                       ss1.absolute_time                         as begin_time,
+                       ss2.absolute_time                         as end_time,
+                       ss2.elapsed_seconds - ss1.elapsed_seconds as elapsed_seconds
+                from sub_splits ss1
+                         cross join sub_splits ss2
+                where ss1.lap = ss2.lap
+                  #{scoping_sql}
+                  and ((ss1.distance_from_start = ss2.distance_from_start and ss1.sub_split_bitkey < ss2.sub_split_bitkey)
+                    or (ss1.distance_from_start < ss2.distance_from_start)))
+
+      insert
+      into effort_segments
+              (select * from sub_split_segments)
+      on conflict (begin_split_id, begin_bitkey, end_split_id, end_bitkey, effort_id, lap) do update
+          set begin_time      = EXCLUDED.begin_time,
+              end_time        = EXCLUDED.end_time,
+              elapsed_seconds = EXCLUDED.elapsed_seconds,
+              data_status     = null;
+    SQL
+  end
+
+  def self.destroy_for_effort(effort)
+    <<~SQL.squish
+      delete
+      from effort_segments
+      where effort_id = #{effort.id}
+    SQL
+  end
+
+  def self.destroy_for_split_time(split_time)
+    effort_id = split_time.effort_id
+    lap = split_time.lap
+    split_id = split_time.split_id
+    bitkey = split_time.bitkey
+
+    <<~SQL.squish
+      delete
+      from effort_segments
+      where effort_id = #{effort_id}
+        and lap = #{lap}
+        and ((begin_split_id = #{split_id} and begin_bitkey = #{bitkey}) 
+         or (end_split_id = #{split_id} and end_bitkey = #{bitkey}));
+    SQL
+  end
+
+end

--- a/app/queries/effort_segment_query.rb
+++ b/app/queries/effort_segment_query.rb
@@ -63,7 +63,7 @@ class EffortSegmentQuery < BaseQuery
     SQL
   end
 
-  def self.destroy_for_effort(effort)
+  def self.delete_for_effort(effort)
     <<~SQL.squish
       delete
       from effort_segments
@@ -71,7 +71,7 @@ class EffortSegmentQuery < BaseQuery
     SQL
   end
 
-  def self.destroy_for_split_time(split_time)
+  def self.delete_for_split_time(split_time)
     effort_id = split_time.effort_id
     lap = split_time.lap
     split_id = split_time.split_id

--- a/lib/tasks/effort_segments.rake
+++ b/lib/tasks/effort_segments.rake
@@ -1,0 +1,43 @@
+require 'active_record'
+
+namespace :effort_segments do
+  desc "sets effort segments for all efforts"
+  task :set => :environment do
+    puts "Setting effort segments for all efforts"
+
+    efforts = Effort.all
+    efforts_count = efforts.count
+
+    puts "Found #{efforts_count} efforts"
+
+    progress_bar = ::ProgressBar.new(efforts_count)
+
+    efforts.find_each do |effort|
+      progress_bar.increment!
+      effort.set_effort_segments
+    rescue ActiveRecordError => e
+      puts "Could not set effort segments for effort #{effort.id}:"
+      puts e
+    end
+  end
+
+  desc "deletes effort segments for all efforts"
+  task :delete => :environment do
+    puts "Deleting effort segments for all efforts"
+
+    efforts = Effort.all
+    efforts_count = efforts.count
+
+    puts "Found #{efforts_count} efforts"
+
+    progress_bar = ::ProgressBar.new(efforts_count)
+
+    efforts.find_each do |effort|
+      progress_bar.increment!
+      effort.delete_effort_segments
+    rescue ActiveRecordError => e
+      puts "Could not delete effort segments for effort #{effort.id}:"
+      puts e
+    end
+  end
+end


### PR DESCRIPTION
Adds callbacks and a rake task to set and delete effort segments scoped to either a single split time or a single effort.

Also includes a rake task to set or destroy all effort segments in the entire table.