### PR TITLE
Implement automatic infinite scrolling for Best Efforts view

### DIFF
--- a/app/presenters/best_efforts_display.rb
+++ b/app/presenters/best_efforts_display.rb
@@ -76,7 +76,7 @@ class BestEffortsDisplay < BasePresenter
   end
 
   def per_page
-    params[:per_page]&.to_i || 30
+    params[:per_page]&.to_i || 25
   end
 
   def split1

--- a/app/views/best_effort_segments/_table.html.erb
+++ b/app/views/best_effort_segments/_table.html.erb
@@ -25,7 +25,7 @@
   <div class="row">
     <div class="col text-center" data-target="infinite-scroll.link">
       <% if @presenter.filtered_segments_count == @presenter.per_page %>
-        <%= link_to "Show More", "#", data: {action: "infinite-scroll#load"} %>
+        <%= link_to "Show More", "#", data: {action: "infinite-scroll#loadFromClick"} %>
       <% else %>
         <p>End of List</p>
       <% end %>


### PR DESCRIPTION
Once the infrastructure was in place, triggering automatic page loads on scroll was surprisingly easy.