### PR TITLE
Move Sentry config to an initializer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,17 +25,5 @@ module OpenSplitTime
     config.autoload_paths += ['app/presenters/*.rb']
 
     config.exceptions_app = self.routes
-
-    # https://docs.sentry.io/clients/ruby/config/
-    Raven.configure do |config|
-      config.dsn = ENV['SENTRY_DSN']
-      config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-      config.environments = ["production"]
-
-      # Set to 1.0 to send 100% of events
-      config.sample_rate = 1.0
-
-      config.async = lambda { |event| SentryJob.perform_later(event) }
-    end
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# https://docs.sentry.io/clients/ruby/config/
+Raven.configure do |config|
+  config.dsn = ENV['SENTRY_DSN']
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  config.environments = ["production"]
+
+  # Set to 1.0 to send 100% of events
+  config.sample_rate = 1.0
+
+  config.async = lambda { |event| SentryJob.perform_later(event) }
+end


### PR DESCRIPTION
Just organizing things a bit by taking the Sentry config out of `application.rb` and moving it to its own config file.