### PR TITLE
Separate roster/start query from ranked-with-status query

### DIFF
--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -60,7 +60,7 @@ class EffortsController < ApplicationController
       case params[:button]&.to_sym
       when :check_in_group
         event_group = effort.event_group
-        view_object = EventGroupPresenter.new(event_group, {}, current_user)
+        view_object = EventGroupRosterPresenter.new(event_group, {}, current_user)
         render :toggle_group_check_in, locals: {effort: effort, view_object: view_object}
       when :check_in_effort_show
         effort = effort_with_splits
@@ -134,7 +134,7 @@ class EffortsController < ApplicationController
       case params[:button]&.to_sym
       when :check_in_group
         event_group = effort.event_group
-        view_object = EventGroupPresenter.new(event_group, {}, current_user)
+        view_object = EventGroupRosterPresenter.new(event_group, {}, current_user)
         render :toggle_group_check_in, locals: {effort: effort, view_object: view_object}
       else
         redirect_to request.referrer

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -78,7 +78,7 @@ class EventGroupsController < ApplicationController
     authorize @event_group
 
     event_group = EventGroup.where(id: @event_group).includes(organization: :stewards, events: :splits).first
-    @presenter = EventGroupPresenter.new(event_group, prepared_params, current_user)
+    @presenter = EventGroupRosterPresenter.new(event_group, prepared_params, current_user)
   end
 
   def stats

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -77,7 +77,7 @@ class EventGroupsController < ApplicationController
   def roster
     authorize @event_group
 
-    event_group = EventGroup.where(id: @event_group).includes(organization: :stewards, events: :splits).references(organization: :stewards, events: :splits).first
+    event_group = EventGroup.where(id: @event_group).includes(organization: :stewards, events: :splits).first
     @presenter = EventGroupPresenter.new(event_group, prepared_params, current_user)
   end
 
@@ -162,7 +162,7 @@ class EventGroupsController < ApplicationController
     authorize @event_group
 
     filter = prepared_params[:filter]
-    efforts = @event_group.efforts.includes(:event, split_times: :split).add_ready_to_start
+    efforts = @event_group.efforts.includes(:event, split_times: :split).roster_subquery
     filtered_efforts = Effort.from(efforts, :efforts).where(filter)
     start_time = params[:actual_start_time]
 

--- a/app/presenters/event_group_presenter.rb
+++ b/app/presenters/event_group_presenter.rb
@@ -39,44 +39,6 @@ class EventGroupPresenter < BasePresenter
     ranked_efforts.size
   end
 
-  def started_efforts
-    @started_efforts ||= roster_efforts.select(&:started?)
-  end
-
-  def unstarted_efforts
-    @unstarted_efforts ||= roster_efforts.reject(&:started?)
-  end
-
-  def ready_efforts
-    @ready_efforts ||= roster_efforts.select(&:ready_to_start)
-  end
-
-  def ready_efforts_count
-    ready_efforts.size
-  end
-
-  def roster_efforts
-    @roster_efforts ||= event_group_efforts.roster_subquery
-  end
-
-  def roster_efforts_count
-    @roster_efforts_count ||= roster_efforts.size
-  end
-
-  def filtered_roster_efforts
-    @filtered_roster_efforts ||= event_group_efforts
-                                   .from(roster_efforts, "efforts")
-                                   .where(filter_hash)
-                                   .search(search_text)
-                                   .order(sort_hash.presence || {bib_number: :asc})
-                                   .select { |effort| matches_criteria?(effort) }
-                                   .paginate(page: page, per_page: per_page)
-  end
-
-  def filtered_roster_efforts_count
-    @filtered_roster_efforts_count ||= filtered_roster_efforts.size
-  end
-
   def dropped_effort_rows
     @dropped_effort_rows ||= ranked_efforts.select(&:dropped?).map { |effort| EffortRow.new(effort) }
   end
@@ -150,53 +112,5 @@ class EventGroupPresenter < BasePresenter
 
   def indexed_events
     @indexed_events = events.index_by(&:id)
-  end
-
-  def matches_criteria?(effort)
-    matches_checked_in_criteria?(effort) && matches_start_criteria?(effort) && matches_unreconciled_criteria?(effort) && matches_problem_criteria?(effort)
-  end
-
-  def matches_checked_in_criteria?(effort)
-    case params[:checked_in]&.to_boolean
-    when true
-      effort.checked_in
-    when false
-      !effort.checked_in
-    else # value is nil so do not filter
-      true
-    end
-  end
-
-  def matches_start_criteria?(effort)
-    case params[:started]&.to_boolean
-    when true
-      effort.started?
-    when false
-      !effort.started?
-    else # value is nil so do not filter
-      true
-    end
-  end
-
-  def matches_unreconciled_criteria?(effort)
-    case params[:unreconciled]&.to_boolean
-    when true
-      effort.unreconciled?
-    when false
-      !effort.unreconciled?
-    else # value is nil so do not filter
-      true
-    end
-  end
-
-  def matches_problem_criteria?(effort)
-    case params[:problem]&.to_boolean
-    when true
-      !effort.valid_status?
-    when false
-      effort.valid_status?
-    else # value is nil so do not filter
-      true
-    end
   end
 end

--- a/app/presenters/event_group_presenter.rb
+++ b/app/presenters/event_group_presenter.rb
@@ -94,10 +94,6 @@ class EventGroupPresenter < BasePresenter
     event_group.efforts.includes(:event)
   end
 
-  def check_in_button_param
-    :check_in_group
-  end
-
   def method_missing(method)
     event_group.send(method)
   end

--- a/app/presenters/event_group_roster_presenter.rb
+++ b/app/presenters/event_group_roster_presenter.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+class EventGroupRosterPresenter < BasePresenter
+  attr_reader :event_group
+  delegate :to_param, to: :event_group
+
+  def initialize(event_group, params, current_user)
+    @event_group = event_group
+    @params = params
+    @current_user = current_user
+  end
+
+  def started_efforts
+    @started_efforts ||= roster_efforts.select(&:started?)
+  end
+
+  def unstarted_efforts
+    @unstarted_efforts ||= roster_efforts.reject(&:started?)
+  end
+
+  def ready_efforts
+    @ready_efforts ||= roster_efforts.select(&:ready_to_start)
+  end
+
+  def ready_efforts_count
+    ready_efforts.size
+  end
+
+  def roster_efforts
+    @roster_efforts ||= event_group_efforts.roster_subquery
+  end
+
+  def roster_efforts_count
+    @roster_efforts_count ||= roster_efforts.size
+  end
+
+  def filtered_roster_efforts
+    @filtered_roster_efforts ||= event_group_efforts
+                                   .from(roster_efforts, "efforts")
+                                   .where(filter_hash)
+                                   .search(search_text)
+                                   .order(sort_hash.presence || {bib_number: :asc})
+                                   .select { |effort| matches_criteria?(effort) }
+                                   .paginate(page: page, per_page: per_page)
+  end
+
+  def filtered_roster_efforts_count
+    @filtered_roster_efforts_count ||= filtered_roster_efforts.size
+  end
+
+  def events
+    @events ||= event_group.events.select_with_params('').order(:scheduled_start_time).to_a
+  end
+
+  def event
+    events.first
+  end
+
+  def display_style
+    nil
+  end
+
+  def event_group_efforts
+    event_group.efforts.includes(:event)
+  end
+
+  def check_in_button_param
+    :check_in_group
+  end
+
+  def method_missing(method)
+    event_group.send(method)
+  end
+
+  private
+
+  attr_reader :params, :current_user
+
+  def matches_criteria?(effort)
+    matches_checked_in_criteria?(effort) && matches_start_criteria?(effort) && matches_unreconciled_criteria?(effort) && matches_problem_criteria?(effort)
+  end
+
+  def matches_checked_in_criteria?(effort)
+    case params[:checked_in]&.to_boolean
+    when true
+      effort.checked_in
+    when false
+      !effort.checked_in
+    else # value is nil so do not filter
+      true
+    end
+  end
+
+  def matches_start_criteria?(effort)
+    case params[:started]&.to_boolean
+    when true
+      effort.started?
+    when false
+      !effort.started?
+    else # value is nil so do not filter
+      true
+    end
+  end
+
+  def matches_unreconciled_criteria?(effort)
+    case params[:unreconciled]&.to_boolean
+    when true
+      effort.unreconciled?
+    when false
+      !effort.unreconciled?
+    else # value is nil so do not filter
+      true
+    end
+  end
+
+  def matches_problem_criteria?(effort)
+    case params[:problem]&.to_boolean
+    when true
+      !effort.valid_status?
+    when false
+      effort.valid_status?
+    else # value is nil so do not filter
+      true
+    end
+  end
+end

--- a/app/views/event_groups/_efforts_roster.html.erb
+++ b/app/views/event_groups/_efforts_roster.html.erb
@@ -1,4 +1,4 @@
-<% if @presenter.event_group_efforts.blank? %>
+<% if @presenter.roster_efforts.blank? %>
   <article class="ost-article container">
     <h3>No entrants have been added to this event group.</h3>
   </article>
@@ -23,30 +23,29 @@
     </aside>
 
     <article class="ost-article container">
-      <% if @presenter.filtered_ranked_efforts.present? %>
-
-        <% if @presenter.unreconciled_efforts.present? %>
-          <div class="row">
-            <div class="col">
-              <div class="card border-primary">
-                <h4 class="card-header bg-primary text-white"><strong>Note</strong></h4>
-                <div class="card-body">
-                  <h5 class="card-text">
-                    Unreconciled efforts exist. Please <%= link_to 'reconcile', reconcile_event_group_path(@presenter.event_group) %> when you have a moment.
-                  </h5>
-                </div>
+      <% if @presenter.unreconciled_efforts.present? %>
+        <div class="row">
+          <div class="col">
+            <div class="card border-primary">
+              <h4 class="card-header bg-primary text-white"><strong>Note</strong></h4>
+              <div class="card-body">
+                <h5 class="card-text">
+                  Unreconciled efforts exist. Please <%= link_to 'reconcile', reconcile_event_group_path(@presenter.event_group) %> when you have a moment.
+                </h5>
               </div>
             </div>
           </div>
-          <br/>
-        <% end %>
+        </div>
+        <br/>
+      <% end %>
 
+      <% if @presenter.filtered_roster_efforts.present? %>
         <div class="row">
           <div class="col-xs-8">
-            <% if @presenter.filtered_ranked_efforts_count == @presenter.efforts_count %>
-              <h4><%= "#{@presenter.efforts_count} efforts" %></h4>
+            <% if @presenter.filtered_roster_efforts_count == @presenter.roster_efforts_count %>
+              <h4><%= "#{@presenter.roster_efforts_count} efforts" %></h4>
             <% else %>
-              <h4><%= "Showing #{@presenter.filtered_ranked_efforts_count} of #{@presenter.efforts_count} efforts" %></h4>
+              <h4><%= "Showing #{@presenter.filtered_roster_efforts_count} of #{@presenter.roster_efforts_count} efforts" %></h4>
             <% end %>
           </div>
           <div class="col-xs-4 text-right">
@@ -55,7 +54,7 @@
 
         <div class="row">
           <div class="col-xs-8">
-            <%= will_paginate(@presenter.filtered_ranked_efforts, inner_window: 2, outer_window: 0) %>
+            <%= will_paginate(@presenter.filtered_roster_efforts, inner_window: 2, outer_window: 0) %>
           </div>
         </div>
 
@@ -83,7 +82,7 @@
           </tr>
           </thead>
           <tbody>
-          <% @presenter.filtered_ranked_efforts.each do |effort| %>
+          <% @presenter.filtered_roster_efforts.each do |effort| %>
             <tr>
               <td class="text-center"><%= effort.unreconciled? ? 'No' : 'Yes' %></td>
               <% if @presenter.multiple_events? %>
@@ -111,7 +110,7 @@
 
         <div class="row">
           <div class="col-xs-8">
-            <%= will_paginate(@presenter.filtered_ranked_efforts, inner_window: 2, outer_window: 0) %>
+            <%= will_paginate(@presenter.filtered_roster_efforts, inner_window: 2, outer_window: 0) %>
           </div>
         </div>
 

--- a/spec/system/start_ready_efforts_flow_spec.rb
+++ b/spec/system/start_ready_efforts_flow_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'start ready efforts from the event groups roster page' do
 
   let(:event_group) { event_groups(:hardrock_2014) }
   let(:organization) { event_group.organization }
-  let(:event_group_efforts) { event_group.efforts.ranked_with_status }
+  let(:event_group_efforts) { event_group.efforts.roster_subquery }
 
   context 'when no efforts are ready to start' do
     before { expect(event_group_efforts.map(&:ready_to_start)).to all eq(false) }


### PR DESCRIPTION
The `ranked_with_status` query has gotten bloated with a bunch of start-related attributes that apply only in the Roster view. 

This MR separates these start-related attributes into their own roster-specific query and also separates roster-specific methods out of the Event Group Presenter and into their own Event Group Roster Presenter.