### PR TITLE
Allow podium rows to be collapsed

### DIFF
--- a/app/assets/stylesheets/utilities/_collapse.scss
+++ b/app/assets/stylesheets/utilities/_collapse.scss
@@ -1,0 +1,8 @@
+.collapse-rotate a {
+    display: inline-block;
+    transform: rotate(90deg) ;
+    transition: all linear 0.1s;
+}
+.collapse-rotate a.collapsed {
+    transform: rotate(0deg) ;
+}

--- a/app/views/events/_podium_category.html.erb
+++ b/app/views/events/_podium_category.html.erb
@@ -1,6 +1,9 @@
 <thead>
 <tr>
-  <th><%= "#{'*' if category.fixed_position} #{category.name}" %></th>
+  <th>
+    <span class="collapse-rotate pr-2"><%= link_to fa_icon("caret-right", size: "lg"), "#collapse_#{category.position}", data: {toggle: "collapse"} %></span>
+    <span><%= "#{'*' if category.fixed_position} #{category.name}" %></span>
+  </th>
   <% if @presenter.multiple_laps? %>
     <th>Laps</th>
   <% end %>
@@ -14,7 +17,7 @@
 </tr>
 </thead>
 
-<tbody>
+<tbody class="collapse show" id="collapse_<%= category.position %>">
 <% if category.efforts.present? %>
   <% category.efforts.each.with_index(1) do |effort, i| %>
     <tr>

--- a/app/views/events/podium.html.erb
+++ b/app/views/events/podium.html.erb
@@ -54,6 +54,6 @@
       <% end %>
     </table>
   <% else %>
-    <h4><%= "The organizer has not specified a podium template." %></h4>
+    <h4><%= "A podium template has not been specified." %></h4>
   <% end %>
 </article>


### PR DESCRIPTION
For an RD reading from the Podium view, allows the individual categories to be collapsed.