### PR TITLE
Remove rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,3 @@ group :development, :test do
   gem 'rubocop', '~> 0.49'
   gem 'spring-commands-rspec'
 end
-
-group :production do
-  gem 'rails_12factor'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,15 +304,10 @@ GEM
       ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
     rails_real_favicon (0.1.0)
       json (>= 1.7, < 3)
       rails
       rubyzip (~> 2)
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.0.3.3)
       actionpack (= 6.0.3.3)
       activesupport (= 6.0.3.3)
@@ -526,7 +521,6 @@ DEPENDENCIES
   pundit
   rails (< 6.1)
   rails-erd
-  rails_12factor
   rails_real_favicon
   record_tag_helper (>= 1.0.0)
   rest-client


### PR DESCRIPTION
This gem is not needed in a Rails 5 (or higher) application. See https://github.com/heroku/rails_12factor#migrating-to-rails-5