### PR TITLE
Restore actual_start_time to the rank_and_status query

### DIFF
--- a/app/services/results/fill_event_series_template.rb
+++ b/app/services/results/fill_event_series_template.rb
@@ -50,7 +50,7 @@ module Results
     end
 
     def indexed_people
-      @indexed_people ||= Person.find(event_series.efforts.pluck(:person_id)).index_by(&:id)
+      @indexed_people ||= Person.where(id: event_series.efforts.select(:person_id)).index_by(&:id)
     end
 
     def ranked_efforts


### PR DESCRIPTION
In #404 we separated the roster-specific logic from the rank_and_status effort query. But we seem to have gotten a bit too aggressive by removing `actual_start_time`, which is used by several different views that rely on enriched effort information.

This MR restores `actual_start_time` to the query.

This should address most of #421 