### PR TITLE
Callback and rake task to properly titleize attributes

### DIFF
--- a/app/models/concerns/titleizable.rb
+++ b/app/models/concerns/titleizable.rb
@@ -19,27 +19,21 @@ module Titleizable
     def titleize_attribute(attribute)
       self.titleizable_attribute_names << attribute.to_s
     end
-
-    def titleize_value(value)
-      return unless value.present?
-      # Only titleize the value if it is all lowercase or all uppercase.
-      # This avoids inadvertently titleizing names intended to have mixed
-      # case, like "McDonald"
-      return unless value.downcase == value || value.upcase == value
-
-      value.titleize
-    end
   end
 
   def titleize_record
     titleizable_attributes = attributes.slice(*self.titleizable_attribute_names)
 
     titleizable_attributes.each do |attr, value|
-      original_value = value
-      value = self.class.titleize_value(value)
-      self.write_attribute(attr, value) if original_value != value
+      # Only titleize the value if it is all lowercase or all uppercase.
+      # This avoids inadvertently titleizing names intended to have mixed
+      # case, like "McDonald"
+      if value.present? && (value.downcase == value || value.upcase == value)
+        self.write_attribute(attr, value.titleize)
+      end
     end
 
-    self
+    # Don't cancel later callbacks
+    true
   end
 end

--- a/app/models/concerns/titleizable.rb
+++ b/app/models/concerns/titleizable.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Used for models with one or more string attributes that should be
+# titleized (for example, first names, last names, and place-names).
+module Titleizable
+  extend ::ActiveSupport::Concern
+
+  included do
+    before_validation :titleize_record
+    class_attribute :titleizable_attribute_names
+    self.titleizable_attribute_names = []
+  end
+
+  module ClassMethods
+    def titleize_attributes(*attributes)
+      attributes.each(&method(:titleize_attribute))
+    end
+
+    def titleize_attribute(attribute)
+      self.titleizable_attribute_names << attribute.to_s
+    end
+
+    def titleize_value(value)
+      return unless value.present?
+      # Only titleize the value if it is all lowercase or all uppercase.
+      # This avoids inadvertently titleizing names intended to have mixed
+      # case, like "McDonald"
+      return unless value.downcase == value || value.upcase == value
+
+      value.titleize
+    end
+  end
+
+  def titleize_record
+    titleizable_attributes = attributes.slice(*self.titleizable_attribute_names)
+
+    titleizable_attributes.each do |attr, value|
+      original_value = value
+      value = self.class.titleize_value(value)
+      self.write_attribute(attr, value) if original_value != value
+    end
+
+    self
+  end
+end

--- a/app/models/concerns/titleizable.rb
+++ b/app/models/concerns/titleizable.rb
@@ -21,6 +21,8 @@ module Titleizable
     end
   end
 
+  private
+
   def titleize_record
     titleizable_attributes = attributes.slice(*self.titleizable_attribute_names)
 

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -8,11 +8,13 @@ class Effort < ApplicationRecord
   VALID_STATUSES = [nil, data_statuses[:good]].freeze
 
   include Auditable, DataStatusMethods, Delegable, DelegatedConcealable, GuaranteedFindable, LapsRequiredMethods,
-          PersonalInfo, Searchable, StateCountrySyncable, Subscribable, TimeZonable, Matchable, UrlAccessible
+          PersonalInfo, Searchable, StateCountrySyncable, Subscribable, TimeZonable, Matchable, Titleizable,
+          UrlAccessible
   extend FriendlyId
 
   strip_attributes collapse_spaces: true
   strip_attributes only: [:phone, :emergency_phone], regex: /[^0-9|+]/
+  titleize_attributes :first_name, :last_name, :city, :emergency_contact
   friendly_id :slug_candidates, use: [:slugged, :history]
   zonable_attributes :actual_start_time, :scheduled_start_time, :event_start_time, :calculated_start_time, :assumed_start_time
   has_paper_trail

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 class Person < ApplicationRecord
-  include Auditable, Concealable, PersonalInfo, Searchable, StateCountrySyncable, Subscribable, Matchable, UrlAccessible
+  include Auditable, Concealable, PersonalInfo, Searchable, StateCountrySyncable, Subscribable,
+          Matchable, Titleizable, UrlAccessible
   extend FriendlyId
 
   strip_attributes collapse_spaces: true
   strip_attributes only: [:phone], :regex => /[^0-9|+]/
+  titleize_attributes :first_name, :last_name, :city
   friendly_id :slug_candidates, use: [:slugged, :history]
   has_paper_trail
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   include PgSearch::Model
+  include ::Titleizable
   extend FriendlyId
 
   devise :database_authenticatable, :registerable, :confirmable,
@@ -10,6 +11,7 @@ class User < ApplicationRecord
   enum pref_distance_unit: [:miles, :kilometers]
   enum pref_elevation_unit: [:feet, :meters]
   strip_attributes collapse_spaces: true
+  titleize_attributes :first_name, :last_name
   friendly_id :slug_candidates, use: [:slugged, :history]
   has_paper_trail
 

--- a/lib/tasks/temp/fix_capitalization.rake
+++ b/lib/tasks/temp/fix_capitalization.rake
@@ -1,0 +1,34 @@
+# This is a temporary rake task that should be deleted
+# once it has been run in all environments.
+
+require 'active_record'
+require 'active_record/errors'
+
+namespace :temp do
+  desc "titleizes fields that are all-lowercase or all-uppercase"
+  task :fix_capitalization => :environment do
+    Rails.application.eager_load!
+
+    models = [::Effort, ::Person, ::User]
+
+    models.each do |model|
+      model_name = model.name
+      records = model.all
+      record_count = records.count
+
+      puts "Updating #{record_count} #{model_name.pluralize}"
+      progress_bar = ::ProgressBar.new(record_count)
+
+      records.find_each do |record|
+        progress_bar.increment!
+        record.send(:titleize_record)
+        record.save!(validate: false)
+      rescue ActiveRecordError => e
+        puts "Could not save record #{model_name} #{record.id}:"
+        puts e
+      end
+
+      puts "Finished updating #{model_name}"
+    end
+  end
+end

--- a/spec/concerns/titleizable_spec.rb
+++ b/spec/concerns/titleizable_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class DummyTitleizableClass
+  include ::ActiveModel::Attributes
+  include ::ActiveModel::Validations
+  include ::ActiveModel::Validations::Callbacks
+  include ::Titleizable
+
+  attribute :first_name
+  attribute :last_name
+  attribute :city
+
+  titleize_attributes :first_name, :last_name
+  titleize_attribute :city
+end
+
+RSpec.describe ::DummyTitleizableClass do
+  it_behaves_like "titleizable", :first_name, :last_name, :city
+end

--- a/spec/models/effort_spec.rb
+++ b/spec/models/effort_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Effort, type: :model do
   it_behaves_like 'auditable'
   it_behaves_like 'matchable'
   it_behaves_like 'subscribable'
+  it_behaves_like "titleizable", :first_name, :last_name, :city, :emergency_contact
   it { is_expected.to strip_attribute(:first_name).collapse_spaces }
   it { is_expected.to strip_attribute(:last_name).collapse_spaces }
   it { is_expected.to strip_attribute(:state_code).collapse_spaces }

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Person, type: :model do
-  it_behaves_like 'auditable'
-  it_behaves_like 'subscribable'
+  it_behaves_like "auditable"
+  it_behaves_like "subscribable"
+  it_behaves_like "titleizable", :first_name, :last_name, :city
   it { is_expected.to strip_attribute(:first_name).collapse_spaces }
   it { is_expected.to strip_attribute(:last_name).collapse_spaces }
+  it { is_expected.to strip_attribute(:city).collapse_spaces }
   it { is_expected.to strip_attribute(:state_code).collapse_spaces }
   it { is_expected.to strip_attribute(:country_code).collapse_spaces }
 
-  describe '#initialize' do
-    it 'saves a generic factory-created record to the database' do
+  describe "#initialize" do
+    it "saves a generic factory-created record to the database" do
       expect { create(:person) }.to change { Person.count }.by(1)
     end
 
-    it 'is valid when created with a first_name, a last_name, and a gender' do
+    it "is valid when created with a first_name, a last_name, and a gender" do
       person = build_stubbed(:person)
       expect(person.first_name).to be_present
       expect(person.last_name).to be_present
@@ -23,25 +25,25 @@ RSpec.describe Person, type: :model do
       expect(person).to be_valid
     end
 
-    it 'is invalid without a first_name' do
+    it "is invalid without a first_name" do
       person = build_stubbed(:person, first_name: nil)
       expect(person).not_to be_valid
       expect(person.errors[:first_name]).to include("can't be blank")
     end
 
-    it 'is invalid without a last_name' do
+    it "is invalid without a last_name" do
       person = build_stubbed(:person, last_name: nil)
       expect(person).not_to be_valid
       expect(person.errors[:last_name]).to include("can't be blank")
     end
 
-    it 'is invalid without a gender' do
+    it "is invalid without a gender" do
       person = build_stubbed(:person, gender: nil)
       expect(person).not_to be_valid
       expect(person.errors[:gender]).to include("can't be blank")
     end
 
-    it 'rejects invalid email' do
+    it "rejects invalid email" do
       bad_emails = %w[johnny@appleseed appleseed.com johnny@.com johnny]
       bad_emails.each do |email|
         person = Person.new(email: email)
@@ -50,13 +52,13 @@ RSpec.describe Person, type: :model do
       end
     end
 
-    it 'permits valid email' do
-      person = build_stubbed(:person, email: 'user@example.com')
+    it "permits valid email" do
+      person = build_stubbed(:person, email: "user@example.com")
       expect(person).to be_valid
     end
 
-    it 'rejects implausible birthdates' do
-      bad_birthdates = {'1880-01-01' => "can't be before 1900",
+    it "rejects implausible birthdates" do
+      bad_birthdates = {"1880-01-01" => "can't be before 1900",
                         1.day.from_now => "can't be today or in the future"}
       bad_birthdates.each do |birthdate, error_message|
         person = Person.new(birthdate: birthdate)
@@ -65,8 +67,8 @@ RSpec.describe Person, type: :model do
       end
     end
 
-    it 'permits plausible birthdates' do
-      person = build_stubbed(:person, birthdate: '1977-01-01')
+    it "permits plausible birthdates" do
+      person = build_stubbed(:person, birthdate: "1977-01-01")
       expect(person).to be_valid
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,103 +1,105 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
-  it 'creates a valid user with name and email and password' do
+  it_behaves_like "titleizable", :first_name, :last_name
+
+  it "creates a valid user with name and email and password" do
     user_attr = FactoryBot.attributes_for(:user)
     user = User.create!(user_attr)
 
     expect(user).to be_valid
   end
 
-  it 'is invalid without a last name' do
+  it "is invalid without a last name" do
     user = build_stubbed(:user, last_name: nil)
     expect(user.valid?).to be_falsey
   end
 
-  it 'is invalid without an email' do
+  it "is invalid without an email" do
     user = build_stubbed(:user, email: nil)
     expect(user.valid?).to be_falsey
   end
 
-  describe '#normalize_phone' do
+  describe "#normalize_phone" do
     subject(:user) { build(:user, phone: phone) }
-    let(:normalized_phone) { '+12025551212' }
+    let(:normalized_phone) { "+12025551212" }
 
-    context 'when phone is a standard US or Canada number with +1 prefix' do
-      let(:phone) { '+12025551212' }
+    context "when phone is a standard US or Canada number with +1 prefix" do
+      let(:phone) { "+12025551212" }
 
-      it 'does not change phone and user is valid' do
+      it "does not change phone and user is valid" do
         user.validate
         expect(user.phone).to eq(normalized_phone)
         expect(user).to be_valid
       end
     end
 
-    context 'when phone is a standard US or Canada number with 1 prefix' do
-      let(:phone) { '12025551212' }
+    context "when phone is a standard US or Canada number with 1 prefix" do
+      let(:phone) { "12025551212" }
 
-      it 'normalizes phone number and user is valid' do
+      it "normalizes phone number and user is valid" do
         user.validate
         expect(user.phone).to eq(normalized_phone)
         expect(user).to be_valid
       end
     end
 
-    context 'when phone is a standard US or Canada number without + or 1 prefix' do
-      let(:phone) { '2025551212' }
+    context "when phone is a standard US or Canada number without + or 1 prefix" do
+      let(:phone) { "2025551212" }
 
-      it 'normalizes phone number and user is valid' do
+      it "normalizes phone number and user is valid" do
         user.validate
         expect(user.phone).to eq(normalized_phone)
         expect(user).to be_valid
       end
     end
 
-    context 'when phone is a standard US or Canada number with +1 prefix and parentheses, spaces, and dashes' do
-      let(:phone) { '+1 (202) 555-1212' }
+    context "when phone is a standard US or Canada number with +1 prefix and parentheses, spaces, and dashes" do
+      let(:phone) { "+1 (202) 555-1212" }
 
-      it 'normalizes phone number and user is valid' do
+      it "normalizes phone number and user is valid" do
         user.validate
         expect(user.phone).to eq(normalized_phone)
         expect(user).to be_valid
       end
     end
 
-    context 'when phone is a standard US or Canada number with parentheses, spaces, and dashes' do
-      let(:phone) { '(202) 555-1212' }
+    context "when phone is a standard US or Canada number with parentheses, spaces, and dashes" do
+      let(:phone) { "(202) 555-1212" }
 
-      it 'normalizes phone number and user is valid' do
+      it "normalizes phone number and user is valid" do
         user.validate
         expect(user.phone).to eq(normalized_phone)
         expect(user).to be_valid
       end
     end
 
-    context 'when phone is a nonstandard number' do
-      let(:phone) { '555-1212' }
+    context "when phone is a nonstandard number" do
+      let(:phone) { "555-1212" }
 
-      it 'attempts to normalize phone number and user is not valid' do
+      it "attempts to normalize phone number and user is not valid" do
         user.validate
-        expect(user.phone).to eq('5551212')
+        expect(user.phone).to eq("5551212")
         expect(user).not_to be_valid
       end
     end
 
-    context 'when phone is nonsensical' do
-      let(:phone) { 'hello234' }
+    context "when phone is nonsensical" do
+      let(:phone) { "hello234" }
 
-      it 'attempts to normalize phone number and user is not valid' do
+      it "attempts to normalize phone number and user is not valid" do
         user.validate
-        expect(user.phone).to eq('234')
+        expect(user.phone).to eq("234")
         expect(user).not_to be_valid
       end
     end
 
-    context 'when phone contains no numeric data' do
-      let(:phone) { 'hello' }
+    context "when phone contains no numeric data" do
+      let(:phone) { "hello" }
 
-      it 'eliminates the data and user is valid' do
+      it "eliminates the data and user is valid" do
         user.validate
         expect(user.phone).to be_nil
         expect(user).to be_valid
@@ -105,13 +107,13 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#interests' do
+  describe "#interests" do
     let(:user_1) { users(:third_user) }
     let(:subject_people) { people.first(2) }
     let(:person) { subject_people.first }
 
-    context 'when adding a single interest' do
-      it 'works as expected' do
+    context "when adding a single interest" do
+      it "works as expected" do
         expect(user_1.interests.size).to eq(0)
         user_1.interests << person
         expect(user_1.interests.size).to eq(1)
@@ -119,8 +121,8 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'when adding multiple interests' do
-      it 'works as expected' do
+    context "when adding multiple interests" do
+      it "works as expected" do
         expect(user_1.interests.size).to eq(0)
         user_1.interests << subject_people
         expect(user_1.interests.size).to eq(2)
@@ -128,10 +130,10 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'when multiple users have interest in the same person' do
+    context "when multiple users have interest in the same person" do
       let(:user_2) { users(:fourth_user) }
 
-      it 'works as expected' do
+      it "works as expected" do
         expect(user_1.interests.size).to eq(0)
         expect(user_2.interests.size).to eq(0)
         expect(person.followers.size).to eq(0)
@@ -151,11 +153,11 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#watch_efforts' do
+  describe "#watch_efforts" do
     let(:user_1) { users(:third_user) }
     let(:subject_efforts) { efforts.first(2) }
     let(:effort) { subject_efforts.first }
-    let(:topic_resource_key) { '123' }
+    let(:topic_resource_key) { "123" }
 
     before do
       subject_efforts.each do |effort|
@@ -163,9 +165,9 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'when adding a single watch_effort that has a topic_resource_key' do
+    context "when adding a single watch_effort that has a topic_resource_key" do
 
-      it 'adds the watch_effort' do
+      it "adds the watch_effort" do
         expect(user_1.watch_efforts.size).to eq(0)
         user_1.watch_efforts << effort
         expect(user_1.watch_efforts.size).to eq(1)
@@ -173,19 +175,19 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'when adding a watch_effort that has no topic_resource_key' do
+    context "when adding a watch_effort that has no topic_resource_key" do
       let(:topic_resource_key) { nil }
 
-      it 'does not add the watch_effort and returns an error' do
+      it "does not add the watch_effort and returns an error" do
         expect(user_1.watch_efforts.size).to eq(0)
         expect { user_1.watch_efforts << effort }.to raise_error(/Resource key can't be blank/)
         expect(user_1.watch_efforts.size).to eq(0)
       end
     end
 
-    context 'when adding multiple watch_efforts with topic_resource_keys' do
+    context "when adding multiple watch_efforts with topic_resource_keys" do
 
-      it 'works as expected' do
+      it "works as expected" do
         expect(user_1.watch_efforts.size).to eq(0)
         user_1.watch_efforts << subject_efforts
         expect(user_1.watch_efforts.size).to eq(2)
@@ -193,10 +195,10 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'when multiple users are watching the same effort' do
+    context "when multiple users are watching the same effort" do
       let(:user_2) { users(:fourth_user) }
 
-      it 'works as expected' do
+      it "works as expected" do
         expect(user_1.watch_efforts.size).to eq(0)
         expect(user_2.watch_efforts.size).to eq(0)
         expect(effort.followers.size).to eq(0)
@@ -216,7 +218,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#steward_of?' do
+  describe "#steward_of?" do
     subject { build_stubbed(:user) }
     let(:organization) { build_stubbed(:organization, stewards: stewards) }
     let(:event_group) { build_stubbed(:event_group, organization: organization) }
@@ -224,34 +226,34 @@ RSpec.describe User, type: :model do
     let(:effort) { build_stubbed(:effort, event: event) }
     let(:split_time) { build_stubbed(:split_time, effort: effort) }
 
-    context 'when the user is a steward' do
+    context "when the user is a steward" do
       let(:stewards) { [subject] }
 
       [:organization, :event_group, :event, :effort, :split_time].each do |resource|
         context "when the provided resource is a/an #{resource}" do
-          it 'returns true' do
+          it "returns true" do
             expect(subject.steward_of?(send(resource))).to eq(true)
           end
         end
       end
     end
 
-    context 'when the user is not a steward' do
+    context "when the user is not a steward" do
       let(:stewards) { [] }
 
       [:organization, :event_group, :event, :effort, :split_time].each do |resource|
         context "when the provided resource is a/an #{resource}" do
-          it 'returns false' do
+          it "returns false" do
             expect(subject.steward_of?(send(resource))).to eq(false)
           end
         end
       end
     end
 
-    context 'when the provided resource does not implement :stewards' do
+    context "when the provided resource does not implement :stewards" do
       let(:user) { build_stubbed(:user) }
 
-      it 'returns false' do
+      it "returns false" do
         expect(subject.steward_of?(user)).to eq(false)
       end
     end

--- a/spec/support/concerns/titleizable.rb
+++ b/spec/support/concerns/titleizable.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for "titleizable" do |*titleizable_attribute_names|
+  subject { described_class.new }
+
+  describe ".titleizable_attribute_names" do
+    it "sets as expected" do
+      expected_attribute_names = titleizable_attribute_names.map(&:to_s)
+      expect(described_class.titleizable_attribute_names).to match_array(expected_attribute_names)
+    end
+  end
+
+  describe "before validation" do
+    titleizable_attribute_names.each do |attribute_name|
+      context "for attribute #{attribute_name}" do
+        let(:setter_method) { "#{attribute_name}=" }
+        it "titleizes all-lowercased fields" do
+          subject.send(setter_method, "lazy name")
+          subject.validate
+
+          expect(subject.send(attribute_name)).to eq("Lazy Name")
+        end
+
+        it "titleizes all-uppercased fields" do
+          subject.send(setter_method, "SHOUTING NAME")
+          subject.validate
+
+          expect(subject.send(attribute_name)).to eq("Shouting Name")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/concerns/titleizable.rb
+++ b/spec/support/concerns/titleizable.rb
@@ -27,6 +27,20 @@ RSpec.shared_examples_for "titleizable" do |*titleizable_attribute_names|
 
           expect(subject.send(attribute_name)).to eq("Shouting Name")
         end
+
+        it "does not modify mixed-case fields" do
+          subject.send(setter_method, "McMixed Case Name")
+          subject.validate
+
+          expect(subject.send(attribute_name)).to eq("McMixed Case Name")
+        end
+
+        it "does not modify nil fields" do
+          subject.send(setter_method, nil)
+          subject.validate
+
+          expect(subject.send(attribute_name)).to eq(nil)
+        end
       end
     end
   end

--- a/spec/support/matchers/strip_attributes.rb
+++ b/spec/support/matchers/strip_attributes.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Monkey patch to get StripAttributes working with Titleizable module
+module StripAttributes
+  module Matchers
+    class StripAttributeMatcher
+      def matches?(subject)
+        @attributes.all? do |attribute|
+          @attribute = attribute
+          subject.send("#{@attribute}=", " string ")
+          subject.valid?
+          subject.send(@attribute).downcase == "string" and collapse_spaces?(subject)
+        end
+      end
+
+      private
+
+      def collapse_spaces?(subject)
+        return true if !@options[:collapse_spaces]
+
+        subject.send("#{@attribute}=", " string    string ")
+        subject.valid?
+        subject.send(@attribute).downcase == "string string"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently we allow names and place-names to be saved with all-lowercase (e.g., "joseph") or all-uppercase (e.g., "PROVO") characters. 

This PR adds a new `Titleizable` module that looks for all-lowercased or all-uppercased attributes and properly titleizes them. 

Note that values having mixed case will not be modified.

To use the module, include it and then list the attributes that should be titleized, as follows:

```ruby
class MyModel < ::ApplicationRecord
  include Titleizable

  titleize_attributes :first_name, :last_name, :city
end

=> record = MyModel.new(first_name: "whisper", last_name: "SHOUT", city: "McCall")
=> record.validate
=> record.first_name
#> "Whisper"
=> record.last_name
#> "Shout"
=> record.city
#> "McCall"
```

This PR also adds the Titleizable module to Effort, Person, and User models.