### PR TITLE
Move phone to user preferences

### DIFF
--- a/app/assets/stylesheets/utilities/_forms.scss
+++ b/app/assets/stylesheets/utilities/_forms.scss
@@ -1,4 +1,4 @@
-.form-group.required label:after {
+.form-group.required label:after, .form-row.required label:after {
     content: " *";
     color: $danger;
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -133,6 +133,10 @@ class User < ApplicationRecord
     avatar.present?
   end
 
+  def from_omniauth?
+    provider? && uid?
+  end
+
   private
 
   def normalize_phone

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -49,6 +49,8 @@
           <div class="col-md-12 mb-3">
             <%= f.label :new_password_confirmation %>
             <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
+
+            <small class="form-text text-muted"><%= t(".leave_blank_if_you_don_t_want_to_change_it") %></small>
           </div>
         </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-    <% "OpenSplitTime: Edit user" %>
+  <% "OpenSplitTime: Edit user" %>
 <% end %>
 
 <header class="ost-header">
@@ -15,50 +15,65 @@
 <article class="ost-article container">
   <div class="row justify-content-center">
     <div class="col col-login">
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put}) do |f| %>
         <%= bootstrap_devise_error_messages! %>
 
-        <div class="form-group required">
-          <%= f.label :first_name, 'First name' %>
-          <%= f.text_field :first_name, autofocus: true, class: "form-control" %>
-        </div>
-        <div class="form-group required">
-          <%= f.label :last_name, 'Last name' %>
-          <%= f.text_field :last_name, class: "form-control" %>
-        </div>
-
-        <div class="form-group required">
-          <%= f.label :email %>
-          <%= f.email_field :email, autocomplete: 'email', class: 'form-control' %>
+        <div class="form-row required">
+          <div class="col-md-6 mb-3">
+            <%= f.label :first_name, 'First name' %>
+            <%= f.text_field :first_name, autofocus: true, class: "form-control" %>
+          </div>
+          <div class="col-md-6 mb-3">
+            <%= f.label :last_name, 'Last name' %>
+            <%= f.text_field :last_name, class: "form-control" %>
+          </div>
         </div>
 
-        <div class="form-group">
-          <%= f.label :password %>
-          <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control' %>
-
-          <small class="form-text text-muted"><%= t('.leave_blank_if_you_don_t_want_to_change_it') %></small>
+        <div class="form-row required">
+          <div class="col-md-12 mb-3">
+            <%= f.label :email %>
+            <%= f.email_field :email, autocomplete: 'email', class: 'form-control' %>
+          </div>
         </div>
 
-        <div class="form-group">
-          <%= f.label :password_confirmation %>
-          <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control'  %>
+        <div class="form-row">
+          <div class="col-md-12 mb-3">
+            <%= f.label :new_password %>
+            <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control' %>
+
+            <small class="form-text text-muted"><%= t('.leave_blank_if_you_don_t_want_to_change_it') %></small>
+          </div>
         </div>
 
-        <div class="form-group required">
-          <%= f.label :current_password %>
-          <%= f.password_field :current_password, autocomplete: 'current-password', class: 'form-control' %>
-
-          <small class="form-text text-muted"><%= t('.we_need_your_current_password_to_confirm_your_changes') %></small>
+        <div class="form-row">
+          <div class="col-md-12 mb-3">
+            <%= f.label :new_password_confirmation %>
+            <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control' %>
+          </div>
         </div>
 
-        <div class="form-group">
-          <%= f.submit t('.update'), class: 'btn btn-primary' %>
+        <div class="form-row required">
+          <div class="col-md-12 mb-3">
+            <%= f.label :current_password %>
+            <%= f.password_field :current_password, autocomplete: 'current-password', class: 'form-control' %>
+
+            <small class="form-text text-muted"><%= t('.we_need_your_current_password_to_confirm_your_changes') %></small>
+          </div>
+        </div>
+        <hr/>
+
+        <div class="form-row">
+          <div class="col-4">
+            <%= f.submit t('.update'), class: 'btn btn-primary' %>
+          </div>
+          <div class="col-4">
+            <%= link_to 'Cancel', :back, class: "btn btn-outline-secondary" %>
+          </div>
         </div>
       <% end %>
+      <hr/>
 
-      <p><span class="brackets"><%= link_to 'Cancel', :back %></span></p>
-
-      <p><%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: 'text-danger' %></p>
+      <p><%= link_to t('.cancel_my_account'), registration_path(resource_name), data: {confirm: t('.are_you_sure')}, method: :delete, class: 'text-danger' %></p>
     </div>
   </div>
 </article>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,7 +6,7 @@
   <div class="container">
     <div class="ost-heading row">
       <div class="ost-title col">
-        <h1><strong><%= t('.title', resource: resource_name.to_s.humanize) %></strong></h1>
+        <h1><strong><%= t(".title", resource: resource_name.to_s.humanize) %></strong></h1>
       </div>
     </div>
   </div>
@@ -20,11 +20,11 @@
 
         <div class="form-row required">
           <div class="col-md-6 mb-3">
-            <%= f.label :first_name, 'First name' %>
+            <%= f.label :first_name, "First name" %>
             <%= f.text_field :first_name, autofocus: true, class: "form-control" %>
           </div>
           <div class="col-md-6 mb-3">
-            <%= f.label :last_name, 'Last name' %>
+            <%= f.label :last_name, "Last name" %>
             <%= f.text_field :last_name, class: "form-control" %>
           </div>
         </div>
@@ -32,48 +32,48 @@
         <div class="form-row required">
           <div class="col-md-12 mb-3">
             <%= f.label :email %>
-            <%= f.email_field :email, autocomplete: 'email', class: 'form-control' %>
+            <%= f.email_field :email, autocomplete: "email", class: "form-control" %>
           </div>
         </div>
 
         <div class="form-row">
           <div class="col-md-12 mb-3">
             <%= f.label :new_password %>
-            <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control' %>
+            <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
 
-            <small class="form-text text-muted"><%= t('.leave_blank_if_you_don_t_want_to_change_it') %></small>
+            <small class="form-text text-muted"><%= t(".leave_blank_if_you_don_t_want_to_change_it") %></small>
           </div>
         </div>
 
         <div class="form-row">
           <div class="col-md-12 mb-3">
             <%= f.label :new_password_confirmation %>
-            <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control' %>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
           </div>
         </div>
 
         <div class="form-row required">
           <div class="col-md-12 mb-3">
             <%= f.label :current_password %>
-            <%= f.password_field :current_password, autocomplete: 'current-password', class: 'form-control' %>
+            <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
 
-            <small class="form-text text-muted"><%= t('.we_need_your_current_password_to_confirm_your_changes') %></small>
+            <small class="form-text text-muted"><%= t(".we_need_your_current_password_to_confirm_your_changes") %></small>
           </div>
         </div>
         <hr/>
 
         <div class="form-row">
           <div class="col-4">
-            <%= f.submit t('.update'), class: 'btn btn-primary' %>
+            <%= f.submit t(".update"), class: "btn btn-primary" %>
           </div>
           <div class="col-4">
-            <%= link_to 'Cancel', :back, class: "btn btn-outline-secondary" %>
+            <%= link_to "Cancel", :back, class: "btn btn-outline-secondary" %>
           </div>
         </div>
       <% end %>
       <hr/>
 
-      <p><%= link_to t('.cancel_my_account'), registration_path(resource_name), data: {confirm: t('.are_you_sure')}, method: :delete, class: 'text-danger' %></p>
+      <p><%= link_to t(".cancel_my_account"), registration_path(resource_name), data: {confirm: t(".are_you_sure")}, method: :delete, class: "text-danger" %></p>
     </div>
   </div>
 </article>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -33,11 +33,6 @@
         </div>
 
         <div class="form-group">
-          <%= f.label :phone, 'US or Canada mobile number (for text notifications)' %>
-          <%= f.text_field :phone, class: "form-control" %>
-        </div>
-
-        <div class="form-group">
           <%= f.label :password %>
           <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control' %>
 

--- a/app/views/layouts/_nav_links_for_auth.html.erb
+++ b/app/views/layouts/_nav_links_for_auth.html.erb
@@ -1,4 +1,4 @@
-<li class="nav-item"><%= link_to 'Donate!', donations_path, class: 'donate nav-link' %></li>
+<li class="nav-item"><%= link_to "Donate!", donations_path, class: "donate nav-link" %></li>
 <% if user_signed_in? %>
   <li class="nav-item">
     <div class="dropdown">
@@ -8,26 +8,26 @@
       </a>
       <div class="dropdown-menu" aria-labelledby="nav-dropdown-auth">
         <% unless current_user.from_omniauth? %>
-          <%= link_to 'Edit My Profile', edit_user_registration_path, class: 'dropdown-item' %>
+          <%= link_to "Edit My Profile", edit_user_registration_path, class: "dropdown-item" %>
         <% end %>
-        <%= link_to 'View My Profile', user_path(current_user), class: 'dropdown-item' %>
-        <%= link_to 'Change Preferences', edit_preferences_user_path(current_user, referrer_path: URI(request.original_url).path), class: 'dropdown-item' %>
+        <%= link_to "View My Profile", user_path(current_user), class: "dropdown-item" %>
+        <%= link_to "Change Preferences", edit_preferences_user_path(current_user, referrer_path: URI(request.original_url).path), class: "dropdown-item" %>
         <% if current_user&.admin? %>
           <div class="dropdown-divider"></div>
-          <%= link_to 'List Users', users_path, class: 'dropdown-item' %>
+          <%= link_to "List Users", users_path, class: "dropdown-item" %>
         <% end %>
         <div class="dropdown-divider"></div>
-        <%= link_to 'Log Out', destroy_user_session_path, method: :delete, class: 'dropdown-item' %>
+        <%= link_to "Log Out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
       </div>
     </div>
   </li>
 <% else %>
   <li class="nav-item">
-    <%= link_to t('devise.sessions.new.sign_in').titleize, '#', class: 'nav-link', data: {toggle: 'modal', target: '#log-in-modal'} %>
+    <%= link_to t("devise.sessions.new.sign_in").titleize, "#", class: "nav-link", data: {toggle: "modal", target: "#log-in-modal"} %>
   </li>
   <li class="nav-item">
-    <%= link_to new_registration_path(resource_name), class: 'nav-link' do %>
-      <%= content_tag(:span, t('devise.registrations.new.sign_up').titleize, class: 'sign-up') %>
+    <%= link_to new_registration_path(resource_name), class: "nav-link" do %>
+      <%= content_tag(:span, t("devise.registrations.new.sign_up").titleize, class: "sign-up") %>
     <% end %>
   </li>
 <% end %>

--- a/app/views/layouts/_nav_links_for_auth.html.erb
+++ b/app/views/layouts/_nav_links_for_auth.html.erb
@@ -7,7 +7,9 @@
         <span class="caret"></span>
       </a>
       <div class="dropdown-menu" aria-labelledby="nav-dropdown-auth">
-        <%= link_to 'Edit My Profile', edit_user_registration_path, class: 'dropdown-item' %>
+        <% unless current_user.from_omniauth? %>
+          <%= link_to 'Edit My Profile', edit_user_registration_path, class: 'dropdown-item' %>
+        <% end %>
         <%= link_to 'View My Profile', user_path(current_user), class: 'dropdown-item' %>
         <%= link_to 'Change Preferences', edit_preferences_user_path(current_user, referrer_path: URI(request.original_url).path), class: 'dropdown-item' %>
         <% if current_user&.admin? %>

--- a/app/views/users/edit_preferences.html.erb
+++ b/app/views/users/edit_preferences.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-    <% "OpenSplitTime: Edit user preferences" %>
+  <% "OpenSplitTime: Edit user preferences" %>
 <% end %>
 
 <header class="ost-header">
@@ -18,31 +18,37 @@
   <div class="row justify-content-center">
     <div class="col col-login">
       <%= form_for(@user, url: {action: "update_preferences"}, method: :put, html: {class: "form-horizontal", role: "form"}) do |f| %>
-        <div class="form-group">
-          <div class="control-label col-8">
-            <%= f.label :pref_distance_unit, 'View distances in' %>
+        <div class="form-row">
+          <div class="col-md-8 mb-3">
+            <%= f.label :phone, 'US or Canada mobile number (for text notifications)' %>
+            <%= f.text_field :phone, class: "form-control" %>
           </div>
-          <div class="col-8">
+        </div>
+
+        <div class="form-row">
+          <div class="col-md-4 mb-3">
+            <%= f.label :pref_distance_unit, 'View distances in' %>
             <%= f.select :pref_distance_unit, User.pref_distance_units.keys.map { |unit| [unit.titleize, unit] },
                          {prompt: true}, {class: "form-control dropdown-select-field"} %>
           </div>
         </div>
-        <div class="form-group">
-          <div class="control-label col-8">
+
+        <div class="form-row">
+          <div class="col-md-4 mb-3">
             <%= f.label :pref_elevation_unit, 'View elevations in' %>
-          </div>
-          <div class="col-8">
             <%= f.select :pref_elevation_unit, User.pref_elevation_units.keys.map { |unit| [unit.titleize, unit] },
                          {prompt: true}, {class: "form-control dropdown-select-field"} %>
           </div>
         </div>
-        <div class="form-group">
-          <div class="col">
+        <hr/>
+
+        <div class="form-row">
+          <div class="col-md-5 mb-3">
             <%= f.button("Update Preferences", name: 'referrer_path', value: params[:referrer_path], class: 'btn btn-primary btn-large') %>
           </div>
-        </div>
-        <div class="col">
-          <span class="brackets"><%= link_to 'Cancel', user_path(@user) %></span>
+          <div class="col-md-2 mb-3">
+            <%= link_to 'Cancel', user_path(@user), class: "btn btn-outline-secondary" %>
+          </div>
         </div>
       <% end %>
     </div>

--- a/app/views/users/edit_preferences.html.erb
+++ b/app/views/users/edit_preferences.html.erb
@@ -12,7 +12,7 @@
   </div>
 </header>
 
-<%= render 'shared/errors', obj: @user %>
+<%= render "shared/errors", obj: @user %>
 
 <article class="ost-article container">
   <div class="row justify-content-center">
@@ -20,14 +20,14 @@
       <%= form_for(@user, url: {action: "update_preferences"}, method: :put, html: {class: "form-horizontal", role: "form"}) do |f| %>
         <div class="form-row">
           <div class="col-md-8 mb-3">
-            <%= f.label :phone, 'US or Canada mobile number (for text notifications)' %>
-            <%= f.text_field :phone, class: "form-control" %>
+            <%= f.label :phone, "US or Canada mobile number (for text notifications)" %>
+            <%= f.text_field :phone, type: "tel", class: "form-control" %>
           </div>
         </div>
 
         <div class="form-row">
           <div class="col-md-4 mb-3">
-            <%= f.label :pref_distance_unit, 'View distances in' %>
+            <%= f.label :pref_distance_unit, "View distances in" %>
             <%= f.select :pref_distance_unit, User.pref_distance_units.keys.map { |unit| [unit.titleize, unit] },
                          {prompt: true}, {class: "form-control dropdown-select-field"} %>
           </div>
@@ -35,7 +35,7 @@
 
         <div class="form-row">
           <div class="col-md-4 mb-3">
-            <%= f.label :pref_elevation_unit, 'View elevations in' %>
+            <%= f.label :pref_elevation_unit, "View elevations in" %>
             <%= f.select :pref_elevation_unit, User.pref_elevation_units.keys.map { |unit| [unit.titleize, unit] },
                          {prompt: true}, {class: "form-control dropdown-select-field"} %>
           </div>
@@ -44,10 +44,10 @@
 
         <div class="form-row">
           <div class="col-md-5 mb-3">
-            <%= f.button("Update Preferences", name: 'referrer_path', value: user_path(@user), class: 'btn btn-primary btn-large') %>
+            <%= f.button("Update Preferences", name: "referrer_path", value: user_path(@user), class: "btn btn-primary btn-large") %>
           </div>
           <div class="col-md-2 mb-3">
-            <%= link_to 'Cancel', user_path(@user), class: "btn btn-outline-secondary" %>
+            <%= link_to "Cancel", user_path(@user), class: "btn btn-outline-secondary" %>
           </div>
         </div>
       <% end %>

--- a/app/views/users/edit_preferences.html.erb
+++ b/app/views/users/edit_preferences.html.erb
@@ -44,7 +44,7 @@
 
         <div class="form-row">
           <div class="col-md-5 mb-3">
-            <%= f.button("Update Preferences", name: 'referrer_path', value: params[:referrer_path], class: 'btn btn-primary btn-large') %>
+            <%= f.button("Update Preferences", name: 'referrer_path', value: user_path(@user), class: 'btn btn-primary btn-large') %>
           </div>
           <div class="col-md-2 mb-3">
             <%= link_to 'Cancel', user_path(@user), class: "btn btn-outline-secondary" %>


### PR DESCRIPTION
Omniauth users should not have a way to edit user information like name and email. But they do need a way to change or add a phone number.

This PR moves the phone into the user preferences screen, and it hides the Edit User page for omniauth users.

This is a follow-on to #441