### PR TITLE
Limit fields in course lookup from Event Staging screen

### DIFF
--- a/app/views/event_staging/events/_event.html.erb
+++ b/app/views/event_staging/events/_event.html.erb
@@ -73,7 +73,7 @@
         <span class="help-tooltip" tabindex="-1" data-controller="popover" data-placement="bottom" data-content="If you have already created a course for a prior Event like this one, you can select it here."><i class="fas fa-question-circle"></i></span>
         <div class="row">
           <div class="col-12 col-md-6 col-xl-7 pr-md-0">
-            <resource-select id="course-select" class="form-control" v-model="eventModel.course" source="courses?filter[editable]=true&page[size]=100&sort=name">
+            <resource-select id="course-select" class="form-control" v-model="eventModel.course" source="courses?fields[courses]=id,name&filter[editable]=true&page[size]=100&sort=name">
               <option :value="null" selected disabled>Select One</option>
             </resource-select>
           </div>

--- a/lib/tasks/database_fixtures.rake
+++ b/lib/tasks/database_fixtures.rake
@@ -8,6 +8,7 @@ namespace :db do
     TABLES_TO_SKIP = [
       "active_storage_attachments",
       "active_storage_blobs",
+      "active_storage_variant_records",
       "ar_internal_metadata",
       "delayed_jobs",
       "effort_segments",
@@ -71,6 +72,7 @@ namespace :db do
     TABLES_TO_SKIP = [
       "active_storage_attachments",
       "active_storage_blobs",
+      "active_storage_variant_records",
       "ar_internal_metadata",
       "delayed_jobs",
       "effort_segments",


### PR DESCRIPTION
The AJAX request for courses in event staging is taking a huge amount of time, because it is bringing in track_points, which is a lot of data.

This PR limits fields pulled in to `id` and `name`.

As a side benefit, fixes the rake task by ignoring the latest activestorage table.