### PR TITLE
Fix bug in serialize_and_render method

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -70,9 +70,12 @@ module Api
         options[:include] = *options[:include] if options[:include].present?
         options[:include] ||= prepared_params[:include]
         options[:fields] ||= prepared_params[:fields]
-        serializer_params = {params: {current_user: current_user}}
+        serializer_params = {params: {current_user: current_user}}.merge(options)
 
-        serializer = serializer_class.new(resource, serializer_params.merge(options))
+        # The BaseSerializer chokes when certain options are passed, so blank them out
+        serializer_params = {} if serializer_class == ::Api::V1::BaseSerializer
+
+        serializer = serializer_class.new(resource, serializer_params)
 
         render json: serializer.serializable_hash.to_json, status: status
       end

--- a/spec/controllers/api/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/v1/courses_controller_spec.rb
@@ -58,6 +58,35 @@ RSpec.describe Api::V1::CoursesController do
           expect(names.last).to eq('SUM 55K Course')
         end
       end
+
+      context "when filtered to a single record" do
+        let(:params) { {filter: {name: "RUFA Course"}} }
+        it "returns just the requested records" do
+          make_request
+          parsed_response = JSON.parse(response.body)
+          data = parsed_response["data"]
+          expect(data.count).to eq(1)
+          expect(data.first.dig("attributes", "name")).to eq("RUFA Course")
+        end
+      end
+
+      context "when filtered to no records" do
+        let(:params) { {filter: {id: 0}} }
+        it "returns an empty response" do
+          make_request
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response["data"]).to be_empty
+        end
+      end
+
+      context "when filtered to no records with include option" do
+        let(:params) { {filter: {id: 0}, include: [:splits]} }
+        it "returns an empty response" do
+          make_request
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response["data"]).to be_empty
+        end
+      end
     end
 
     context "without logging in" do


### PR DESCRIPTION
The `serialize_and_render` method in the `Api::V1::BaseController` was being passed an empty relation, but with `includes` set to `["splits"]`. When passed an empty collection without explicit instructions as to which serializer to use, `serialize_and_render` uses the `Api::V1::BaseSerializer`. The `include` option was causing that serializer to crash. 

This fixes the problem by blanking out options if we are using the `Api::V1::BaseSerializer`.