### PR TITLE
Fix headless browser in system specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,6 @@ group :test do
   gem 'capybara', '~> 3.33', '>= 3.33.0'
   gem 'factory_bot_rails', '~> 5.2', '>= 5.2.0', require: false
   gem 'pry'
-  gem 'selenium-webdriver'
   gem 'vcr', '~> 4.0'
   gem "webdrivers"
   gem 'webmock', '~> 3.5'

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :test do
   gem 'pry'
   gem 'selenium-webdriver'
   gem 'vcr', '~> 4.0'
+  gem "webdrivers"
   gem 'webmock', '~> 3.5'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,6 +499,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.5.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.11.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -596,6 +600,7 @@ DEPENDENCIES
   vcr (~> 4.0)
   vuejs-rails
   web-console (~> 3.7, >= 3.7.0)
+  webdrivers
   webmock (~> 3.5)
   webpacker (~> 4.3, >= 4.3.0)
   will_paginate (~> 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -584,7 +584,6 @@ DEPENDENCIES
   sass-rails (~> 5.0.8)
   scenic (>= 1.5.3)
   scout_apm
-  selenium-webdriver
   sentry-raven
   shortener
   sidekiq

--- a/app.json
+++ b/app.json
@@ -4,9 +4,11 @@
       "addons": ["heroku-postgresql:in-dyno", "heroku-redis:in-dyno"],
       "buildpacks": [
         { "url": "heroku/ruby" },
-        { "url": "https://github.com/heroku/heroku-buildpack-chromedriver" },
         { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" }
       ],
+      "env": {
+        "WD_CHROME_PATH": "/app/.apt/usr/bin/google-chrome-stable"
+      },
       "formation": {
         "test": {
           "quantity": 1,

--- a/spec/support/basic_configure.rb
+++ b/spec/support/basic_configure.rb
@@ -6,8 +6,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    # For compatibility with Heroku CI, driven_by must be set to a Capybara registered driver
-    # that sets chromeOptions: :binary to the path of the chrome assets in the Heroku CI environment
-    driven_by :headless_chrome
+    driven_by :selenium_chrome_headless
   end
 end


### PR DESCRIPTION
For a while now we've been unable to use a headless browser on local system specs. We always get real Chrome instead.

This PR uses the `webdrivers` gem and resets some config files to work properly both locally and in Heroku CI.