### PR TITLE
Handle nils in oauth failure method

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -28,10 +28,10 @@ module Users
 
     def failure
       case
-      when params[:strategy] == "facebook" || request.referrer.include?("facebook")
+      when params[:strategy] == "facebook" || request.referrer&.include?("facebook")
         kind = "Facebook"
         reason = params[:error_description]
-      when params[:strategy] == "google_oauth2" || request.referrer.include?("google_oauth2")
+      when params[:strategy] == "google_oauth2" || request.referrer&.include?("google_oauth2")
         kind = "Google"
         reason = params[:error_description]
       else


### PR DESCRIPTION
OAuth failures are resulting in 500 errors when the `request.referrer` doesn't exist.

This PR handles those nils and allows us to fail gracefully.