### PR TITLE
Rework spam method to avoid multiple redirects

### DIFF
--- a/spec/system/visitor_signs_up_spec.rb
+++ b/spec/system/visitor_signs_up_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Visitor signs up" do
   end
 
   scenario "if names are randomly generated" do
-    sign_up_with "swdeSDFjd", "WERlkjJdq", "realemail@example.com", "password"
+    sign_up_with "swdeSDFjd", "WERlkjJdq", "valid@example.com", "password"
 
     expect(page).not_to have_content(:all, "A message with a confirmation link has been sent to your email address.")
   end


### PR DESCRIPTION
The bot protection appears to be working, but we are seeing a new error for multiple redirects: https://sentry.io/organizations/opensplittime/issues/2308494022/?project=3805803

This PR reworks the conditional logic to ensure only one redirect is executed.