### PR TITLE
Use memory store for dev cache

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,11 +18,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :dalli_store, 'localhost', {:namespace => 'ost-dev', :expires_in => 1.day, :compress => true}
-
-    config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
-    }
+    config.cache_store = :memory_store
   else
     config.action_controller.perform_caching = false
 


### PR DESCRIPTION
Eliminates the deprecation warning for dalli_store.