### PR TITLE
Feature to ignore a specific time index for data import from RR

### DIFF
--- a/lib/etl/importer.rb
+++ b/lib/etl/importer.rb
@@ -25,7 +25,7 @@ module ETL
       when :race_result_entrants
         import_with(source_data, Extractors::RaceResultStrategy, Transformers::RaceResultEntrantsStrategy, Loaders::UpsertStrategy, {delete_blank_times: false, unique_key: [:event_id, :bib_number]}.merge(options))
       when :race_result_api_times
-        import_with(source_data, Extractors::RaceResultApiStrategy, Transformers::RaceResultApiSplitTimesStrategy, Loaders::SplitTimeUpsertStrategy, {delete_blank_times: false}.merge(options))
+        import_with(source_data, Extractors::RaceResultApiStrategy, Transformers::RaceResultApiSplitTimesStrategy, Loaders::SplitTimeUpsertStrategy, {delete_blank_times: true}.merge(options))
       when :adilas_bear_times
         import_with(source_data, Extractors::AdilasBearHTMLStrategy, Transformers::AdilasBearStrategy, Loaders::InsertStrategy, options)
       when :its_your_race_times

--- a/lib/etl/importer_from_context.rb
+++ b/lib/etl/importer_from_context.rb
@@ -37,10 +37,11 @@ module ETL
     end
 
     def options
-      result = {parent: parent, current_user_id: current_user.id, strict: strict}
-      result[:unique_key] = unique_key if unique_key
-      result[:split_name] = params[:split_name] if params[:split_name]
-      result
+      options_hash = {parent: parent, current_user_id: current_user.id, strict: strict}
+      options_hash[:unique_key] = unique_key if unique_key
+      options_hash[:split_name] = params[:split_name] if params[:split_name]
+      options_hash[:ignore_time_indicies] = params[:ignore_time_indicies] if params[:ignore_time_indicies]
+      options_hash
     end
 
     def strict

--- a/spec/controllers/api/v1/events_controller_spec.rb
+++ b/spec/controllers/api/v1/events_controller_spec.rb
@@ -400,8 +400,8 @@ RSpec.describe Api::V1::EventsController do
         end
 
         context 'when existing efforts have existing split times' do
-          it 'overwrites existing times and adds new times but does not erase existing times when blanks appear' do
-            expect { make_request }.to change { event.efforts.count }.by(0).and change { SplitTime.count }.by(2)
+          it 'overwrites existing times, adds new times, and erases existing times when blanks appear' do
+            expect { make_request }.to change { event.efforts.count }.by(0).and change { SplitTime.count }.by(-1)
             expect(response.status).to eq(201)
             event.reload
 
@@ -419,9 +419,8 @@ RSpec.describe Api::V1::EventsController do
 
             effort = event.efforts.find_by(bib_number: 1117)
             split_times = effort.ordered_split_times
-            expect(split_times.size).to eq(7)
+            expect(split_times.size).to eq(6)
             expected_absolute_times = ['2017-06-03 08:01:48 -0600',
-                                       '2017-06-03 07:52:00 -0600',
                                        '2017-06-03 09:41:07 -0600',
                                        '2017-06-03 10:31:45 -0600',
                                        '2017-06-03 11:40:33 -0600',
@@ -436,7 +435,7 @@ RSpec.describe Api::V1::EventsController do
             it 'sends notifications to followers for only the new split times' do
               expect(event.permit_notifications?).to eq(true)
               allow(BulkProgressNotifier).to receive(:notify)
-              expect { make_request }.to change { SplitTime.count }.by(2)
+              expect { make_request }.to change { SplitTime.count }.by(-1)
               split_times = SplitTime.last(2)
               expect(BulkProgressNotifier).to have_received(:notify).with(split_times)
             end

--- a/spec/lib/etl/transformers/race_result_api_split_times_strategy_spec.rb
+++ b/spec/lib/etl/transformers/race_result_api_split_times_strategy_spec.rb
@@ -3,8 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe ETL::Transformers::RaceResultApiSplitTimesStrategy do
-  subject { ETL::Transformers::RaceResultApiSplitTimesStrategy.new(parsed_structs, options) }
-  let(:options) { {parent: event} }
+  subject { described_class.new(parsed_structs, options) }
+  let(:options) { {parent: event}.merge(delete_blank_times_option).merge(ignore_time_indicies_option) }
+  let(:delete_blank_times_option) { {} }
+  let(:ignore_time_indicies_option) { {} }
   let(:proto_records) { subject.transform }
   let(:first_proto_record) { proto_records.first }
   let(:second_proto_record) { proto_records.second }
@@ -61,7 +63,7 @@ RSpec.describe ETL::Transformers::RaceResultApiSplitTimesStrategy do
                          rr_id: '250')
       ] }
 
-      let(:expected_times) { times_with_zone(time_strings) }
+      let(:expected_times) { times_with_zone(expected_time_strings) }
 
       it 'returns the same number of ProtoRecords as it is given OpenStructs' do
         expect(proto_records.size).to eq(4)
@@ -78,17 +80,17 @@ RSpec.describe ETL::Transformers::RaceResultApiSplitTimesStrategy do
 
       context 'when all times are present' do
         let(:records) { first_proto_record.children }
-        let(:time_strings) { ['2018-10-31 07:05:05',
-                              '2018-10-31 08:05:19',
-                              '2018-10-31 08:50:50',
-                              '2018-10-31 09:37:57',
-                              '2018-10-31 10:30:59',
-                              '2018-10-31 11:11:22',
-                              '2018-10-31 12:04:37'] }
+        let(:expected_time_strings) { ['2018-10-31 07:05:05',
+                                       '2018-10-31 08:05:19',
+                                       '2018-10-31 08:50:50',
+                                       '2018-10-31 09:37:57',
+                                       '2018-10-31 10:30:59',
+                                       '2018-10-31 11:11:22',
+                                       '2018-10-31 12:04:37'] }
 
         it 'sorts split headers and returns an array of children' do
           expect(records.size).to eq(7)
-          expect(records.map(&:record_type)).to eq([:split_time] * records.size)
+          expect(records.map(&:record_type)).to all eq(:split_time)
           expect(records.map { |pr| pr[:lap] }).to eq(time_points.map(&:lap))
           expect(records.map { |pr| pr[:split_id] }).to eq(time_points.map(&:split_id))
           expect(records.map { |pr| pr[:sub_split_bitkey] }).to eq(time_points.map(&:bitkey))
@@ -97,38 +99,38 @@ RSpec.describe ETL::Transformers::RaceResultApiSplitTimesStrategy do
       end
 
       context 'when options[:delete_blank_times] is true' do
-        let(:options) { {parent: event, delete_blank_times: true} }
+        let(:delete_blank_times_option) { {delete_blank_times: true} }
 
         context 'when end times are not present' do
           let(:records) { third_proto_record.children }
-          let(:time_strings) { ['2018-10-31 07:05:42',
-                                '2018-10-31 08:22:41',
-                                '2018-10-31 09:15:25',
-                                '2018-10-31 10:07:56',
-                                '2018-10-31 10:54:19',
-                                nil,
-                                nil] }
+          let(:expected_time_strings) { ['2018-10-31 07:05:42',
+                                         '2018-10-31 08:22:41',
+                                         '2018-10-31 09:15:25',
+                                         '2018-10-31 10:07:56',
+                                         '2018-10-31 10:54:19',
+                                         nil,
+                                         nil] }
           it 'returns expected absolute_times array and marks blank records for destruction' do
             expect(records.size).to eq(7)
             expect(records.map { |pr| pr[:split_id] }).to eq(time_points.map(&:split_id))
             expect(records.map { |pr| pr[:absolute_time] }).to eq(expected_times)
-            expect(records.map(&:record_action)).to eq([nil] * 5 + [:destroy] * 2)
+            expect(records.map(&:record_action)).to eq([nil, nil, nil, nil, nil, :destroy, :destroy])
           end
         end
 
         context 'when middle segment times are missing' do
           let(:records) { second_proto_record.children }
-          let(:time_strings) { ['2018-10-31 07:05:29',
-                                '2018-10-31 08:11:19',
-                                '2018-10-31 08:58:41',
-                                '2018-10-31 09:45:39',
-                                nil,
-                                '2018-10-31 11:22:34',
-                                '2018-10-31 12:18:13'] }
+          let(:expected_time_strings) { ['2018-10-31 07:05:29',
+                                         '2018-10-31 08:11:19',
+                                         '2018-10-31 08:58:41',
+                                         '2018-10-31 09:45:39',
+                                         nil,
+                                         '2018-10-31 11:22:34',
+                                         '2018-10-31 12:18:13'] }
 
           it 'returns expected absolute_times' do
             expect(records.map { |pr| pr[:absolute_time] }).to eq(expected_times)
-            expect(records.map(&:record_action)).to eq([nil] * 4 + [:destroy] + [nil] * 2)
+            expect(records.map(&:record_action)).to eq([nil, nil, nil, nil, :destroy, nil, nil])
           end
         end
 
@@ -136,12 +138,20 @@ RSpec.describe ETL::Transformers::RaceResultApiSplitTimesStrategy do
           let(:records) { last_proto_record.children }
           let(:time_points) { event.required_time_points }
 
+          it 'creates the expected number of records' do
+            expect(records.size).to eq(7)
+          end
+
           it 'returns expected times_from_start array' do
             expect(records.map { |pr| pr[:absolute_time] }).to all eq(nil)
           end
 
-          it 'returns expected split_id array when no times are present' do
+          it 'returns expected split_id array' do
             expect(records.map { |pr| pr[:split_id] }).to eq(time_points.map(&:split_id))
+          end
+
+          it 'destroys all records' do
+            expect(records.map(&:record_action)).to all eq(:destroy)
           end
         end
 
@@ -161,18 +171,86 @@ RSpec.describe ETL::Transformers::RaceResultApiSplitTimesStrategy do
             expect(last_proto_record.children.map { |pr| pr[:stopped_here] }).to all be_nil
           end
         end
+
+        context "when time indicies are to be ignored" do
+          let(:ignore_time_indicies_option) { {ignore_time_indicies: [4]} }
+          let(:expected_split_ids) { (time_points[0..3] + time_points[5..6]).map(&:split_id) }
+
+          context "when all times are present" do
+            let(:records) { first_proto_record.children }
+            let(:expected_time_strings) { ['2018-10-31 07:05:05',
+                                           '2018-10-31 08:05:19',
+                                           '2018-10-31 08:50:50',
+                                           '2018-10-31 09:37:57',
+                                           '2018-10-31 11:11:22',
+                                           '2018-10-31 12:04:37'] }
+
+            it 'ignores the index as instructed' do
+              expect(records.size).to eq(6)
+              expect(records.map { |pr| pr[:absolute_time] }).to eq(expected_times)
+            end
+
+            it 'does not mark any records for destruction' do
+              expect(records.map(&:record_action)).to all be_nil
+            end
+
+            it 'returns expected split_id array' do
+              expect(records.map { |pr| pr[:split_id] }).to eq(expected_split_ids)
+            end
+          end
+
+          context 'when the ignored segment time is missing' do
+            let(:records) { second_proto_record.children }
+            let(:expected_time_strings) { ['2018-10-31 07:05:29',
+                                           '2018-10-31 08:11:19',
+                                           '2018-10-31 08:58:41',
+                                           '2018-10-31 09:45:39',
+                                           '2018-10-31 11:22:34',
+                                           '2018-10-31 12:18:13'] }
+
+            it 'ignores the index as instructed' do
+              expect(records.size).to eq(6)
+              expect(records.map { |pr| pr[:absolute_time] }).to eq(expected_times)
+            end
+
+            it 'does not mark any records for destruction' do
+              expect(records.map(&:record_action)).to all be_nil
+            end
+
+            it 'returns expected split_id array' do
+              expect(records.map { |pr| pr[:split_id] }).to eq(expected_split_ids)
+            end
+          end
+
+          context 'when no times are present' do
+            let(:records) { last_proto_record.children }
+
+            it 'ignores the index as instructed' do
+              expect(records.size).to eq(6)
+              expect(records.map { |pr| pr[:absolute_time] }).to all eq(nil)
+            end
+
+            it 'returns expected split_id array' do
+              expect(records.map { |pr| pr[:split_id] }).to eq(expected_split_ids)
+            end
+
+            it 'marks all records for destruction' do
+              expect(records.map(&:record_action)).to all eq(:destroy)
+            end
+          end
+        end
       end
 
       context 'when options[:delete_blank_times] is false' do
-        let(:options) { {parent: event, delete_blank_times: false} }
+        let(:delete_blank_times_option) { {delete_blank_times: false} }
 
         context 'when some times are not present' do
           let(:records) { third_proto_record.children }
-          let(:time_strings) { ['2018-10-31 07:05:42',
-                                '2018-10-31 08:22:41',
-                                '2018-10-31 09:15:25',
-                                '2018-10-31 10:07:56',
-                                '2018-10-31 10:54:19'] }
+          let(:expected_time_strings) { ['2018-10-31 07:05:42',
+                                         '2018-10-31 08:22:41',
+                                         '2018-10-31 09:15:25',
+                                         '2018-10-31 10:07:56',
+                                         '2018-10-31 10:54:19'] }
 
           it 'returns expected absolute_times array' do
             expect(records.size).to eq(5)
@@ -203,6 +281,87 @@ RSpec.describe ETL::Transformers::RaceResultApiSplitTimesStrategy do
             expect(first_proto_record.children.map { |pr| pr[:stopped_here] }).to all be_nil
             expect(second_proto_record.children.map { |pr| pr[:stopped_here] }).to all be_nil
             expect(last_proto_record.children.map { |pr| pr[:stopped_here] }).to all be_nil
+          end
+        end
+
+        context "when time indicies are to be ignored" do
+          let(:ignore_time_indicies_option) { {ignore_time_indicies: [4]} }
+          let(:expected_split_ids) { (time_points[0..3] + time_points[5..6]).map(&:split_id) }
+
+          context "when all times are present" do
+            let(:records) { first_proto_record.children }
+            let(:expected_time_strings) { ['2018-10-31 07:05:05',
+                                           '2018-10-31 08:05:19',
+                                           '2018-10-31 08:50:50',
+                                           '2018-10-31 09:37:57',
+                                           '2018-10-31 11:11:22',
+                                           '2018-10-31 12:04:37'] }
+
+            it 'ignores the index as instructed' do
+              expect(records.size).to eq(6)
+              expect(records.map { |pr| pr[:absolute_time] }).to eq(expected_times)
+            end
+
+            it 'does not mark any records for destruction' do
+              expect(records.map(&:record_action)).to all be_nil
+            end
+
+            it 'returns expected split_id array' do
+              expect(records.map { |pr| pr[:split_id] }).to eq(expected_split_ids)
+            end
+          end
+
+          context 'when the ignored segment time is missing' do
+            let(:records) { second_proto_record.children }
+            let(:expected_time_strings) { ['2018-10-31 07:05:29',
+                                           '2018-10-31 08:11:19',
+                                           '2018-10-31 08:58:41',
+                                           '2018-10-31 09:45:39',
+                                           '2018-10-31 11:22:34',
+                                           '2018-10-31 12:18:13'] }
+
+            it 'ignores the index as instructed' do
+              expect(records.size).to eq(6)
+              expect(records.map { |pr| pr[:absolute_time] }).to eq(expected_times)
+            end
+
+            it 'does not mark any records for destruction' do
+              expect(records.map(&:record_action)).to all be_nil
+            end
+
+            it 'returns expected split_id array' do
+              expect(records.map { |pr| pr[:split_id] }).to eq(expected_split_ids)
+            end
+          end
+
+          context 'when non-ignored segment times are missing' do
+            let(:records) { third_proto_record.children }
+            let(:expected_split_ids) { time_points.first(4).map(&:split_id) }
+            let(:expected_time_strings) { ['2018-10-31 07:05:42',
+                                           '2018-10-31 08:22:41',
+                                           '2018-10-31 09:15:25',
+                                           '2018-10-31 10:07:56'] }
+
+            it 'ignores the index and also the missing segment times' do
+              expect(records.size).to eq(4)
+              expect(records.map { |pr| pr[:absolute_time] }).to eq(expected_times)
+            end
+
+            it 'does not mark any records for destruction' do
+              expect(records.map(&:record_action)).to all be_nil
+            end
+
+            it 'returns expected split_id array' do
+              expect(records.map { |pr| pr[:split_id] }).to eq(expected_split_ids)
+            end
+          end
+
+          context 'when no times are present' do
+            let(:records) { last_proto_record.children }
+
+            it 'creates no child records' do
+              expect(records.size).to eq(0)
+            end
           end
         end
       end
@@ -239,7 +398,6 @@ RSpec.describe ETL::Transformers::RaceResultApiSplitTimesStrategy do
                                              bib: '194',
                                              status: 'OK',
                                              rr_id: '194')] }
-
 
       it 'returns nil and adds an error' do
         expect(proto_records).to be_nil


### PR DESCRIPTION
Currently when taking in RR times, we ignore blank data because we don't want to overwrite times we get in for Windy Peak aid station via OST Remote.

This PR adds the ability to provide an `ignore_time_indicies` data element to the import endpoint.