### PR TITLE
Set effort status to bad if times exist without start time

### DIFF
--- a/app/services/interactors/set_effort_status.rb
+++ b/app/services/interactors/set_effort_status.rb
@@ -44,7 +44,9 @@ module Interactors
     end
 
     def set_effort_status
-      effort.data_status = ordered_split_times.map(&:data_status_numeric).push(Effort.data_statuses[:good]).compact.min
+      worst_split_time_status = ordered_split_times.map(&:data_status_numeric).push(Effort.data_statuses[:good]).compact.min
+      effort_status = times_without_start_time? ? ::Effort.data_statuses[:bad] : ::Effort.data_statuses[:good]
+      effort.data_status = [worst_split_time_status, effort_status].min
     end
 
     def set_subject_attributes(split_time)
@@ -62,6 +64,10 @@ module Interactors
 
     def beyond_drop?
       ordered_split_times.included_after?(first_dropped_split_time, subject_split_time)
+    end
+
+    def times_without_start_time?
+      ordered_split_times.present? && ordered_split_times.first.time_point != start_time_point
     end
 
     def time_predictor

--- a/spec/services/interactors/set_effort_status_spec.rb
+++ b/spec/services/interactors/set_effort_status_spec.rb
@@ -51,6 +51,24 @@ RSpec.describe Interactors::SetEffortStatus do
       end
     end
 
+    context "when split_times are good but start time does not exist" do
+      let(:effort) { efforts(:hardrock_2014_finished_first) }
+      before do
+        effort.ordered_split_times.first.destroy
+        effort.reload
+      end
+
+      it "does not set data_status of the split times" do
+        subject.perform
+        expect(subject_split_times.map(&:data_status)).to all be_nil
+      end
+
+      it "sets data_status of the effort to 'bad'" do
+        subject.perform
+        expect(effort.data_status).to eq('bad')
+      end
+    end
+
     context 'when one split_time is questionable' do
       let(:split_time) { subject_split_times.second }
       before { split_time.update(absolute_time: split_time.absolute_time - 3.hours) }


### PR DESCRIPTION
Efforts should be marked as `:bad` if times exist when there is no start time. This will surface those efforts in the Problems screen.

Addresses #496 