### PR TITLE
Set effort status after starting efforts

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -166,7 +166,9 @@ class EventGroupsController < ApplicationController
     filtered_efforts = Effort.from(efforts, :efforts).where(filter)
     start_time = params[:actual_start_time]
 
-    response = Interactors::StartEfforts.perform!(efforts: filtered_efforts, start_time: start_time, current_user_id: current_user.id)
+    start_response = Interactors::StartEfforts.perform!(efforts: filtered_efforts, start_time: start_time, current_user_id: current_user.id)
+    set_response = ::Interactors::SetEffortStatus.perform(efforts)
+    response = start_response.merge(set_response)
 
     respond_to do |format|
       format.html do

--- a/app/services/interactors/start_efforts.rb
+++ b/app/services/interactors/start_efforts.rb
@@ -38,11 +38,12 @@ module Interactors
 
     def start_effort(effort)
       return if effort.split_times.any?(&:starting_split_time?)
-      split_time = SplitTime.new(effort_id: effort.id,
-                                 time_point: TimePoint.new(1, effort.start_split_id, SubSplit::IN_BITKEY),
-                                 absolute_time: effort_start_time(effort),
-                                 created_by: current_user_id)
-      if split_time.save
+
+      time_point = TimePoint.new(1, effort.start_split_id, SubSplit::IN_BITKEY)
+      split_time = effort.split_times.new(time_point: time_point,
+                                          absolute_time: effort_start_time(effort),
+                                          created_by: current_user_id)
+      if effort.save
         saved_split_times << split_time
       else
         errors << resource_error_object(split_time)


### PR DESCRIPTION
Now that effort status depends in part on whether or not the effort has a start time, we need to set the effort status after starting it.

This PR sets effort status in the controller after starting efforts.

Addresses a portion of #496 