### PR TITLE
Expand ready_to_start to include in-progress efforts having no starting split time

### DIFF
--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -220,7 +220,7 @@ class EffortQuery < BaseQuery
           bsst.effort_id is not null                                                            as beyond_start,
           coalesce(ef.scheduled_start_time, ev.scheduled_start_time)                            as assumed_start_time,
           extract(epoch from (ef.scheduled_start_time - ev.scheduled_start_time))               as scheduled_start_offset,
-          (checked_in and 
+          ((checked_in or (bsst.effort_id is not null)) and 
               sst.absolute_time is null and 
               (coalesce(ef.scheduled_start_time, ev.scheduled_start_time) < current_timestamp)) as ready_to_start
       from efforts ef


### PR DESCRIPTION
Sometimes people don't check in, and as a result we end up with efforts on the course that have not checked in and have no starting split time.

This PR expands the definition of `ready_to_start` efforts to include non-checked-in efforts that have a split time beyond the start.

Addresses #497 