### PR TITLE
Call the correct Interactor to set multiple effort status

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -167,7 +167,7 @@ class EventGroupsController < ApplicationController
     start_time = params[:actual_start_time]
 
     start_response = ::Interactors::StartEfforts.perform!(efforts: filtered_efforts, start_time: start_time, current_user_id: current_user.id)
-    set_response = ::Interactors::UpdateEffortsStatus.perform!(efforts)
+    set_response = ::Interactors::UpdateEffortsStatus.perform!(filtered_efforts)
     response = start_response.merge(set_response)
 
     respond_to do |format|

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -167,6 +167,9 @@ class EventGroupsController < ApplicationController
     start_time = params[:actual_start_time]
 
     start_response = ::Interactors::StartEfforts.perform!(efforts: filtered_efforts, start_time: start_time, current_user_id: current_user.id)
+
+    # Need to pick up the new start split time before setting status
+    filtered_efforts = filtered_efforts.includes(split_times: :split)
     set_response = ::Interactors::UpdateEffortsStatus.perform!(filtered_efforts)
     response = start_response.merge(set_response)
 

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -166,8 +166,8 @@ class EventGroupsController < ApplicationController
     filtered_efforts = Effort.from(efforts, :efforts).where(filter)
     start_time = params[:actual_start_time]
 
-    start_response = Interactors::StartEfforts.perform!(efforts: filtered_efforts, start_time: start_time, current_user_id: current_user.id)
-    set_response = ::Interactors::SetEffortStatus.perform(efforts)
+    start_response = ::Interactors::StartEfforts.perform!(efforts: filtered_efforts, start_time: start_time, current_user_id: current_user.id)
+    set_response = ::Interactors::UpdateEffortsStatus.perform!(efforts)
     response = start_response.merge(set_response)
 
     respond_to do |format|


### PR DESCRIPTION
OK, so #502 was caused at least in part by a problem introduced in the `start_efforts` action in the controller. We were passing a collection of efforts to an Interactor (StartEffort) that takes only a single effort at a time.

This PR fixes that problem. 

We need better system tests to catch this kind of problem in the future.