### PR TITLE
Use RawTime matchable bib number where appropriate

### DIFF
--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -39,7 +39,7 @@ class RawTime < ApplicationRecord
   def self.search(search_text)
     return all unless search_text.present?
     bib_numbers = search_text.split(/[\s,]+/)
-    where(bib_number: bib_numbers)
+    where(matchable_bib_number: bib_numbers)
   end
 
   def clean?

--- a/app/queries/event_group_query.rb
+++ b/app/queries/event_group_query.rb
@@ -70,7 +70,7 @@ class EventGroupQuery < BaseQuery
                                                     'created_by', rt.created_by)
                                   order by case when rt.absolute_time is null then rt.entered_time else to_char((rt.absolute_time at time zone 'UTC'), 'HH24:MI:SS') end) as raw_times_attributes
         from raw_times rt
-        left join efforts ef on ef.event_id in (select id from events where events.event_group_id = #{event_group.id}) and ef.bib_number::text = rt.bib_number
+        left join efforts ef on ef.event_id in (select id from events where events.event_group_id = #{event_group.id}) and ef.bib_number = rt.matchable_bib_number
         where rt.event_group_id = #{event_group.id} and rt.parameterized_split_name = '#{parameterized_split_name}' and rt.bitkey = #{bitkey}
         group by ef.id, ef.first_name, ef.last_name, rt.bib_number, rt.sortable_bib_number),
   

--- a/app/view_models/effort_audit_view.rb
+++ b/app/view_models/effort_audit_view.rb
@@ -33,7 +33,7 @@ class EffortAuditView < EffortWithLapSplitRows
   def raw_times
     @raw_times ||=
       begin
-        result = event_group.raw_times.where(bib_number: effort.bib_number).with_relation_ids
+        result = event_group.raw_times.where(matchable_bib_number: effort.bib_number).with_relation_ids
         result.each { |rt| rt.lap ||= 1 }
         result
       end


### PR DESCRIPTION
In the Effort > Audit view, the Raw Times > Splits view, and the RawTime.search method, we are currently using `bib_number` instead of `matchable_bib_number`. This results in bib numbers having a `0` at the start not matching up with their counterpart efforts as expected.

This PR fixes these problems.