### PR TITLE
Handle cases where matchable bib number is nil

### DIFF
--- a/app/queries/event_group_query.rb
+++ b/app/queries/event_group_query.rb
@@ -70,7 +70,7 @@ class EventGroupQuery < BaseQuery
                                                     'created_by', rt.created_by)
                                   order by case when rt.absolute_time is null then rt.entered_time else to_char((rt.absolute_time at time zone 'UTC'), 'HH24:MI:SS') end) as raw_times_attributes
         from raw_times rt
-        left join efforts ef on ef.event_id in (select id from events where events.event_group_id = #{event_group.id}) and ef.bib_number = rt.matchable_bib_number
+        left join efforts ef on ef.event_id in (select id from events where events.event_group_id = #{event_group.id}) and ef.bib_number is not null and ef.bib_number = rt.matchable_bib_number
         where rt.event_group_id = #{event_group.id} and rt.parameterized_split_name = '#{parameterized_split_name}' and rt.bitkey = #{bitkey}
         group by ef.id, ef.first_name, ef.last_name, rt.bib_number, rt.sortable_bib_number),
   

--- a/app/view_models/effort_audit_view.rb
+++ b/app/view_models/effort_audit_view.rb
@@ -31,6 +31,8 @@ class EffortAuditView < EffortWithLapSplitRows
   private
 
   def raw_times
+    return [] unless effort.bib_number.present?
+
     @raw_times ||=
       begin
         result = event_group.raw_times.where(matchable_bib_number: effort.bib_number).with_relation_ids


### PR DESCRIPTION
When RawTime bib numbers contain non-numeric values (like `1*2`), the `matchable_bib_number` is `nil`. This PR tweaks a few searches to ensure we don't match those Raw Times having `nil` for `matchable_bib_number` with efforts having no bib number. 