### PR TITLE
Export to ITRA

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,6 +4,7 @@ class EventsController < ApplicationController
   after_action :verify_authorized, except: [:show, :spread, :summary, :podium, :series, :place, :analyze]
 
   MAX_SUMMARY_EFFORTS = 1000
+  FINISHERS_ONLY_EXPORT_FORMATS = [:finishers].freeze
 
   def show
     redirect_to :spread_event
@@ -138,37 +139,27 @@ class EventsController < ApplicationController
     end
   end
 
-  def export_finishers
+  def export
     authorize @event
     params[:per_page] = @event.efforts.size # Get all efforts without pagination
-    @presenter = EventWithEffortsPresenter.new(event: @event, params: prepared_params)
+    @presenter = ::EventWithEffortsPresenter.new(event: @event, params: prepared_params)
     respond_to do |format|
       format.csv do
         options = {}
-        export_format = :finishers
-        current_time = Time.current.in_time_zone(@event.home_time_zone)
-        records = @presenter.ranked_effort_rows.select(&:finished?)
-        csv_stream = render_to_string(partial: 'finishers.csv.ruby', locals: {current_time: current_time, records: records, options: options})
-        send_data(csv_stream, type: 'text/csv',
-                  filename: "#{@presenter.name}-#{export_format}-#{current_time.strftime('%Y-%m-%d-%H-%M-%S')}.csv")
-      end
-    end
-  end
+        options[:event_finished] = @presenter.event_finished?
 
-  def export_to_ultrasignup
-    authorize @event
-    params[:per_page] = @event.efforts.size # Get all efforts without pagination
-    @presenter = EventWithEffortsPresenter.new(event: @event, params: prepared_params)
-    respond_to do |format|
-      format.csv do
-        options = {}
-        export_format = :ultrasignup
+        export_format = params[:export_format].to_sym
         current_time = Time.current.in_time_zone(@event.home_time_zone)
         records = @presenter.ranked_effort_rows
-        options[:event_finished] = @presenter.event_finished?
-        csv_stream = render_to_string(partial: 'ultrasignup.csv.ruby', locals: {current_time: current_time, records: records, options: options})
-        send_data(csv_stream, type: 'text/csv',
-                  filename: "#{@presenter.name}-#{export_format}-#{current_time.strftime('%Y-%m-%d-%H-%M-%S')}.csv")
+        records = records.select(&:finished?) if export_format.in?(FINISHERS_ONLY_EXPORT_FORMATS)
+        filename = "#{@presenter.name}-#{export_format}-#{current_time.iso8601}.csv"
+
+        csv_stream = render_to_string(
+          partial: "#{export_format}.csv.ruby",
+          locals: {current_time: current_time, records: records, options: options}
+        )
+
+        send_data(csv_stream, type: 'text/csv', filename: filename)
       end
     end
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -154,8 +154,11 @@ class EventsController < ApplicationController
         records = records.select(&:finished?) if export_format.in?(FINISHERS_ONLY_EXPORT_FORMATS)
         filename = "#{@presenter.name}-#{export_format}-#{current_time.iso8601}.csv"
 
+        requested_export_template = "#{export_format}.csv.ruby"
+        requested_partial_name = Rails.root.join("app/views/events/_#{requested_export_template}")
+        partial = File.exists?(requested_partial_name) ? requested_export_template : "not_found.csv.ruby"
         csv_stream = render_to_string(
-          partial: "#{export_format}.csv.ruby",
+          partial: partial,
           locals: {current_time: current_time, records: records, options: options}
         )
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,7 +4,7 @@ class EventsController < ApplicationController
   after_action :verify_authorized, except: [:show, :spread, :summary, :podium, :series, :place, :analyze]
 
   MAX_SUMMARY_EFFORTS = 1000
-  FINISHERS_ONLY_EXPORT_FORMATS = [:finishers].freeze
+  FINISHERS_ONLY_EXPORT_FORMATS = [:finishers, :itra].freeze
 
   def show
     redirect_to :spread_event

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -284,6 +284,8 @@ module DropdownHelper
         {role: :separator},
         {name: 'Export Finishers List',
          link: export_event_path(event, format: :csv, export_format: :finishers)},
+        {name: 'Export to ITRA',
+         link: export_event_path(event, format: :csv, export_format: :itra)},
         {name: 'Export to Ultrasignup',
          link: export_event_path(event, format: :csv, export_format: :ultrasignup)}
     ]

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -283,9 +283,9 @@ module DropdownHelper
          visible: current_user.admin?},
         {role: :separator},
         {name: 'Export Finishers List',
-         link: export_finishers_event_path(event, format: :csv)},
+         link: export_event_path(event, format: :csv, export_format: :finishers)},
         {name: 'Export to Ultrasignup',
-         link: export_to_ultrasignup_event_path(event, format: :csv)}
+         link: export_event_path(event, format: :csv, export_format: :ultrasignup)}
     ]
     build_dropdown_menu('Actions', dropdown_items, button: true)
   end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -52,11 +52,7 @@ class EventPolicy < ApplicationPolicy
     user.authorized_fully?(event)
   end
 
-  def export_finishers?
-    user.authorized_to_edit?(event)
-  end
-
-  def export_to_ultrasignup?
+  def export?
     user.authorized_to_edit?(event)
   end
 

--- a/app/views/docs/visitors/_management_wind_up_3.html.erb
+++ b/app/views/docs/visitors/_management_wind_up_3.html.erb
@@ -1,11 +1,12 @@
 <div class="card">
   <h4 class="card-header">Exporting Data</h4>
   <div class="card-body">
-    <p>OpenSplitTime provides tools for exporting your results in three different formats.</p>
+    <p>OpenSplitTime provides tools for exporting your results in different formats, including:</p>
     <ul>
-      <li>Full Results</li>
-      <li>Finisher List</li>
-      <li>Ultrasignup Results</li>
+      <li>Full results</li>
+      <li>Finisher list</li>
+      <li>ITRA results format</li>
+      <li>Ultrasignup results format</li>
     </ul>
   </div>
 </div>
@@ -29,6 +30,16 @@
     <p>You can export a summary finisher list to a CSV file. Access the tool from the Settings page
       (<strong>Admin > Settings > Actions > Export Finisher List</strong>).</p>
     <p>This export option is available at any time during or after the Event.</p>
+  </div>
+</div>
+<br/>
+
+<div class="card">
+  <h4 class="card-header">Exporting ITRA Results</h4>
+  <div class="card-body">
+    <p>You can export results to ITRA format. Access the tool from the Settings page
+      (<strong>Admin > Settings > Actions > Export ITRA</strong>).</p>
+    <p>This export option is available at any time during or after the Event, but it includes only finished runners.</p>
   </div>
 </div>
 <br/>

--- a/app/views/events/_itra.csv.ruby
+++ b/app/views/events/_itra.csv.ruby
@@ -1,0 +1,31 @@
+if records.present?
+    CSV.generate do |csv|
+        csv << [
+                 "Ranking",
+                 "Time",
+                 "Last name",
+                 "First name",
+                 "Birthdate",
+                 "Gender",
+                 "Nationality",
+                 "City",
+                 "Bib number"
+               ]
+
+        records.each do |record|
+            csv << [
+                     record.overall_rank,
+                     record.final_elapsed_seconds && time_format_hhmmss(record.final_elapsed_seconds),
+                     record.last_name,
+                     record.first_name,
+                     record.birthdate&.strftime("%F"),
+                     record.gender,
+                     record.country_code,
+                     record.city,
+                     record.bib_number
+                   ]
+        end
+    end
+else
+    'No entrants have finished.'
+end

--- a/app/views/events/_not_found.csv.ruby
+++ b/app/views/events/_not_found.csv.ruby
@@ -1,0 +1,1 @@
+"Unknown export format."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,8 +120,7 @@ Rails.application.routes.draw do
     member do
       get :admin
       get :edit_start_time
-      get :export_finishers
-      get :export_to_ultrasignup
+      get :export
       get :podium
       get :spread
       get :summary


### PR DESCRIPTION
Currently we have two export formats for runner results, each of which has its own separate route and controller action. 

This MR consolidates these into a single route and action. It also adds the ability to export to ITRA format.

Addresses #517 