### PR TITLE
Get Devise working with Turbo

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -11,7 +11,7 @@
 <article class="ost-article container">
   <div class="row justify-content-center">
     <div class="col col-login">
-      <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+      <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: {method: :post, data: {turbo: false}}) do |f| %>
         <%= bootstrap_devise_error_messages! %>
 
         <div class="form-group">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -11,7 +11,7 @@
 <article class="ost-article container">
   <div class="row justify-content-center">
     <div class="col col-login">
-      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: {method: :post, data: {turbo: false}}) do |f| %>
         <%= bootstrap_devise_error_messages! %>
 
         <div class="form-group">

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {data: {turbo: false}}) do |f| %>
   <%= bootstrap_devise_error_messages! %>
 
   <div class="form-group required">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -15,7 +15,7 @@
 <article class="ost-article container">
   <div class="row justify-content-center">
     <div class="col col-login">
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put}) do |f| %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {method: :put, data: {turbo: false}}) do |f| %>
         <%= bootstrap_devise_error_messages! %>
 
         <div class="form-row required">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -15,14 +15,19 @@
 <article class="ost-article container">
   <div class="row justify-content-center">
     <div class="col col-login">
-      <%= link_to(fab_icon("facebook-square", text: " Sign up with Facebook"),
-                  user_facebook_omniauth_authorize_path,
-                  method: :post,
-                  class: "btn btn-facebook btn-block") %>
-      <%= link_to(fab_icon("google", text: " Sign up with Google"),
-                  user_google_oauth2_omniauth_authorize_path,
-                  method: :post,
-                  class: "btn btn-google btn-block") %>
+      <%= button_to(user_facebook_omniauth_authorize_path,
+                    method: :post,
+                    form: {data: {turbo: false}},
+                    class: "btn btn-facebook btn-block") do %>
+        <%= fab_icon("facebook-square", text: " Sign up with Facebook") %>
+      <% end %>
+      <br/>
+      <%= button_to(user_google_oauth2_omniauth_authorize_path,
+                    method: :post,
+                    form: {data: {turbo: false}},
+                    class: "btn btn-google btn-block") do %>
+        <%= fab_icon("google", text: " Sign up with Google") %>
+      <% end %>
       <hr class="hr-text" data-content="or">
       <p class="text-center">Sign up with your Email</p>
       <%= render "devise/registrations/form" %>

--- a/app/views/devise/sessions/_new.html.erb
+++ b/app/views/devise/sessions/_new.html.erb
@@ -17,18 +17,21 @@
         </div>
         <div class="row justify-content-center">
           <div class="col col-login">
-            <%= link_to(fab_icon("facebook-square", text: " Log in with Facebook"),
-                        user_facebook_omniauth_authorize_path,
-                        method: :post,
-                        id: "facebook-log-in-button",
-                        class: "btn btn-facebook btn-block",
-                        data: {turbo: false}) %>
-            <%= link_to(fab_icon("google", text: " Log in with Google"),
-                        user_google_oauth2_omniauth_authorize_path,
-                        method: :post,
-                        id: "google-log-in-button",
-                        class: "btn btn-google btn-block",
-                        data: {turbo: false}) %>
+            <%= button_to(user_facebook_omniauth_authorize_path,
+                          method: :post,
+                          id: "facebook-log-in-button",
+                          form: {data: {turbo: false}},
+                          class: "btn btn-facebook btn-block") do %>
+              <%= fab_icon("facebook-square", text: " Log in with Facebook") %>
+            <% end %>
+            <br/>
+            <%= button_to(user_google_oauth2_omniauth_authorize_path,
+                          method: :post,
+                          id: "google-log-in-button",
+                          form: {data: {turbo: false}},
+                          class: "btn btn-google btn-block") do %>
+              <%= fab_icon("google", text: " Log in with Google") %>
+            <% end %>
             <hr class="hr-text" data-content="or">
             <p class="text-center">Log in with Email</p>
             <%= render 'devise/sessions/form', modal: true %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -18,10 +18,4 @@
   <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
     <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
   <% end -%>
-
-  <%- if devise_mapping.omniauthable? %>
-    <%- resource_class.omniauth_providers.each do |provider| %>
-      <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %><br />
-    <% end -%>
-  <% end -%>
 </div>

--- a/spec/system/user_logs_in_with_modal_facebook_spec.rb
+++ b/spec/system/user_logs_in_with_modal_facebook_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "User logs in with modal facebook", js: true do
     end
 
     within("#log-in-modal") do
-      click_link "facebook-log-in-button"
+      click_button "facebook-log-in-button"
     end
   end
 

--- a/spec/system/user_logs_in_with_modal_google_spec.rb
+++ b/spec/system/user_logs_in_with_modal_google_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "User logs in with modal google", js: true do
     end
 
     within("#log-in-modal") do
-      click_link "google-log-in-button"
+      click_button "google-log-in-button"
     end
   end
 


### PR DESCRIPTION
Devise doesn't play nicely with Turbo, so we need to disable it on Devise forms.

This fixes most problems but we still can't edit user information or change passwords.

Addresses a portion of #523 