### PR TITLE
Remove extraneous `method: :get` from the spreadsheet export button

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -26,7 +26,7 @@ module EventsHelper
     if current_user&.authorized_to_edit?(view_object.event) && view_object.event_finished?
       link_to 'Export spreadsheet',
               spread_event_path(view_object.event, format: :csv, display_style: view_object.display_style, sort: view_object.sort_hash),
-              method: :get, class: 'btn btn-md btn-success'
+              class: 'btn btn-md btn-success'
     end
   end
 


### PR DESCRIPTION
For some reason putting a `method: :get` attribute on a link triggers Turbo to intercept the call and results (in this case) in a JavaScript error ("Failed to load resource: Frame load interrupted"). This results in the bug described in #526. 

This PR removes `method: :get`, which fixes the bug.