### PR TITLE
Don't check for spambot on update

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,7 +2,7 @@
 
 module Users
   class RegistrationsController < Devise::RegistrationsController
-    before_action :protect_from_spam, only: [:create, :update]
+    before_action :protect_from_spam, only: [:create]
 
     BOT_FORM_FILL_DURATION_LIMIT = 10.seconds
 


### PR DESCRIPTION
The `protect_from_spam` logic is causing user updates to silently break.

This PR removes `protect_from_spam` from `#update` so that it now applies only to `#create`, which is all that is needed for spam protection in any case.