### PR TITLE
New Donate button for Paypal

### DIFF
--- a/app/views/visitors/donations.html.erb
+++ b/app/views/visitors/donations.html.erb
@@ -20,10 +20,10 @@
     donate Bitcoin, click <%= link_to 'here', bitcoin_donations_path %>.)
   </p>
   <hr>
-  <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-    <input type="hidden" name="cmd" value="_s-xclick">
-    <input type="hidden" name="hosted_button_id" value="EF926DS8KX3CU">
-    <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-    <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+
+  <form action="https://www.paypal.com/donate" method="post" target="_top" data-turbo="false">
+    <input type="hidden" name="hosted_button_id" value="XZHPAF5S95AFE" />
+    <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" />
+    <img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />
   </form>
 </article>


### PR DESCRIPTION
Someone pointed out this afternoon that the PayPal Donate button is broken. Looks like another Turbo problem.

This MR uses a new button (to make sure we have all the most modern PayPal things) and disables Turbo for the submission.