### PR TITLE
Trim time attribute concern and apply to effort and event

### DIFF
--- a/app/models/concerns/trim_time_attributes.rb
+++ b/app/models/concerns/trim_time_attributes.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Used for models with one or more datetime attributes
+# that need to be trimmed to integer seconds.
+
+module TrimTimeAttributes
+  extend ::ActiveSupport::Concern
+
+  included do
+    before_validation :trim_time_attributes
+    class_attribute :trimmable_time_attribute_names
+    self.trimmable_time_attribute_names = []
+  end
+
+  module ClassMethods
+    def trim_time_attributes(*attributes)
+      attributes.each(&method(:trim_time_attribute))
+    end
+
+    def trim_time_attribute(attribute)
+      self.trimmable_time_attribute_names << attribute.to_s
+    end
+  end
+
+  private
+
+  def trim_time_attributes
+    trimmable_time_attributes = attributes.slice(*self.trimmable_time_attribute_names)
+
+    trimmable_time_attributes.each do |attr, value|
+      if value.present?
+        new_value = ::Time.zone.at(value.to_i)
+        self.send("#{attr}=", new_value) if new_value != value
+      end
+    end
+
+    # Don't cancel later callbacks
+    true
+  end
+end

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -9,13 +9,14 @@ class Effort < ApplicationRecord
 
   include Auditable, CapitalizeAttributes, DataStatusMethods, Delegable, DelegatedConcealable,
           GuaranteedFindable, LapsRequiredMethods, PersonalInfo, Searchable, StateCountrySyncable,
-          Subscribable, TimeZonable, Matchable, UrlAccessible
+          Subscribable, TimeZonable, TrimTimeAttributes, Matchable, UrlAccessible
   extend FriendlyId
 
   strip_attributes collapse_spaces: true
   strip_attributes only: [:phone, :emergency_phone], regex: /[^0-9|+]/
   capitalize_attributes :first_name, :last_name, :city, :emergency_contact
   friendly_id :slug_candidates, use: [:slugged, :history]
+  trim_time_attributes :scheduled_start_time
   zonable_attributes :actual_start_time, :scheduled_start_time, :event_start_time, :calculated_start_time, :assumed_start_time
   has_paper_trail
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
-  include Auditable, Delegable, DelegatedConcealable, SplitMethods, LapsRequiredMethods, Reconcilable, TimeZonable, UrlAccessible
+  include Auditable, Delegable, DelegatedConcealable, SplitMethods, LapsRequiredMethods, Reconcilable,
+          TimeZonable, TrimTimeAttributes, UrlAccessible
   extend FriendlyId
 
   strip_attributes collapse_spaces: true
   friendly_id :name, use: [:slugged, :history]
+  trim_time_attributes :scheduled_start_time
   zonable_attributes :scheduled_start_time
   has_paper_trail
 

--- a/spec/models/effort_spec.rb
+++ b/spec/models/effort_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Effort, type: :model do
   it { is_expected.to strip_attribute(:state_code).collapse_spaces }
   it { is_expected.to strip_attribute(:country_code).collapse_spaces }
   it { is_expected.to localize_time_attribute(:scheduled_start_time) }
+  it { is_expected.to trim_time_attribute(:scheduled_start_time) }
 
   describe 'validations' do
     context 'for validations independent of existing database records' do
@@ -617,6 +618,36 @@ RSpec.describe Effort, type: :model do
 
       it 'returns false' do
         expect(effort.send(:generate_new_topic_resource?)).to eq(false)
+      end
+    end
+  end
+
+  describe "#trim_scheduled_start_time" do
+    subject(:effort) { efforts(:sum_100k_un_started) }
+    let(:scheduled_start_time) { nil }
+
+    before do
+      effort.scheduled_start_time = scheduled_start_time
+      effort.validate
+    end
+
+    context "when scheduled_start_time is nil" do
+      it "does not change scheduled start time" do
+        expect(effort.scheduled_start_time).to be_nil
+      end
+    end
+
+    context "when scheduled_start_time has no partial seconds" do
+      let(:scheduled_start_time) { "2020-08-01 13:30:30" }
+      it "does not change scheduled start time" do
+        expect(effort.scheduled_start_time).to eq(scheduled_start_time)
+      end
+    end
+
+    context "when scheduled_start_time has partial seconds" do
+      let(:scheduled_start_time) { "2020-08-01 13:30:30.5" }
+      it "does not change scheduled start time" do
+        expect(effort.scheduled_start_time).to eq("2020-08-01 13:30:30")
       end
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Event, type: :model do
   it_behaves_like 'auditable'
   it { is_expected.to strip_attribute(:short_name).collapse_spaces }
   it { is_expected.to localize_time_attribute(:scheduled_start_time) }
+  it { is_expected.to trim_time_attribute(:scheduled_start_time) }
 
   describe 'initialize' do
     it 'is valid when created with a course, organization, event_group, scheduled start time, laps_required' do

--- a/spec/support/matchers/trim_time_attribute.rb
+++ b/spec/support/matchers/trim_time_attribute.rb
@@ -1,0 +1,10 @@
+RSpec::Matchers.define :trim_time_attribute do |attribute|
+  match do |record|
+    time_with_decimal = "2021-08-01 13:30:30.5"
+    time_without_decimal = "2021-08-01 13:30:30"
+    record.assign_attributes(attribute => time_with_decimal)
+    record.validate
+
+    record.send(attribute) == time_without_decimal
+  end
+end


### PR DESCRIPTION
This MR adds a TrimTimeAttribute concern and applies it to `scheduled_start_time` for efforts and events. This ensures we have just integer seconds in both of these fields.

Addresses #538 