### PR TITLE
Rake task to delete orphaned people from the database

### DIFF
--- a/lib/tasks/maintenance/delete_orphaned_people.rake
+++ b/lib/tasks/maintenance/delete_orphaned_people.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :maintenance do
+  desc "Deletes people who have no efforts"
+  task :delete_orphaned_people => :environment do
+    puts "Attempting to delete all orphaned person records from the database"
+
+    orphaned_people = ::Person.left_joins(:efforts).where(efforts: {person_id: nil})
+    orphan_count = orphaned_people.count
+
+    puts "Found #{orphan_count} orphaned people"
+
+    progress_bar = ::ProgressBar.new(orphan_count)
+
+    orphaned_people.find_each do |person|
+      progress_bar.increment!
+      person.destroy
+    rescue ActiveRecordError => e
+      puts "Could not destroy person #{person.id}:"
+      puts e
+    end
+  end
+end


### PR DESCRIPTION
We have 2100+ person records in the database having no associated efforts. 

This PR introduces a rake task to delete those records.