### PR TITLE
Alpha 3 country codes for ITRA export

### DIFF
--- a/app/view_models/effort_row.rb
+++ b/app/view_models/effort_row.rb
@@ -5,6 +5,12 @@ class EffortRow < SimpleDelegator
 
   ULTRASIGNUP_STATUS_TABLE = {'Finished' => 1, 'Dropped' => 2, 'Not Started' => 3}
 
+  def country_code_alpha_3
+    return nil unless country_code.present?
+
+    Carmen::Country.coded(country_code).alpha_3_code
+  end
+
   def final_lap_split_name
     multiple_laps? ? "#{final_split_name} Lap #{final_lap}" : final_split_name
   end

--- a/app/view_models/effort_row.rb
+++ b/app/view_models/effort_row.rb
@@ -8,7 +8,7 @@ class EffortRow < SimpleDelegator
   def country_code_alpha_3
     return nil unless country_code.present?
 
-    Carmen::Country.coded(country_code).alpha_3_code
+    Carmen::Country.coded(country_code)&.alpha_3_code
   end
 
   def final_lap_split_name

--- a/app/views/events/_itra.csv.ruby
+++ b/app/views/events/_itra.csv.ruby
@@ -20,7 +20,7 @@ if records.present?
                      record.first_name,
                      record.birthdate&.strftime("%F"),
                      record.gender,
-                     record.country_code,
+                     record.country_code_alpha_3,
                      record.city,
                      record.bib_number
                    ]

--- a/spec/models/effort_row_spec.rb
+++ b/spec/models/effort_row_spec.rb
@@ -3,27 +3,33 @@
 require 'rails_helper'
 
 RSpec.describe EffortRow, type: :model do
-  let(:test_effort) { build_stubbed(:effort, state_code: 'CA', country_code: country_code, age: 30) }
+  subject { described_class.new(test_effort) }
+
+  let(:test_effort) { build_stubbed(:effort, state_code: "CA", country_code: country_code, age: 30) }
   let(:test_person) { build_stubbed(:person) }
   let(:country_code) { "US" }
 
-  describe '#initializate' do
-    it 'instantiates an EffortRow if provided an effort' do
+  before do
+    allow(test_effort).to receive(:finished?).and_return(false)
+    allow(test_effort).to receive(:dropped?).and_return(false)
+    allow(test_effort).to receive(:in_progress?).and_return(false)
+  end
+
+  describe "#initializate" do
+    it "instantiates an EffortRow if provided an effort" do
       expect { EffortRow.new(test_effort) }.not_to raise_error
     end
   end
 
-  describe 'effort_attributes' do
-    subject { EffortRow.new(test_effort) }
-
-    it 'returns delegated effort attributes' do
+  describe "effort_attributes" do
+    it "returns delegated effort attributes" do
       expect(subject.first_name).to eq(test_effort.first_name)
       expect(subject.last_name).to eq(test_effort.last_name)
       expect(subject.gender).to eq(test_effort.gender)
       expect(subject.state_code).to eq(test_effort.state_code)
     end
 
-    it 'returns attributes from PersonalInfo module' do
+    it "returns attributes from PersonalInfo module" do
       expect(subject.full_name).to eq(test_effort.full_name)
       expect(subject.bio_historic).to eq(test_effort.bio_historic)
       expect(subject.state_and_country).to eq(test_effort.state_and_country)
@@ -31,8 +37,8 @@ RSpec.describe EffortRow, type: :model do
   end
 
   describe "#country_code_alpha_3" do
-    subject { EffortRow.new(test_effort) }
     let(:result) { subject.country_code_alpha_3 }
+
     context "when country code is nil" do
       let(:country_code) { nil }
       it "returns nil" do
@@ -46,55 +52,72 @@ RSpec.describe EffortRow, type: :model do
         expect(result).to eq("USA")
       end
     end
-  end
 
-  describe '#effort_status' do
-    subject { EffortRow.new(test_effort) }
-    it 'returns "Finished" when the run is finished' do
-      allow(test_effort).to receive(:finished?).and_return(true)
-      expect(subject.effort_status).to eq('Finished')
-    end
-
-    it 'returns "Dropped" when the run is dropped' do
-      allow(test_effort).to receive(:dropped?).and_return(true)
-      expect(subject.effort_status).to eq('Dropped')
-    end
-
-    it 'returns "In Progress" when the run is in progress' do
-      allow(test_effort).to receive(:in_progress?).and_return(true)
-      expect(subject.effort_status).to eq('In Progress')
-    end
-
-    it 'returns "Not Started" when the run is neither finished nor dropped nor in progress' do
-      allow(test_effort).to receive(:finished?).and_return(false)
-      allow(test_effort).to receive(:dropped?).and_return(false)
-      allow(test_effort).to receive(:in_progress?).and_return(false)
-      expect(subject.effort_status).to eq('Not Started')
+    context "when country code is invalid" do
+      let(:country_code) { "XX" }
+      it "returns nil" do
+        expect(result).to be_nil
+      end
     end
   end
 
-  describe '#ultrasignup_finish_status' do
-    subject { EffortRow.new(test_effort) }
-    it 'returns 1 when the run is finished' do
-      allow(test_effort).to receive(:finished?).and_return(true)
-      expect(subject.ultrasignup_finish_status).to eq(1)
+  describe "#effort_status" do
+    context "when the run is neither finished nor dropped nor in progress" do
+      it "returns 'Not Started'" do
+        expect(subject.effort_status).to eq("Not Started")
+      end
     end
 
-    it 'returns 2 when the run is dropped' do
-      allow(test_effort).to receive(:dropped?).and_return(true)
-      expect(subject.ultrasignup_finish_status).to eq(2)
+    context "when the run is finished" do
+      before { allow(test_effort).to receive(:finished?).and_return(true) }
+      it "returns 'Finished'" do
+        expect(subject.effort_status).to eq("Finished")
+      end
     end
 
-    it 'returns a warning message when the run is in progress' do
-      allow(test_effort).to receive(:in_progress?).and_return(true)
-      expect(subject.ultrasignup_finish_status).to match(/is in progress/)
+    context "when the run is dropped" do
+      before { allow(test_effort).to receive(:dropped?).and_return(true) }
+      it "returns 'Dropped'" do
+        expect(subject.effort_status).to eq("Dropped")
+      end
     end
 
-    it 'returns 3 when the run is neither finished nor dropped nor in progress' do
-      allow(test_effort).to receive(:finished?).and_return(false)
-      allow(test_effort).to receive(:dropped?).and_return(false)
-      allow(test_effort).to receive(:in_progress?).and_return(false)
-      expect(subject.ultrasignup_finish_status).to eq(3)
+    context "when the run is in progress" do
+      before { allow(test_effort).to receive(:in_progress?).and_return(true) }
+      it "returns 'In Progress'" do
+        expect(subject.effort_status).to eq("In Progress")
+      end
+    end
+  end
+
+  describe "#ultrasignup_finish_status" do
+    let(:result) { subject.ultrasignup_finish_status }
+
+    context "when the run is neither finished nor dropped nor in progress" do
+      it "returns 3" do
+        expect(result).to eq(3)
+      end
+    end
+
+    context "when the run is finished" do
+      before { allow(test_effort).to receive(:finished?).and_return(true) }
+      it "returns 1" do
+        expect(result).to eq(1)
+      end
+    end
+
+    context "when the run is dropped" do
+      before { allow(test_effort).to receive(:dropped?).and_return(true) }
+      it "returns 2" do
+        expect(result).to eq(2)
+      end
+    end
+
+    context "when a run is in progress" do
+      before { allow(test_effort).to receive(:in_progress?).and_return(true) }
+      it "returns a warning message" do
+        expect(result).to match(/is in progress/)
+      end
     end
   end
 end

--- a/spec/models/effort_row_spec.rb
+++ b/spec/models/effort_row_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe EffortRow, type: :model do
-  let (:test_effort) { build_stubbed(:effort, state_code: 'CA', country_code: 'US', age: 30) }
-  let (:test_person) { build_stubbed(:person) }
+  let(:test_effort) { build_stubbed(:effort, state_code: 'CA', country_code: country_code, age: 30) }
+  let(:test_person) { build_stubbed(:person) }
+  let(:country_code) { "US" }
 
   describe '#initializate' do
     it 'instantiates an EffortRow if provided an effort' do
@@ -26,6 +27,24 @@ RSpec.describe EffortRow, type: :model do
       expect(subject.full_name).to eq(test_effort.full_name)
       expect(subject.bio_historic).to eq(test_effort.bio_historic)
       expect(subject.state_and_country).to eq(test_effort.state_and_country)
+    end
+  end
+
+  describe "#country_code_alpha_3" do
+    subject { EffortRow.new(test_effort) }
+    let(:result) { subject.country_code_alpha_3 }
+    context "when country code is nil" do
+      let(:country_code) { nil }
+      it "returns nil" do
+        expect(result).to be_nil
+      end
+    end
+
+    context "when country code is valid" do
+      let(:country_code) { "US" }
+      it "returns the three-letter equivalent code" do
+        expect(result).to eq("USA")
+      end
     end
   end
 


### PR DESCRIPTION
ITRA (now UTMB) requires 3-letter alpha codes for countries. 

This PR changes the existing 2-letter country codes to 3-letter codes for ITRA export.