### PR TITLE
Fix Split parameters to permit arrays where appropriate

### DIFF
--- a/app/controllers/concerns/prepared_params.rb
+++ b/app/controllers/concerns/prepared_params.rb
@@ -6,7 +6,7 @@ class PreparedParams
 
   def initialize(params, permitted, permitted_query = nil)
     @params = params
-    @permitted = (permitted || []).map(&:to_s)
+    @permitted = (permitted || []).map { |attr| attr.is_a?(Symbol) ? attr.to_s : attr }
     @permitted_query = (permitted_query || @permitted).map(&:to_s)
   end
 

--- a/app/parameters/split_parameters.rb
+++ b/app/parameters/split_parameters.rb
@@ -3,10 +3,30 @@
 class SplitParameters < BaseParameters
 
   def self.permitted
-    [:id, :course_id, :split_id, :distance_from_start, :distance, :distance_in_preferred_units,
-     :vert_gain_from_start, :vert_gain, :vert_gain_in_preferred_units, :vert_loss_from_start, :vert_loss,
-     :vert_loss_in_preferred_units, :kind, :base_name, :description, :sub_split_bitmap, :latitude, :longitude,
-     :elevation, :elevation_in_preferred_units, :name_extensions, :sub_split_kinds]
+    [
+      :id,
+      :course_id,
+      :split_id,
+      :distance_from_start,
+      :distance,
+      :distance_in_preferred_units,
+      :vert_gain_from_start,
+      :vert_gain,
+      :vert_gain_in_preferred_units,
+      :vert_loss_from_start,
+      :vert_loss,
+      :vert_loss_in_preferred_units,
+      :kind,
+      :base_name,
+      :description,
+      :sub_split_bitmap,
+      :latitude,
+      :longitude,
+      :elevation,
+      :elevation_in_preferred_units,
+      {:name_extensions => []},
+      {:sub_split_kinds => []},
+    ]
   end
 
   def self.csv_export_attributes


### PR DESCRIPTION
The existing `name_extensions` param is being ignored because it does not specify that an array is permitted. 

This PR permits that attribute as an array, and it modifies `PreparedParams` so that the Hash values like `{:name_extensions => []}` are not converted to strings.