### PR TITLE
Touch related events when split is updated (to bust spread cache)

### DIFF
--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -18,6 +18,7 @@ class Split < ApplicationRecord
   delegate :organization, :stewards, to: :course
 
   before_validation :parameterize_base_name
+  after_commit :touch_all_events
 
   validates_presence_of :base_name, :distance_from_start, :sub_split_bitmap, :kind
   validates :kind, inclusion: {in: Split.kinds.keys}
@@ -168,5 +169,9 @@ class Split < ApplicationRecord
 
   def parameterize_base_name
     self.parameterized_base_name = base_name&.parameterize
+  end
+
+  def touch_all_events
+    events.touch_all
   end
 end


### PR DESCRIPTION
Currently, when a split is updated, we don't see the results of the update in the spread view, because the view is cached and the event hasn't been updated.

This PR adds a callback that touches all related events when a split is updated.

Related to #552