### PR TITLE
Allow for stewardships to have a lottery_manager level

### DIFF
--- a/app/controllers/stewardships_controller.rb
+++ b/app/controllers/stewardships_controller.rb
@@ -1,5 +1,6 @@
 class StewardshipsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_stewardship, only: [:update, :destroy]
   after_action :verify_authorized
 
   def create
@@ -22,8 +23,17 @@ class StewardshipsController < ApplicationController
     redirect_to organization_path(organization, display_style: :stewards)
   end
 
+  def update
+    authorize @stewardship
+
+    if @stewardship.update(permitted_params)
+      redirect_to organization_path(@stewardship.organization, display_style: :stewards), notice: "Stewardship updated."
+    else
+      redirect_to organization_path(@stewardship.organization, display_style: :stewards), alert: "Unable to update stewardship."
+    end
+  end
+
   def destroy
-    @stewardship = Stewardship.find(params[:id])
     authorize @stewardship
 
     if @stewardship.destroy
@@ -33,5 +43,11 @@ class StewardshipsController < ApplicationController
     end
 
     redirect_to organization_path(@stewardship.organization, display_style: :stewards)
+  end
+
+  private
+
+  def set_stewardship
+    @stewardship = Stewardship.find(params[:id])
   end
 end

--- a/app/models/stewardship.rb
+++ b/app/models/stewardship.rb
@@ -5,7 +5,7 @@ class Stewardship < ApplicationRecord
 
   belongs_to :user
   belongs_to :organization
-  enum level: [:volunteer, :manager, :owner]
+  enum level: [:volunteer, :lottery_manager]
 
   delegate :full_name, :email, to: :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,7 +94,7 @@ class User < ApplicationRecord
   end
 
   def authorized_for_lotteries?(resource)
-    authorized_fully?(resource)
+    admin? || owner_of?(resource) || lottery_steward_of?(resource)
   end
 
   def authorized_fully?(resource)
@@ -112,6 +112,12 @@ class User < ApplicationRecord
 
   def authorized_to_edit_personal?(effort)
     admin? || (effort.person ? (avatar == effort.person) : authorized_to_edit?(effort))
+  end
+
+  def lottery_steward_of?(resource)
+    return false unless resource.respond_to?(:stewards)
+
+    resource.stewards.where(stewardships: {level: :lottery_manager}).include?(self)
   end
 
   def owner_of?(resource)

--- a/app/parameters/stewardship_parameters.rb
+++ b/app/parameters/stewardship_parameters.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class StewardshipParameters < BaseParameters
+  def self.permitted
+    [
+      :level,
+    ]
+  end
+end

--- a/app/views/organizations/_stewards_list.html.erb
+++ b/app/views/organizations/_stewards_list.html.erb
@@ -4,6 +4,7 @@
     <th>Name</th>
     <th>Email</th>
     <th>Steward since</th>
+    <th>Level</th>
     <th></th>
   </tr>
   </thead>
@@ -13,6 +14,12 @@
         <td><%= stewardship.full_name %></td>
         <td><%= stewardship.email %></td>
         <td><%= l(stewardship.created_at, format: :full_with_weekday) %></td>
+        <td>
+          <%= form_for(stewardship) do |f| %>
+            <%= f.select(:level, Stewardship.levels.keys.map { |level| [level.titleize, level] }, {}, class: "dropdown-select-field") %>
+            <%= f.submit 'Confirm', :class => 'btn btn-primary' %>
+          <% end %>
+        </td>
         <td>
           <%= link_to "Remove",
                       stewardship_path(stewardship),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,7 +157,7 @@ Rails.application.routes.draw do
 
   resources :split_times, only: [:update]
   resources :splits
-  resources :stewardships, only: [:create, :destroy]
+  resources :stewardships, only: [:create, :update, :destroy]
   resources :subscriptions, only: [:create, :destroy]
 
   get '/sitemap.xml.gz', to: redirect("https://#{ENV['S3_BUCKET']}.s3.amazonaws.com/sitemaps/sitemap.xml.gz"), as: :sitemap


### PR DESCRIPTION
We need to have someone other than an owner who can conduct a lottery, but we don't want this open to all stewards. 

This PR adds a `lottery_manager` level to Stewardship and adds UI to allow the organization owner to set that level.

Part of #556