### PR TITLE
Lottery divisions controller

### DIFF
--- a/app/controllers/lotteries_controller.rb
+++ b/app/controllers/lotteries_controller.rb
@@ -109,7 +109,7 @@ class LotteriesController < ApplicationController
   private
 
   def set_lottery
-    @lottery = policy_scope(Lottery).friendly.find(params[:id])
+    @lottery = policy_scope(@organization.lotteries).friendly.find(params[:id])
   end
 
   def set_organization

--- a/app/controllers/lotteries_controller.rb
+++ b/app/controllers/lotteries_controller.rb
@@ -109,7 +109,7 @@ class LotteriesController < ApplicationController
   private
 
   def set_lottery
-    @lottery = policy_scope(Lottery).friendly.find(params[:lottery_id])
+    @lottery = policy_scope(Lottery).friendly.find(params[:id])
   end
 
   def set_organization

--- a/app/controllers/lotteries_controller.rb
+++ b/app/controllers/lotteries_controller.rb
@@ -94,13 +94,33 @@ class LotteriesController < ApplicationController
     redirect_to setup_organization_lottery_path(@organization, @lottery)
   end
 
+  def generate_entrants
+    authorize @lottery
+
+    if @lottery.divisions.present?
+      if @lottery.generate_entrants!
+        flash[:success] = "Generated lottery entrants"
+      else
+        flash[:danger] = "Unable to generate lottery entrants"
+      end
+    else
+      flash[:danger] = "Add at least one division first"
+    end
+
+    redirect_to setup_organization_lottery_path(@organization, @lottery)
+  end
+
   def generate_tickets
     authorize @lottery
 
-    if @lottery.delete_and_insert_tickets!
-      flash[:success] = "Generated lottery tickets"
+    if @lottery.entrants.present?
+      if @lottery.delete_and_insert_tickets!
+        flash[:success] = "Generated lottery tickets"
+      else
+        flash[:danger] = "Unable to generate lottery tickets"
+      end
     else
-      flash[:danger] = "Unable to generate lottery tickets"
+      flash[:danger] = "You need to add entrants first"
     end
 
     redirect_to setup_organization_lottery_path(@organization, @lottery)

--- a/app/controllers/lottery_divisions_controller.rb
+++ b/app/controllers/lottery_divisions_controller.rb
@@ -40,10 +40,13 @@ class LotteryDivisionsController < ApplicationController
   def destroy
     authorize @lottery_division
 
-    if @lottery_division.destroy
+    if @lottery_division.tickets.present?
+      flash[:warning] = "A lottery division cannot be deleted unless all tickets and draws have been deleted first."
+      redirect_to setup_organization_lottery_path(@organization, @lottery)
+    elsif @lottery_division.destroy
       redirect_to setup_organization_lottery_path(@organization, @lottery)
     else
-      flash[:danger] = @lottery.errors.full_messages.join("\n")
+      flash[:danger] = @lottery_division.errors.full_messages.join("\n")
       redirect_to setup_organization_lottery_path(@organization, @lottery)
     end
   end

--- a/app/controllers/lottery_divisions_controller.rb
+++ b/app/controllers/lottery_divisions_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class LotteryDivisionsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_organization
+  before_action :set_lottery
+  before_action :set_lottery_division, except: [:new, :create]
+  after_action :verify_authorized
+
+  def new
+    @lottery_division = @lottery.divisions.new
+    authorize @lottery_division
+  end
+
+  def edit
+    authorize @lottery
+  end
+
+  def create
+    @lottery_division = @lottery.divisions.new(permitted_params)
+    authorize @lottery_division
+
+    if @lottery_division.save
+      redirect_to setup_organization_lottery_path(@organization, @lottery)
+    else
+      render "new"
+    end
+  end
+
+  def update
+    authorize @lottery_division
+
+    if @lottery_division.update(permitted_params)
+      redirect_to setup_organization_lottery_path(@organization, @lottery)
+    else
+      render "edit"
+    end
+  end
+
+  def destroy
+    authorize @lottery_division
+
+    if @lottery_division.destroy
+      redirect_to setup_organization_lottery_path(@organization, @lottery)
+    else
+      flash[:danger] = @lottery.errors.full_messages.join("\n")
+      redirect_to setup_organization_lottery_path(@organization, @lottery)
+    end
+  end
+
+  private
+
+  def set_lottery
+    @lottery = policy_scope(@organization.lotteries).friendly.find(params[:lottery_id])
+  end
+
+  def set_lottery_division
+    @lottery_division = policy_scope(@lottery.divisions).find(params[:id])
+  end
+
+  def set_organization
+    @organization = policy_scope(Organization).friendly.find(params[:organization_id])
+  end
+end

--- a/app/helpers/lottery_helper.rb
+++ b/app/helpers/lottery_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module LotteryHelper
+  def link_to_division_delete(division)
+    url = organization_lottery_lottery_division_path(division.organization, division.lottery, division)
+    tooltip = "Delete this division"
+    options = {method: :delete,
+               data: {confirm: "This will delete the division, together with all related entrants. Are you sure you want to proceed?",
+                      turbo: false,
+                      toggle: :tooltip,
+                      placement: :bottom,
+                      "original-title" => tooltip},
+               class: "btn btn-danger btn-sm has-tooltip"}
+    link_to fa_icon("trash"), url, options
+  end
+
+  def link_to_division_edit(division)
+    url = edit_organization_lottery_lottery_division_path(division.organization, division.lottery, division)
+    tooltip = "Edit this division"
+    options = {data: {toggle: :tooltip,
+                      placement: :bottom,
+                      "original-title" => tooltip},
+               class: "btn btn-primary btn-sm has-tooltip"}
+    link_to fa_icon("pencil-alt"), url, options
+  end
+end

--- a/app/models/lottery.rb
+++ b/app/models/lottery.rb
@@ -21,6 +21,27 @@ class Lottery < ApplicationRecord
     from(select("lotteries.*, organizations.concealed").joins(:organization), :lotteries)
   end
 
+  def generate_entrants!
+    divisions.each do |division|
+      entrant_count = rand(10) + 5
+
+      entrant_count.times do
+        attributes = {
+          first_name: FFaker::Name.first_name,
+          last_name: FFaker::Name.last_name,
+          gender: [:male, :female].sample,
+          birthdate: 65.years.ago.to_date + rand(45 * 365),
+          city: FFaker::AddressUS.city,
+          state_code: FFaker::AddressUS.state_abbr,
+          country_code: "US",
+          number_of_tickets: rand(10) + 1,
+        }
+
+        division.entrants.create!(attributes)
+      end
+    end
+  end
+
   def generate_ticket_hashes(beginning_reference_number: 10_000)
     entrant_structs = entrants.struct_pluck(:id, :number_of_tickets)
 

--- a/app/models/lottery_division.rb
+++ b/app/models/lottery_division.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LotteryDivision < ApplicationRecord
-  include CapitalizeAttributes
+  include CapitalizeAttributes, Delegable
 
   belongs_to :lottery, touch: true
   has_many :entrants, class_name: "LotteryEntrant", dependent: :destroy
@@ -12,6 +12,12 @@ class LotteryDivision < ApplicationRecord
 
   validates_presence_of :maximum_entries, :name
   validates_uniqueness_of :name, case_sensitive: false, scope: :lottery
+
+  scope :with_policy_scope_attributes, -> do
+    from(select("lottery_divisions.*, organizations.concealed").joins(lottery: :organization), :lottery_divisions)
+  end
+
+  delegate :organization, to: :lottery
 
   def draw_ticket!
     drawn_entrants = entrants.joins(tickets: :draw)

--- a/app/models/lottery_division.rb
+++ b/app/models/lottery_division.rb
@@ -27,7 +27,7 @@ class LotteryDivision < ApplicationRecord
   end
 
   def reverse_loaded_draws
-    ordered_loaded_draws.reorder(created_at: :desc)
+    loaded_draws.reorder(created_at: :desc)
   end
 
   def wait_list_entrants
@@ -40,9 +40,8 @@ class LotteryDivision < ApplicationRecord
 
   private
 
-  def ordered_loaded_draws
+  def loaded_draws
     draws.includes(ticket: :entrant)
-         .order(:created_at)
   end
 
   def ordered_drawn_entrants

--- a/app/parameters/lottery_division_parameters.rb
+++ b/app/parameters/lottery_division_parameters.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class LotteryDivisionParameters < BaseParameters
+  def self.permitted
+    [
+      :maximum_entries,
+      :maximum_wait_list,
+      :name,
+    ]
+  end
+end

--- a/app/policies/lottery_division_policy.rb
+++ b/app/policies/lottery_division_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LotteryPolicy < ApplicationPolicy
+class LotteryDivisionPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def post_initialize
     end
@@ -16,8 +16,8 @@ class LotteryPolicy < ApplicationPolicy
 
   attr_reader :organization
 
-  def post_initialize(lottery)
-    @organization = lottery.organization
+  def post_initialize(lottery_division)
+    @organization = lottery_division.lottery.organization
   end
 
   def new?
@@ -37,26 +37,6 @@ class LotteryPolicy < ApplicationPolicy
   end
 
   def destroy?
-    user.authorized_for_lotteries?(organization)
-  end
-
-  def draw_tickets?
-    user.authorized_for_lotteries?(organization)
-  end
-
-  def setup?
-    user.authorized_for_lotteries?(organization)
-  end
-
-  def draw?
-    user.authorized_for_lotteries?(organization)
-  end
-
-  def delete_tickets?
-    user.authorized_for_lotteries?(organization)
-  end
-
-  def generate_tickets?
     user.authorized_for_lotteries?(organization)
   end
 end

--- a/app/policies/lottery_policy.rb
+++ b/app/policies/lottery_policy.rb
@@ -56,6 +56,10 @@ class LotteryPolicy < ApplicationPolicy
     user.authorized_for_lotteries?(organization)
   end
 
+  def generate_entrants?
+    user.authorized_for_lotteries?(organization)
+  end
+
   def generate_tickets?
     user.authorized_for_lotteries?(organization)
   end

--- a/app/views/lotteries/setup.html.erb
+++ b/app/views/lotteries/setup.html.erb
@@ -45,11 +45,11 @@
           <%= link_to "Import Entrants", "#",
                       class: "btn btn-success" %>
           <% if @presenter.lottery_tickets.present? %>
-          <%= link_with_strong_confirm("Delete all tickets", delete_tickets_organization_lottery_path(@presenter.organization, @presenter.lottery),
-                                       class: "btn btn-outline-secondary text-danger",
-                                       message: "This action will permanently delete all tickets and draws from the #{@presenter.name} lottery.",
-                                       required_pattern: "DELETE TICKETS",
-                                       strong_confirm_id: "strong-confirm-tickets-lottery-#{@presenter.lottery.id}") %>
+            <%= link_with_strong_confirm("Delete all tickets", delete_tickets_organization_lottery_path(@presenter.organization, @presenter.lottery),
+                                         class: "btn btn-outline-secondary text-danger",
+                                         message: "This action will permanently delete all tickets and draws from the #{@presenter.name} lottery.",
+                                         required_pattern: "DELETE TICKETS",
+                                         strong_confirm_id: "strong-confirm-tickets-lottery-#{@presenter.lottery.id}") %>
           <% else %>
             <%= link_to "Generate Tickets", generate_tickets_organization_lottery_path(@presenter.organization, @presenter.lottery),
                         method: :post,
@@ -64,7 +64,11 @@
 <article class="ost-article container">
   <div class="card mt-4">
     <div class="card-header">
-      <h2><strong>Divisions</strong></h2>
+      <div class="row">
+        <div class="col">
+          <h2><strong>Divisions</strong></h2>
+        </div>
+      </div>
     </div>
     <div class="card-body">
       <table class="table">
@@ -79,16 +83,14 @@
         </tr>
         </thead>
         <tbody>
-        <% @presenter.divisions.each do |division| %>
-          <tr class="font-weight-bold">
-            <td><%= division.name %></td>
-            <td class="text-center"><%= division.maximum_entries %></td>
-            <td class="text-center"><%= division.maximum_wait_list %></td>
-            <td class="text-center"><%= division.entrants.count %></td>
-            <td class="text-center"><%= division.tickets.count %></td>
-            <td class="text-center"><%= division.draws.count %></td>
-          </tr>
-        <% end %>
+        <%= render partial: "lottery_divisions/lottery_division", collection: @presenter.divisions, as: :division %>
+        <tr>
+          <td colspan="6">
+            <%= link_to fa_icon("plus", text: "Add"),
+                        new_organization_lottery_lottery_division_path(@presenter.organization, @presenter.lottery),
+                        id: "add-event-series", class: "btn btn-success" %>
+          </td>
+        </tr>
         </tbody>
       </table>
     </div>

--- a/app/views/lotteries/setup.html.erb
+++ b/app/views/lotteries/setup.html.erb
@@ -42,7 +42,9 @@
     <div class="row">
       <div class="col form-inline">
         <div>
-          <%= link_to "Import Entrants", "#",
+          <%= link_to "Generate Entrants",
+                      generate_entrants_organization_lottery_path(@presenter.organization, @presenter.lottery),
+                      method: :post,
                       class: "btn btn-success" %>
           <% if @presenter.lottery_tickets.present? %>
             <%= link_with_strong_confirm("Delete all tickets", delete_tickets_organization_lottery_path(@presenter.organization, @presenter.lottery),

--- a/app/views/lotteries/setup.html.erb
+++ b/app/views/lotteries/setup.html.erb
@@ -82,6 +82,7 @@
           <th class="text-center">Entrants</th>
           <th class="text-center">Tickets</th>
           <th class="text-center">Draws</th>
+          <th></th>
         </tr>
         </thead>
         <tbody>

--- a/app/views/lottery_divisions/_form.html.erb
+++ b/app/views/lottery_divisions/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row">
   <div class="col-md-12">
-    <%= form_with(model: [@lottery_division.organization, @lottery_division.lottery, @lottery_division], local: true, html: {class: "form-horizontal"}) do |f| %>
+    <%= form_with(model: [@lottery_division.organization, @lottery_division.lottery, @lottery_division], local: true, html: {class: "form-horizontal", data: {turbo: false}}) do |f| %>
       <div class="form-row">
         <div class="form-group col-md-6">
           <%= f.label :name %>

--- a/app/views/lottery_divisions/_form.html.erb
+++ b/app/views/lottery_divisions/_form.html.erb
@@ -1,0 +1,40 @@
+<%= render 'shared/errors', obj: @lottery_division %>
+
+<div class="row">
+  <div class="col-md-12">
+    <%= form_with(model: [@lottery_division.organization, @lottery_division.lottery, @lottery_division], local: true, html: {class: "form-horizontal"}) do |f| %>
+      <div class="form-row">
+        <div class="form-group col-md-6">
+          <%= f.label :name %>
+          <%= f.text_field :name, class: "form-control", placeholder: "My New Division", autofocus: true %>
+        </div>
+
+        <div class="form-group col-md-3">
+          <%= f.label "Winner slots" %>
+          <%= f.text_field :maximum_entries, class: "form-control", placeholder: "# of winner slots" %>
+        </div>
+
+        <div class="form-group col-md-3">
+          <%= f.label "Wait list slots" %>
+          <%= f.text_field :maximum_wait_list, class: "form-control", placeholder: "# of wait list slots" %>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <%= f.submit(@lottery_division.new_record? ? "Create Division" : "Update Division", class: "btn btn-primary") %>
+          </div>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <span class="brackets"><%= link_to "Cancel", setup_organization_lottery_path(@lottery_division.organization, @lottery_division.lottery) %></span>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/lottery_divisions/_lottery_division.html.erb
+++ b/app/views/lottery_divisions/_lottery_division.html.erb
@@ -5,4 +5,8 @@
   <td class="text-center"><%= division.entrants.count %></td>
   <td class="text-center"><%= division.tickets.count %></td>
   <td class="text-center"><%= division.draws.count %></td>
+  <td class="text-center">
+    <%= link_to_division_edit(division) %>
+    <%= link_to_division_delete(division) %>
+  </td>
 </tr>

--- a/app/views/lottery_divisions/_lottery_division.html.erb
+++ b/app/views/lottery_divisions/_lottery_division.html.erb
@@ -1,0 +1,8 @@
+<tr class="font-weight-bold">
+  <td><%= division.name %></td>
+  <td class="text-center"><%= division.maximum_entries %></td>
+  <td class="text-center"><%= division.maximum_wait_list %></td>
+  <td class="text-center"><%= division.entrants.count %></td>
+  <td class="text-center"><%= division.tickets.count %></td>
+  <td class="text-center"><%= division.draws.count %></td>
+</tr>

--- a/app/views/lottery_divisions/edit.html.erb
+++ b/app/views/lottery_divisions/edit.html.erb
@@ -7,7 +7,7 @@
     <div class="ost-heading row">
       <div class="col">
         <div class="ost-title">
-          <h1><strong>Edit Lottery Division</strong></h1>
+          <h1><strong><%= "#{@lottery_division.lottery.name}: Edit Division" %></strong></h1>
           <ul class="breadcrumb breadcrumb-ost">
             <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
             <li class="breadcrumb-item"><%= link_to @lottery_division.organization.name, organization_lotteries_path(@lottery_division.organization) %></li>

--- a/app/views/lottery_divisions/edit.html.erb
+++ b/app/views/lottery_divisions/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for :title do %>
+  <% "OpenSplitTime: Edit lottery division" %>
+<% end %>
+
+<header class="ost-header">
+  <div class="container">
+    <div class="ost-heading row">
+      <div class="col">
+        <div class="ost-title">
+          <h1><strong>Edit Lottery Division</strong></h1>
+          <ul class="breadcrumb breadcrumb-ost">
+            <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
+            <li class="breadcrumb-item"><%= link_to @lottery_division.organization.name, organization_lotteries_path(@lottery_division.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to "Lotteries", organization_lotteries_path(@lottery_division.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to @lottery_division.lottery.name, organization_lottery_path(@lottery_division.organization, @lottery_division.lottery) %></li>
+            <li class="breadcrumb-item active">Edit Division</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+
+<article class="ost-article container">
+  <%= render "form" %>
+</article>

--- a/app/views/lottery_divisions/new.html.erb
+++ b/app/views/lottery_divisions/new.html.erb
@@ -7,7 +7,7 @@
     <div class="ost-heading row">
       <div class="col">
         <div class="ost-title">
-          <h1><strong>New Lottery Division</strong></h1>
+          <h1><strong><%= "#{@lottery_division.lottery.name}: New Division" %></strong></h1>
           <ul class="breadcrumb breadcrumb-ost">
             <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
             <li class="breadcrumb-item"><%= link_to @lottery_division.organization.name, organization_lotteries_path(@lottery_division.organization) %></li>

--- a/app/views/lottery_divisions/new.html.erb
+++ b/app/views/lottery_divisions/new.html.erb
@@ -1,0 +1,26 @@
+<% content_for :title do %>
+  <% "OpenSplitTime: New lottery division" %>
+<% end %>
+
+<header class="ost-header">
+  <div class="container">
+    <div class="ost-heading row">
+      <div class="col">
+        <div class="ost-title">
+          <h1><strong>New Lottery Division</strong></h1>
+          <ul class="breadcrumb breadcrumb-ost">
+            <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
+            <li class="breadcrumb-item"><%= link_to @lottery_division.organization.name, organization_lotteries_path(@lottery_division.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to "Lotteries", organization_lotteries_path(@lottery_division.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to @lottery_division.lottery.name, organization_lottery_path(@lottery_division.organization, @lottery_division.lottery) %></li>
+            <li class="breadcrumb-item active">New Division</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+
+<article class="ost-article container">
+  <%= render "form" %>
+</article>

--- a/app/views/shared/_strong_confirm.html.erb
+++ b/app/views/shared/_strong_confirm.html.erb
@@ -14,7 +14,7 @@
         <p>To proceed, please type <strong><%= required_pattern %></strong> below and click the Delete button.</p>
       </div>
       <div class="modal-footer">
-        <%= text_field_tag 'confirm', nil, class: 'form-control input-block', autofocus: true, tabindex: 1, data: {action: 'keyup->confirm#compare', "confirm-target" => 'pattern', 'pattern-required' => required_pattern} %>
+        <%= text_field_tag 'confirm', nil, class: 'form-control col', autofocus: true, tabindex: 1, data: {action: 'keyup->confirm#compare', "confirm-target" => 'pattern', 'pattern-required' => required_pattern} %>
         <%= link_to 'Permanently Delete', path_on_confirm, tabindex: -1, class: 'btn btn-block btn-danger font-weight-bold disabled', method: :delete, data: {"confirm-target" => 'deleteButton', action: 'click->confirm#onClickDelete'} %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,6 +138,7 @@ Rails.application.routes.draw do
       member { get :draw_tickets }
       member { get :setup }
       member { post :draw }
+      member { post :generate_entrants }
       member { post :generate_tickets }
       member { delete :delete_tickets }
       resources :lottery_divisions, except: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,12 +134,13 @@ Rails.application.routes.draw do
   get '/events', to: redirect('event_groups')
 
   resources :organizations do
-    resources :lotteries, param: :lottery_id do
+    resources :lotteries do
       member { get :draw_tickets }
       member { get :setup }
       member { post :draw }
       member { post :generate_tickets }
       member { delete :delete_tickets }
+      resources :lottery_divisions, except: [:index, :show]
     end
   end
 


### PR DESCRIPTION
This PR allows us to create, edit, and delete lottery divisions.

It also adds logic to generate entrants from the setup screen. This ability will be replaced with the ability to import entrants.