### PR TITLE
Draw pre-selected entrants

### DIFF
--- a/app/controllers/lotteries_controller.rb
+++ b/app/controllers/lotteries_controller.rb
@@ -93,9 +93,9 @@ class LotteriesController < ApplicationController
     authorize @lottery
 
     division = @lottery.divisions.find(params[:division_id])
-    ticket = division.draw_ticket!
+    lottery_draw = division.draw_ticket!
 
-    if ticket.present?
+    if lottery_draw.present?
       head :created
     else
       head :no_content

--- a/app/controllers/lottery_entrants_controller.rb
+++ b/app/controllers/lottery_entrants_controller.rb
@@ -60,6 +60,19 @@ class LotteryEntrantsController < ApplicationController
     end
   end
 
+  # GET /organizations/:organization_id/lotteries/:lottery_id/lottery_entrants/:id/draw
+  def draw
+    authorize @lottery_entrant
+
+    lottery_draw = @lottery_entrant.draw_ticket!
+
+    if lottery_draw.present?
+      head :created
+    else
+      head :no_content
+    end
+  end
+
   private
 
   def set_lottery

--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -39,4 +39,17 @@ class LotteryEntrant < ApplicationRecord
   def delegated_division_name
     division.name
   end
+
+  def draw_ticket!
+    return if drawn?
+
+    drawn_ticket_index = rand(tickets.count)
+    drawn_ticket = tickets.offset(drawn_ticket_index).first
+
+    lottery.draws.create(ticket: drawn_ticket) if drawn_ticket.present?
+  end
+
+  def drawn?
+    tickets.joins(:draw).present?
+  end
 end

--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -12,8 +12,9 @@ class LotteryEntrant < ApplicationRecord
   strip_attributes collapse_spaces: true
   capitalize_attributes :first_name, :last_name, :city
 
-  scope :with_division_name, -> { from(select("lottery_entrants.*, lottery_divisions.name as division_name").joins(:division), :lottery_entrants) }
   scope :drawn_and_ordered, -> { from(select("lottery_entrants.*, lottery_draws.created_at as drawn_at").joins(tickets: :draw).order(:drawn_at), :lottery_entrants) }
+  scope :pre_selected, -> { where(pre_selected: true) }
+  scope :with_division_name, -> { from(select("lottery_entrants.*, lottery_divisions.name as division_name").joins(:division), :lottery_entrants) }
   scope :with_policy_scope_attributes, -> do
     from(select("lottery_entrants.*, organizations.concealed, organizations.id as organization_id").joins(division: {lottery: :organization}), :lottery_entrants)
   end

--- a/app/policies/lottery_entrant_policy.rb
+++ b/app/policies/lottery_entrant_policy.rb
@@ -39,4 +39,8 @@ class LotteryEntrantPolicy < ApplicationPolicy
   def destroy?
     user.authorized_for_lotteries?(organization)
   end
+
+  def draw?
+    user.authorized_for_lotteries?(organization)
+  end
 end

--- a/app/views/lotteries/draw_tickets.html.erb
+++ b/app/views/lotteries/draw_tickets.html.erb
@@ -52,7 +52,14 @@
         <%= link_to "Draw a Ticket", draw_organization_lottery_path(@presenter.organization, @presenter.lottery, division_id: division.id),
                     method: :post,
                     class: "btn btn-lg btn-danger btn-block font-weight-bold" %>
+        <% division.entrants.pre_selected.each do |entrant| %>
+          <%= link_to "Draw #{entrant.full_name}", draw_organization_lottery_lottery_entrant_path(@presenter.organization, @presenter.lottery, entrant),
+                      method: :post,
+                      disabled: entrant.drawn?,
+                      class: "btn btn-lg btn-danger btn-block font-weight-bold" %>
+        <% end %>
         <hr/>
+
         <div id="<%= dom_id(division, :lottery_draws) %>">
           <%= render partial: "lottery_draws/lottery_draw_admin", collection: division.reverse_loaded_draws, as: :lottery_draw %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,7 +142,9 @@ Rails.application.routes.draw do
       member { post :generate_tickets }
       member { delete :delete_tickets }
       resources :lottery_divisions, except: [:index, :show]
-      resources :lottery_entrants, except: [:index, :show]
+      resources :lottery_entrants, except: [:index, :show] do
+        member { post :draw }
+      end
     end
   end
 

--- a/spec/models/lottery_entrant_spec.rb
+++ b/spec/models/lottery_entrant_spec.rb
@@ -32,4 +32,69 @@ RSpec.describe LotteryEntrant, type: :model do
       end
     end
   end
+
+  describe "#draw_ticket!" do
+    subject { lottery.entrants.find_by(last_name: "Crona") }
+    let(:lottery) { lotteries(:lottery_without_tickets) }
+    let(:execute_method) { subject.draw_ticket! }
+
+    context "when the entrant has no tickets" do
+      it "does not create a draw" do
+        expect { execute_method }.not_to change { LotteryDraw.count }
+      end
+
+      it "returns nil" do
+        expect(execute_method).to eq(nil)
+      end
+    end
+
+    context "when the entrant has tickets that have not been drawn" do
+      before { lottery.delete_and_insert_tickets! }
+      it "creates a draw" do
+        expect { execute_method }.to change { LotteryDraw.count }.by(1)
+      end
+
+      it "returns the draw" do
+        expect(execute_method).to be_a(LotteryDraw)
+      end
+    end
+    context "when the entrant has already been drawn" do
+      before do
+        lottery.delete_and_insert_tickets!
+        lottery.draws.create(ticket: subject.tickets.first)
+      end
+
+      it "does not create a draw" do
+        expect { execute_method }.not_to change { LotteryDraw.count }
+      end
+
+      it "returns nil" do
+        expect(execute_method).to eq(nil)
+      end
+    end
+  end
+
+  describe "#drawn?" do
+    subject { lottery.entrants.find_by(last_name: "Crona") }
+    let(:lottery) { lotteries(:lottery_without_tickets) }
+    let(:result) { subject.drawn? }
+
+    context "when the entrant has no tickets" do
+      it { expect(result).to eq(false) }
+    end
+
+    context "when the entrant has tickets that have not been drawn" do
+      before { lottery.delete_and_insert_tickets! }
+      it { expect(result).to eq(false) }
+    end
+
+    context "when the entrant has been drawn" do
+      before do
+        lottery.delete_and_insert_tickets!
+        lottery.draws.create(ticket: subject.tickets.first)
+      end
+
+      it { expect(result).to eq(true) }
+    end
+  end
 end


### PR DESCRIPTION
Adds buttons to draw pre-selected entrants, together with the routes and supporting logic in the models.

Addresses a portion of #568 