### PR TITLE
Better UI for pre-selected entrants

### DIFF
--- a/app/views/lotteries/draw_tickets.html.erb
+++ b/app/views/lotteries/draw_tickets.html.erb
@@ -43,20 +43,47 @@
       <hr/>
     </div>
   </div>
-  <div class="row">
-    <% @presenter.divisions.each do |division| %>
-      <%= turbo_stream_from division, :lottery_draws %>
-      <div class="col">
-        <h2 class="text-center"><strong><%= division.name %></strong></h2>
-        <hr/>
-        <%= link_to "Draw a Ticket", draw_organization_lottery_path(@presenter.organization, @presenter.lottery, division_id: division.id),
-                    method: :post,
-                    class: "btn btn-lg btn-danger btn-block font-weight-bold" %>
-        <hr/>
-        <div id="<%= dom_id(division, :lottery_draws) %>">
-          <%= render partial: "lottery_draws/lottery_draw_admin", collection: division.reverse_loaded_draws, as: :lottery_draw %>
+  <% if @presenter.lottery_tickets.present? %>
+    <div class="row">
+      <% @presenter.divisions.each do |division| %>
+        <%= turbo_stream_from division, :lottery_draws %>
+        <div class="col">
+          <h2 class="text-center"><strong><%= division.name %></strong></h2>
+          <hr/>
+
+          <div class="btn-group btn-lg btn-block p-0">
+            <%= link_to "Draw a Ticket", draw_organization_lottery_path(@presenter.organization, @presenter.lottery, division_id: division.id),
+                        method: :post,
+                        class: "btn btn-lg btn-block btn-danger font-weight-bold" %>
+            <% if division.entrants.pre_selected.present? %>
+              <button class="btn btn-lg btn-danger font-weight-bold dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="sr-only">Toggle Dropdown</span>
+              </button>
+              <div class="dropdown-menu">
+                <a class="dropdown-item disabled" href="#">Pre-Selected Entrants</a>
+                <div class="dropdown-divider"></div>
+                <% division.entrants.pre_selected.each do |entrant| %>
+                  <%= link_to "Draw #{entrant.full_name}", draw_organization_lottery_lottery_entrant_path(@presenter.organization, @presenter.lottery, entrant),
+                              method: :post,
+                              disabled: entrant.drawn?,
+                              class: "dropdown-item" %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+          <hr/>
+
+          <div id="<%= dom_id(division, :lottery_draws) %>">
+            <%= render partial: "lottery_draws/lottery_draw_admin", collection: division.reverse_loaded_draws, as: :lottery_draw %>
+          </div>
         </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="row">
+      <div class="col">
+        <h4 class="text-center">No tickets have been generated yet</h4>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </article>


### PR DESCRIPTION
Removes the multiple buttons for pre-selected entrants in favor of a single split button with a dropdown that lists all pre-selected entrants for a division.

Addresses a portion of #568 