### PR TITLE
Improve lottery responsiveness in public views

### DIFF
--- a/app/assets/stylesheets/utilities/_back_and_forth.scss
+++ b/app/assets/stylesheets/utilities/_back_and_forth.scss
@@ -1,0 +1,33 @@
+.back-and-forth-path {
+    position: relative;
+    overflow: hidden;
+    width: 200px;
+    height: 2px;
+    background-color: #c1c1c1;
+    margin: auto;
+}
+.back-and-forth-shape {
+    position: absolute;
+    left: 0;
+    background-color: red;
+    width: 30px;
+    height: 2px;
+    display: block;
+    top: 0;
+
+    x-transition: all 1s ease-in-out;
+    animation: back-and-forth-animation 1.5s infinite;
+}
+
+
+@keyframes back-and-forth-animation {
+    0% {
+        left: -20px;
+    }
+    50% {
+        left: 190px;
+    }
+    100% {
+        left: -20px;
+    }
+}

--- a/app/views/lotteries/draw_tickets.html.erb
+++ b/app/views/lotteries/draw_tickets.html.erb
@@ -43,25 +43,24 @@
       <hr/>
     </div>
   </div>
+  <div class="row">
   <% if @presenter.lottery_tickets.present? %>
-    <div class="row">
       <% @presenter.ordered_divisions.each do |division| %>
         <%= turbo_stream_from division, :lottery_draws %>
         <%= turbo_stream_from division, :lottery_draw_header %>
-        <div class="col">
+        <div class="col-12 col-md">
           <%= render "lottery_divisions/draw_tickets_header", division: division %>
           <hr/>
           <div id="<%= dom_id(division, :lottery_draws) %>">
             <%= render partial: "lottery_draws/lottery_draw_admin", collection: division.draws.with_entrant_and_ticket.most_recent_first, as: :lottery_draw %>
           </div>
+          <hr/>
         </div>
       <% end %>
-    </div>
   <% else %>
-    <div class="row">
       <div class="col">
         <h4 class="text-center">No tickets have been generated yet</h4>
       </div>
-    </div>
   <% end %>
+  </div>
 </article>

--- a/app/views/lotteries/setup.html.erb
+++ b/app/views/lotteries/setup.html.erb
@@ -21,7 +21,6 @@
         </div>
       </div>
       <aside class="col-auto">
-        <%= link_to "Edit", edit_organization_lottery_path(@presenter.organization, @presenter.lottery), class: "btn btn-outline-secondary" %>
         <%= link_to "Public", organization_lottery_path(@presenter.organization, @presenter.lottery), class: "btn btn-outline-secondary" %>
       </aside>
     </div>
@@ -42,18 +41,19 @@
     <div class="row">
       <div class="col form-inline">
         <div>
-          <%= link_to "Generate Entrants",
+          <%= link_to "Edit lottery", edit_organization_lottery_path(@presenter.organization, @presenter.lottery), class: "btn btn-primary" %>
+          <%= link_to "Generate entrants",
                       generate_entrants_organization_lottery_path(@presenter.organization, @presenter.lottery),
                       method: :post,
                       class: "btn btn-success" %>
           <% if @presenter.lottery_tickets.present? %>
-            <%= link_with_strong_confirm("Delete all tickets", delete_tickets_organization_lottery_path(@presenter.organization, @presenter.lottery),
+            <%= link_with_strong_confirm("Delete tickets", delete_tickets_organization_lottery_path(@presenter.organization, @presenter.lottery),
                                          class: "btn btn-outline-secondary text-danger",
                                          message: "This action will permanently delete all tickets and draws from the #{@presenter.name} lottery.",
                                          required_pattern: "DELETE TICKETS",
                                          strong_confirm_id: "strong-confirm-tickets-lottery-#{@presenter.lottery.id}") %>
           <% else %>
-            <%= link_to "Generate Tickets", generate_tickets_organization_lottery_path(@presenter.organization, @presenter.lottery),
+            <%= link_to "Generate tickets", generate_tickets_organization_lottery_path(@presenter.organization, @presenter.lottery),
                         method: :post,
                         class: "btn btn-danger" %>
           <% end %>

--- a/app/views/lotteries/setup.html.erb
+++ b/app/views/lotteries/setup.html.erb
@@ -72,7 +72,7 @@
         </div>
       </div>
     </div>
-    <div class="card-body">
+    <div class="card-body table-responsive">
       <table class="table">
         <thead>
         <tr>
@@ -107,7 +107,7 @@
         </div>
       </div>
     </div>
-    <div class="card-body">
+    <div class="card-body table-responsive">
       <aside class="ost-toolbar">
         <div class="container">
           <div class="row">

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -28,7 +28,7 @@
     </div>
     <% if @presenter.display_style == "draws" %>
       <div>
-        <%= link_to "Browse Entrants and Results", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :entrants), class: "btn btn-success btn-block font-weight-bold" %>
+        <%= link_to "Browse Entrants and Winners", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :entrants), class: "btn btn-success btn-block font-weight-bold" %>
       </div>
     <% else %>
       <div>
@@ -44,8 +44,8 @@
         <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'tickets'}" do
           link_to "Tickets", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :tickets)
         end %>
-        <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'results'}" do
-          link_to "Results", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :results)
+        <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'winners'}" do
+          link_to "Winners", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :winners)
         end %>
       </ul>
     <% end %>
@@ -69,20 +69,10 @@
       <div data-controller="infinite-scroll"
            data-infinite-scroll-next-page-url="<%= @presenter.next_page_url %>"
            data-infinite-scroll-html-template="lottery_entrants/lottery_entrant">
-        <table class="table table-condensed table-striped">
-          <thead>
-          <tr>
-            <th><%= link_to_reversing_sort_heading("Name", "last_name,first_name", params[:sort]) %></th>
-            <th><%= link_to_reversing_sort_heading("Gender", "gender,last_name,first_name", params[:sort]) %></th>
-            <th><%= link_to_reversing_sort_heading("From", "state_code", params[:sort]) %></th>
-            <th class="text-center"><%= link_to_reversing_sort_heading("Division", "division_name,-number_of_tickets", params[:sort]) %></th>
-            <th class="text-center"><%= link_to_reversing_sort_heading("Tickets", "number_of_tickets", params[:sort]) %></th>
-          </tr>
-          </thead>
-          <tbody data-infinite-scroll-target="result">
+        <div data-infinite-scroll-target="result">
           <%= render partial: "lottery_entrants/lottery_entrant", collection: @presenter.lottery_entrants_paginated, as: :record %>
-          </tbody>
-        </table>
+        </div>
+        <hr/>
 
         <div class="row">
           <div class="col text-center" data-infinite-scroll-target="link">
@@ -120,20 +110,10 @@
       <div data-controller="infinite-scroll"
            data-infinite-scroll-next-page-url="<%= @presenter.next_page_url %>"
            data-infinite-scroll-html-template="lottery_tickets/lottery_ticket">
-        <table class="table table-condensed table-striped">
-          <thead>
-          <tr>
-            <th><%= link_to_reversing_sort_heading("Ticket", "reference_number", params[:sort]) %></th>
-            <th><%= link_to_reversing_sort_heading("Name", "last_name,first_name", params[:sort]) %></th>
-            <th><%= link_to_reversing_sort_heading("Gender", "gender,last_name,first_name", params[:sort]) %></th>
-            <th><%= link_to_reversing_sort_heading("From", "state_code", params[:sort]) %></th>
-            <th class="text-center"><%= link_to_reversing_sort_heading("Division", "division_name,last_name,first_name", params[:sort]) %></th>
-          </tr>
-          </thead>
-          <tbody data-infinite-scroll-target="result">
+        <div data-infinite-scroll-target="result">
           <%= render partial: "lottery_tickets/lottery_ticket", collection: @presenter.lottery_tickets_paginated, as: :record %>
-          </tbody>
-        </table>
+        </div>
+        <hr/>
 
         <div class="row">
           <div class="col text-center" data-infinite-scroll-target="link">
@@ -162,13 +142,13 @@
       <%= render partial: "lottery_draws/lottery_draw", collection: @presenter.lottery_draws_ordered %>
     </div>
 
-  <% when "results" %>
+  <% when "winners" %>
     <% if @presenter.lottery_draws.present? %>
       <% @presenter.divisions.each do |division| %>
         <div class="card">
           <h4 class="card-header font-weight-bold bg-primary text-white"><%= "#{division.name}" %></h4>
           <div class="card-body">
-            <h5>Entrants</h5>
+            <h5>Winners</h5>
             <% if division.winning_entrants.present? %>
               <ol>
                 <% division.winning_entrants.each do |entrant| %>

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -26,21 +26,29 @@
         <% end %>
       </aside>
     </div>
+    <% if @presenter.display_style == "draws" %>
+      <div>
+        <%= link_to "Browse Entrants and Results", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :entrants), class: "btn btn-success btn-block font-weight-bold" %>
+      </div>
+    <% else %>
+      <div>
+        <%= link_to "View Draws", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :draws), class: "btn btn-outline-secondary btn-block text-success font-weight-bold" %>
+      </div>
+    <% end %>
     <!-- Navigation -->
-    <ul class="nav nav-tabs nav-tabs-ost">
-      <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'entrants'}" do
-        link_to "Entrants", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :entrants)
-      end %>
-      <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'tickets'}" do
-        link_to "Tickets", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :tickets)
-      end %>
-      <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'draws'}" do
-        link_to "Draws", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :draws)
-      end %>
-      <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'results'}" do
-        link_to "Results", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :results)
-      end %>
-    </ul>
+    <% unless @presenter.display_style == "draws" %>
+      <ul class="nav nav-tabs nav-tabs-ost">
+        <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'entrants'}" do
+          link_to "Entrants", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :entrants)
+        end %>
+        <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'tickets'}" do
+          link_to "Tickets", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :tickets)
+        end %>
+        <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'results'}" do
+          link_to "Results", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :results)
+        end %>
+      </ul>
+    <% end %>
   </div>
 </header>
 

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -137,6 +137,11 @@
 
   <% when "draws" %>
     <%= turbo_stream_from @presenter.lottery, :lottery_draws %>
+    <h6 class="text-center">Live updating</h6>
+    <div class="back-and-forth-path">
+      <span class="back-and-forth-shape trail"></span>
+    </div>
+
     <div id="lottery_draws">
       <%= render partial: "lottery_draws/lottery_draw", collection: @presenter.lottery_draws_ordered %>
     </div>

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -19,7 +19,7 @@
           <p><%= l(@presenter.scheduled_start_date, format: :full_with_weekday) %></p>
         </div>
       </div>
-      <aside class="col-auto">
+      <aside class="col text-right">
         <% if current_user&.authorized_for_lotteries?(@presenter.organization) %>
           <%= link_to "Draw Tickets", draw_tickets_organization_lottery_path(@presenter.organization, @presenter.lottery), class: "btn btn-outline-secondary" %>
           <%= link_to "Setup", setup_organization_lottery_path(@presenter.organization, @presenter.lottery), class: "btn btn-outline-secondary" %>
@@ -27,7 +27,7 @@
       </aside>
     </div>
     <% if @presenter.display_style == "draws" %>
-      <div>
+      <div class="mb-4">
         <%= link_to "Browse Entrants and Winners", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :entrants), class: "btn btn-success btn-block font-weight-bold" %>
       </div>
     <% else %>

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -19,10 +19,9 @@
           <p><%= l(@presenter.scheduled_start_date, format: :full_with_weekday) %></p>
         </div>
       </div>
-      <aside class="col text-right">
+      <aside class="col-auto text-right">
         <% if current_user&.authorized_for_lotteries?(@presenter.organization) %>
-          <%= link_to "Draw Tickets", draw_tickets_organization_lottery_path(@presenter.organization, @presenter.lottery), class: "btn btn-outline-secondary" %>
-          <%= link_to "Setup", setup_organization_lottery_path(@presenter.organization, @presenter.lottery), class: "btn btn-outline-secondary" %>
+          <%= link_to "Admin", setup_organization_lottery_path(@presenter.organization, @presenter.lottery), class: "btn btn-outline-secondary" %>
         <% end %>
       </aside>
     </div>

--- a/app/views/lottery_draws/_lottery_draw.html.erb
+++ b/app/views/lottery_draws/_lottery_draw.html.erb
@@ -16,7 +16,7 @@
         <h6 class="mb-0"><%= lottery_draw.entrant_bio %></h6>
       </div>
       <div class="col text-right">
-        <h3><span class="badge badge-secondary"><%= lottery_draw.entrant_division_name %></span></h3>
+        <h4><span class="badge badge-secondary"><%= lottery_draw.entrant_division_name %></span></h4>
       </div>
     </div>
   </div>

--- a/app/views/lottery_entrants/_entrant_lookup.html.erb
+++ b/app/views/lottery_entrants/_entrant_lookup.html.erb
@@ -1,15 +1,15 @@
-<%= form_tag organization_lottery_path(@presenter.organization, @presenter.lottery), class: 'w-100', method: :get do %>
+<%= form_tag organization_lottery_path(@presenter.organization, @presenter.lottery), class: "w-100", method: :get do %>
   <div class="input-group">
     <%= hidden_field_tag :sort, nil %>
     <%= hidden_field_tag :display_style, @presenter.display_style %>
-    <%= text_field_tag 'filter[search]',
+    <%= text_field_tag "filter[search]",
                        prepared_params[:search],
-                       placeholder: 'First name, last name, state, or country',
+                       placeholder: "Find someone",
                        autofocus: true,
-                       class: 'form-control search-box' %>
+                       class: "form-control search-box" %>
     <span class="input-group-append">
-      <%= button_tag(type: :submit, id: 'lottery-entrant-lookup-submit', class: 'btn btn-primary') do %>
-          <i class='fas fa-search'></i>
+      <%= button_tag(type: :submit, id: "lottery-entrant-lookup-submit", class: "btn btn-primary") do %>
+          <i class="fas fa-search"></i>
       <% end %>
     </span>
   </div>

--- a/app/views/lottery_entrants/_entrant_lookup_admin.html.erb
+++ b/app/views/lottery_entrants/_entrant_lookup_admin.html.erb
@@ -3,7 +3,6 @@
     <%= text_field_tag "filter[search]",
                        prepared_params[:search],
                        placeholder: "Find an entrant",
-                       autofocus: true,
                        class: "form-control search-box" %>
     <span class="input-group-append">
       <%= button_tag(type: :submit, id: "lottery-entrant-admin-lookup-submit", class: "btn btn-primary") do %>

--- a/app/views/lottery_entrants/_entrant_lookup_admin.html.erb
+++ b/app/views/lottery_entrants/_entrant_lookup_admin.html.erb
@@ -1,13 +1,13 @@
-<%= form_tag setup_organization_lottery_path(@presenter.organization, @presenter.lottery), class: 'w-100', method: :get do %>
+<%= form_tag setup_organization_lottery_path(@presenter.organization, @presenter.lottery), class: "w-100", method: :get do %>
   <div class="input-group">
-    <%= text_field_tag 'filter[search]',
+    <%= text_field_tag "filter[search]",
                        prepared_params[:search],
-                       placeholder: 'First name, last name, state, or country',
+                       placeholder: "Find an entrant",
                        autofocus: true,
-                       class: 'form-control search-box' %>
+                       class: "form-control search-box" %>
     <span class="input-group-append">
-      <%= button_tag(type: :submit, id: 'lottery-entrant-admin-lookup-submit', class: 'btn btn-primary') do %>
-          <i class='fas fa-search'></i>
+      <%= button_tag(type: :submit, id: "lottery-entrant-admin-lookup-submit", class: "btn btn-primary") do %>
+          <i class="fas fa-search"></i>
       <% end %>
     </span>
   </div>

--- a/app/views/lottery_entrants/_lottery_entrant.html.erb
+++ b/app/views/lottery_entrants/_lottery_entrant.html.erb
@@ -1,7 +1,14 @@
-<tr>
-  <td><%= record.name %></td>
-  <td><%= record.gender.titleize %></td>
-  <td><%= record.flexible_geolocation %></td>
-  <td class="text-center"><h4 class="mb-0"><span class="badge badge-secondary"><%= record.division_name %></span></h4></td>
-  <td class="text-center"><%= record.number_of_tickets %></td>
-</tr>
+<div class="card bg-light mt-2">
+  <div class="card-body">
+    <div class="row">
+      <div class="col">
+        <h5 class="font-weight-bold"><%= record.name %></h5>
+        <h6><%= record.flexible_geolocation %></h6>
+      </div>
+      <div class="col">
+        <h4 class="text-right"><span class="badge badge-secondary"><%= record.division_name %></span></h4>
+        <h6 class="text-right font-weight-bold"><%= "#{pluralize(record.number_of_tickets, 'ticket')}" %></h6>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/lottery_tickets/_lottery_ticket.html.erb
+++ b/app/views/lottery_tickets/_lottery_ticket.html.erb
@@ -1,7 +1,14 @@
-<tr>
-  <td><%= record.reference_number %></td>
-  <td><%= record.entrant_full_name %></td>
-  <td><%= record.entrant_gender.titleize %></td>
-  <td><%= record.entrant_flexible_geolocation %></td>
-  <td class="text-center"><h4 class="mb-0"><span class="badge badge-secondary"><%= record.division_name %></span></h4></td>
-</tr>
+<div class="card bg-light mt-2">
+  <div class="card-body">
+    <div class="row">
+      <div class="col">
+        <h5 class="font-weight-bold"><%= record.entrant_full_name %></h5>
+        <h6><%= record.entrant_flexible_geolocation %></h6>
+      </div>
+      <div class="col">
+        <h4 class="text-right"><span class="badge badge-secondary"><%= record.division_name %></span></h4>
+        <h5 class="text-right font-weight-bold"><%= "##{record.reference_number}" %></h5>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/lottery_tickets/_lottery_ticket.html.erb
+++ b/app/views/lottery_tickets/_lottery_ticket.html.erb
@@ -7,7 +7,7 @@
       </div>
       <div class="col">
         <h4 class="text-right"><span class="badge badge-secondary"><%= record.division_name %></span></h4>
-        <h5 class="text-right font-weight-bold"><%= "##{record.reference_number}" %></h5>
+        <h6 class="text-right font-weight-bold"><%= "##{record.reference_number}" %></h6>
       </div>
     </div>
   </div>

--- a/spec/system/create_lottery_spec.rb
+++ b/spec/system/create_lottery_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Create and update a lottery" do
     expect(new_lottery.name).to eq(new_lottery_name)
     expect(new_lottery.scheduled_start_date).to eq(new_lottery_date.to_date)
 
-    click_link "Edit"
+    click_link "Edit lottery"
 
     expect(page).to have_content("Edit Lottery")
     expect(page).to have_button("Update Lottery")


### PR DESCRIPTION
- Removes tables in favor of responsive cards
- Renames "Results" to "Winners"
- Makes "Draws" view separate from Entrants/Tickets/Winners

Addresses #584