### PR TITLE
Make the lottery_draws lottery_ticket_id index unique

### DIFF
--- a/db/migrate/20211011062916_add_unique_index_to_lottery_draws_lottery_ticket_id.rb
+++ b/db/migrate/20211011062916_add_unique_index_to_lottery_draws_lottery_ticket_id.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToLotteryDrawsLotteryTicketId < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :lottery_draws, :lottery_ticket_id
+    add_index :lottery_draws, :lottery_ticket_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_06_133743) do
+ActiveRecord::Schema.define(version: 2021_10_11_062916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -252,7 +252,7 @@ ActiveRecord::Schema.define(version: 2021_10_06_133743) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["lottery_id"], name: "index_lottery_draws_on_lottery_id"
-    t.index ["lottery_ticket_id"], name: "index_lottery_draws_on_lottery_ticket_id"
+    t.index ["lottery_ticket_id"], name: "index_lottery_draws_on_lottery_ticket_id", unique: true
   end
 
   create_table "lottery_entrants", force: :cascade do |t|


### PR DESCRIPTION
Fixes an oversight. There should never be an attempt to create more than one draw for a single ticket, but let's have the database enforce that for us.