### PR TITLE
Set a configurable sample rate for Scout APM

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   before_action :set_current_user
   before_action :set_paper_trail_whodunnit
   before_action :set_sentry_context
+  before_action :sample_requests_for_scout_apm
   after_action :store_user_location!, if: :storable_location?
   helper_method :prepared_params
 
@@ -110,6 +111,10 @@ class ApplicationController < ActionController::Base
   def set_sentry_context
     Sentry.set_user(id: current_user&.id)
     Sentry.set_extras(params: params.to_unsafe_h, url: request.url)
+  end
+
+  def sample_requests_for_scout_apm
+    ::ScoutApm::Transaction.ignore! if rand > ::OstConfig.scout_apm_sample_rate
   end
 
   def jsonapi_error_object(record)

--- a/config/initializers/01_ost_config.rb
+++ b/config/initializers/01_ost_config.rb
@@ -12,7 +12,7 @@ module OstConfig
   end
 
   def self.scout_apm_sample_rate
-    ::ENV["SCOUT_APM_SAMPLE_RATE"]&.to_f
+    ::ENV["SCOUT_APM_SAMPLE_RATE"]&.to_f || 1.0
   end
 
   def self.timestamp_bot_detection?

--- a/config/initializers/01_ost_config.rb
+++ b/config/initializers/01_ost_config.rb
@@ -11,6 +11,10 @@ module OstConfig
     ::ActiveModel::Type::Boolean.new.cast(value)
   end
 
+  def self.scout_apm_sample_rate
+    ::ENV["SCOUT_APM_SAMPLE_RATE"]&.to_f
+  end
+
   def self.timestamp_bot_detection?
     cast_to_boolean ::ENV["TIMESTAMP_BOT_DETECTION"]
   end


### PR DESCRIPTION
We keep hitting the limits of our plan with Scout. This PR provides a configurable sample rate allowing us to statistically sample requests.