### PR TITLE
Reverse order of drawn preselected and total preselected in the division header

### DIFF
--- a/app/views/lottery_divisions/_draw_tickets_header.html.erb
+++ b/app/views/lottery_divisions/_draw_tickets_header.html.erb
@@ -53,7 +53,7 @@
           <h6 class="font-weight-bold">Pre-selects</h6>
         </div>
         <div class="col-4">
-          <h6 class="text-right"><%= "(#{division.entrants.pre_selected.count}/#{division.entrants.pre_selected.drawn.count})" %></h6>
+          <h6 class="text-right"><%= "(#{division.entrants.pre_selected.drawn.count}/#{division.entrants.pre_selected.count})" %></h6>
         </div>
       </div>
       <div class="progress">


### PR DESCRIPTION
Right now this is displaying backwards, i.e., if three pre-selected entrants exist and one has been drawn, we see `3/1`.

This PR reverses/corrects the order.