### PR TITLE
Specify version policy for #show action

### DIFF
--- a/app/controllers/admin/versions_controller.rb
+++ b/app/controllers/admin/versions_controller.rb
@@ -9,8 +9,8 @@ module Admin
     end
 
     def show
+      authorize Version, policy_class: Admin::VersionPolicy
       @version = Version.find_by(id: params[:id])
-      authorize @version
     end
   end
 end


### PR DESCRIPTION
There's no UI to get to a Versions index, and it's accessible only to an admin, but clicking a link to a specific Version is resulting in 500 because the #show action doesn't specify the policy class.

This MR fixes the error.

There is still no view for the #show action however.

Addresses https://sentry.io/organizations/opensplittime/issues/2770124864/?environment=production&project=3805803&referrer=alert_email