### PR TITLE
Delegate lottery authorization to the parent organization

### DIFF
--- a/app/controllers/lottery_divisions_controller.rb
+++ b/app/controllers/lottery_divisions_controller.rb
@@ -3,6 +3,7 @@
 class LotteryDivisionsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_organization
+  before_action :authorize_organization
   before_action :set_lottery
   before_action :set_lottery_division, except: [:new, :create]
   after_action :verify_authorized
@@ -10,18 +11,15 @@ class LotteryDivisionsController < ApplicationController
   # GET /organizations/:organization_id/lotteries/:lottery_id/lottery_divisions/new
   def new
     @lottery_division = @lottery.divisions.new
-    authorize @lottery_division
   end
 
   # GET /organizations/:organization_id/lotteries/:lottery_id/lottery_divisions/:id/edit
   def edit
-    authorize @lottery_division
   end
 
   # POST /organizations/:organization_id/lotteries/:lottery_id/lottery_divisions
   def create
     @lottery_division = @lottery.divisions.new(permitted_params)
-    authorize @lottery_division
 
     if @lottery_division.save
       redirect_to setup_organization_lottery_path(@organization, @lottery)
@@ -33,8 +31,6 @@ class LotteryDivisionsController < ApplicationController
   # PUT   /organizations/:organization_id/lotteries/:lottery_id/lottery_divisions/:id
   # PATCH /organizations/:organization_id/lotteries/:lottery_id/lottery_divisions/:id
   def update
-    authorize @lottery_division
-
     if @lottery_division.update(permitted_params)
       redirect_to setup_organization_lottery_path(@organization, @lottery)
     else
@@ -44,8 +40,6 @@ class LotteryDivisionsController < ApplicationController
 
   # DELETE /organizations/:organization_id/lotteries/:lottery_id/lottery_divisions/:id
   def destroy
-    authorize @lottery_division
-
     if @lottery_division.tickets.present?
       flash[:warning] = "A lottery division cannot be deleted unless all tickets and draws have been deleted first."
       redirect_to setup_organization_lottery_path(@organization, @lottery)
@@ -58,6 +52,10 @@ class LotteryDivisionsController < ApplicationController
   end
 
   private
+
+  def authorize_organization
+    authorize @organization, policy_class: ::LotteryDivisionPolicy
+  end
 
   def set_lottery
     @lottery = policy_scope(@organization.lotteries).friendly.find(params[:lottery_id])

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -83,4 +83,15 @@ class ApplicationPolicy
   def destroy?
     user.authorized_fully?(record)
   end
+
+  private
+
+  def verify_authorization_was_delegated(organization, delegating_class)
+    unless organization.is_a?(::Organization)
+      raise AuthorizationNotDelegatedError, "A #{delegating_class} must be authorized using the parent Organization"
+    end
+  end
+
+  class AuthorizationNotDelegatedError < Pundit::Error
+  end
 end

--- a/app/policies/lottery_division_policy.rb
+++ b/app/policies/lottery_division_policy.rb
@@ -16,8 +16,9 @@ class LotteryDivisionPolicy < ApplicationPolicy
 
   attr_reader :organization
 
-  def post_initialize(lottery_division)
-    @organization = lottery_division.lottery.organization
+  def post_initialize(organization)
+    verify_authorization_was_delegated(organization, ::LotteryDivision)
+    @organization = organization
   end
 
   def new?

--- a/app/policies/lottery_entrant_policy.rb
+++ b/app/policies/lottery_entrant_policy.rb
@@ -16,8 +16,9 @@ class LotteryEntrantPolicy < ApplicationPolicy
 
   attr_reader :organization
 
-  def post_initialize(lottery_entrant)
-    @organization = lottery_entrant.lottery.organization
+  def post_initialize(organization)
+    verify_authorization_was_delegated(organization, ::LotteryEntrant)
+    @organization = organization
   end
 
   def new?

--- a/app/policies/lottery_policy.rb
+++ b/app/policies/lottery_policy.rb
@@ -16,8 +16,12 @@ class LotteryPolicy < ApplicationPolicy
 
   attr_reader :organization
 
-  def post_initialize(lottery)
-    @organization = lottery.organization
+  def post_initialize(organization)
+    @organization = organization
+
+    unless organization.is_a?(::Organization)
+      raise ArgumentError, "Lotteries must be authorized using the parent Organization"
+    end
   end
 
   def new?

--- a/app/policies/lottery_policy.rb
+++ b/app/policies/lottery_policy.rb
@@ -17,11 +17,8 @@ class LotteryPolicy < ApplicationPolicy
   attr_reader :organization
 
   def post_initialize(organization)
+    verify_authorization_was_delegated(organization, ::Lottery)
     @organization = organization
-
-    unless organization.is_a?(::Organization)
-      raise ArgumentError, "Lotteries must be authorized using the parent Organization"
-    end
   end
 
   def new?


### PR DESCRIPTION
We ultimately use the parent Organization for authorization of lotteries, lottery divisions, and lottery entrants. But we are currently using indirect methods to get back to that Organization when authorizing controller actions related to those lottery classes.

This PR makes changes to the controllers and policies to use the Organization directly.