### PR TITLE
Lottery#export_entrants action to download import template

### DIFF
--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -19,6 +19,7 @@ class LotteryEntrant < ApplicationRecord
            .left_joins(tickets: :draw).order("lottery_tickets.lottery_entrant_id, drawn_at"), :lottery_entrants)
   end
   scope :ordered, -> { order(:drawn_at) }
+  scope :ordered_for_export, -> { with_division_name.order("division_name, last_name") }
   scope :pre_selected, -> { where(pre_selected: true) }
   scope :with_division_name, -> { from(select("lottery_entrants.*, lottery_divisions.name as division_name").joins(:division), :lottery_entrants) }
   scope :with_policy_scope_attributes, -> do

--- a/app/parameters/effort_parameters.rb
+++ b/app/parameters/effort_parameters.rb
@@ -2,7 +2,22 @@
 
 class EffortParameters < BaseParameters
   def self.csv_export_attributes
-    %w(first_name last_name gender birthdate bib_number city state country phone email emergency_contact emergency_phone scheduled_start_time_local comments)
+    [
+      "first_name",
+      "last_name",
+      "gender",
+      "birthdate",
+      "bib_number",
+      "city",
+      "state",
+      "country",
+      "phone",
+      "email",
+      "emergency_contact",
+      "emergency_phone",
+      "scheduled_start_time_local",
+      "comments",
+    ]
   end
 
   def self.permitted_query

--- a/app/parameters/lottery_entrant_parameters.rb
+++ b/app/parameters/lottery_entrant_parameters.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 
 class LotteryEntrantParameters < BaseParameters
+  def self.csv_export_attributes
+    [
+      "division_name",
+      "first_name",
+      "last_name",
+      "gender",
+      "birthdate",
+      "city",
+      "state",
+      "country",
+      "number_of_tickets",
+    ]
+  end
+
   def self.mapping
     lottery_entrant_mapping = {
       tickets: :number_of_tickets,

--- a/app/policies/lottery_policy.rb
+++ b/app/policies/lottery_policy.rb
@@ -49,6 +49,10 @@ class LotteryPolicy < ApplicationPolicy
     user.authorized_for_lotteries?(organization)
   end
 
+  def export_entrants?
+    user.authorized_for_lotteries?(organization)
+  end
+
   def draw?
     user.authorized_for_lotteries?(organization)
   end

--- a/app/views/lotteries/setup.html.erb
+++ b/app/views/lotteries/setup.html.erb
@@ -53,7 +53,7 @@
             <div class="dropdown-menu">
               <%= link_to "Lottery entrants", new_import_job_path(import_job: {parent_type: "Lottery", parent_id: @presenter.lottery.id, format: :lottery_entrants}), class: "dropdown-item" %>
               <div class="dropdown-divider"></div>
-              <%= link_to "Download template", "#", class: "dropdown-item" %>
+              <%= link_to "Download template", export_entrants_organization_lottery_path(@presenter.organization, @presenter.lottery, format: :csv, params: {filter: {id: 0}}), format: :csv, class: "dropdown-item" %>
             </div>
           </div>
           <% if @presenter.lottery_tickets.present? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,7 @@ Rails.application.routes.draw do
     resources :lotteries do
       member { get :draw_tickets }
       member { get :setup }
+      member { get :export_entrants }
       member { post :draw }
       member { post :generate_entrants }
       member { post :generate_tickets }


### PR DESCRIPTION
We need the ability to download an import template. This PR uses existing patterns in the codebase to add an export_entrants action, which will download an import template when a filter using `id: 0` is provided.