### PR TITLE
Better error reporting in lottery import and use division_name key

### DIFF
--- a/app/models/proto_record.rb
+++ b/app/models/proto_record.rb
@@ -26,6 +26,10 @@ class ProtoRecord
     attributes.to_h.has_key?(key)
   end
 
+  def keys
+    attributes.to_h.keys
+  end
+
   def record_class
     record_type&.to_s&.classify&.constantize
   end

--- a/lib/etl/errors.rb
+++ b/lib/etl/errors.rb
@@ -64,16 +64,26 @@ module ETL
        detail: {messages: ['This import requires that an event be provided']}}
     end
 
+    def missing_fields_error(raw_data)
+      {title: 'Invalid fields',
+       detail: {messages: ["The provided file #{raw_data} has a problem with the ['list'] key " +
+                               "or the ['list']['fields'] key or its values"]}}
+    end
+
+    def missing_key_error(*keys)
+      {title: "Key is missing",
+       detail: {messages: ["This import requires a column titled '#{keys.join(" or ")}' in order to proceed"]}}
+    end
+
     def missing_parent_error(type = nil)
       type ||= "record"
       {title: "Parent is missing",
        detail: {messages: ["This import requires that a parent #{type} be provided"]}}
     end
 
-    def missing_fields_error(raw_data)
-      {title: 'Invalid fields',
-       detail: {messages: ["The provided file #{raw_data} has a problem with the ['list'] key " +
-                               "or the ['list']['fields'] key or its values"]}}
+    def missing_records_error
+      {title: "No records were provided",
+       detail: {messages: ["No records were provided for this import"]}}
     end
 
     def missing_split_error

--- a/lib/etl/transformers/lottery_entrants_strategy.rb
+++ b/lib/etl/transformers/lottery_entrants_strategy.rb
@@ -16,7 +16,7 @@ module ETL
 
         proto_records.each.with_index(1) do |proto_record, row_index|
           proto_record.underscore_keys!
-          parameterized_division_name = proto_record.delete_field(:division)&.parameterize
+          parameterized_division_name = proto_record.delete_field(:division_name)&.parameterize
           division = divisions_by_name[parameterized_division_name]
 
           if division.present?
@@ -47,6 +47,13 @@ module ETL
 
       def validate_setup
         errors << missing_parent_error("Lottery") unless lottery.present?
+        errors << missing_records_error unless proto_records.present?
+
+        if proto_records.present?
+          unless proto_records.first.keys.map { |key| key.to_s.underscore}.include?("division_name")
+            errors << missing_key_error("Division name")
+          end
+        end
       end
     end
   end

--- a/spec/fixtures/files/test_lottery_entrants.csv
+++ b/spec/fixtures/files/test_lottery_entrants.csv
@@ -1,4 +1,4 @@
-﻿first_name,last_name,gender,birthdate,city,state_code,country_code,tickets,division
+﻿first_name,last_name,gender,birthdate,city,state_code,country_code,tickets,division_name
 Bjorn,Borg,male,1990-02-02,Svendborg,,,4,Fast People
 Charlie,Brown,male,2005-04-01,Peanuts,OH,US,1,Slow People
 Lucy,Pendergrast,female,2006-08-08,Psych,OH,US,3,Slow People

--- a/spec/fixtures/files/test_lottery_entrants_load_problems.csv
+++ b/spec/fixtures/files/test_lottery_entrants_load_problems.csv
@@ -1,4 +1,4 @@
-﻿first_name,last_name,gender,birthdate,city,state_code,country_code,tickets,division
+﻿first_name,last_name,gender,birthdate,city,state_code,country_code,tickets,division_name
 Bjorn,Borg,male,1990-02-02,Svendborg,,,4,Fast People
 Charlie,Brown,,2005-04-01,Peanuts,OH,US,1,Slow People
 Lucy,Pendergrast,female,2006-08-08,Psych,OH,US,,Slow People

--- a/spec/fixtures/files/test_lottery_entrants_transform_problems.csv
+++ b/spec/fixtures/files/test_lottery_entrants_transform_problems.csv
@@ -1,4 +1,4 @@
-﻿first_name,last_name,gender,birthdate,city,state_code,country_code,tickets,division
+﻿first_name,last_name,gender,birthdate,city,state_code,country_code,tickets,division_name
 Bjorn,Borg,male,1990-02-02,Svendborg,,,4,Non Existent Division
 Charlie,Brown,male,2005-04-01,Peanuts,OH,US,1,Slow People
 Lucy,Pendergrast,female,2006-08-08,Psych,OH,US,3,Slow People

--- a/spec/lib/etl/transformers/lottery_entrants_strategy_spec.rb
+++ b/spec/lib/etl/transformers/lottery_entrants_strategy_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe ::ETL::Transformers::LotteryEntrantsStrategy do
   let(:temp_people) { build_list(:person, 2) }
 
   let(:parsed_structs) { [
-    OpenStruct.new(first: person_1.first_name, last: person_1.last_name, sex: person_1.gender, State: "Colorado", country: "US", Tickets: 4, Division: division_name_1),
-    OpenStruct.new(first: person_2.first_name, last: person_2.last_name, sex: person_2.gender, state: "NY", number_of_tickets: 1, division: division_name_2),
+    OpenStruct.new(first: person_1.first_name, last: person_1.last_name, sex: person_1.gender, State: "Colorado", country: "US", Tickets: 4, Division_name: division_name_1),
+    OpenStruct.new(first: person_2.first_name, last: person_2.last_name, sex: person_2.gender, state: "NY", number_of_tickets: 1, division_name: division_name_2),
   ] }
 
   let(:division_name_1) { "Fast People" }


### PR DESCRIPTION
This PR allows us to use the import template in the exact form it is exported.