### PR TITLE
Show split traffic by event

### DIFF
--- a/app/models/interval_split_traffic.rb
+++ b/app/models/interval_split_traffic.rb
@@ -21,7 +21,11 @@ class IntervalSplitTraffic < ::ApplicationQuery
     parameterized_split_name = split_name.parameterize
     band_width = band_width / 1.second
     split_times = ::SplitTime.joins(effort: :event).joins(:split).where(splits: {parameterized_base_name: parameterized_split_name}, events: {event_group: event_group})
-    time_span = split_times.maximum(:absolute_time) - split_times.minimum(:absolute_time)
+    max = split_times.maximum(:absolute_time)
+    min = split_times.minimum(:absolute_time)
+    return [] unless max.present? && min.present?
+
+    time_span = max - min
     return if time_span / band_width > ROW_LIMIT
 
     super

--- a/app/models/interval_split_traffic.rb
+++ b/app/models/interval_split_traffic.rb
@@ -117,9 +117,17 @@ class IntervalSplitTraffic < ::ApplicationQuery
   end
 
   # Includes the overall event group counts under the 'nil' key
+  # @param [Integer, nil] event_id
+  # @return [Counts]
+  def counts_for_event(event_id)
+    all_counts_by_event[event_id]
+  end
+
+  private
+
   # @return [Hash{Integer, nil => Counts}]
-  def counts_by_event
-    @counts_by_event ||=
+  def all_counts_by_event
+    @all_counts_by_event ||=
       begin
         raw_data = event_ids.zip(short_names, in_counts, out_counts, finished_in_counts, finished_out_counts)
         counts_array = raw_data.map { |array| Counts.new(*array) }
@@ -128,8 +136,6 @@ class IntervalSplitTraffic < ::ApplicationQuery
         counts_array.index_by(&:event_id)
       end
   end
-
-  private
 
   # @return [Counts]
   def overall_counts

--- a/app/models/interval_split_traffic.rb
+++ b/app/models/interval_split_traffic.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+class IntervalSplitTraffic < ::ApplicationQuery
+  attribute :start_time, :datetime
+  attribute :end_time, :datetime
+  attribute :total_in_count, :integer
+  attribute :total_out_count, :integer
+  attribute :total_finished_in_count, :integer
+  attribute :total_finished_out_count, :integer
+  attribute :event_ids, :integer_array_from_string
+  attribute :short_names, :string_array_from_string
+  attribute :in_counts, :integer_array_from_string
+  attribute :out_counts, :integer_array_from_string
+  attribute :finished_in_counts, :integer_array_from_string
+  attribute :finished_out_counts, :integer_array_from_string
+
+  Counts = Struct.new(:event_id, :name, :in, :out, :finished_in, :finished_out)
+
+  # @param [EventGroup] event_group
+  # @param [String] split_name
+  # @param [ActiveSupport::Duration] band_width
+  # @return [String]
+  def self.sql(event_group:, split_name:, band_width:)
+    parameterized_split_name = split_name.parameterize
+    band_width = band_width / 1.second
+
+    <<~SQL.squish
+      with 
+      scoped_split_times as (
+        select st.effort_id, st.sub_split_bitkey, st.lap, st.absolute_time, ef.event_id
+        from split_times st
+          inner join efforts ef on ef.id = st.effort_id
+          inner join events ev on ev.id = ef.event_id
+          inner join splits s on s.id = st.split_id
+        where event_group_id = #{event_group.id} and s.parameterized_base_name = '#{parameterized_split_name}'
+        order by absolute_time
+      ),
+      
+      finish_split_times as (
+        select effort_id, lap
+        from efforts ef
+          inner join split_times st on st.effort_id = ef.id
+          inner join splits s on s.id = st.split_id
+        where ef.id in (select effort_id from scoped_split_times) and s.kind = 1
+        order by ef.id
+      ),
+         
+      interval_starts as (
+        select *
+        from generate_series((select min(to_timestamp(floor((extract(epoch from absolute_time)) / #{band_width}) * #{band_width})) from scoped_split_times), 
+                             (select max(to_timestamp(floor((extract(epoch from absolute_time)) / #{band_width}) * #{band_width})) + interval '#{band_width} seconds' from scoped_split_times), 
+                              interval '#{band_width} seconds') time
+      ),
+         
+      intervals as (
+        select time as start_time, lead(time) over(order by time) as end_time 
+        from interval_starts
+      ),
+      
+      intervals_with_event_ids as (
+        select start_time, end_time, event_ids.id as event_id
+        from intervals
+          cross join (select id from events where events.event_group_id = #{event_group.id}) event_ids
+      ),
+
+      ungrouped_results as (
+        select i.event_id,
+             short_name,
+             i.start_time,
+             i.end_time, 
+             count(case when st.sub_split_bitkey = 1 then 1 else null end) as in_count, 
+             count(case when st.sub_split_bitkey = 64 then 1 else null end) as out_count,
+             count(case when st.sub_split_bitkey = 1 and fst.effort_id is not null then 1 else null end) as finished_in_count,
+             count(case when st.sub_split_bitkey = 64 and fst.effort_id is not null then 1 else null end) as finished_out_count
+        from scoped_split_times st
+          left join finish_split_times fst
+            on fst.effort_id = st.effort_id and fst.lap = st.lap
+          right join intervals_with_event_ids i
+            on st.absolute_time >= i.start_time and st.absolute_time < i.end_time and st.event_id = i.event_id
+          left join events on events.id = i.event_id
+        where i.end_time is not null
+        group by i.start_time, i.end_time, i.event_id, short_name
+        order by i.start_time, i.event_id
+      )
+
+      select start_time, 
+           end_time, 
+           array_agg(event_id) as event_ids, 
+           array_agg(short_name) as short_names, 
+           array_agg(in_count) as in_counts, 
+           array_agg(out_count) as out_counts,
+           array_agg(finished_in_count) as finished_in_counts,
+           array_agg(finished_out_count) as finished_out_counts,
+           sum(in_count) as total_in_count,
+           sum(out_count) as total_out_count,
+           sum(finished_in_count) as total_finished_in_count,
+           sum(finished_out_count) as total_finished_out_count
+      from ungrouped_results
+      group by start_time, end_time
+      order by start_time;
+    SQL
+  end
+
+  # Includes the overall event group counts under the 'nil' key
+  # @return [Hash{Integer, nil => Counts}]
+  def counts_by_event
+    @counts_by_event ||=
+      begin
+        raw_data = event_ids.zip(short_names, in_counts, out_counts, finished_in_counts, finished_out_counts)
+        counts_array = raw_data.map { |array| Counts.new(*array) }
+        counts_array << overall_counts
+
+        counts_array.index_by(&:event_id)
+      end
+  end
+
+  private
+
+  # @return [Counts]
+  def overall_counts
+    Counts.new(nil, nil, total_in_count, total_out_count, total_finished_in_count, total_finished_out_count)
+  end
+end

--- a/app/models/interval_split_traffic.rb
+++ b/app/models/interval_split_traffic.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 class IntervalSplitTraffic < ::ApplicationQuery
-  attribute :start_time, :datetime
   attribute :end_time, :datetime
-  attribute :total_in_count, :integer
-  attribute :total_out_count, :integer
-  attribute :total_finished_in_count, :integer
-  attribute :total_finished_out_count, :integer
   attribute :event_ids, :integer_array_from_string
-  attribute :short_names, :string_array_from_string
-  attribute :in_counts, :integer_array_from_string
-  attribute :out_counts, :integer_array_from_string
   attribute :finished_in_counts, :integer_array_from_string
   attribute :finished_out_counts, :integer_array_from_string
+  attribute :in_counts, :integer_array_from_string
+  attribute :out_counts, :integer_array_from_string
+  attribute :short_names, :string_array_from_string
+  attribute :start_time, :datetime
+  attribute :total_finished_in_count, :integer
+  attribute :total_finished_out_count, :integer
+  attribute :total_in_count, :integer
+  attribute :total_out_count, :integer
 
   Counts = Struct.new(:event_id, :name, :in, :out, :finished_in, :finished_out)
   ROW_LIMIT = 300

--- a/app/presenters/event_group_traffic_presenter.rb
+++ b/app/presenters/event_group_traffic_presenter.rb
@@ -39,11 +39,6 @@ class EventGroupTrafficPresenter < BasePresenter
       end
   end
 
-  # Represents the overall counts for the event group
-  def overall_dummy_event
-    ::Event.new(id: nil, short_name: "Overall")
-  end
-
   def counts_header_string
     sub_split_kinds.many? ? sub_split_kinds.map { |kind| kind.to_s.titleize }.join(" / ") : 'Count'
   end
@@ -54,10 +49,6 @@ class EventGroupTrafficPresenter < BasePresenter
 
   def sub_split_counts_for_event(row, event_id)
     sub_split_kinds.map { |kind| row_counts(row, event_id, kind) }.join(" / ")
-  end
-
-  def sub_split_kinds
-    @sub_split_kinds ||= split ? split.sub_split_kinds.map { |kind| kind.downcase.to_sym } : []
   end
 
   def event
@@ -76,6 +67,11 @@ class EventGroupTrafficPresenter < BasePresenter
 
   attr_reader :parameterized_split_name
 
+  # Represents the overall counts for the event group
+  def overall_dummy_event
+    ::Event.new(id: nil, short_name: "Overall")
+  end
+
   def row_counts(row, event_id, kind)
     row.counts_by_event[event_id].send(kind)
   end
@@ -84,8 +80,8 @@ class EventGroupTrafficPresenter < BasePresenter
     @split ||= Split.where(course_id: events.map(&:course_id)).find_by(parameterized_base_name: parameterized_split_name)
   end
 
-  def indexed_events
-    @indexed_events ||= events.index_by(&:id)
+  def sub_split_kinds
+    @sub_split_kinds ||= split ? split.sub_split_kinds.map { |kind| kind.downcase.to_sym } : []
   end
 
   def localized_time(datetime)

--- a/app/presenters/event_group_traffic_presenter.rb
+++ b/app/presenters/event_group_traffic_presenter.rb
@@ -73,7 +73,7 @@ class EventGroupTrafficPresenter < BasePresenter
   end
 
   def row_counts(row, event_id, kind)
-    row.counts_by_event[event_id].send(kind)
+    row.counts_for_event(event_id).send(kind)
   end
 
   def split

--- a/app/views/event_groups/traffic.html.erb
+++ b/app/views/event_groups/traffic.html.erb
@@ -48,40 +48,42 @@
 <article class="ost-article container">
   <h4><%= @presenter.table_title %></h4>
   <div>
-    <table class="table table-condensed table-striped" style="width:80%">
-      <thead>
-      <% if @presenter.events.many? %>
+    <% if @presenter.interval_split_traffics.present? %>
+      <table class="table table-condensed table-striped" style="width:80%">
+        <thead>
+        <% if @presenter.events.many? %>
+          <tr>
+            <th></th>
+            <% @presenter.events_to_show.each do |event| %>
+              <th class="text-center"><%= event.short_name || "Overall" %></th>
+            <% end %>
+          </tr>
+        <% end %>
         <tr>
-          <th></th>
-          <% @presenter.events_to_show.each do |event| %>
-            <th class="text-center"><%= event.short_name || "Overall" %></th>
+          <th>Time Range</th>
+          <% @presenter.events_to_show.each do |_| %>
+            <th class="text-center"><%= @presenter.counts_header_string %></th>
           <% end %>
         </tr>
-      <% end %>
-      <tr>
-        <th>Time Range</th>
-        <% @presenter.events_to_show.each do |_| %>
-          <th class="text-center"><%= @presenter.counts_header_string %></th>
-        <% end %>
-      </tr>
-      </thead>
+        </thead>
 
-      <tbody>
-      <% @presenter.table.each do |row| %>
+        <tbody>
+        <% @presenter.interval_split_traffics.each do |ist| %>
+          <tr>
+            <td><%= @presenter.range_string(ist) %></td>
+            <% @presenter.events_to_show.each do |event| %>
+              <td class="text-center" style="white-space:pre-wrap; word-wrap:break-word"><%= @presenter.sub_split_counts_for_event(ist, event.id) %></td>
+            <% end %>
+          </tr>
+        <% end %>
         <tr>
-          <td><%= @presenter.range_string(row) %></td>
+          <th>Totals</th>
           <% @presenter.events_to_show.each do |event| %>
-            <td class="text-center" style="white-space:pre-wrap; word-wrap:break-word"><%= @presenter.sub_split_counts_for_event(row, event.id) %></td>
+            <th class="text-center" style="white-space:pre-wrap; word-wrap:break-word"><%= @presenter.overall_totals(event.id) %></th>
           <% end %>
         </tr>
-      <% end %>
-      <tr>
-        <th>Totals</th>
-        <% @presenter.events_to_show.each do |event| %>
-          <th class="text-center" style="white-space:pre-wrap; word-wrap:break-word"><%= @presenter.overall_totals(event.id) %></th>
-        <% end %>
-      </tr>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    <% end %>
   </div>
 </article>

--- a/app/views/event_groups/traffic.html.erb
+++ b/app/views/event_groups/traffic.html.erb
@@ -50,14 +50,18 @@
   <div>
     <table class="table table-condensed table-striped" style="width:80%">
       <thead>
-      <tr>
-        <th></th>
-        <th class="text-center" colspan="<%= @presenter.sub_split_kinds.size %>"><%= @presenter.sub_split_kinds.many? ? 'Sub Split' : '' %></th>
-      </tr>
+      <% if @presenter.events.many? %>
+        <tr>
+          <th></th>
+          <% @presenter.events_to_show.each do |event| %>
+            <th class="text-center"><%= event.short_name || "Overall" %></th>
+          <% end %>
+        </tr>
+      <% end %>
       <tr>
         <th>Time Range</th>
-        <% @presenter.sub_split_kinds.each do |kind| %>
-          <th class="text-center"><%= @presenter.sub_split_kinds.many? ? "#{kind.to_s.titleize} Count" : 'Count' %></th>
+        <% @presenter.events_to_show.each do |_| %>
+          <th class="text-center"><%= @presenter.counts_header_string %></th>
         <% end %>
       </tr>
       </thead>
@@ -65,16 +69,16 @@
       <tbody>
       <% @presenter.table.each do |row| %>
         <tr>
-          <td><%= row.range %></td>
-          <% @presenter.sub_split_kinds.each do |kind| %>
-            <td class="text-center" style="white-space:pre-wrap; word-wrap:break-word"><%= row.count[kind] %></td>
+          <td><%= @presenter.range_string(row) %></td>
+          <% @presenter.events_to_show.each do |event| %>
+            <td class="text-center" style="white-space:pre-wrap; word-wrap:break-word"><%= @presenter.sub_split_counts_for_event(row, event.id) %></td>
           <% end %>
         </tr>
       <% end %>
       <tr>
         <th>Totals</th>
-        <% @presenter.sub_split_kinds.each do |kind| %>
-          <th class="text-center" style="white-space:pre-wrap; word-wrap:break-word"><%= @presenter.totals(kind) %></th>
+        <% @presenter.events_to_show.each do |event| %>
+          <th class="text-center" style="white-space:pre-wrap; word-wrap:break-word"><%= @presenter.overall_totals(event.id) %></th>
         <% end %>
       </tr>
       </tbody>

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -2,3 +2,5 @@ require "type/integer_array_from_string"
 
 ActiveModel::Type.register(:integer_array_from_string, ::Type::IntegerArrayFromString)
 ActiveRecord::Type.register(:integer_array_from_string, ::Type::IntegerArrayFromString)
+ActiveModel::Type.register(:string_array_from_string, ::Type::StringArrayFromString)
+ActiveRecord::Type.register(:string_array_from_string, ::Type::StringArrayFromString)

--- a/lib/type/string_array_from_string.rb
+++ b/lib/type/string_array_from_string.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Postgres returns an array_agg field as a comma-delimited String
+# surrounded by curly braces, like "{hello,there,world}".
+#
+# This Type converts such a String to an array of Strings.
+#
+module Type
+  class StringArrayFromString < ::ActiveModel::Type::Value
+    # @param [String, Array, nil] value
+    # @return [Array<String>]
+    def cast(value)
+      return super if value.is_a?(Enumerable)
+      return [] unless value.present?
+
+      stripped_value = value.to_s.match(/\A{(.*)}\z/)[1]
+      return [] unless stripped_value.present?
+
+      stripped_value.split(",")
+    end
+  end
+end

--- a/spec/lib/type/string_array_from_string_spec.rb
+++ b/spec/lib/type/string_array_from_string_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::Type::StringArrayFromString do
+  module TestDummy
+    class QueryModel
+      include ::ActiveModel::Model
+      include ::ActiveModel::Attributes
+
+      attribute :names, :string_array_from_string
+    end
+  end
+
+  describe "#cast" do
+    subject { ::TestDummy::QueryModel.new(names: names) }
+    context "when given a Postgres-style array" do
+      let(:names) { "{hello,there,world}" }
+      it "casts names as an array" do
+        expect(subject.names).to eq(["hello", "there", "world"])
+      end
+    end
+
+    context "when given a Postgres-style array with numbers and symbols" do
+      let(:names) { "{hello1,there2*,world{3!}}" }
+      it "casts names as an array" do
+        expect(subject.names).to eq(["hello1", "there2*", "world{3!}"])
+      end
+    end
+
+    context "when given an empty Postgres-style array" do
+      let(:names) { "{}" }
+      it "casts as an empty array" do
+        expect(subject.names).to eq([])
+      end
+    end
+
+    context "when given an empty string" do
+      let(:names) { "" }
+      it "casts as an empty array" do
+        expect(subject.names).to eq([])
+      end
+    end
+
+    context "when given an array" do
+      let(:names) { ["hello", "there", "world"] }
+      it "returns the array" do
+        expect(subject.names).to eq(["hello", "there", "world"])
+      end
+    end
+
+    context "when given nil" do
+      let(:names) { nil }
+      it "casts as an empty array" do
+        expect(subject.names).to eq([])
+      end
+    end
+  end
+end

--- a/spec/models/interval_split_traffic_spec.rb
+++ b/spec/models/interval_split_traffic_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IntervalSplitTraffic, type: :model do
+  describe ".execute_query" do
+    subject { described_class.execute_query(event_group: event_group, split_name: split_name, band_width: band_width) }
+    let(:event_group) { event_groups(:hardrock_2015) }
+
+    context "for a split close to the start" do
+      let(:split_name) { "Cunningham" }
+      let(:band_width) { 1.hour }
+
+      it "returns an array of IntervalSplitTraffic objects" do
+        expect(subject.size).to eq(3)
+        expect(subject.map(&:start_time)).to eq(["2015-07-10 13:00:00", "2015-07-10 14:00:00", "2015-07-10 15:00:00"])
+        expect(subject.map(&:end_time)).to eq(["2015-07-10 14:00:00", "2015-07-10 15:00:00", "2015-07-10 16:00:00"])
+        expect(subject.map(&:total_in_count)).to eq([2, 20, 8])
+        expect(subject.map(&:total_out_count)).to eq([2, 20, 8])
+      end
+    end
+
+    context "for a split extending over multiple days" do
+      let(:split_name) { "Telluride" }
+      let(:band_width) { 1.hour }
+
+      it "returns an array of IntervalSplitTraffic objects reflecting multiple days" do
+        expect(subject.size).to eq(19)
+
+        subject_ist = subject[10]
+        expect(subject_ist.start_time).to eq("2015-07-11 13:00:00")
+        expect(subject_ist.end_time).to eq("2015-07-11 14:00:00")
+        expect(subject_ist.total_in_count).to eq(5)
+        expect(subject_ist.total_finished_in_count).to eq(5)
+        expect(subject_ist.total_out_count).to eq(4)
+        expect(subject_ist.total_finished_out_count).to eq(4)
+      end
+    end
+
+    context "for an event group with multiple events" do
+      let(:event_group) { event_groups(:sum) }
+      let(:split_name) { "Start" }
+      let(:band_width) { 1.day }
+
+      it "returns an array of IntervalSplitTraffic objects with counts for each event" do
+        expect(subject.size).to eq(44)
+
+        subject_ist = subject.first
+        expect(subject_ist.start_time).to eq("2017-09-23 00:00:00")
+        expect(subject_ist.end_time).to eq("2017-09-24 00:00:00")
+        expect(subject_ist.short_names).to eq(["100K", "55K"])
+        expect(subject_ist.event_ids).to eq([56, 57])
+        expect(subject_ist.in_counts).to eq([2, 2])
+        expect(subject_ist.out_counts).to eq([0, 0])
+        expect(subject_ist.finished_in_counts).to eq([0, 2])
+        expect(subject_ist.finished_out_counts).to eq([0, 0])
+      end
+    end
+  end
+
+  describe "#counts_by_event" do
+    subject do
+      described_class.new(
+        short_names: ["First Event", "Second Event"],
+        event_ids: [1, 2],
+        in_counts: [3, 4],
+        out_counts: [3, 3],
+        finished_in_counts: [2, 3],
+        finished_out_counts: [2, 2],
+        total_in_count: 7,
+        total_out_count: 6,
+        total_finished_in_count: 5,
+        total_finished_out_count: 4,
+      )
+    end
+
+    let(:result) { subject.counts_by_event }
+    let(:expected_result) do
+      {
+        1 => described_class::Counts.new(1, "First Event", 3, 3, 2, 2),
+        2 => described_class::Counts.new(2, "Second Event", 4, 3, 3, 2),
+        nil => described_class::Counts.new(nil, nil, 7, 6, 5, 4),
+      }
+    end
+
+    it "returns a hash with organized information" do
+      expect(result).to eq(expected_result)
+    end
+  end
+end

--- a/spec/models/interval_split_traffic_spec.rb
+++ b/spec/models/interval_split_traffic_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe IntervalSplitTraffic, type: :model do
     end
   end
 
-  describe "#counts_by_event" do
+  describe "#counts_for_event" do
     subject do
       described_class.new(
         short_names: ["First Event", "Second Event"],
@@ -93,17 +93,21 @@ RSpec.describe IntervalSplitTraffic, type: :model do
       )
     end
 
-    let(:result) { subject.counts_by_event }
-    let(:expected_result) do
-      {
-        1 => described_class::Counts.new(1, "First Event", 3, 3, 2, 2),
-        2 => described_class::Counts.new(2, "Second Event", 4, 3, 3, 2),
-        nil => described_class::Counts.new(nil, nil, 7, 6, 5, 4),
-      }
+    let(:result) { subject.counts_for_event(event_id) }
+
+    context "for the first event" do
+      let(:event_id) { 1 }
+      it { expect(result).to eq(described_class::Counts.new(1, "First Event", 3, 3, 2, 2)) }
     end
 
-    it "returns a hash with organized information" do
-      expect(result).to eq(expected_result)
+    context "for the second event" do
+      let(:event_id) { 2 }
+      it { expect(result).to eq(described_class::Counts.new(2, "Second Event", 4, 3, 3, 2)) }
+    end
+
+    context "for the overall event group" do
+      let(:event_id) { nil }
+      it { expect(result).to eq(described_class::Counts.new(nil, nil, 7, 6, 5, 4)) }
     end
   end
 end

--- a/spec/models/interval_split_traffic_spec.rb
+++ b/spec/models/interval_split_traffic_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe IntervalSplitTraffic, type: :model do
   describe ".execute_query" do
     subject { described_class.execute_query(event_group: event_group, split_name: split_name, band_width: band_width) }
     let(:event_group) { event_groups(:hardrock_2015) }
+    let(:band_width) { 1.hour }
 
     context "for a split close to the start" do
       let(:split_name) { "Cunningham" }
-      let(:band_width) { 1.hour }
 
       it "returns an array of IntervalSplitTraffic objects" do
         expect(subject.size).to eq(3)
@@ -22,7 +22,6 @@ RSpec.describe IntervalSplitTraffic, type: :model do
 
     context "for a split extending over multiple days" do
       let(:split_name) { "Telluride" }
-      let(:band_width) { 1.hour }
 
       it "returns an array of IntervalSplitTraffic objects reflecting multiple days" do
         expect(subject.size).to eq(19)
@@ -54,6 +53,26 @@ RSpec.describe IntervalSplitTraffic, type: :model do
         expect(subject_ist.out_counts).to eq([0, 0])
         expect(subject_ist.finished_in_counts).to eq([0, 2])
         expect(subject_ist.finished_out_counts).to eq([0, 0])
+      end
+    end
+
+    context "when the query would return too many rows" do
+      let(:split_name) { "Telluride" }
+      let(:band_width) { 1.minute }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "for a split that has not yet seen any traffic" do
+      let(:event_group) { event_groups(:hardrock_2016) }
+      let(:split_name) { "Finish" }
+      let(:split) { event_group.events.first.course.finish_split }
+      before { event_group.split_times.where(split: split).each(&:destroy) }
+
+      it "returns an empty array" do
+        expect(subject).to eq([])
       end
     end
   end

--- a/spec/queries/split_time_query_spec.rb
+++ b/spec/queries/split_time_query_spec.rb
@@ -42,37 +42,4 @@ RSpec.describe SplitTimeQuery do
       end
     end
   end
-
-  describe '.split_traffic' do
-    subject { SplitTimeQuery.split_traffic(event_group: event_group, split_name: split_name, band_width: band_width) }
-    let(:event_group) { event_groups(:hardrock_2015) }
-
-    context 'for a split close to the start' do
-      let(:split_name) { 'Cunningham' }
-      let(:band_width) { 1.hour }
-
-      it 'returns a hash with time intervals and effort counts in and out' do
-        expect(subject.size).to eq(3)
-        expect(subject.map { |row| row['start_time'] }).to eq(['Fri 07:00', 'Fri 08:00', 'Fri 09:00'])
-        expect(subject.map { |row| row['end_time'] }).to eq(['Fri 08:00', 'Fri 09:00', 'Fri 10:00'])
-        expect(subject.map { |row| row['in_count'] }).to eq([2, 20, 8])
-        expect(subject.map { |row| row['out_count'] }).to eq([2, 20, 8])
-      end
-    end
-
-    context 'for a split extending over multiple days' do
-      let(:split_name) { 'Telluride' }
-      let(:band_width) { 1.hour }
-
-      it 'returns a hash with time intervals reflecting multiple days' do
-        expect(subject.size).to eq(19)
-        expect(subject[10]).to eq({'start_time' => 'Sat 07:00',
-                                  'end_time' => 'Sat 08:00',
-                                  'in_count' => 5,
-                                  'out_count' => 4,
-                                  'finished_in_count' => 5,
-                                  'finished_out_count' => 4})
-      end
-    end
-  end
 end


### PR DESCRIPTION
To show split traffic broken down by event, we need a new custom query and a modified presenter and view.

This PR adds those items and removes the code that is obsoleted by this change.

Addresses #618 