### PR TITLE
Fix spread API casting

### DIFF
--- a/app/serializers/api/v1/effort_times_row_serializer.rb
+++ b/app/serializers/api/v1/effort_times_row_serializer.rb
@@ -6,9 +6,20 @@ module Api
       set_type :effort_times_rows
 
       attributes *EffortTimesRow::EXPORT_ATTRIBUTES, :display_style, :stopped, :dropped, :finished
-      attribute :elapsed_times, if: Proc.new { |row| row.show_elapsed_times? }
       attribute :absolute_times, if: Proc.new { |row| row.show_absolute_times? }
-      attribute :segment_times, if: Proc.new { |row| row.show_segment_times? }
+
+      attribute :elapsed_times, if: Proc.new { |row|
+        row.show_elapsed_times?
+      } do |object|
+        object.elapsed_times.map { |e| e.map(&:to_f) }
+      end
+
+      attribute :segment_times, if: Proc.new { |row|
+        row.show_segment_times?
+      } do |object|
+        object.segment_times.map { |e| e.map { |time| time&.to_f } }
+      end
+
       attribute :pacer_flags, if: Proc.new { |row| row.show_pacer_flags? }
       attribute :stopped_here_flags, if: Proc.new { |row| row.show_stopped_here_flags? }
       attribute :time_data_statuses, if: Proc.new { |row| row.show_time_data_statuses? }

--- a/app/serializers/api/v1/effort_times_row_serializer.rb
+++ b/app/serializers/api/v1/effort_times_row_serializer.rb
@@ -11,7 +11,7 @@ module Api
       attribute :elapsed_times, if: Proc.new { |row|
         row.show_elapsed_times?
       } do |object|
-        object.elapsed_times.map { |e| e.map(&:to_f) }
+        object.elapsed_times.map { |e| e.map { |time| time&.to_f } }
       end
 
       attribute :segment_times, if: Proc.new { |row|

--- a/spec/controllers/api/v1/events_controller_spec.rb
+++ b/spec/controllers/api/v1/events_controller_spec.rb
@@ -1,245 +1,245 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Api::V1::EventsController do
-  let(:type) { 'events' }
+  let(:type) { "events" }
   let(:event) { create(:event, course: course, event_group: event_group) }
   let(:course) { create(:course) }
   let(:event_group) { create(:event_group) }
 
-  describe '#index' do
+  let(:parsed_response) { JSON.parse(response.body) }
+
+  describe "#index" do
     subject(:make_request) { get :index, params: params }
     let(:params) { {} }
 
     via_login_and_jwt do
-      it 'returns a successful 200 response' do
+      it "returns a successful 200 response" do
         make_request
         expect(response.status).to eq(200)
       end
 
-      context 'when no params are given' do
-        it 'returns all available events' do
+      context "when no params are given" do
+        it "returns all available events" do
           make_request
           expect(response.status).to eq(200)
-          parsed_response = JSON.parse(response.body)
-          expect(parsed_response['data'].map { |item| item['id'].to_i }).to match_array(Event.all.map(&:id).sort)
+          expect(parsed_response["data"].map { |item| item["id"].to_i }).to match_array(Event.all.map(&:id).sort)
         end
       end
     end
   end
 
-  describe '#show' do
+  describe "#show" do
     subject(:make_request) { get :show, params: params }
 
     via_login_and_jwt do
-      context 'when an existing event.id is provided' do
+      context "when an existing event.id is provided" do
         let(:params) { {id: event.id} }
 
-        it 'returns a successful 200 response' do
+        it "returns a successful 200 response" do
           make_request
           expect(response.status).to eq(200)
         end
 
-        it 'returns data of a single event' do
+        it "returns data of a single event" do
           make_request
-          parsed_response = JSON.parse(response.body)
-          expect(parsed_response['data']['id'].to_i).to eq(event.id)
+          expect(parsed_response["data"]["id"].to_i).to eq(event.id)
           expect(response.body).to be_jsonapi_response_for(type)
         end
       end
 
-      context 'if the event does not exist' do
+      context "if the event does not exist" do
         let(:params) { {id: 0} }
 
-        it 'returns an error' do
+        it "returns an error" do
           make_request
-          parsed_response = JSON.parse(response.body)
-          expect(parsed_response['errors']).to include(/not found/)
+          expect(parsed_response["errors"]).to include(/not found/)
           expect(response.status).to eq(404)
         end
       end
     end
   end
 
-  describe '#create' do
+  describe "#create" do
     subject(:make_request) { post :create, params: params }
     let(:params) { {data: {type: type, attributes: attributes}} }
 
     via_login_and_jwt do
-      context 'when provided data is valid' do
-        let(:attributes) { {course_id: course.id, event_group_id: event_group.id, short_name: '50M',
-                            scheduled_start_time_local: '2017-03-01 06:00:00', laps_required: 1} }
+      context "when provided data is valid" do
+        let(:attributes) { {course_id: course.id, event_group_id: event_group.id, short_name: "50M",
+                            scheduled_start_time_local: "2017-03-01 06:00:00", laps_required: 1} }
 
-        it 'returns a successful json response' do
+        it "returns a successful json response" do
           make_request
           expect(response.status).to eq(201)
           expect(response.body).to be_jsonapi_response_for(type)
-          parsed_response = JSON.parse(response.body)
-          expect(parsed_response['data']['id']).not_to be_nil
+          expect(parsed_response["data"]["id"]).not_to be_nil
         end
 
-        it 'creates an event record with an id' do
+        it "creates an event record with an id" do
           expect { make_request }.to change { Event.count }.by(1)
         end
       end
     end
   end
 
-  describe '#update' do
+  describe "#update" do
     subject(:make_request) { put :update, params: params }
     let(:params) { {id: event_id, data: {type: type, attributes: attributes}} }
-    let(:attributes) { {short_name: 'Updated Short Name'} }
+    let(:attributes) { {short_name: "Updated Short Name"} }
 
     via_login_and_jwt do
-      context 'when the event exists' do
+      context "when the event exists" do
         let(:event_id) { event.id }
 
-        it 'returns a successful json response' do
+        it "returns a successful json response" do
           make_request
           expect(response.body).to be_jsonapi_response_for(type)
           expect(response.status).to eq(200)
         end
 
-        it 'updates the specified fields' do
+        it "updates the specified fields" do
           make_request
           event.reload
           expect(event.short_name).to eq(attributes[:short_name])
         end
       end
 
-      context 'when the event does not exist' do
+      context "when the event does not exist" do
         let(:event_id) { 0 }
 
-        it 'returns an error' do
+        it "returns an error" do
           make_request
-          parsed_response = JSON.parse(response.body)
-          expect(parsed_response['errors']).to include(/not found/)
+          expect(parsed_response["errors"]).to include(/not found/)
           expect(response.status).to eq(404)
         end
       end
     end
   end
 
-  describe '#destroy' do
+  describe "#destroy" do
     subject(:make_request) { delete :destroy, params: {id: event_id} }
 
     via_login_and_jwt do
-      context 'when the event exists' do
+      context "when the event exists" do
         let!(:event) { create(:event) }
         let(:event_id) { event.id }
 
-        it 'returns a successful json response' do
+        it "returns a successful json response" do
           make_request
           expect(response.status).to eq(200)
         end
 
-        it 'destroys the event record' do
+        it "destroys the event record" do
           expect { make_request }.to change { Event.count }.by(-1)
         end
       end
 
-      context 'when the event does not exist' do
+      context "when the event does not exist" do
         let(:event_id) { 0 }
-        it 'returns an error' do
+        it "returns an error" do
           make_request
-          parsed_response = JSON.parse(response.body)
-          expect(parsed_response['errors']).to include(/not found/)
+          expect(parsed_response["errors"]).to include(/not found/)
           expect(response.status).to eq(404)
         end
       end
     end
   end
 
-  describe '#spread' do
+  describe "#spread" do
     subject(:make_request) { get :spread, params: params }
     let(:params) { {id: event_id, display_style: display_style} }
     let(:event_id) { event.id }
-    let(:display_style) { 'absolute' }
+    let(:display_style) { "absolute" }
     before { Rails.cache.clear }
 
     via_login_and_jwt do
-      context 'when the event exists' do
+      context "when the event exists" do
         let(:event_id) { event.id }
 
-        it 'returns a successful 200 response' do
+        it "returns a successful 200 response" do
           make_request
           expect(response.status).to eq(200)
         end
 
-        it 'returns data of a single event' do
+        it "returns data of a single event" do
           make_request
-          parsed_response = JSON.parse(response.body)
-          expect(parsed_response['data']['id'].to_i).to eq(event.id)
-          expect(response.body).to be_jsonapi_response_for('event_spread_displays')
+          expect(parsed_response["data"]["id"].to_i).to eq(event.id)
+          expect(response.body).to be_jsonapi_response_for("event_spread_displays")
         end
       end
 
-      context 'when the event does not exist' do
+      context "when the event does not exist" do
         let(:event_id) { 0 }
 
-        it 'returns an error' do
+        it "returns an error" do
           make_request
-          parsed_response = JSON.parse(response.body)
-          expect(parsed_response['errors']).to include(/not found/)
+          expect(parsed_response["errors"]).to include(/not found/)
           expect(response.status).to eq(404)
         end
       end
 
-      context 'when split and effort data are available' do
+      context "when split and effort data are available" do
         let(:event) { events(:hardrock_2015) }
 
-        context 'when display_style is not provided' do
-          it 'returns split data in the expected format' do
+        context "when display_style is not provided" do
+          it "returns split data in the expected format" do
             make_request
-            parsed_response = JSON.parse(response.body)
-            expect(parsed_response.dig('data', 'attributes', 'splitHeaderData').map { |header| header['title'] })
-                .to match_array(event.splits.map(&:base_name))
+            expect(parsed_response.dig("data", "attributes", "splitHeaderData").map { |header| header["title"] })
+              .to match_array(event.splits.map(&:base_name))
           end
 
-          it 'returns effort data in the expected format' do
+          it "returns effort data in the expected format" do
             make_request
-            parsed_response = JSON.parse(response.body)
-            expect(parsed_response['included'].map { |effort| effort.dig('attributes', 'lastName') })
-                .to match_array(event.efforts.map(&:last_name))
+            expect(parsed_response["included"].map { |effort| effort.dig("attributes", "lastName") })
+              .to match_array(event.efforts.map(&:last_name))
           end
 
-          it 'returns time data in absolute time format' do
+          it "returns time data in absolute time format" do
             make_request
-            parsed_response = JSON.parse(response.body)
-            subject_row = parsed_response['included'].first
-            subject_effort = Effort.find(subject_row['id'])
-            expect(subject_row.dig('attributes', 'displayStyle')).to eq('absolute')
+            subject_row = parsed_response["included"].first
+            subject_effort = Effort.find(subject_row["id"])
+            expect(subject_row.dig("attributes", "displayStyle")).to eq("absolute")
 
-            response_times = subject_row.dig('attributes', 'absoluteTimes').flatten.map(&:in_time_zone)
+            response_times = subject_row.dig("attributes", "absoluteTimes").flatten.map(&:in_time_zone)
             expected_times = subject_effort.ordered_split_times.map(&:absolute_time)
             expect(response_times).to eq(expected_times)
           end
         end
 
-        context 'when display_style is elapsed' do
-          let(:display_style) { 'elapsed' }
+        context "when display_style is elapsed" do
+          let(:display_style) { "elapsed" }
+          let(:subject_effort) { ::Effort.find(subject_row["id"]) }
+          let(:response_times) { subject_row.dig("attributes", "elapsedTimes").flatten }
 
-          it 'returns time data in elapsed time format' do
-            make_request
-            parsed_response = JSON.parse(response.body)
-            subject_row = parsed_response['included'].first
-            subject_effort = Effort.find(subject_row['id'])
-            expect(subject_row.dig('attributes', 'displayStyle')).to eq('elapsed')
+          context "when all times are present" do
+            let(:subject_row) { parsed_response["included"].first }
+            let(:expected_times) { subject_effort.ordered_split_times.map(&:time_from_start) }
+            it "returns time data in elapsed time format" do
+              make_request
+              expect(subject_row.dig("attributes", "displayStyle")).to eq("elapsed")
 
-            response_times = subject_row.dig('attributes', 'elapsedTimes').flatten
-            expected_times = subject_effort.ordered_split_times.map(&:time_from_start)
-            expect(response_times).to eq(expected_times)
+              expect(response_times).to eq(expected_times)
+            end
+          end
+
+          context "when a time is missing" do
+            let(:subject_row) { parsed_response["included"][22] }
+            let(:expected_times) { [0.0, 11760.0, 11760.0, 39000.0, 39720.0, 62700.0, 63480.0, nil, nil, 112260.0, 112860.0, 163560.0, 163560.0, 171060.0] }
+            it "represents the missing time with nil" do
+              make_request
+              expect(response_times).to eq(expected_times)
+            end
           end
         end
 
-        context 'when a sort param is provided' do
-          let(:params) { {id: event.id, sort: 'last_name'} }
+        context "when a sort param is provided" do
+          let(:params) { {id: event.id, sort: "last_name"} }
 
-          it 'sorts effort data based on the sort param' do
+          it "sorts effort data based on the sort param" do
             make_request
-            parsed_response = JSON.parse(response.body)
-            last_names = parsed_response['included'].map { |effort| effort.dig('attributes', 'lastName') }
+            last_names = parsed_response["included"].map { |effort| effort.dig("attributes", "lastName") }
             expect(last_names.sort).to eq(last_names)
           end
         end
@@ -247,106 +247,104 @@ RSpec.describe Api::V1::EventsController do
     end
   end
 
-  describe '#import' do
+  describe "#import" do
     subject(:make_request) { post :import, params: request_params }
 
     let(:event) { events(:ggd30_50k) }
     let(:event_group) { event.event_group }
 
     via_login_and_jwt do
-      context 'when provided with a file' do
-        let(:request_params) { {id: event.id, data_format: 'csv_efforts', file: file} }
-        let(:file) { fixture_file_upload(file_fixture('test_efforts_utf_8.csv')) }
+      context "when provided with a file" do
+        let(:request_params) { {id: event.id, data_format: "csv_efforts", file: file} }
+        let(:file) { fixture_file_upload(file_fixture("test_efforts_utf_8.csv")) }
 
-        it 'creates efforts' do
+        it "creates efforts" do
           expect { make_request }.to change { Effort.count }.by(3)
           expect(response.status).to eq(201)
-          parsed_response = JSON.parse(response.body)
           expect(parsed_response).to eq({})
         end
       end
 
-      context 'when provided with a file having start_time or start_offset' do
-        let(:request_params) { {id: event.id, data_format: 'csv_efforts', file: file} }
-        let(:file) { fixture_file_upload(file_fixture('test_efforts_start_attributes.csv')) }
+      context "when provided with a file having start_time or start_offset" do
+        let(:request_params) { {id: event.id, data_format: "csv_efforts", file: file} }
+        let(:file) { fixture_file_upload(file_fixture("test_efforts_start_attributes.csv")) }
 
-        it 'sets scheduled_start_time based on the start_time or start_offset or event start_time' do
+        it "sets scheduled_start_time based on the start_time or start_offset or event start_time" do
           expect { make_request }.to change { Effort.count }.by(3)
           expect(response.status).to eq(201)
 
           efforts = Effort.last(3)
-          expected_absolute_times = ['2017-06-03 19:30:00 -0600',
-                                     '2017-06-03 08:00:00 -0600',
-                                     '2017-06-03 19:00:00 -0600'].map(&:to_datetime)
+          expected_absolute_times = ["2017-06-03 19:30:00 -0600",
+                                     "2017-06-03 08:00:00 -0600",
+                                     "2017-06-03 19:00:00 -0600"].map(&:to_datetime)
           expect(efforts.map(&:scheduled_start_time)).to match_array(expected_absolute_times)
 
-          # parsed_response = JSON.parse(response.body)
-          # expect(parsed_response['data'].size).to eq(3)
+          # expect(parsed_response["data"].size).to eq(3)
           #
-          # start_times = parsed_response['data'].map { |row| row['attributes']['scheduledStartTime']&.in_time_zone(event_group.home_time_zone) }
+          # start_times = parsed_response["data"].map { |row| row["attributes"]["scheduledStartTime"]&.in_time_zone(event_group.home_time_zone) }
           # expect(start_times).to eq(expected_absolute_times)
         end
       end
 
-      context 'when provided with an adilas url and data_format adilas_bear_times' do
-        let(:request_params) { {id: event.id, data_format: 'adilas_bear_times', data: source_data} }
+      context "when provided with an adilas url and data_format adilas_bear_times" do
+        let(:request_params) { {id: event.id, data_format: "adilas_bear_times", data: source_data} }
         let(:source_data) do
-          VCR.use_cassette("adilas/#{url.split('?').last}") do
+          VCR.use_cassette("adilas/#{url.split("?").last}") do
             Net::HTTP.get(URI(url))
           end
         end
-        let(:url) { 'https://www.adilas.biz/bear100/runner_details.cfm?id=500' }
+        let(:url) { "https://www.adilas.biz/bear100/runner_details.cfm?id=500" }
 
-        it 'creates an effort and split_times' do
+        it "creates an effort and split_times" do
           expect { make_request }.to change { event.efforts.count }.by(1)
           expect(response.status).to eq(201)
           event.reload
           effort = event.efforts.last
-          expect(effort.first_name).to eq('Linda')
-          expect(effort.last_name).to eq('McFadden')
+          expect(effort.first_name).to eq("Linda")
+          expect(effort.last_name).to eq("McFadden")
           split_times = effort.ordered_split_times
           expect(split_times.size).to eq(7)
-          expected_absolute_times = ['2016-09-23 06:00:00 -0600',
-                                     '2016-09-23 08:49:10 -0600',
-                                     '2016-09-23 08:49:10 -0600',
-                                     '2016-09-23 12:30:27 -0600',
-                                     '2016-09-23 12:30:29 -0600',
-                                     '2016-09-24 13:49:11 -0600',
-                                     '2016-09-23 13:49:11 -0600']
+          expected_absolute_times = ["2016-09-23 06:00:00 -0600",
+                                     "2016-09-23 08:49:10 -0600",
+                                     "2016-09-23 08:49:10 -0600",
+                                     "2016-09-23 12:30:27 -0600",
+                                     "2016-09-23 12:30:29 -0600",
+                                     "2016-09-24 13:49:11 -0600",
+                                     "2016-09-23 13:49:11 -0600"]
 
           expect(split_times.map(&:absolute_time)).to eq(expected_absolute_times)
         end
       end
 
-      context 'when provided with JSON data from api.raceresult.com and data_format race_result_api_times' do
-        let(:request_params) { {id: event.id, data_format: 'race_result_api_times', data: source_data} }
+      context "when provided with JSON data from api.raceresult.com and data_format race_result_api_times" do
+        let(:request_params) { {id: event.id, data_format: "race_result_api_times", data: source_data} }
         let(:source_data) do
           {"list" =>
-               {"list_name" => "Result Lists|Tracking Details - json for API",
-                "orders" => [],
-                "filters" => [{"expression1" => "CONTEST", "expression2" => "1", "operator" => "=", "or_conjunction" => false}],
-                "fields" => [{"alignment" => 1, "expression" => "\"#\" & [BIB] & \". \" & ucase([FLNAME])"},
-                             {"alignment" => 1, "expression" => "\"STATUS: \" & [STATUSTEXT]"},
-                             {"alignment" => 1, "expression" => "\"START\""},
-                             {"alignment" => 1, "expression" => "iif([TIMESET100];\"Time: \" & format(T100;\"Hh:mm:ss A\"))"},
-                             {"alignment" => 1, "expression" => "\"AID 1\""},
-                             {"alignment" => 1, "expression" => "iif([TIMESET151];\"Time: \" & format(T151;\"Hh:mm:ss A\"))", "line" => 3},
-                             {"alignment" => 1, "expression" => "iif([TIMESET151];\"Split: \" & [Section1Split])", "line" => 3},
-                             {"alignment" => 1, "expression" => "\"AID 2\"", "line" => 4},
-                             {"alignment" => 1, "expression" => "iif([TIMESET152];\"Time: \" & format(T152;\"Hh:mm:ss A\"))", "line" => 4},
-                             {"alignment" => 1, "expression" => "iif([TIMESET152];\"Split: \" & [Section2Split])", "line" => 4},
-                             {"alignment" => 1, "expression" => "\"AID 3\"", "line" => 5},
-                             {"alignment" => 1, "expression" => "iif([TIMESET153];\"Time: \" & format(T153;\"Hh:mm:ss A\"))", "line" => 5},
-                             {"alignment" => 1, "expression" => "iif([TIMESET153];\"Split: \" & [Section3Split])", "line" => 5},
-                             {"alignment" => 1, "expression" => "\"AID 4\"", "line" => 6},
-                             {"alignment" => 1, "expression" => "iif([TIMESET154];\"Time: \" & format(T154;\"Hh:mm:ss A\"))", "line" => 6},
-                             {"alignment" => 1, "expression" => "iif([TIMESET154];\"Split: \" & [Section4Split])", "line" => 6},
-                             {"alignment" => 1, "expression" => "\"AID 5\"", "line" => 7},
-                             {"alignment" => 1, "expression" => "iif([TIMESET155];\"Time: \" & format(T155;\"Hh:mm:ss A\"))", "line" => 7},
-                             {"alignment" => 1, "expression" => "iif([TIMESET155];\"Split: \" & [Section6Split])", "line" => 7},
-                             {"alignment" => 1, "expression" => "\"FINISH\"", "line" => 8},
-                             {"alignment" => 1, "expression" => "iif([TIMESET200];\"Time: \" & format(T200;\"Hh:mm:ss A\"))", "line" => 8},
-                             {"alignment" => 1, "expression" => "iif([TIMESET200];\"Total Time: \" & [TIMETEXT])", "line" => 8}]},
+             {"list_name" => "Result Lists|Tracking Details - json for API",
+              "orders" => [],
+              "filters" => [{"expression1" => "CONTEST", "expression2" => "1", "operator" => "=", "or_conjunction" => false}],
+              "fields" => [{"alignment" => 1, "expression" => "\"#\" & [BIB] & \". \" & ucase([FLNAME])"},
+                           {"alignment" => 1, "expression" => "\"STATUS: \" & [STATUSTEXT]"},
+                           {"alignment" => 1, "expression" => "\"START\""},
+                           {"alignment" => 1, "expression" => "iif([TIMESET100];\"Time: \" & format(T100;\"Hh:mm:ss A\"))"},
+                           {"alignment" => 1, "expression" => "\"AID 1\""},
+                           {"alignment" => 1, "expression" => "iif([TIMESET151];\"Time: \" & format(T151;\"Hh:mm:ss A\"))", "line" => 3},
+                           {"alignment" => 1, "expression" => "iif([TIMESET151];\"Split: \" & [Section1Split])", "line" => 3},
+                           {"alignment" => 1, "expression" => "\"AID 2\"", "line" => 4},
+                           {"alignment" => 1, "expression" => "iif([TIMESET152];\"Time: \" & format(T152;\"Hh:mm:ss A\"))", "line" => 4},
+                           {"alignment" => 1, "expression" => "iif([TIMESET152];\"Split: \" & [Section2Split])", "line" => 4},
+                           {"alignment" => 1, "expression" => "\"AID 3\"", "line" => 5},
+                           {"alignment" => 1, "expression" => "iif([TIMESET153];\"Time: \" & format(T153;\"Hh:mm:ss A\"))", "line" => 5},
+                           {"alignment" => 1, "expression" => "iif([TIMESET153];\"Split: \" & [Section3Split])", "line" => 5},
+                           {"alignment" => 1, "expression" => "\"AID 4\"", "line" => 6},
+                           {"alignment" => 1, "expression" => "iif([TIMESET154];\"Time: \" & format(T154;\"Hh:mm:ss A\"))", "line" => 6},
+                           {"alignment" => 1, "expression" => "iif([TIMESET154];\"Split: \" & [Section4Split])", "line" => 6},
+                           {"alignment" => 1, "expression" => "\"AID 5\"", "line" => 7},
+                           {"alignment" => 1, "expression" => "iif([TIMESET155];\"Time: \" & format(T155;\"Hh:mm:ss A\"))", "line" => 7},
+                           {"alignment" => 1, "expression" => "iif([TIMESET155];\"Split: \" & [Section6Split])", "line" => 7},
+                           {"alignment" => 1, "expression" => "\"FINISH\"", "line" => 8},
+                           {"alignment" => 1, "expression" => "iif([TIMESET200];\"Time: \" & format(T200;\"Hh:mm:ss A\"))", "line" => 8},
+                           {"alignment" => 1, "expression" => "iif([TIMESET200];\"Total Time: \" & [TIMETEXT])", "line" => 8}]},
            "data" => {"#1_50k" => [[1116, "#1116. FINISHED FIRST", "STATUS: OK", "START", "Time: 8:01:49 AM", "AID 1", "Time: 8:41:08 AM", "Split: 0:39:19.11", "AID 2", "Time: 9:38:32 AM", "Split: 0:57:23.56", "AID 3", "Time: 10:24:12 AM", "Split: 0:45:39.80", "AID 4", "Time: 11:29:45 AM", "Split: 1:05:33.06", "AID 5", "Time: 12:20:44 PM", "Split: 0:10:44.34", "FINISH", "Time: 12:37:41 PM", "Total Time: 4:35:52.1"],
                                    [1117, "#1117. FINISHED SECOND", "STATUS: OK", "START", "Time: 8:01:48 AM", "AID 1", "", "", "AID 2", "Time: 9:41:07 AM", "Split: 0:59:30.85", "AID 3", "Time: 10:31:45 AM", "Split: 0:50:38.20", "AID 4", "Time: 11:40:33 AM", "Split: 1:08:48.08", "AID 5", "Time: 12:31:31 PM", "Split: 0:18:31.84", "FINISH", "Time: 12:48:04 PM", "Total Time: 4:46:15.7"],
                                    [1118, "#1118. PROGRESS AID4", "STATUS: OK", "START", "Time: 6:08:18 AM", "AID 1", "Time: 7:27:44 AM", "Split: 1:19:26.03", "AID 2", "Time: 9:31:50 AM", "Split: 2:04:05.72", "AID 3", "Time: 11:36:00 AM", "Split: 2:04:09.50", "AID 4", "Time: 14:26:38 PM", "Split: 2:50:37.96", "AID 5", "Time: 16:38:50 PM", "Split: 0:37:50.18", "FINISH", "Time: 17:22:12 PM", "Total Time: 11:13:54.0"],
@@ -355,14 +353,14 @@ RSpec.describe Api::V1::EventsController do
           }.to_json
         end
 
-        context 'when existing efforts have no split times' do
+        context "when existing efforts have no split times" do
           before do
             event.efforts.each do |effort|
               effort.split_times.each(&:destroy)
             end
           end
 
-          it 'adds times to existing efforts' do
+          it "adds times to existing efforts" do
             expect { make_request }.to change { event.efforts.count }.by(0).and change { SplitTime.count }.by(23)
             expect(response.status).to eq(201)
             event.reload
@@ -370,26 +368,26 @@ RSpec.describe Api::V1::EventsController do
             effort = event.efforts.find_by(bib_number: 1116)
             split_times = effort.ordered_split_times
             expect(split_times.size).to eq(7)
-            expected_absolute_times = ['2017-06-03 08:01:49 -0600',
-                                       '2017-06-03 08:41:08 -0600',
-                                       '2017-06-03 09:38:32 -0600',
-                                       '2017-06-03 10:24:12 -0600',
-                                       '2017-06-03 11:29:45 -0600',
-                                       '2017-06-03 12:20:44 -0600',
-                                       '2017-06-03 12:37:41 -0600']
+            expected_absolute_times = ["2017-06-03 08:01:49 -0600",
+                                       "2017-06-03 08:41:08 -0600",
+                                       "2017-06-03 09:38:32 -0600",
+                                       "2017-06-03 10:24:12 -0600",
+                                       "2017-06-03 11:29:45 -0600",
+                                       "2017-06-03 12:20:44 -0600",
+                                       "2017-06-03 12:37:41 -0600"]
             expect(split_times.map(&:absolute_time)).to eq(expected_absolute_times)
 
             effort = event.efforts.find_by(bib_number: 433)
             split_times = effort.ordered_split_times
             expect(split_times.size).to eq(1)
-            expected_absolute_times = ['2017-06-03 08:01:49 -0600']
+            expected_absolute_times = ["2017-06-03 08:01:49 -0600"]
             expect(split_times.map(&:absolute_time)).to eq(expected_absolute_times)
           end
 
-          context 'when the event permits notifications' do
+          context "when the event permits notifications" do
             before { event.event_group.update(available_live: true, concealed: false) }
 
-            it 'sends notifications to followers' do
+            it "sends notifications to followers" do
               expect(event.permit_notifications?).to eq(true)
               allow(BulkProgressNotifier).to receive(:notify)
               expect { make_request }.to change { SplitTime.count }.by(23)
@@ -399,8 +397,8 @@ RSpec.describe Api::V1::EventsController do
           end
         end
 
-        context 'when existing efforts have existing split times' do
-          it 'overwrites existing times, adds new times, and erases existing times when blanks appear' do
+        context "when existing efforts have existing split times" do
+          it "overwrites existing times, adds new times, and erases existing times when blanks appear" do
             expect { make_request }.to change { event.efforts.count }.by(0).and change { SplitTime.count }.by(-1)
             expect(response.status).to eq(201)
             event.reload
@@ -408,31 +406,31 @@ RSpec.describe Api::V1::EventsController do
             effort = event.efforts.find_by(bib_number: 1116)
             split_times = effort.ordered_split_times
             expect(split_times.size).to eq(7)
-            expected_absolute_times = ['2017-06-03 08:01:49 -0600',
-                                       '2017-06-03 08:41:08 -0600',
-                                       '2017-06-03 09:38:32 -0600',
-                                       '2017-06-03 10:24:12 -0600',
-                                       '2017-06-03 11:29:45 -0600',
-                                       '2017-06-03 12:20:44 -0600',
-                                       '2017-06-03 12:37:41 -0600']
+            expected_absolute_times = ["2017-06-03 08:01:49 -0600",
+                                       "2017-06-03 08:41:08 -0600",
+                                       "2017-06-03 09:38:32 -0600",
+                                       "2017-06-03 10:24:12 -0600",
+                                       "2017-06-03 11:29:45 -0600",
+                                       "2017-06-03 12:20:44 -0600",
+                                       "2017-06-03 12:37:41 -0600"]
             expect(split_times.map(&:absolute_time)).to eq(expected_absolute_times)
 
             effort = event.efforts.find_by(bib_number: 1117)
             split_times = effort.ordered_split_times
             expect(split_times.size).to eq(6)
-            expected_absolute_times = ['2017-06-03 08:01:48 -0600',
-                                       '2017-06-03 09:41:07 -0600',
-                                       '2017-06-03 10:31:45 -0600',
-                                       '2017-06-03 11:40:33 -0600',
-                                       '2017-06-03 12:31:31 -0600',
-                                       '2017-06-03 12:48:04 -0600']
+            expected_absolute_times = ["2017-06-03 08:01:48 -0600",
+                                       "2017-06-03 09:41:07 -0600",
+                                       "2017-06-03 10:31:45 -0600",
+                                       "2017-06-03 11:40:33 -0600",
+                                       "2017-06-03 12:31:31 -0600",
+                                       "2017-06-03 12:48:04 -0600"]
             expect(split_times.map(&:absolute_time)).to eq(expected_absolute_times)
           end
 
-          context 'when the event permits notifications' do
+          context "when the event permits notifications" do
             before { event.event_group.update(available_live: true, concealed: false) }
 
-            it 'sends notifications to followers for only the new split times' do
+            it "sends notifications to followers for only the new split times" do
               expect(event.permit_notifications?).to eq(true)
               allow(BulkProgressNotifier).to receive(:notify)
               expect { make_request }.to change { SplitTime.count }.by(-1)

--- a/spec/controllers/api/v1/events_controller_spec.rb
+++ b/spec/controllers/api/v1/events_controller_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe Api::V1::EventsController do
         context 'when display_style is elapsed' do
           let(:display_style) { 'elapsed' }
 
-          it 'returns time data in absolute time format' do
+          it 'returns time data in elapsed time format' do
             make_request
             parsed_response = JSON.parse(response.body)
             subject_row = parsed_response['included'].first

--- a/spec/controllers/api/v1/events_controller_spec.rb
+++ b/spec/controllers/api/v1/events_controller_spec.rb
@@ -212,8 +212,8 @@ RSpec.describe Api::V1::EventsController do
             expect(subject_row.dig('attributes', 'displayStyle')).to eq('absolute')
 
             response_times = subject_row.dig('attributes', 'absoluteTimes').flatten.map(&:in_time_zone)
-            expected_times = subject_effort.split_times.map(&:absolute_time)
-            expect(response_times).to match_array(expected_times)
+            expected_times = subject_effort.ordered_split_times.map(&:absolute_time)
+            expect(response_times).to eq(expected_times)
           end
         end
 
@@ -228,8 +228,8 @@ RSpec.describe Api::V1::EventsController do
             expect(subject_row.dig('attributes', 'displayStyle')).to eq('elapsed')
 
             response_times = subject_row.dig('attributes', 'elapsedTimes').flatten
-            expected_times = subject_effort.split_times.map(&:time_from_start)
-            expect(response_times).to match_array(expected_times)
+            expected_times = subject_effort.ordered_split_times.map(&:time_from_start)
+            expect(response_times).to eq(expected_times)
           end
         end
 


### PR DESCRIPTION
The API for the `/spread` endpoint is returning strings instead of float numeric values for durations (elapsed times and segment times). 

This PR fixes that problem.