### PR TITLE
Rename "Winners"

### DIFF
--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -27,7 +27,7 @@
     </div>
     <% if @presenter.display_style == "draws" %>
       <div class="mb-4">
-        <%= link_to "Browse Entrants and Winners", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :entrants), class: "btn btn-success btn-block font-weight-bold" %>
+        <%= link_to "Browse Entrants and Results", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :entrants), class: "btn btn-success btn-block font-weight-bold" %>
       </div>
     <% else %>
       <div>
@@ -43,8 +43,8 @@
         <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'tickets'}" do
           link_to "Tickets", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :tickets)
         end %>
-        <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'winners'}" do
-          link_to "Winners", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :winners)
+        <%= content_tag :li, class: "nav-item #{'active' if @presenter.display_style == 'results'}" do
+          link_to "Results", organization_lottery_path(@presenter.organization, @presenter.lottery, display_style: :results)
         end %>
       </ul>
     <% end %>
@@ -146,13 +146,13 @@
       <%= render partial: "lottery_draws/lottery_draw", collection: @presenter.lottery_draws_ordered %>
     </div>
 
-  <% when "winners" %>
+  <% when "results" %>
     <% if @presenter.lottery_draws.present? %>
       <% @presenter.divisions.each do |division| %>
         <div class="card">
           <h4 class="card-header font-weight-bold bg-primary text-white"><%= "#{division.name}" %></h4>
           <div class="card-body">
-            <h5>Winners</h5>
+            <h5>Accepted</h5>
             <% if division.winning_entrants.present? %>
               <ol>
                 <% division.winning_entrants.each do |entrant| %>

--- a/app/views/lottery_divisions/_draw_tickets_header.html.erb
+++ b/app/views/lottery_divisions/_draw_tickets_header.html.erb
@@ -28,7 +28,7 @@
     <div class="card-body">
       <div class="row">
         <div class="col-8">
-          <h6 class="font-weight-bold">Winners</h6>
+          <h6 class="font-weight-bold">Accepted</h6>
         </div>
         <div class="col-4">
           <h6 class="text-right"><%= "(#{division.winning_entrants.count}/#{division.maximum_entries})" %></h6>
@@ -39,7 +39,7 @@
       </div>
       <div class="row mt-2">
         <div class="col-8">
-          <h6 class="font-weight-bold">Waitlist</h6>
+          <h6 class="font-weight-bold">Wait List</h6>
         </div>
         <div class="col-4">
           <h6 class="text-right"><%= "(#{division.wait_list_entrants.count}/#{division.maximum_wait_list})" %></h6>
@@ -50,7 +50,7 @@
       </div>
       <div class="row mt-2">
         <div class="col-8">
-          <h6 class="font-weight-bold">Pre-selects</h6>
+          <h6 class="font-weight-bold">Pre-selected</h6>
         </div>
         <div class="col-4">
           <h6 class="text-right"><%= "(#{division.entrants.pre_selected.drawn.count}/#{division.entrants.pre_selected.count})" %></h6>

--- a/spec/models/lottery_division_spec.rb
+++ b/spec/models/lottery_division_spec.rb
@@ -78,14 +78,14 @@ RSpec.describe LotteryDivision, type: :model do
 
   describe "#full?" do
     let(:result) { subject.full? }
-    context "when the winners list and wait list are full" do
+    context "when the accepted list and wait list are full" do
       let(:division_name) { "Never Ever Evers" }
       it "returns true" do
         expect(result).to eq(true)
       end
     end
 
-    context "when the winners list is full but the wait list is not full" do
+    context "when the accepted list is full but the wait list is not full" do
       let(:division_name) { "Elses" }
       before { 2.times { subject.draw_ticket! } }
       it "returns false" do
@@ -93,7 +93,7 @@ RSpec.describe LotteryDivision, type: :model do
       end
     end
 
-    context "when the winners list is not full" do
+    context "when the accepted list is not full" do
       let(:division_name) { "Elses" }
       it "returns false" do
         expect(result).to eq(false)


### PR DESCRIPTION
"Winners" is not very descriptive and may evoke unintended emotions. 

This PR renames the "Winners" view tab to "Results." It also renames "Winners" in the Results view and the Draw Tickets view to "Accepted."

Addresses #627 