### PR TITLE
Put concealed and status UI in a single dropdown menu

### DIFF
--- a/app/helpers/lottery_helper.rb
+++ b/app/helpers/lottery_helper.rb
@@ -47,24 +47,6 @@ module LotteryHelper
     link_to fa_icon("pencil-alt"), url, options
   end
 
-  def link_to_toggle_lottery_public_private(presenter)
-    if presenter.concealed?
-      set_to_value = false
-      button_text = "Make public"
-      confirm_text = "NOTE: This will make #{presenter.name} visible to the public. Are you sure you want to proceed?"
-    else
-      set_to_value = true
-      button_text = "Make private"
-      confirm_text = "NOTE: This will conceal #{presenter.name} from the public. Are you sure you want to proceed?"
-    end
-
-    link_to button_text,
-            organization_lottery_path(presenter.organization, presenter.lottery, lottery: {concealed: set_to_value}),
-            data: {confirm: confirm_text},
-            method: :put,
-            class: "btn btn-md btn-warning"
-  end
-
   def pre_selected_badge_with_label(entrant, tag: :h5)
     content_tag(tag) do
       concat "Pre-selected: "

--- a/app/views/lotteries/setup.html.erb
+++ b/app/views/lotteries/setup.html.erb
@@ -45,7 +45,7 @@
       <div class="col form-inline">
         <div>
           <%= link_to "Edit lottery", edit_organization_lottery_path(@presenter.organization, @presenter.lottery), class: "btn btn-primary" %>
-          <div class="btn-group" data-controller="">
+          <div class="btn-group">
             <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="import-dropdown-button" data-toggle="dropdown" aria-expanded="false">
               Entrants
             </button>
@@ -80,7 +80,31 @@
                         method: :post,
                         class: "btn btn-danger" %>
           <% end %>
-         <%= link_to_toggle_lottery_public_private(@presenter) %>
+          <div class="btn-group">
+            <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="import-dropdown-button" data-toggle="dropdown" aria-expanded="false">
+              Change status
+            </button>
+            <div class="dropdown-menu">
+              <%= link_to "Make public",
+                          organization_lottery_path(@presenter.organization, @presenter.lottery, lottery: {concealed: false}),
+                          method: :put,
+                          disabled: @presenter.lottery.visible?,
+                          class: "dropdown-item" %>
+              <%= link_to "Make private",
+                          organization_lottery_path(@presenter.organization, @presenter.lottery, lottery: {concealed: true}),
+                          method: :put,
+                          disabled: @presenter.lottery.concealed?,
+                          class: "dropdown-item" %>
+              <div class="dropdown-divider"></div>
+              <% ::Lottery.statuses.keys.each do |status| %>
+                <%= link_to "Set to #{status.titleize}",
+                            organization_lottery_path(@presenter.organization, @presenter.lottery, lottery: {status: status}),
+                            method: :put,
+                            disabled: @presenter.lottery.send("#{status}?"),
+                            class: "dropdown-item" %>
+              <% end %>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Concealed attribute and status enum are in place, but there is no UI for changing status.

This PR adds a single dropdown menu that handles changes from concealed to visible and also changes in status.

Addresses the balance of #629 