### PR TITLE
Make lottery draw view more responsive

### DIFF
--- a/app/assets/stylesheets/utilities/_layout.scss
+++ b/app/assets/stylesheets/utilities/_layout.scss
@@ -12,3 +12,9 @@
 .ost-article {
     margin-top: 20px;
 }
+
+.horizontal-scroll {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    white-space: nowrap;
+}

--- a/app/views/lotteries/draw_tickets.html.erb
+++ b/app/views/lotteries/draw_tickets.html.erb
@@ -39,19 +39,19 @@
   </div>
 </header>
 
-<article class="ost-article container">
+<article class="ost-article container-fluid">
   <div class="row">
     <div class="col text-center">
       <h1><strong>Draw Lottery Tickets</strong></h1>
       <hr/>
     </div>
   </div>
-  <div class="row">
+  <div class="row horizontal-scroll">
   <% if @presenter.lottery_tickets.present? %>
       <% @presenter.ordered_divisions.each do |division| %>
         <%= turbo_stream_from division, :lottery_draws %>
         <%= turbo_stream_from division, :lottery_draw_header %>
-        <div class="col-12 col-md">
+        <div class="col-12 col-sm-6 col-lg-4 col-xl-3">
           <%= render "lottery_divisions/draw_tickets_header", division: division %>
           <hr/>
           <div id="<%= dom_id(division, :lottery_draws) %>">


### PR DESCRIPTION
Creates a horizontal scrolling mechanism for the Lottery > Admin > Draw Tickets view. This allows each lottery division to have a column that is appropriately wide.

Addresses #622