### PR TITLE
Revert "Webpacker | Change resolved_paths to additional_paths"

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  additional_paths: ['app/javascript/src']
+  resolved_paths: ['app/javascript/src']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
Reverts SplitTime/OpenSplitTime#636

We are seeing some websockets closing before they are opened on the staging site. Making sure this isn't causing that problem.