### PR TITLE
Make test for nextPageUrl more robust

### DIFF
--- a/app/javascript/controllers/infinite_scroll_controller.js
+++ b/app/javascript/controllers/infinite_scroll_controller.js
@@ -38,7 +38,9 @@ export default class extends Controller {
         const htmlTemplate = this.data.get("htmlTemplate")
         const endOfListHtml = "<p>End of List</p>"
 
-        if (nextPageUrl !== "null") {
+        if (!nextPageUrl || nextPageUrl.length === 0 || nextPageUrl === "null") {
+            this.linkTarget.innerHTML = endOfListHtml
+        } else {
             const url = nextPageUrl + "&html_template=" + htmlTemplate
 
             Rails.ajax({
@@ -53,8 +55,6 @@ export default class extends Controller {
                     }
                 }
             })
-        } else {
-            this.linkTarget.innerHTML = endOfListHtml
         }
     }
 }


### PR DESCRIPTION
Infinite scrolling in development environment is failing because `nextPageUrl` is coming back as `""` instead of `"null"`. I don't know what is causing this discrepancy, but this PR checks for either (in addition to a true `null`) and returns the End Of List HTML if any of the conditions are true.