### PR TITLE
Fix Shortener bugs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,6 +23,10 @@ class ApplicationController < ActionController::Base
     head :not_acceptable
   end
 
+  def route_not_found
+    raise ::ActionController::RoutingError, "Route does not exist"
+  end
+
   protected
 
   def after_sign_in_path_for(resource)

--- a/app/services/progress_notifier.rb
+++ b/app/services/progress_notifier.rb
@@ -24,7 +24,7 @@ class ProgressNotifier < BaseNotifier
   def shortened_url
     key = Shortener::ShortenedUrl.generate!(effort_path).unique_key
 
-    "#{OST::SHORTENED_URI}/#{key}"
+    "#{OST::SHORTENED_URI}/s/#{key}"
   end
 
   def effort_path

--- a/config/initializers/01_ost_config.rb
+++ b/config/initializers/01_ost_config.rb
@@ -11,6 +11,10 @@ module OstConfig
     ::ActiveModel::Type::Boolean.new.cast(value)
   end
 
+  def self.full_uri
+    ::ENV["FULL_URI"]
+  end
+
   def self.google_analytics_4_measurement_id
     ::ENV["GOOGLE_ANALYTICS_4_MEASUREMENT_ID"]
   end

--- a/config/initializers/shortener.rb
+++ b/config/initializers/shortener.rb
@@ -1,2 +1,2 @@
 Shortener.charset = :alphanumcase
-Shortener.default_redirect = OST::BASE_URI
+Shortener.default_redirect = ::OstConfig.full_uri

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,5 +242,7 @@ Rails.application.routes.draw do
     get "/:id/app", to: "events#app", as: "app"
   end
 
-  get "/:id" => "shortener/shortened_urls#show"
+  get "/s/:id" => "shortener/shortened_urls#show"
+
+  match "*unmatched", to: "application#route_not_found", via: :all
 end

--- a/spec/services/progress_notifier_spec.rb
+++ b/spec/services/progress_notifier_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ProgressNotifier do
         Results on OpenSplitTime: #{expected_shortened_url}
       MESSAGE
     end
-    let(:expected_shortened_url) { "#{OST::SHORTENED_URI}/#{expected_key}" }
+    let(:expected_shortened_url) { "#{OST::SHORTENED_URI}/s/#{expected_key}" }
     let(:expected_key) { Shortener::ShortenedUrl.find_by(url: effort_path).unique_key }
     let(:effort_path) { subject.send(:effort_path) }
     let(:stubbed_response) { OpenStruct.new(successful?: true) }


### PR DESCRIPTION
Shortener currently looks for routes matching `/:id`, which makes it susceptible to picking up all manner of things it should be ignoring. The result is that some requests (like `/favicon`) have been redirected by Shortener.

To make matters worse, the redirect base URL does not include `https://` before it, so the redirects have been tacked onto the existing URL, making for a nonsense URL.

This PR changes the Shortener route to `/s/:id` and makes a few other changes to catch some edge cases. It also changes the default redirect to a full URL.