### PR TITLE
Change resolved_paths to additional_paths

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ['app/javascript/src']
+  additional_paths: ['app/javascript/src']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
This was done in #636 and then reverted in #639 when searching for the source of a difficult bug. The source seems to have been elsewhere, so it's time to revert the revert and get rid of the deprecation notice once again.