### PR TITLE
Remove dmetaphone search from Searchable module

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -8,8 +8,7 @@ module Searchable
     pg_search_scope :search_names_and_locations,
                     against: [:first_name, :last_name, :city, :state_name, :country_name],
                     using: {
-                      tsearch: {prefix: true},
-                      dmetaphone: {}
+                      tsearch: {prefix: true}
                     }
 
     scope :names_locations_default_all, -> (param) { param.present? ? search_names_and_locations(param) : all }

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -103,7 +103,6 @@
   <% when "tickets" %>
     <h4 class="mt-5"><strong><%= "Lottery Tickets" %></strong><small class="text-muted"><%= " #{pluralize_with_delimiter(@presenter.lottery_tickets.count, 'total ticket')}" %></small></h4>
     <hr/>
-    <% if @presenter.lottery_tickets_paginated.present? %>
       <aside class="ost-toolbar">
         <div class="container">
           <div class="row">
@@ -114,6 +113,7 @@
         </div>
       </aside>
 
+    <% if @presenter.lottery_tickets_paginated.present? %>
       <div data-controller="infinite-scroll"
            data-infinite-scroll-next-page-url="<%= @presenter.next_page_url %>"
            data-infinite-scroll-html-template="lottery_tickets/lottery_ticket">


### PR DESCRIPTION
We are seeing a lot of timeouts on lottery entrant and ticket searches. Long queries appear to be a part of the problem. My hypothesis is that dmetaphone searches are tying up the database.

This PR removes dmetaphone from the `search_names_and_locations` pg search scope.