### PR TITLE
Optimize lottery ticket search

### DIFF
--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -35,7 +35,7 @@ class LotteryEntrant < ApplicationRecord
   validates_with ::LotteryEntrantUniqueValidator
 
   def self.search(param)
-    return all unless param
+    return all unless param.present?
     return none unless param.size > 2
 
     search_names_and_locations(param)

--- a/app/models/lottery_ticket.rb
+++ b/app/models/lottery_ticket.rb
@@ -18,15 +18,11 @@ class LotteryTicket < ApplicationRecord
   pg_search_scope :search_against_entrants,
                   against: :reference_number,
                   associated_against: {
-                    entrant: [:first_name, :last_name, :city, :state_name, :country_name]
-                  },
-                  using: {
-                    tsearch: {prefix: true},
-                    dmetaphone: {}
+                    entrant: [:first_name, :last_name]
                   }
 
   def self.search(param)
-    return all unless param
+    return all unless param.present?
     return none unless param.size > 2
 
     search_against_entrants(param)


### PR DESCRIPTION
The lottery ticket search is still using dmetaphone. 

This PR removes that feature.