### PR TITLE
Logic to export lottery winners to Ultrasignup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,3 +76,6 @@ Style/StringLiterals:
 
 Style/SymbolArray:
   Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false

--- a/app/parameters/lottery_entrant_parameters.rb
+++ b/app/parameters/lottery_entrant_parameters.rb
@@ -12,6 +12,8 @@ class LotteryEntrantParameters < BaseParameters
       state
       country
       number_of_tickets
+      pre_selected
+      external_id
     ]
   end
 
@@ -31,6 +33,7 @@ class LotteryEntrantParameters < BaseParameters
       :city,
       :country_code,
       :division,
+      :external_id,
       :first_name,
       :gender,
       :id,

--- a/app/views/lotteries/_ultrasignup.csv.ruby
+++ b/app/views/lotteries/_ultrasignup.csv.ruby
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+if records.present?
+  CSV.generate do |csv|
+    csv << [
+      "Order ID",
+      "First name",
+      "Last name",
+      "Gender",
+      "Birthdate",
+    ]
+    records.each do |row|
+      csv << [
+        row.external_id,
+        row.first_name,
+        row.last_name,
+        row.gender,
+        row.birthdate,
+      ]
+    end
+  end
+else
+  "No records to export."
+end

--- a/app/views/lotteries/setup.html.erb
+++ b/app/views/lotteries/setup.html.erb
@@ -68,6 +68,10 @@
                             class: "dropdown-item" %>
               <% end %>
               <div class="dropdown-divider"></div>
+              <%= link_to "Export to ultrasignup",
+                          export_entrants_organization_lottery_path(@presenter.organization, @presenter.lottery, format: :csv, export_format: :ultrasignup),
+                          class: "dropdown-item" %>
+              <div class="dropdown-divider"></div>
               <%= link_to "Edit lottery details", edit_organization_lottery_path(@presenter.organization, @presenter.lottery), class: "dropdown-item" %>
             </div>
           </div>

--- a/app/views/lottery_entrants/_form.html.erb
+++ b/app/views/lottery_entrants/_form.html.erb
@@ -62,6 +62,11 @@
           <%= f.label :pre_selected %>
           <%= f.select :pre_selected, [["No", false], ["Yes", true]], {}, {class: "form-control"} %>
         </div>
+
+        <div class="form-group col-md-2">
+          <%= f.label "External ID" %>
+          <%= f.text_field :external_id, class: "form-control", placeholder: "abc123" %>
+        </div>
       </div>
 
       <div class="form-row">


### PR DESCRIPTION
Adds a feature to export lottery winners to Ultrasignup using an external ID field that corresponds to Ultrasignup Order ID.