### PR TITLE
Return empty array if display_style is not an expected value

### DIFF
--- a/app/presenters/lottery_presenter.rb
+++ b/app/presenters/lottery_presenter.rb
@@ -55,6 +55,8 @@ class LotteryPresenter < BasePresenter
       lottery_entrants_paginated
     when "draws"
       lottery_draws
+    else
+      []
     end
   end
 


### PR DESCRIPTION
We are still seeing a Sentry error when someone requests json for the LotteryPresenter#show endpoint.

https://sentry.io/organizations/opensplittime/issues/2836636762/?project=3805803&query=is%3Aunresolved#request

<img width="742" alt="Screen Shot 2021-12-16 at 1 28 57 PM" src="https://user-images.githubusercontent.com/14797300/146444520-164f9634-ca89-4374-a0dc-156c933af4f9.png">

This PR handles this unexpected edge case.