### PR TITLE
Tool to fix stops on multi-lap efforts

### DIFF
--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -151,6 +151,15 @@ class EffortsController < ApplicationController
     redirect_to effort_path(effort)
   end
 
+  def fix_multi_lap_stop
+    authorize @effort
+    effort = effort_with_splits
+
+    response = Interactors::FixMultiLapEffortStop.perform!(effort)
+    set_flash_message(response)
+    redirect_to effort_path(effort)
+  end
+
   def create_split_time_from_raw_time
     @effort = policy_scope(Effort).friendly.find(params[:id])
     authorize @effort

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -34,7 +34,7 @@ class Effort < ApplicationRecord
 
   belongs_to :event, counter_cache: true, touch: true
   belongs_to :person, optional: true
-  has_many :split_times, dependent: :destroy
+  has_many :split_times, dependent: :destroy, autosave: true
   has_many :notifications, dependent: :destroy
   has_one_attached :photo
 

--- a/app/policies/effort_policy.rb
+++ b/app/policies/effort_policy.rb
@@ -36,6 +36,10 @@ class EffortPolicy < ApplicationPolicy
     user.authorized_to_edit?(effort)
   end
 
+  def fix_multi_lap_stop?
+    user.authorized_to_edit?(effort)
+  end
+
   def create_split_time_from_raw_time?
     user.authorized_to_edit?(effort)
   end

--- a/app/services/interactors/errors.rb
+++ b/app/services/interactors/errors.rb
@@ -42,6 +42,11 @@ module Interactors
        detail: {messages: ["Event group for #{resource_1} does not match the event group for #{resource_2}"]}}
     end
 
+    def finish_split_missing_error
+      {title: "Finish split missing",
+       detail: {messages: ["The event associated with the provided effort has no finish split"]}}
+    end
+
     def invalid_raw_time_error(raw_time, valid_sub_splits)
       {title: "Invalid raw time",
        detail: {messages: ["#{raw_time} is invalid; the sub_split #{raw_time.sub_split} must be one of #{valid_sub_splits}"]}}

--- a/app/services/interactors/fix_multi_lap_effort_stop.rb
+++ b/app/services/interactors/fix_multi_lap_effort_stop.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Interactors
+  class FixMultiLapEffortStop
+    def self.perform!(effort)
+      new(effort).perform!
+    end
+
+    def initialize(effort)
+      @effort = effort
+      validate_setup
+    end
+
+    def perform!
+      return if ordered_split_times.empty?
+
+      set_finish_split_time
+      destroy_hanging_split_time
+      set_effort_stop
+      save_effort
+
+      ::Interactors::Response.new(errors)
+    end
+
+    private
+
+    attr_reader :effort, :errors
+    attr_accessor :finish_split_time
+
+    def set_finish_split_time
+      self.finish_split_time = effort.split_times.find_or_initialize_by(
+        lap: final_finished_lap,
+        split: finish_split,
+        bitkey: ::SubSplit::IN_BITKEY,
+        )
+
+      finish_split_time.absolute_time ||= last_split_time.absolute_time
+    end
+
+    def destroy_hanging_split_time
+      hanging_split_time&.mark_for_destruction
+    end
+
+    def set_effort_stop
+      ::Interactors::SetEffortStop.perform(effort)
+    end
+
+    def save_effort
+      effort.save
+      errors << resource_error_object(effort) if effort.errors.present?
+    end
+
+    def final_finished_lap
+      hanging_split_time? ? last_split_time.lap - 1 : last_split_time.lap
+    end
+
+    def finish_split
+      effort.ordered_splits.find(&:finish?)
+    end
+
+    def hanging_split_time
+      return unless last_split_time.start? && last_split_time.lap > 1
+
+      last_split_time
+    end
+
+    def hanging_split_time?
+      hanging_split_time.present?
+    end
+
+    def last_split_time
+      ordered_split_times.last
+    end
+
+    def ordered_split_times
+      @ordered_split_times ||= effort.ordered_split_times.reject { |st| st.destroyed? || st.marked_for_destruction? }
+    end
+
+    def validate_setup
+      errors << finish_split_missing_error unless finish_split.present?
+    end
+  end
+end

--- a/app/services/interactors/set_effort_stop.rb
+++ b/app/services/interactors/set_effort_stop.rb
@@ -25,7 +25,7 @@ module Interactors
     attr_reader :effort, :stop_status, :split_time_id, :errors
 
     def ordered_split_times
-      @ordered_split_times ||= effort.ordered_split_times.reject(&:destroyed?)
+      @ordered_split_times ||= effort.ordered_split_times.reject { |st| st.destroyed? || st.marked_for_destruction? }
     end
 
     def split_time

--- a/app/views/efforts/show.html.erb
+++ b/app/views/efforts/show.html.erb
@@ -23,17 +23,26 @@
             <% if @presenter.needs_final_stop? %>
               <%= link_to 'Set stop', stop_effort_path(@presenter.effort),
                           method: :patch,
-                          class: "btn btn-success" %>
+                          class: "btn btn-success has-tooltip",
+                          data: {toggle: "tooltip",
+                                 placement: :bottom,
+                                 "original-title" => "Sets a stop on the final split time"} %>
             <% end %>
             <% if @presenter.has_removable_stop? %>
               <%= link_to 'Remove stop', stop_effort_path(@presenter.effort, status: false),
                           method: :patch,
-                          class: "btn btn-success" %>
+                          class: "btn btn-success has-tooltip",
+                          data: {toggle: "tooltip",
+                                 placement: :bottom,
+                                 "original-title" => "Removes the stop from all split times"} %>
             <% end %>
             <% if @presenter.multiple_laps? %>
               <%= link_to 'Fix multi-lap stop', fix_multi_lap_stop_effort_path(@presenter.effort),
                           method: :patch,
-                          class: "btn btn-success" %>
+                          class: "btn btn-success has-tooltip",
+                          data: {toggle: "tooltip",
+                                 placement: :bottom,
+                                 "original-title" => "Deletes any hanging split time, fills in a final finish time if needed, and sets a stop on the final finish time"} %>
             <% end %>
             <% if @presenter.next_problem_effort %>
               <%= link_to 'Find a problem effort', effort_path(@presenter.next_problem_effort),

--- a/app/views/efforts/show.html.erb
+++ b/app/views/efforts/show.html.erb
@@ -30,6 +30,11 @@
                           method: :patch,
                           class: "btn btn-success" %>
             <% end %>
+            <% if @presenter.multiple_laps? %>
+              <%= link_to 'Fix multi-lap stop', fix_multi_lap_stop_effort_path(@presenter.effort),
+                          method: :patch,
+                          class: "btn btn-success" %>
+            <% end %>
             <% if @presenter.next_problem_effort %>
               <%= link_to 'Find a problem effort', effort_path(@presenter.next_problem_effort),
                           class: "btn btn-success" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
       patch :rebuild
       patch :unstart
       patch :stop
+      patch :fix_multi_lap_stop
       delete :delete_split_times
     end
   end

--- a/spec/services/interactors/fix_multi_lap_effort_stop_spec.rb
+++ b/spec/services/interactors/fix_multi_lap_effort_stop_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::Interactors::FixMultiLapEffortStop do
+  subject { described_class.new(effort) }
+
+  context "when the effort does not have a hanging split time" do
+    let(:effort) { efforts(:rufa_2017_24h_progress_lap6) }
+    context "when the effort is not stopped" do
+      it "sets the stop on the final finish time" do
+        effort.reload
+        expect(effort.ordered_split_times.last).not_to be_stopped_here
+        expect { subject.perform! }.not_to change { effort.split_times.count }
+        expect(effort.ordered_split_times.last).to be_stopped_here
+      end
+    end
+
+    context "when the effort is stopped" do
+      before { ::Interactors::UpdateEffortsStop.perform!(effort) }
+      it "sets the stop on the final finish time" do
+        effort.reload
+        expect(effort.ordered_split_times.last).to be_stopped_here
+        expect { subject.perform! }.not_to change { effort.split_times.count }
+        expect(effort.ordered_split_times.last).to be_stopped_here
+      end
+    end
+  end
+
+  context "when the effort has a hanging split time" do
+    let(:effort) { efforts(:rufa_2017_24h_progress_lap6) }
+    before { effort.ordered_split_times.last(2).each(&:destroy) }
+
+    context "when the effort is not stopped" do
+      it "destroys the hanging split time and sets the stop on the final finish time" do
+        effort.reload
+        expect(effort.ordered_split_times.last.split).not_to be_finish
+        expect { subject.perform! }.to change { effort.split_times.count }.by(-1)
+        expect(effort.ordered_split_times.last.split).to be_finish
+        expect(effort.ordered_split_times.last).to be_stopped_here
+      end
+    end
+
+    context "when the effort is already stopped" do
+      before { ::Interactors::UpdateEffortsStop.perform!(effort) }
+      it "destroys the hanging split time and sets the stop on the final finish time" do
+        effort.reload
+        expect(effort.ordered_split_times.last.split).not_to be_finish
+        expect { subject.perform! }.to change { effort.split_times.count }.by(-1)
+        expect(effort.ordered_split_times.last.split).to be_finish
+        expect(effort.ordered_split_times.last).to be_stopped_here
+      end
+    end
+  end
+
+  context "when the effort has a hanging split time and no final finish time" do
+    let(:effort) { efforts(:rufa_2017_24h_progress_lap6) }
+    before do
+      effort.ordered_split_times.last(2).each(&:destroy)
+      effort.reload
+      effort.ordered_split_times.last(2).first.destroy
+    end
+
+    context "when the effort is not stopped" do
+      it "destroys the hanging split time, creates a final finish time, and sets the stop on the final finish time" do
+        effort.reload
+        existing_absolute_time = effort.ordered_split_times.last.absolute_time
+
+        expect(effort.ordered_split_times.last.split).not_to be_finish
+        expect(effort.ordered_split_times.last).not_to be_stopped_here
+        expect { subject.perform! }.not_to change { effort.split_times.count }
+        expect(effort.ordered_split_times.last.split).to be_finish
+        expect(effort.ordered_split_times.last).to be_stopped_here
+        expect(effort.ordered_split_times.last.absolute_time).to eq(existing_absolute_time)
+      end
+    end
+
+    context "when the effort is already stopped" do
+      before { ::Interactors::UpdateEffortsStop.perform!(effort) }
+      it "destroys the hanging split time, creates a final finish time, and sets the stop on the final finish time" do
+        effort.reload
+        existing_absolute_time = effort.ordered_split_times.last.absolute_time
+
+        expect(effort.ordered_split_times.last.split).not_to be_finish
+        expect(effort.ordered_split_times.last).to be_stopped_here
+        expect { subject.perform! }.not_to change { effort.split_times.count }
+        expect(effort.ordered_split_times.last.split).to be_finish
+        expect(effort.ordered_split_times.last).to be_stopped_here
+        expect(effort.ordered_split_times.last.absolute_time).to eq(existing_absolute_time)
+      end
+    end
+  end
+
+  context "when the effort has no split times" do
+    let(:effort) { efforts(:rufa_2017_24h_not_started) }
+    it "does nothing" do
+      expect(effort.split_times).to be_empty
+      subject.perform!
+      expect(effort.split_times).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
In multi-lap events, we often see final split times that are actually "out" start split times for the following lap. In many cases, the effort ends up missing the "in" time for the actual final lap as well.

This tool removes "hanging" split times, creates a final "in" time if needed, and sets the stop on that final time.