### PR TITLE
Fix broken CSV exports (from Rails 7 upgrade)

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -87,7 +87,7 @@ class CoursesController < ApplicationController
         session[:return_to] = plan_effort_course_path(@course)
       end
       format.csv do
-        csv_stream = render_to_string(partial: "plan.csv.ruby")
+        csv_stream = render_to_string(partial: "plan", formats: :csv)
         filename = "#{@course.name}-pacing-plan-#{@presenter.cleaned_time}-#{Date.today}.csv"
         send_data(csv_stream, type: "text/csv", filename: filename)
       end

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -212,7 +212,7 @@ class EventGroupsController < ApplicationController
 
     respond_to do |format|
       format.csv do
-        csv_stream = render_to_string(partial: "#{csv_template}.csv.ruby")
+        csv_stream = render_to_string(partial: csv_template, formats: :csv)
         send_data(csv_stream, type: "text/csv",
                               filename: "#{@event_group.name}-#{split_name}-#{csv_template}-#{Date.today}.csv")
       end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -69,7 +69,7 @@ class EventsController < ApplicationController
       format.html
       format.csv do
         authorize @event
-        csv_stream = render_to_string(partial: "spread.csv.ruby")
+        csv_stream = render_to_string(partial: "spread", formats: :csv)
         send_data(csv_stream, type: "text/csv",
                               filename: "#{@event.name}-#{@presenter.display_style}-#{Date.today}.csv")
       end
@@ -156,9 +156,10 @@ class EventsController < ApplicationController
 
         requested_export_template = "#{export_format}.csv.ruby"
         requested_partial_name = Rails.root.join("app/views/events/_#{requested_export_template}")
-        partial = File.exist?(requested_partial_name) ? requested_export_template : "not_found.csv.ruby"
+        partial = File.exist?(requested_partial_name) ? export_format.to_s : "not_found"
         csv_stream = render_to_string(
           partial: partial,
+          formats: :csv,
           locals: {current_time: current_time, records: records, options: options}
         )
 

--- a/app/controllers/lotteries_controller.rb
+++ b/app/controllers/lotteries_controller.rb
@@ -90,12 +90,12 @@ class LotteriesController < ApplicationController
         when :ultrasignup
           entrants = @lottery.divisions.flat_map(&:winning_entrants)
           filename = "#{@lottery.name}-export-for-ultrasignup-#{Time.now.strftime('%Y-%m-%d')}.csv"
-          csv_stream = render_to_string(partial: "ultrasignup", locals: {records: entrants})
+          csv_stream = render_to_string(partial: "ultrasignup", formats: :csv, locals: {records: entrants})
 
           send_data(csv_stream, type: "text/csv", filename: filename)
         when :results
           filename = "#{@lottery.name}-results-#{Time.now.strftime('%Y-%m-%d')}.csv"
-          csv_stream = render_to_string(partial: "results", locals: {lottery: @lottery})
+          csv_stream = render_to_string(partial: "results", formats: :csv, locals: {lottery: @lottery})
 
           send_data(csv_stream, type: "text/csv", filename: filename)
         else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        csv_stream = render_to_string(partial: "users.csv.ruby", locals: {users: users})
+        csv_stream = render_to_string(partial: "users", formats: :csv, locals: {users: users})
         send_data(csv_stream, type: "text/csv", filename: "users-#{Date.today}.csv")
       end
     end

--- a/app/views/courses/_plan.csv.ruby
+++ b/app/views/courses/_plan.csv.ruby
@@ -1,4 +1,6 @@
-CSV.generate do |csv|
+require "csv"
+
+::CSV.generate do |csv|
   csv << plan_export_headers
   @presenter.lap_split_rows.each do |row|
     csv << lap_split_export_row(row)

--- a/app/views/event_groups/_summit.csv.ruby
+++ b/app/views/event_groups/_summit.csv.ruby
@@ -1,4 +1,6 @@
-CSV.generate do |csv|
+require "csv"
+
+::CSV.generate do |csv|
   csv << %w[Bib Kind Time Combined]
   if @raw_times.present?
     @raw_times.sort_by { |rt| rt.military_time(rt.event_group.home_time_zone) }.each do |rt|

--- a/app/views/events/_finishers.csv.ruby
+++ b/app/views/events/_finishers.csv.ruby
@@ -1,6 +1,8 @@
+require "csv"
+
 if records.present?
   header = "Finishers for #{@presenter.name} as of #{day_time_full_format(current_time)}"
-  CSV.generate do |csv|
+  ::CSV.generate do |csv|
     csv << [header] if header
     csv << %w[place time first last age gender city state bib]
     records.each do |record|

--- a/app/views/events/_itra.csv.ruby
+++ b/app/views/events/_itra.csv.ruby
@@ -1,5 +1,7 @@
+require "csv"
+
 if records.present?
-  CSV.generate do |csv|
+  ::CSV.generate do |csv|
     csv << [
       "Ranking",
       "Time",

--- a/app/views/events/_spread.csv.ruby
+++ b/app/views/events/_spread.csv.ruby
@@ -1,4 +1,6 @@
-CSV.generate do |csv|
+require "csv"
+
+::CSV.generate do |csv|
   csv << spread_export_headers
   @presenter.effort_times_rows.each do |row|
     csv << time_row_export_row(row)

--- a/app/views/events/_ultrasignup.csv.ruby
+++ b/app/views/events/_ultrasignup.csv.ruby
@@ -1,6 +1,8 @@
+require "csv"
+
 if records.present?
   if options[:event_finished]
-    CSV.generate do |csv|
+    ::CSV.generate do |csv|
       csv << %w[place time first last age gender city state dob bib status]
       records.each do |row|
         csv << [row.overall_rank,

--- a/app/views/lotteries/_results.csv.ruby
+++ b/app/views/lotteries/_results.csv.ruby
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "csv"
+
 if lottery.entrants.exists?
   ::CSV.generate do |csv|
     csv << ["Results for #{lottery.name}"]

--- a/app/views/lotteries/_ultrasignup.csv.ruby
+++ b/app/views/lotteries/_ultrasignup.csv.ruby
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+require "csv"
+
 if records.present?
-  CSV.generate do |csv|
+  ::CSV.generate do |csv|
     csv << [
       "Order ID",
       "First name",

--- a/app/views/users/_users.csv.ruby
+++ b/app/views/users/_users.csv.ruby
@@ -1,4 +1,6 @@
-CSV.generate do |csv|
+require "csv"
+
+::CSV.generate do |csv|
   attributes = %w[email first_name last_name confirmed_at]
   csv << attributes
   users.each do |user|


### PR DESCRIPTION
Rails 7 broke the ability to use file extensions within a partial reference. This resulted in most CSV exports breaking.

This PR conforms to the Rails 7 practice of specifying partial names without file extensions and using `formats: :csv` to designate the format of the expected partial.