### PR TITLE
Fix event group redirect bug

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -16,9 +16,9 @@ class EventGroupsController < ApplicationController
   end
 
   def show
-    events = @event_group.events
+    event = @event_group.first_event
 
-    if events.present?
+    if event.present?
       redirect_to spread_event_path(events.first)
     else
       redirect_to setup_event_group_path(@event_group)

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -19,7 +19,7 @@ class EventGroupsController < ApplicationController
     event = @event_group.first_event
 
     if event.present?
-      redirect_to spread_event_path(events.first)
+    redirect_to spread_event_path(event)
     else
       redirect_to setup_event_group_path(@event_group)
     end


### PR DESCRIPTION
As a result of the significant refactoring contained in #564, the event group redirect to `events/:id/spread` no longer found the first event in chronological order. 

This PR adds restores chronological ordering to the logic.