### PR TITLE
Make in-progress efforts eligible for podium in time-based events

### DIFF
--- a/app/models/concerns/rankable.rb
+++ b/app/models/concerns/rankable.rb
@@ -8,14 +8,17 @@
 module Rankable
   extend ActiveSupport::Concern
 
+  # @return [String (frozen)]
   def display_overall_rank
-    started? ? overall_rank : "--"
+    overall_rank || "--"
   end
 
+  # @return [String (frozen)]
   def display_gender_rank
-    started? ? gender_rank : "--"
+    gender_rank || "--"
   end
 
+  # @return [String (frozen)]
   def effort_status
     if finished?
       "Finished"

--- a/app/services/results/fill_event_template.rb
+++ b/app/services/results/fill_event_template.rb
@@ -2,6 +2,8 @@
 
 module Results
   class FillEventTemplate
+    # @param [::Event] event
+    # @return [::ResultsTemplate]
     def self.perform(event)
       new(event).perform
     end
@@ -11,13 +13,21 @@ module Results
       @template = event.results_template.dup_with_categories
     end
 
+    # @return [::ResultsTemplate]
     def perform
       Results::Compute.perform(efforts: efforts, template: template)
       template
     end
 
+    # @return [Array<::Effort>]
     def efforts
-      event.efforts.ranked_with_status.select(&:finished)
+      ranked_efforts = event.efforts.ranked_with_status
+
+      if event.laps_unlimited?
+        ranked_efforts.select(&:overall_rank)
+      else
+        ranked_efforts.select(&:finished)
+      end
     end
 
     private


### PR DESCRIPTION
Currently, efforts must be finished to show up on the podium. This works fine for distance-based events, where non-finishers might not finish at all. But for time-based events, once an effort has a time recorded beyond the start, those efforts should show up on the podium, so we can keep track of progress during the race.

This PR does two things:
- Removes ranking from efforts until they have a split time recorded beyond the start
- For time-based events, makes anyone with an overall rank eligible for the podium