### PR TITLE
Fix N+1 query problem in FillEventTemplate class

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -281,12 +281,18 @@ class Effort < ApplicationRecord
     @lap_splits ||= event.required_lap_splits.presence || event.lap_splits_through(laps_started)
   end
 
+  # @return [Integer, nil]
   def overall_rank
-    attributes["overall_rank"] || enriched.attributes["overall_rank"]
+    return attributes["overall_rank"] if attributes.has_key?("overall_rank")
+
+    enriched.attributes["overall_rank"]
   end
 
+  # @return [Integer, nil]
   def gender_rank
-    attributes["gender_rank"] || enriched.attributes["overall_rank"]
+    return attributes["gender_rank"] if attributes.has_key?("gender_rank")
+
+    enriched.attributes["gender_rank"]
   end
 
   def current_age_approximate

--- a/app/services/results/fill_event_template.rb
+++ b/app/services/results/fill_event_template.rb
@@ -24,9 +24,9 @@ module Results
       ranked_efforts = event.efforts.ranked_with_status
 
       if event.laps_unlimited?
-        ranked_efforts.select(&:overall_rank)
+        ranked_efforts.select(&:beyond_start?)
       else
-        ranked_efforts.select(&:finished)
+        ranked_efforts.select(&:finished?)
       end
     end
 


### PR DESCRIPTION
Similar problem to the one described in #707 was occurring in the Podium view because of `overall_rank`. 

This fixes the N+1 query by using `beyond_start?` instead.