### PR TITLE
Optimize effort ranking query

### DIFF
--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -25,7 +25,7 @@ class EffortQuery < BaseQuery
                  order by effort_id),		
 
            beyond_start_split_times as (
-               select effort_id
+               select distinct on(effort_id) effort_id
                from split_times
                         join splits on splits.id = split_times.split_id
                where kind != 0


### PR DESCRIPTION
Adding `beyond_start` has greatly degraded performance of the effort ranking query, which results in degraded performance across the site.

This PR makes a simple change to the SQL that should get performance back to where we were.