### PR TITLE
Fix the discrepancy in ranking criteria

### DIFF
--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -128,7 +128,8 @@ class EffortQuery < BaseQuery
                            when beyond_start then
                                        rank() over
                                    (partition by event_id
-                                   order by started desc,
+                                   order by beyond_start desc,
+                                       started desc,
                                        dropped,
                                        final_lap desc nulls last,
                                        final_lap_distance desc,
@@ -142,7 +143,8 @@ class EffortQuery < BaseQuery
                            when beyond_start then
                                        rank() over
                                    (partition by event_id, gender
-                                   order by started desc,
+                                   order by beyond_start desc,
+                                       started desc,
                                        dropped,
                                        final_lap desc nulls last,
                                        final_lap_distance desc,


### PR DESCRIPTION
The conditional logic and the actual ranking logic were not lining up since this query was changed in #704, and that discrepancy carried over in #712.

This PR resolves the conflict.