### PR TITLE
Limit beyond_start subquery to scoped efforts

### DIFF
--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -28,8 +28,8 @@ class EffortQuery < BaseQuery
                select distinct on(effort_id) effort_id
                from split_times
                         join splits on splits.id = split_times.split_id
-               where kind != 0
-                  or lap != 1
+               where (kind != 0 or lap != 1)
+                 and effort_id in (select id from efforts_scoped)		
            ),
 
            stopped_split_times as


### PR DESCRIPTION
This was just a miss when we added the `beyond_start` subquery. This additional scoping of that subquery should save significant execution time.

Follows up on #712 