### PR TITLE
Show rank when started even if not beyond start

### DIFF
--- a/app/models/concerns/rankable.rb
+++ b/app/models/concerns/rankable.rb
@@ -10,12 +10,12 @@ module Rankable
 
   # @return [String (frozen)]
   def display_overall_rank
-    beyond_start? ? overall_rank : "--"
+    started? ? overall_rank : "--"
   end
 
   # @return [String (frozen)]
   def display_gender_rank
-    beyond_start? ? gender_rank : "--"
+    started? ? gender_rank : "--"
   end
 
   # @return [String (frozen)]


### PR DESCRIPTION
It looks strange when beyond_start efforts don't get a rank, but dropped efforts (which come later) do have a rank.

This PR makes rank visible for all started efforts.