### PR TITLE
Order efforts by rank before passing to Results::Compute

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -69,6 +69,7 @@ class Effort < ApplicationRecord
   scope :checked_in, -> { where(checked_in: true) }
   scope :finish_info_subquery, -> { from(EffortQuery.finish_info_subquery(self)) }
   scope :ranking_subquery, -> { from(EffortQuery.ranking_subquery(self)) }
+  scope :ranked_order, -> { order(overall_performance: :desc) }
   scope :roster_subquery, -> { from(EffortQuery.roster_subquery(self)) }
   scope :with_policy_scope_attributes, lambda {
     from(select("efforts.*, event_groups.organization_id, event_groups.concealed").joins(event: :event_group), :efforts)

--- a/app/services/results/fill_event_template.rb
+++ b/app/services/results/fill_event_template.rb
@@ -21,7 +21,7 @@ module Results
 
     # @return [Array<::Effort>]
     def efforts
-      ranked_efforts = event.efforts.finish_info_subquery
+      ranked_efforts = event.efforts.finish_info_subquery.ranked_order
 
       if event.laps_unlimited?
         ranked_efforts.select(&:beyond_start?)


### PR DESCRIPTION
This orders efforts by `overall_performance` before passing them in to be computed for the results template.

Resolves #727 