### PR TITLE
Add comments to the csv effort attributes

### DIFF
--- a/app/parameters/effort_parameters.rb
+++ b/app/parameters/effort_parameters.rb
@@ -17,6 +17,7 @@ class EffortParameters < BaseParameters
       emergency_phone
       event_name
       scheduled_start_time_local
+      comments
     ]
   end
 


### PR DESCRIPTION
Efforts can have associated comments when uploaded into the system. This PR adds `comments` to the CSV attributes within the effort parameters file. This results in comments being added to the CSV template.

Addresses a portion of #742