### PR TITLE
Add beacon_url to the effort form

### DIFF
--- a/app/parameters/effort_parameters.rb
+++ b/app/parameters/effort_parameters.rb
@@ -18,6 +18,7 @@ class EffortParameters < BaseParameters
       event_name
       scheduled_start_time_local
       comments
+      beacon_url
     ]
   end
 

--- a/app/views/efforts/_form.html.erb
+++ b/app/views/efforts/_form.html.erb
@@ -60,6 +60,10 @@
             <%= f.label :bib_number %>
             <%= f.number_field :bib_number, class: "form-control", placeholder: "Bib #" %>
           </div>
+          <div class="col-md-6 mb-3">
+            <%= f.label "Tracking Beacon URL" %>
+            <%= f.text_field :beacon_url, class: "form-control", placeholder: "https://www.a-tracking-site.com" %>
+          </div>
         </div>
 
         <div class="form-row">


### PR DESCRIPTION
Adds the `beacon_url` field back to the efforts form. 

Resolves #746 