### PR TITLE
Set overall performance in an after_save callback

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -58,6 +58,7 @@ class Effort < ApplicationRecord
             size: {less_than: 5000.kilobytes}
 
   before_save :reset_age_from_birthdate
+  after_save :set_performance_data
   after_touch :set_performance_data
 
   pg_search_scope :search_bib, against: :bib_number, using: {tsearch: {any_word: true}}

--- a/spec/models/effort_spec.rb
+++ b/spec/models/effort_spec.rb
@@ -157,12 +157,25 @@ RSpec.describe Effort, type: :model do
     end
 
     describe "sets performance data" do
-      subject { efforts(:hardrock_2014_finished_first) }
-      before { allow(subject).to receive(:set_performance_data) }
       context "when touched" do
-        it "sets performance data" do
-          expect(subject).to receive(:set_performance_data)
+        subject { efforts(:hardrock_2014_finished_first) }
+        before { subject.update_column(:overall_performance, nil) }
+
+        it "sets overall performance attribute" do
+          expect(subject.overall_performance).to be_nil
           subject.touch
+          subject.reload
+          expect(subject.overall_performance).to be_present
+        end
+      end
+
+      context "when created" do
+        subject { build(:effort) }
+        it "sets overall performance attribute" do
+          expect(subject.overall_performance).to be_nil
+          subject.save
+          subject.reload
+          expect(subject.overall_performance).to be_present
         end
       end
     end


### PR DESCRIPTION
This PR sets performance data (the `overall_performance` attribute and other attributes like `started` and `finished`) in an `after_save` callback. This is in addition to the existing `after_touch` callback that currently sets this data when split times are created, updated, or destroyed.

Resolves #752 