### PR TITLE
Use OstConfig for S3 bucket name

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,7 +179,7 @@ Rails.application.routes.draw do
   resources :stewardships, only: [:create, :update, :destroy]
   resources :subscriptions, only: [:create, :destroy]
 
-  get "/sitemap.xml.gz", to: redirect("https://#{ENV['S3_BUCKET']}.s3.amazonaws.com/sitemaps/sitemap.xml.gz"), as: :sitemap
+  get "/sitemap.xml.gz", to: redirect("https://#{::OstConfig.aws_s3_bucket}.s3.amazonaws.com/sitemaps/sitemap.xml.gz"), as: :sitemap
 
   namespace :admin do
     get "dashboard", to: "dashboard#show"

--- a/lib/tasks/sitemap.rake
+++ b/lib/tasks/sitemap.rake
@@ -8,7 +8,7 @@ namespace :sitemap do
   task upload_to_s3: :environment do
     puts "Starting sitemap upload to S3..."
 
-    bucket = Aws::S3::Resource.new.bucket(ENV["S3_BUCKET"])
+    bucket = Aws::S3::Resource.new.bucket(::OstConfig.aws_s3_bucket)
 
     Dir.entries(File.join(Rails.root, "tmp", "sitemaps")).each do |file_name|
       next if %w[. .. .DS_Store].include?(file_name)


### PR DESCRIPTION
There are a few places where the code references the old environment variables for the s3 bucket. 

This PR changes those references over to the new OstConfig methods.