### PR TITLE
Bib auto-assignment for Hardrock

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -211,6 +211,19 @@ class EventGroupsController < ApplicationController
     @presenter = ::EventGroupSetupPresenter.new(@event_group, prepared_params, current_user)
   end
 
+  # PATCH /event_groups/1/auto_assign_bibs
+  def auto_assign_bibs
+    authorize @event_group
+
+    event = @event_group.first_event
+    strategy = params[:strategy]
+    bib_assignments = ::ComputeBibAssignments.perform(event, strategy)
+    response = ::Interactors::BulkSetBibNumbers.perform!(@event_group, bib_assignments)
+
+    set_flash_message(response)
+    redirect_to assign_bibs_event_group_path(@event_group)
+  end
+
   # PATCH /event_groups/1/update_bibs
   def update_bibs
     authorize @event_group

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -60,9 +60,12 @@ module DropdownHelper
 
   def bib_number_auto_assignment_dropdown(view_object)
     dropdown_items = [
-      {name: "Hardrock",
-       link: auto_assign_bibs_event_group_path(view_object.event_group, strategy: :hardrock),
-       method: :patch},
+      {
+        name: "Hardrock",
+        link: auto_assign_bibs_event_group_path(view_object.event_group, strategy: :hardrock),
+        method: :patch,
+        data: {confirm: "Assign bib numbers beginning at 1 to prior-year entrants in order of finish rank, and to other entrants beginning at 100 in alphabetical name order. Proceed?"}
+      },
     ]
     build_dropdown_menu("Auto Assign", dropdown_items, button: true)
   end

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -58,6 +58,15 @@ module DropdownHelper
     build_dropdown_menu("Admin", dropdown_items, class: "nav-item")
   end
 
+  def bib_number_auto_assignment_dropdown(view_object)
+    dropdown_items = [
+      {name: "Hardrock",
+       link: auto_assign_bibs_event_group_path(view_object.event_group, strategy: :hardrock),
+       method: :patch},
+    ]
+    build_dropdown_menu("Auto Assign", dropdown_items, button: true)
+  end
+
   def live_dropdown_menu(view_object)
     dropdown_items = [
       {name: "Time Entry",

--- a/app/policies/event_group_policy.rb
+++ b/app/policies/event_group_policy.rb
@@ -60,6 +60,10 @@ class EventGroupPolicy < ApplicationPolicy
     user.authorized_to_edit?(event_group)
   end
 
+  def auto_assign_bibs?
+    user.authorized_to_edit?(event_group)
+  end
+
   def update_bibs?
     user.authorized_to_edit?(event_group)
   end

--- a/app/services/compute_bib_assignments.rb
+++ b/app/services/compute_bib_assignments.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class ComputeBibAssignments
+  # @param [::Event] event
+  # @param [String,Symbol] strategy
+  # @return [Hash]
+  def self.perform(event, strategy)
+    new(event, strategy).perform
+  end
+
+  # @param [::Event] event
+  # @param [String,Symbol] strategy
+  def initialize(event, strategy)
+    @event = event
+    @strategy = strategy
+    @result = {}
+  end
+
+  # @return [Hash]
+  def perform
+    return unless strategy.present?
+
+    case strategy.to_sym
+    when :hardrock
+      compute_for_hardrock
+    else
+      raise ArgumentError, "Unknown bib assignment strategy"
+    end
+
+    result
+  end
+
+  private
+
+  attr_reader :event, :strategy, :result
+
+  def compute_for_hardrock
+    efforts = event.efforts.select(:id, :person_id, :first_name, :last_name).to_a
+    prior_hardrock = event.organization.events.where("scheduled_start_time < ?", event.scheduled_start_time).order(scheduled_start_time: :desc).first
+    ordered_prior_person_ids = prior_hardrock.efforts.ranked_order.pluck(:person_id)
+
+    current_bib = 1
+    ordered_prior_person_ids.each do |person_id|
+      matching_effort = efforts.find { |effort| effort.person_id == person_id }
+      next unless matching_effort.present?
+
+      efforts.delete(matching_effort)
+      result[matching_effort.id] = current_bib
+      current_bib += 1
+    end
+
+    efforts.sort_by { |effort| [effort.last_name, effort.first_name] }.each.with_index(100) do |effort, index|
+      result[effort.id] = index
+    end
+  end
+end

--- a/app/views/event_groups/assign_bibs.html.erb
+++ b/app/views/event_groups/assign_bibs.html.erb
@@ -27,13 +27,23 @@
 </header>
 
 <article class="ost-article container">
+  <aside class="ost-toolbar">
+    <div class="container">
+      <div class="row">
+        <div class="col">
+          <%= bib_number_auto_assignment_dropdown(@presenter) %>
+        </div>
+      </div>
+    </div>
+  </aside>
+
   <%= form_with(model: @presenter.event_group,
                 url: update_bibs_event_group_path(@presenter.event_group),
                 method: :patch,
                 data: {turbo: false}) do |f| %>
     <% @presenter.event_group.events.each do |event| %>
       <div class="form-row">
-        <h5><%= event.name %></h5>
+        <h4 class="mt-3"><%= event.name %></h4>
         <table class="table table-condensed">
           <thead>
           <tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ Rails.application.routes.draw do
       post :create_people
       post :load_lottery_entrants
       patch :set_data_status
+      patch :auto_assign_bibs
       patch :auto_reconcile
       patch :associate_people
       patch :start_efforts


### PR DESCRIPTION
Adds logic to auto-assign bib numbers per the Hardrock strategy, which is:
- For prior-year entrants, assign bibs starting at 1 in ranked order of finish
- For other entrants, assign bibs starting at 100 in alphabetical order by name

Addresses the last bit of #772 