### PR TITLE
Simplify and test bib assignment logic

### DIFF
--- a/spec/services/compute_bib_assignments_spec.rb
+++ b/spec/services/compute_bib_assignments_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ComputeBibAssignments do
+  subject { described_class.new(event, strategy) }
+
+  describe "#perform" do
+    let(:result) { subject.perform }
+
+    context "hardrock strategy" do
+      let(:strategy) { :hardrock }
+      let(:event) { events(:hardrock_2016) }
+      let(:effort_1) { event.efforts.ranked_order.first }
+      let(:effort_2) { event.efforts.ranked_order.second }
+      let(:effort_3) { event.efforts.ranked_order.third }
+      let(:effort_4) { event.efforts.ranked_order.fourth }
+
+      context "when no entrants finished the prior year" do
+        before { event.efforts.ranked_order.last(15).each(&:destroy) }
+
+        let(:expected_result) do
+          {
+            effort_1.id => 102,
+            effort_2.id => 100,
+            effort_3.id => 101,
+            effort_4.id => 103
+          }
+        end
+
+        it "computes bibs alphabetically starting at 100" do
+          expect(result).to eq(expected_result)
+        end
+      end
+
+      context "when some entrants finished the prior year" do
+        let(:prior_event) { events(:hardrock_2015) }
+        let(:prior_event_effort_1) { prior_event.efforts.ranked_order.first }
+        let(:prior_event_effort_2) { prior_event.efforts.ranked_order.second }
+
+        before do
+          event.efforts.ranked_order.last(15).each(&:destroy)
+          effort_1.update(person_id: prior_event_effort_1.person_id)
+          effort_2.update(person_id: prior_event_effort_2.person_id)
+        end
+
+        let(:expected_result) do
+          {
+            effort_1.id => 1,
+            effort_2.id => 2,
+            effort_3.id => 100,
+            effort_4.id => 101
+          }
+        end
+
+        it "computes bibs of prior year finishers starting at 1 and other bibs alphabetically starting at 100" do
+          expect(result).to eq(expected_result)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/interactors/bulk_set_bib_numbers_spec.rb
+++ b/spec/services/interactors/bulk_set_bib_numbers_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Interactors::BulkSetBibNumbers do
+  subject { described_class.new(event_group, bib_assignments) }
+  let(:event_group) { event_groups(:hardrock_2016) }
+  let(:event) { event_group.first_event }
+  let(:effort_1) { event.efforts.ranked_order.first }
+  let(:effort_2) { event.efforts.ranked_order.second }
+  let(:bib_assignments) do
+    {
+      effort_1.id => "22",
+      effort_2.id => "23",
+    }
+  end
+
+  describe "#perform!" do
+    let(:result) { subject.perform! }
+    context "when assignments are given and no duplicates exist" do
+      it "sets bib numbers as directed" do
+        result
+        expect(effort_1.reload.bib_number).to eq(22)
+        expect(effort_2.reload.bib_number).to eq(23)
+      end
+    end
+
+    context "when a provided bib number is a duplicate" do
+      let!(:existing_effort) { efforts(:hardrock_2016_shad_hirthe) }
+      let!(:existing_effort_bib_number) { existing_effort.bib_number.to_s }
+
+      let(:bib_assignments) do
+        {
+          effort_1.id => "22",
+          effort_2.id => existing_effort_bib_number,
+        }
+      end
+
+      it "sets bib numbers as directed and blanks out the duplicate" do
+        result
+        expect(effort_1.reload.bib_number).to eq(22)
+        expect(effort_2.reload.bib_number).to eq(existing_effort_bib_number.to_i)
+        expect(existing_effort.reload.bib_number).to be_nil
+      end
+    end
+
+    context "when the assignments contain an internal duplicate" do
+      let(:bib_assignments) do
+        {
+          effort_1.id => "22",
+          effort_2.id => "22",
+        }
+      end
+
+      it "sets the second and blanks out the first" do
+        result
+        expect(effort_1.reload.bib_number).to be_nil
+        expect(effort_2.reload.bib_number).to eq(22)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a few tests to bib assignment logic. It also simplifies the BulkSetBibNumbers class by removing the redundant duplicate number checking logic.

Relates to #772 