### PR TITLE
Better effort sorting in person show view

### DIFF
--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -12,8 +12,12 @@ class PersonPresenter < BasePresenter
   end
 
   def efforts
-    @efforts ||= EffortPolicy::Scope.new(current_user, Effort).viewable.includes(event: :event_group, split_times: :split)
-        .where(person: person).sort_by { |effort| -effort.actual_start_time.to_i }
+    @efforts ||= EffortPolicy::Scope.new(current_user, person.efforts)
+                                    .viewable
+                                    .includes(event: :event_group)
+                                    .joins(:event)
+                                    .finish_info_subquery
+                                    .order("events.scheduled_start_time desc")
   end
 
   def participation_notifiable?

--- a/app/views/efforts/_efforts_list_person.html.erb
+++ b/app/views/efforts/_efforts_list_person.html.erb
@@ -5,25 +5,27 @@
   <tr>
     <th><%= "#{@presenter.full_name}'s efforts:" %></th>
     <th>From</th>
+    <th>Date</th>
     <th class="text-right">Finish Time</th>
     <% if current_user&.admin? %>
-        <th class="text-right">Actions</th>
+      <th class="text-right">Actions</th>
     <% end %>
   </tr>
   </thead>
   <tbody>
-    <% efforts.each do |effort| %>
-      <tr>
+  <% efforts.each do |effort| %>
+    <tr>
       <td><strong><%= link_to effort.event.name, effort_path(effort) %></strong></td>
       <td><%= effort.state_and_country %></td>
+      <td><%= l(effort.final_absolute_time.to_date, format: :full_with_weekday) %></td>
       <td class="text-right"><%= text_with_status_indicator(effort.finish_status, effort.data_status, data_type: :effort_time_data) %></td>
       <% if current_user&.admin? %>
-          <td class="text-right"><%= link_to 'Disassociate',
-                                             effort_path(effort, effort: {person_id: nil}, button: :disassociate),
-                                             method: :patch,
-                                             class: 'btn btn-xs btn-danger' %></td>
+        <td class="text-right"><%= link_to "Disassociate",
+                                           effort_path(effort, effort: {person_id: nil}, button: :disassociate),
+                                           method: :patch,
+                                           class: "btn btn-xs btn-danger" %></td>
       <% end %>
-      </tr>
+    </tr>
   <% end %>
   </tbody>
 </table>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -9,7 +9,7 @@
         <div class="ost-title">
           <h1><strong><%= @presenter.full_name %></strong></h1>
           <ul class="breadcrumb breadcrumb-ost">
-            <li class="breadcrumb-item"><%= link_to 'People', people_path %></li>
+            <li class="breadcrumb-item"><%= link_to "People", people_path %></li>
             <li class="breadcrumb-item active"><%= @presenter.full_name %></li>
           </ul>
         </div>
@@ -32,10 +32,10 @@
       </div>
       <% if @presenter.photo.attached? %>
         <div class="col-3">
-          <%= image_tag(@presenter.photo.variant(resize: '150x150')) %>
+          <%= image_tag(@presenter.photo.variant(resize: "150x150")) %>
         </div>
       <% end %>
-      <%= render 'subscription_buttons', view_object: @presenter %>
+      <%= render "subscription_buttons", view_object: @presenter %>
     </div>
   </div>
 </header>
@@ -46,7 +46,7 @@
       <div class="col form-inline justify-content-between">
         <div>
           <% if @presenter.unclaimed? && current_user&.authorized_to_claim?(@presenter.person) %>
-            <%= link_to 'This is me', avatar_claim_person_path(@presenter.person),
+            <%= link_to "This is me", avatar_claim_person_path(@presenter.person),
                         data: {confirm: "Is this really you? (Please cancel if you were just kidding.)"},
                         class: "btn btn-success" %>
           <% end %>
@@ -61,6 +61,6 @@
 
 <article class="ost-article container">
   <% if @presenter.efforts.present? %>
-    <%= render 'efforts/efforts_list_person', efforts: @presenter.efforts %>
+    <%= render "efforts/efforts_list_person", efforts: @presenter.efforts %>
   <% end %>
 </article>


### PR DESCRIPTION
Efforts are currently being sorted correctly only if there is a start time. Any efforts lacking a start time are sorted arbitrarily.

This PR reworks the Person Presenter to use a join and includes and sorts by event scheduled start time instead.