### PR TITLE
Show all splits in the Plan Effort view

### DIFF
--- a/app/models/projected_effort.rb
+++ b/app/models/projected_effort.rb
@@ -14,10 +14,13 @@ class ProjectedEffort
 
   def ordered_split_times
     @ordered_split_times ||= projections.map do |projection|
-      effort.split_times.new(time_point: projection.time_point,
-                             absolute_time: add_to_baseline(projection.average_seconds),
-                             absolute_estimate_early: add_to_baseline(projection.low_seconds),
-                             absolute_estimate_late: add_to_baseline(projection.high_seconds))
+      effort.split_times.new(
+        time_point: projection.time_point,
+        designated_seconds_from_start: add_to_baseline(projection.average_seconds) - start_time,
+        absolute_time: add_to_baseline(projection.average_seconds),
+        absolute_estimate_early: add_to_baseline(projection.low_seconds),
+        absolute_estimate_late: add_to_baseline(projection.high_seconds),
+      )
     end
   end
 

--- a/app/models/projected_effort.rb
+++ b/app/models/projected_effort.rb
@@ -29,7 +29,7 @@ class ProjectedEffort
   end
 
   def effort_count
-    projections.map(&:effort_count).max
+    projections.map(&:effort_count).max || 0
   end
 
   private

--- a/app/models/projection.rb
+++ b/app/models/projection.rb
@@ -81,6 +81,7 @@ class Projection < ::ApplicationQuery
           
         quartiles as
             (select lap, 
+                effort_id, 
                 split_id, 
                 sub_split_bitkey,
                 effort_year,
@@ -105,11 +106,16 @@ class Projection < ::ApplicationQuery
               q1 - ((q3 - q1) * 1.5) as lower_bound,
               q3 + ((q3 - q1) * 1.5) as upper_bound
           from quartiles),
-              
-        valid_ratios as
-          (select *
+
+        valid_ratios as (
+          select *
           from bounds
-          where ratio between lower_bound and upper_bound),
+          where effort_id not in (
+            select distinct effort_id 
+            from bounds 
+            where ratio not between lower_bound and upper_bound
+          )
+        ),
 
         stats_subquery as
           (select lap, 

--- a/app/models/split_time.rb
+++ b/app/models/split_time.rb
@@ -28,6 +28,7 @@ class SplitTime < ApplicationRecord
 
   attribute :absolute_estimate_early, :datetime
   attribute :absolute_estimate_late, :datetime
+  attribute :designated_seconds_from_start, :integer
   attribute :matching_raw_time_id, :integer
   attribute :effort_ids_ahead, :integer_array_from_string
 
@@ -134,6 +135,7 @@ class SplitTime < ApplicationRecord
 
   def time_from_start
     return attributes["time_from_start"] if attributes.has_key?("time_from_start")
+    return designated_seconds_from_start if designated_seconds_from_start.present?
     return nil unless absolute_time
     return 0 if starting_split_time?
 

--- a/app/view_models/effort_with_lap_split_rows.rb
+++ b/app/view_models/effort_with_lap_split_rows.rb
@@ -16,6 +16,10 @@ class EffortWithLapSplitRows
     @event ||= Event.where(id: effort.event_id).includes(:splits).first
   end
 
+  def event_splits
+    @event_splits ||= event.splits
+  end
+
   def total_time_in_aid
     lap_split_rows.map(&:time_in_aid).compact.sum
   end
@@ -72,10 +76,13 @@ class EffortWithLapSplitRows
 
   def rows_from_lap_splits(lap_splits, indexed_times, in_times_only: false)
     lap_splits.map do |lap_split|
-      LapSplitRow.new(lap_split: lap_split,
-                      split_times: related_split_times(lap_split, indexed_times),
-                      show_laps: event.multiple_laps?,
-                      in_times_only: in_times_only)
+      LapSplitRow.new(
+        lap_split: lap_split,
+        split_times: related_split_times(lap_split, indexed_times),
+        show_laps: event.multiple_laps?,
+        in_times_only: in_times_only,
+        not_in_event: event_splits.exclude?(lap_split.split),
+      )
     end
   end
 

--- a/app/view_models/lap_split_row.rb
+++ b/app/view_models/lap_split_row.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 class LapSplitRow
+  attr_reader :not_in_event
+
   delegate :distance_from_start, :lap, :split, :key, :time_points, to: :lap_split
-  delegate :id, :kind, :start?, :intermediate?, :finish?, to: :split
+  delegate :id, :kind, :start?, :intermediate?, :finish?, :base_name, to: :split
   delegate :segment_time, :time_in_aid, :times_from_start, :absolute_times_local, :time_data_statuses,
            :split_time_ids, :stopped_here_flags, :stopped_here?, to: :time_cluster
 
@@ -12,12 +14,13 @@ class LapSplitRow
   def initialize(args)
     ArgsValidator.validate(params: args,
                            required: [:lap_split, :split_times],
-                           exclusive: [:lap_split, :split_times, :show_laps, :in_times_only],
+                           exclusive: [:lap_split, :split_times, :show_laps, :in_times_only, :not_in_event],
                            class: self.class)
     @lap_split = args[:lap_split]
     @split_times = args[:split_times]
     @show_laps = args[:show_laps]
     @in_times_only = args[:in_times_only]
+    @not_in_event = args[:not_in_event]
     validate_setup
   end
 

--- a/app/view_models/plan_display.rb
+++ b/app/view_models/plan_display.rb
@@ -68,10 +68,6 @@ class PlanDisplay < EffortWithLapSplitRows
     lap_split_rows.map(&:segment_time).compact.sum
   end
 
-  def finish_time_from_start
-    ordered_split_times.last.absolute_time - start_time
-  end
-
   def relevant_efforts_count
     projected_effort.effort_count
   end
@@ -121,10 +117,6 @@ class PlanDisplay < EffortWithLapSplitRows
         laps = event.laps_required || expected_laps
         course.lap_splits_through(laps)
       end
-  end
-
-  def event_lap_splits
-    @event_lap_splits ||= event.required_lap_splits.presence || event.lap_splits_through(expected_laps)
   end
 
   def default_start_time

--- a/app/view_models/plan_display.rb
+++ b/app/view_models/plan_display.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PlanDisplay < EffortWithLapSplitRows
+  MINIMUM_EFFORT_COUNT = 4
+
   include TimeFormats
   attr_reader :course, :error_messages
 
@@ -23,7 +25,10 @@ class PlanDisplay < EffortWithLapSplitRows
   end
 
   def ordered_split_times
-    projected_effort&.ordered_split_times || []
+    return [] if projected_effort.nil?
+    return [] if projected_effort.effort_count < MINIMUM_EFFORT_COUNT
+
+    projected_effort.ordered_split_times
   end
 
   def expected_time

--- a/app/views/courses/_plan_detail.html.erb
+++ b/app/views/courses/_plan_detail.html.erb
@@ -17,18 +17,51 @@
   <tbody>
   <% presenter.lap_split_rows.each do |row| %>
     <tr>
-      <td><%= strong_conditional row.name, row.finish? %></td>
-      <td class="text-right"><%= strong_conditional d(row.distance_from_start), row.finish? %></td>
-      <td class="text-center"><%= strong_conditional row.absolute_times_local.map(&method(:day_time_format)).join(' / '), row.finish? %></td>
-      <td class="text-center"><%= strong_conditional row.times_from_start.map(&method(:time_format_hhmm)).join(' / '), row.finish? %></td>
-      <td class="text-center"><%= strong_conditional time_format_hhmm(row.segment_time), row.finish? %></td>
+      <td>
+        <span class="<%= 'brackets' if row.not_in_event %>">
+          <%= strong_conditional row.name, row.finish? %>
+        </span>
+        <% if row.not_in_event %>
+          <span class="text-danger">
+            <%= fa_icon("exclamation-circle",
+                        class: "has-tooltip",
+                        data: {toggle: "tooltip", "original-title" => "#{row.base_name} does not exist as an aid station in the upcoming event. It is presented here for reference only."}) %>
+          </span>
+        <% end %>
+      </td>
+      <td class="text-right">
+        <span class="<%= 'brackets' if row.not_in_event %>">
+          <%= strong_conditional d(row.distance_from_start), row.finish? %>
+        </span>
+      </td>
+      <td class="text-center">
+        <span class="<%= 'brackets' if row.not_in_event %>">
+          <%= strong_conditional row.absolute_times_local.map(&method(:day_time_format)).join(' / '), row.finish? %>
+        </span>
+      </td>
+      <td class="text-center">
+        <span class="<%= 'brackets' if row.not_in_event %>">
+          <%= strong_conditional row.times_from_start.map(&method(:time_format_hhmm)).join(' / '), row.finish? %>
+        </span>
+      </td>
+      <td class="text-center">
+        <span class="<%= 'brackets' if row.not_in_event %>">
+          <%= strong_conditional time_format_hhmm(row.segment_time), row.finish? %>
+        </span>
+      </td>
       <% if presenter.out_sub_splits? %>
-        <td class="text-right"><%= strong_text_conditional time_format_minutes(presenter.total_time_in_aid), time_format_minutes(row.time_in_aid), row.finish? %></td>
+        <td class="text-right">
+          <span class="<%= 'brackets' if row.not_in_event %>">
+            <%= strong_text_conditional time_format_minutes(presenter.total_time_in_aid), time_format_minutes(row.time_in_aid), row.finish? %>
+          </span>
+        </td>
       <% end %>
       <% if presenter.multiple_laps? %>
         <td class="text-right">
           <% if row.finish? %>
-            <%= strong_conditional lap_time_text(presenter, row), true %>
+            <span class="<%= 'brackets' if row.not_in_event %>">
+              <%= strong_conditional lap_time_text(presenter, row), true %>
+            </span>
           <% end %>
         </td>
       <% end %>

--- a/spec/models/projection_spec.rb
+++ b/spec/models/projection_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe ::Projection, type: :model do
         expect(projection.low_ratio).to be_within(0.05).of(0.30)
         expect(projection.average_ratio).to be_within(0.05).of(0.35)
         expect(projection.high_ratio).to be_within(0.05).of(0.40)
-        expect(projection.low_seconds).to be_within(100).of(33_100)
-        expect(projection.average_seconds).to be_within(100).of(40_600)
-        expect(projection.high_seconds).to be_within(100).of(48_200)
+        expect(projection.low_seconds).to be_within(100).of(35_300)
+        expect(projection.average_seconds).to be_within(100).of(39_700)
+        expect(projection.high_seconds).to be_within(100).of(44_200)
       end
     end
 


### PR DESCRIPTION
- Shows all course splits in the Plan Effort view. 
- Moves projection logic from TypicalEffort to ProjectedEffort
- Cleans up effort projection logic to avoid anomalous results