### PR TITLE
Incremental lottery entrant import

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -185,7 +185,7 @@ class EventGroupsController < ApplicationController
     @presenter = ::EventGroupSetupPresenter.new(@event_group, prepared_params, current_user)
   end
 
-  # POST /event_groups/1/load_lottery_entrants
+  # POST /event_groups/1/load_lottery_entrants?lottery_id=1&event_id=1
   def load_lottery_entrants
     authorize @event_group
 

--- a/lib/etl/async_importer.rb
+++ b/lib/etl/async_importer.rb
@@ -48,7 +48,7 @@ module ETL
         self.extract_strategy = Extractors::CsvFileStrategy
         self.transform_strategy = Transformers::GenericResourcesStrategy
         self.load_strategy = Loaders::AsyncInsertStrategy
-        self.custom_options = { model: :effort, unique_key: [:first_name, :last_name, :birthdate] }
+        self.custom_options = { model: :effort, unique_key: [:first_name, :last_name, :birthdate, :event_id] }
       else
         errors << format_not_recognized_error(format)
       end

--- a/lib/etl/loaders/async_insert_strategy.rb
+++ b/lib/etl/loaders/async_insert_strategy.rb
@@ -52,7 +52,7 @@ module ETL
           record = build_record(proto_record)
 
           if unique_key.present?
-            unique_attributes = unique_key.map { |attr| [attr => record.send(attr)] }.to_h
+            unique_attributes = unique_key.map { |attr| [attr, record.send(attr)] }.to_h
 
             next if record.class.exists?(unique_attributes)
           end

--- a/lib/etl/loaders/async_insert_strategy.rb
+++ b/lib/etl/loaders/async_insert_strategy.rb
@@ -2,6 +2,12 @@
 
 module ETL
   module Loaders
+    # If no unique_key is provided, this is a plain insert loader that will
+    # keep track of errors if validations are violated at the model or database
+    # level.
+    #
+    # If a unique_key is provided, records having the same unique key as an existing
+    # database record will be ignored.
     class AsyncInsertStrategy
       include ETL::Errors
 
@@ -22,6 +28,7 @@ module ETL
         @proto_records = proto_records
         @options = options
         @import_job = options[:import_job]
+        @unique_key = options[:unique_key]
         @errors = []
       end
 
@@ -32,7 +39,7 @@ module ETL
 
       private
 
-      attr_reader :proto_records, :options, :import_job
+      attr_reader :proto_records, :options, :import_job, :unique_key
 
       # @return [nil]
       def custom_load
@@ -43,6 +50,12 @@ module ETL
           end
 
           record = build_record(proto_record)
+
+          if unique_key.present?
+            unique_attributes = unique_key.map { |attr| [attr => record.send(attr)] }.to_h
+
+            next if record.class.exists?(unique_attributes)
+          end
 
           if record.save
             import_job.increment!(:succeeded_count)

--- a/spec/lib/etl/loaders/async_insert_strategy_spec.rb
+++ b/spec/lib/etl/loaders/async_insert_strategy_spec.rb
@@ -86,8 +86,9 @@ RSpec.describe ETL::Loaders::AsyncInsertStrategy do
   end
 
   let(:all_proto_records) { valid_proto_records + invalid_proto_record }
-  let(:options) { {event: event, import_job: import_job} }
+  let(:options) { { event: event, import_job: import_job, unique_key: unique_key } }
   let!(:import_job) { create(:import_job, parent_type: "Event", parent_id: event.id, format: :test_format) }
+  let(:unique_key) { nil }
 
   describe "#load_records" do
     context "when all provided records are valid and none previously exists" do
@@ -145,7 +146,7 @@ RSpec.describe ETL::Loaders::AsyncInsertStrategy do
       end
     end
 
-    context "when one or more records previously exists" do
+    context "when one or more records fails validation" do
       let(:proto_records) { valid_proto_records }
       let(:first_child) { valid_proto_records.first.children.first }
       let(:second_child) { valid_proto_records.first.children.second }
@@ -153,12 +154,12 @@ RSpec.describe ETL::Loaders::AsyncInsertStrategy do
       before do
         existing_effort = create(:effort, event: event, bib_number: valid_proto_records.first[:bib_number])
         create(:split_time, effort: existing_effort, lap: first_child[:lap], split_id: first_child[:split_id],
-                            bitkey: first_child[:sub_split_bitkey], time_from_start: 0)
+               bitkey: first_child[:sub_split_bitkey], time_from_start: 0)
         create(:split_time, effort: existing_effort, lap: second_child[:lap], split_id: second_child[:split_id],
-                            bitkey: second_child[:sub_split_bitkey], time_from_start: 1000)
+               bitkey: second_child[:sub_split_bitkey], time_from_start: 1000)
       end
 
-      it "inserts only those records that do not previously exist" do
+      it "inserts only those records that do not fail validation" do
         expect { subject.load_records }.to change { Effort.count }.by(2).and change { SplitTime.count }.by(3)
       end
 
@@ -171,6 +172,49 @@ RSpec.describe ETL::Loaders::AsyncInsertStrategy do
       it "returns a descriptive error message" do
         subject.load_records
         expect(subject.errors.first.dig(:detail, :messages).first).to match(/Bib number \d already exists/)
+      end
+    end
+
+    context "when a unique key is provided" do
+      let(:unique_key) { [:first_name, :last_name, :birthdate, :event_id] }
+      let(:proto_records) { valid_proto_records }
+
+      context "when no records match the unique key" do
+        it "assigns attributes and creates new records" do
+          expect { subject.load_records }.to change { Effort.count }.by(3)
+          subject_efforts = Effort.last(3)
+
+          expect(subject_efforts.map(&:first_name)).to match_array(%w[Jatest Castest Mictest])
+          expect(subject_efforts.map(&:bib_number)).to match_array([5, 661, 633])
+          expect(subject_efforts.map(&:gender)).to match_array(%w[male female female])
+          expect(subject_efforts.map(&:event_id)).to all eq(event.id)
+        end
+      end
+
+      context "when an existing record matches the unique key" do
+        let!(:existing_effort) do
+          create(:effort,
+                 event: event,
+                 first_name: valid_proto_records.first[:first_name],
+                 last_name: valid_proto_records.first[:last_name],
+                 birthdate: valid_proto_records.first[:birthdate])
+        end
+
+        it "creates new records only for non-matching protos" do
+          expect { subject.load_records }.to change { Effort.count }.by(2)
+          subject_efforts = Effort.last(2)
+
+          expect(subject_efforts.map(&:first_name)).to match_array(%w[Castest Mictest])
+          expect(subject_efforts.map(&:bib_number)).to match_array([661, 633])
+          expect(subject_efforts.map(&:gender)).to match_array(%w[female female])
+          expect(subject_efforts.map(&:event_id)).to all eq(event.id)
+        end
+
+        it "ignores the matching record" do
+          expect(existing_effort).not_to receive(:update)
+          expect(existing_effort).not_to receive(:save)
+          subject.load_records
+        end
       end
     end
 


### PR DESCRIPTION
Currently, we can't import lottery entrants on an incremental basis because we would get a lot of duplicates. 

This PR adds a `unique_key` option to the Async Import Loader to allow it to skip over entrants that match the same name and birthdate.