### PR TITLE
Individually delete entrant photos from manage photos view

### DIFF
--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -89,6 +89,14 @@ class EffortsController < ApplicationController
     redirect_to setup_event_group_path(@effort.event_group, display_style: :entrants)
   end
 
+  # DELETE /efforts/1/delete_photo
+  def delete_photo
+    authorize @effort
+
+    @effort.photo.purge_later
+    redirect_to manage_entrant_photos_event_group_path(@effort.event_group)
+  end
+
   def projections
     @presenter = EffortProjectionsView.new(@effort)
 

--- a/app/policies/effort_policy.rb
+++ b/app/policies/effort_policy.rb
@@ -20,6 +20,10 @@ class EffortPolicy < ApplicationPolicy
     @effort = effort
   end
 
+  def delete_photo?
+    user.authorized_to_edit?(effort)
+  end
+
   def audit?
     user.authorized_to_edit?(effort)
   end

--- a/app/views/event_groups/manage_entrant_photos.html.erb
+++ b/app/views/event_groups/manage_entrant_photos.html.erb
@@ -93,7 +93,7 @@
     <div class="col-12 col-md-6">
       <div class="row my-3">
         <div class="col">
-          <h4 class="font-weight-bold">Already assigned</h4>
+          <h4 class="font-weight-bold">Already assigned <span class="font-weight-light text-muted small"><%= @presenter.event_group.efforts.photo_assigned.count %></span></h4>
         </div>
         <div class="col">
           <%= link_to "Remove all",
@@ -105,21 +105,32 @@
       </div>
       <% @presenter.event_group.efforts.photo_assigned.with_attached_photo.order(:bib_number).each do |effort| %>
         <div class="row">
-          <div class="col">
+          <div class="col-1 text-center my-auto pr-0">
+            <%= link_to fa_icon("times-circle"),
+                        delete_photo_effort_path(effort),
+                        method: :delete,
+                        data: { confirm: "This will remove the photo. Proceed?" },
+                        class: "btn btn-sm btn-outline-danger" %>
+          </div>
+          <div class="col-2 mx-auto text-center">
             <%= image_tag effort.photo.variant(:thumbnail) %>
-            <span class="font-weight-bold"><%= "#{effort.full_name} ##{effort.bib_number}" %></span>
+          </div>
+          <div class="col-9 my-auto">
+            <span class="font-weight-bold align-baseline"><%= "#{effort.full_name} ##{effort.bib_number}" %></span>
           </div>
         </div>
       <% end %>
     </div>
 
     <div class="col-12 col-md-6">
-      <h4 class="my-3"><strong>Not yet assigned</strong></h4>
+      <h4 class="my-3"><strong>Not yet assigned <span class="font-weight-light text-muted small"><%= @presenter.event_group.efforts.no_photo_assigned.count %></span></strong></h4>
       <% @presenter.event_group.efforts.no_photo_assigned.order(:bib_number).each do |effort| %>
         <div class="row">
-          <div class="col">
+          <div class="col-2 text-center">
             <%= image_tag "small/avatar-empty.jpg" %>
-            <span class="font-weight-bold"><%= "#{effort.full_name} ##{effort.bib_number}" %></span>
+          </div>
+          <div class="col-10 my-auto">
+            <span class="font-weight-bold align-baseline"><%= "#{effort.full_name} ##{effort.bib_number}" %></span>
           </div>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Rails.application.routes.draw do
       patch :unstart
       patch :stop
       patch :smart_stop
+      delete :delete_photo
       delete :delete_split_times
     end
   end


### PR DESCRIPTION
Currently, from the Manage Photos view, we have the ability to add photos individually, and we can remove them all in a single batch. But we don't yet have the ability to remove a single photo, which would come in handy if one or two photos are wrong. 

This PR adds the ability to delete photos individually for an effort from the Manage Photos view.