### PR TITLE
Use bib number in breaking ties for ranked order queries

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -74,7 +74,7 @@ class Effort < ApplicationRecord
   scope :photo_assigned, -> { joins("join active_storage_attachments asa on asa.record_type = 'Effort' and asa.name = 'photo' and asa.record_id = efforts.id") }
   scope :no_photo_assigned, -> { joins("left join active_storage_attachments asa on asa.record_type = 'Effort' and asa.name = 'photo' and asa.record_id = efforts.id").where("asa.id is null") }
   scope :finish_info_subquery, -> { from(EffortQuery.finish_info_subquery(self)) }
-  scope :ranked_order, -> { order(overall_performance: :desc) }
+  scope :ranked_order, -> { order(overall_performance: :desc, bib_number: :asc) }
   scope :ranking_subquery, -> { from(EffortQuery.ranking_subquery(self)) }
   scope :roster_subquery, -> { from(EffortQuery.roster_subquery(self)) }
   scope :with_policy_scope_attributes, lambda {

--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -16,7 +16,7 @@ class EffortQuery < BaseQuery
            ),
 
            efforts_for_ranking as (
-               select id as effort_id, event_id, gender, overall_performance
+               select id as effort_id, event_id, gender, overall_performance, bib_number
                from efforts
                where efforts.event_id in (select event_id from event_subquery)
            ),
@@ -26,7 +26,8 @@ class EffortQuery < BaseQuery
                       rank() over overall_window          as overall_rank,
                       rank() over gender_window           as gender_rank,
                       lag(effort_id) over overall_window  as prior_effort_id,
-                      lead(effort_id) over overall_window as next_effort_id
+                      lead(effort_id) over overall_window as next_effort_id,
+                      bib_number
                from efforts_for_ranking
                window overall_window as (partition by event_id order by overall_performance desc),
                       gender_window as (partition by event_id, gender order by overall_performance desc)
@@ -39,7 +40,7 @@ class EffortQuery < BaseQuery
              next_effort_id
       from existing_scope
            join ranking_subquery on ranking_subquery.effort_id = existing_scope.id
-      order by event_id, overall_rank, bib_number
+      order by event_id, overall_rank, ranking_subquery.bib_number
       )
 
       as efforts

--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -39,7 +39,7 @@ class EffortQuery < BaseQuery
              next_effort_id
       from existing_scope
            join ranking_subquery on ranking_subquery.effort_id = existing_scope.id
-      order by event_id, overall_rank
+      order by event_id, overall_rank, bib_number
       )
 
       as efforts


### PR DESCRIPTION
Currently, we are using bib number to break ties in the spread view, but bib number doesn't factor in when doing things like calculating the next effort. 

This PR adds bib number to the `ranked_order` scope and also to the effort ranking query.