### PR TITLE
Live Entry | Fix timestamp / military time issue

### DIFF
--- a/app/assets/javascripts/new_live_entry.js
+++ b/app/assets/javascripts/new_live_entry.js
@@ -1015,8 +1015,8 @@
                         <td class="bib-number js-bib-number ' + bibStatus + '">' + (rawTime.bibNumber || '') + bibIcon + '</td>\
                         <td class="effort-name js-effort-name text-nowrap">' + (effort ? '<a href="/efforts/' + effort.id + '">' + effort.attributes.fullName + '</a>' : '[Bib not found]') + '</td>\
                         <td class="lap-number js-lap-number lap-only">' + rawTime.enteredLap + '</td>\
-                        <td class="time-in js-time-in text-nowrap time-in-only ' + inRawTime.dataStatus + '">' + (inRawTime.enteredTime || '') + timeInIcon + '</td>\
-                        <td class="time-out js-time-out text-nowrap time-out-only ' + outRawTime.dataStatus + '">' + (outRawTime.enteredTime || '') + timeOutIcon + '</td>\
+                        <td class="time-in js-time-in text-nowrap time-in-only ' + inRawTime.dataStatus + '">' + (inRawTime.militaryTime || '') + timeInIcon + '</td>\
+                        <td class="time-out js-time-out text-nowrap time-out-only ' + outRawTime.dataStatus + '">' + (outRawTime.militaryTime || '') + timeOutIcon + '</td>\
                         <td class="pacer-inout js-pacer-inout pacer-only">' + (inRawTime.withPacer ? 'Yes' : 'No') + ' / ' + (outRawTime.withPacer ? 'Yes' : 'No') + '</td>\
                         <td class="dropped-here js-dropped-here">' + (inRawTime.stoppedHere || outRawTime.stoppedHere ? '<span class="btn btn-warning btn-xs disabled">Done</span>' : '') + '</td>\
                         <td class="row-edit-btns">\
@@ -1196,6 +1196,7 @@
                         return {
                             bibNumber: rawTime.bibNumber,
                             enteredTime: rawTime.enteredTime,
+                            militaryTime: rawTime.militaryTime,
                             lap: rawTime.enteredLap,
                             splitName: rawTime.splitName,
                             subSplitKind: rawTime.subSplitKind,

--- a/app/assets/javascripts/new_live_entry.js
+++ b/app/assets/javascripts/new_live_entry.js
@@ -695,6 +695,7 @@
                                 eventGroupId: liveEntry.currentEventGroupId,
                                 bibNumber: $('#js-bib-number').val(),
                                 enteredTime: $timeField.val(),
+                                militaryTime: $timeField.val(),
                                 enteredLap: $('#js-lap-number').val(),
                                 splitName: liveEntry.currentStation().title,
                                 subSplitKind: kind,
@@ -723,8 +724,8 @@
                 $('#js-unique-id').val(rawTimeRow.uniqueId);
                 $('#js-bib-number').val(rawTime.bibNumber).focus();
                 $('#js-lap-number').val(rawTime.enteredLap);
-                $inTimeField.val(inRawTime.enteredTime);
-                $outTimeField.val(outRawTime.enteredTime);
+                $inTimeField.val(inRawTime.militaryTime);
+                $outTimeField.val(outRawTime.militaryTime);
                 $('#js-pacer-in').prop('checked', inRawTime.withPacer);
                 $('#js-pacer-out').prop('checked', outRawTime.withPacer);
                 $('#js-dropped').prop('checked', inRawTime.stoppedHere || outRawTime.stoppedHere).change();

--- a/spec/lib/time_conversion_spec.rb
+++ b/spec/lib/time_conversion_spec.rb
@@ -176,6 +176,15 @@ RSpec.describe TimeConversion do
   end
 
   describe ".user_entered_to_military" do
+    let(:result) { described_class.user_entered_to_military(time_string) }
+    context "when provided as a timestamp" do
+      let(:time_string) { "2022-07-15 06:34:12-0600" }
+      let(:expected) { "06:34:12" }
+
+      it "returns just the time information as a string" do
+        expect(result).to eq(expected)
+      end
+    end
     it "returns time in hh:mm:ss format when provided in hh:mm:ss format" do
       file_string = "12:30:45"
       expected = "12:30:45"
@@ -200,30 +209,6 @@ RSpec.describe TimeConversion do
       expect(TimeConversion.user_entered_to_military(file_string)).to eq(expected)
     end
 
-    it "properly determines colon insertion points when time is provided in hhmmss format" do
-      file_string = "123045"
-      expected = "12:30:45"
-      expect(TimeConversion.user_entered_to_military(file_string)).to eq(expected)
-    end
-
-    it "properly determines colon insertion points when time is provided in hhmm format" do
-      file_string = "1230"
-      expected = "12:30:00"
-      expect(TimeConversion.user_entered_to_military(file_string)).to eq(expected)
-    end
-
-    it "properly determines colon insertion points when time is provided in hmmss format" do
-      file_string = "23045"
-      expected = "02:30:45"
-      expect(TimeConversion.user_entered_to_military(file_string)).to eq(expected)
-    end
-
-    it "properly determines colon insertion points when time is provided in hmm format" do
-      file_string = "230"
-      expected = "02:30:00"
-      expect(TimeConversion.user_entered_to_military(file_string)).to eq(expected)
-    end
-
     it "substitutes zeros for non-numeric characters at the end of the string" do
       file_string = "12:30:xx"
       expected = "12:30:00"
@@ -231,13 +216,13 @@ RSpec.describe TimeConversion do
     end
 
     it "substitutes zeros for non-numeric characters in the middle of the string" do
-      file_string = "12xx30"
+      file_string = "12:xx:30"
       expected = "12:00:30"
       expect(TimeConversion.user_entered_to_military(file_string)).to eq(expected)
     end
 
     it "substitutes zeros for non-numeric characters at the beginning of the string" do
-      file_string = "xx3000"
+      file_string = "xx:30:00"
       expected = "00:30:00"
       expect(TimeConversion.user_entered_to_military(file_string)).to eq(expected)
     end

--- a/spec/models/raw_time_spec.rb
+++ b/spec/models/raw_time_spec.rb
@@ -123,8 +123,8 @@ RSpec.describe RawTime, type: :model do
       end
     end
 
-    context "when entered_time has text where it should have zeros" do
-      let(:entered_time) { "08:mm:ss" }
+    context "when entered_time has `x` where it should have zeros" do
+      let(:entered_time) { "08:xx:xx" }
 
       it "returns the entered_time as a string with imputed :00 minutes and seconds" do
         expect(subject).to eq("08:00:00")

--- a/spec/support/concerns/time_recordable.rb
+++ b/spec/support/concerns/time_recordable.rb
@@ -59,7 +59,7 @@ RSpec.shared_examples_for "time_recordable" do
 
     context "when absolute_time exists but zone does not exist" do
       it "returns the entered_time in hh:mm:ss format" do
-        resource = build_stubbed(model_name, absolute_time: "2017-07-31 09:30:45 -0000", entered_time: "0123")
+        resource = build_stubbed(model_name, absolute_time: "2017-07-31 09:30:45 -0000", entered_time: "01:23")
         zone = nil
         expect(resource.military_time(zone)).to eq("01:23:00")
       end
@@ -68,13 +68,6 @@ RSpec.shared_examples_for "time_recordable" do
     context "when no absolute_time exists" do
       it "returns the entered_time in hh:mm:ss format" do
         resource = build_stubbed(model_name, absolute_time: nil, entered_time: "16:30:45")
-        expect(resource.military_time).to eq("16:30:45")
-      end
-    end
-
-    context "when entered_time has no colons" do
-      it "returns the entered_time in hh:mm:ss format" do
-        resource = build_stubbed(model_name, absolute_time: nil, entered_time: "163045")
         expect(resource.military_time).to eq("16:30:45")
       end
     end


### PR DESCRIPTION
Times entered from OST Remote and pulled into the Live Entry screen were coming in as full timestamps instead of truncated military times. 

This PR fixes that issue so that times entered as full timestamps are handled properly in the Live Entry screen.