### PR TITLE
Use VIPS-compatible syntax for image variants

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -37,7 +37,9 @@ class Effort < ApplicationRecord
   has_many :split_times, dependent: :destroy, autosave: true
   has_many :notifications, dependent: :destroy
   has_one_attached :photo do |photo|
-    photo.variant :thumbnail, resize: "50x50"
+    photo.variant :thumbnail, resize_to_limit: [50, 50]
+    photo.variant :small, resize_to_limit: [150, 150]
+    photo.variant :medium, resize_to_limit: [500, 500]
   end
 
   accepts_nested_attributes_for :split_times, allow_destroy: true, reject_if: :reject_split_time?

--- a/app/models/event_group.rb
+++ b/app/models/event_group.rb
@@ -24,7 +24,8 @@ class EventGroup < ApplicationRecord
   belongs_to :organization
 
   has_many_attached :entrant_photos do |photo|
-    photo.variant :small, resize: "200x200"
+    photo.variant :thumbnail, resize_to_limit: [50, 50]
+    photo.variant :small, resize_to_limit: [200, 200]
   end
 
   after_create :notify_admin

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -7,7 +7,10 @@ class Partner < ApplicationRecord
   strip_attributes collapse_spaces: true
   has_paper_trail
 
-  has_one_attached :banner
+  has_one_attached :banner do |banner|
+    banner.variant :banner_small, resize_to_limit: [364, 45]
+    banner.variant :banner_large, resize_to_limit: [728, 90]
+  end
 
   validates :banner,
             content_type: %w[image/png image/jpeg],

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -21,7 +21,11 @@ class Person < ApplicationRecord
   enum gender: [:male, :female]
   has_many :efforts, dependent: :nullify
   belongs_to :claimant, class_name: "User", foreign_key: "user_id", optional: true
-  has_one_attached :photo
+  has_one_attached :photo do |photo|
+    photo.variant :thumbnail, resize_to_limit: [50, 50]
+    photo.variant :small, resize_to_limit: [150, 150]
+    photo.variant :medium, resize_to_limit: [500, 500]
+  end
 
   attr_accessor :suggested_match
 

--- a/app/views/efforts/_effort_header.html.erb
+++ b/app/views/efforts/_effort_header.html.erb
@@ -25,7 +25,7 @@
       <% unless action_name == 'audit' %>
         <% if view_object.photo.attached? %>
           <div class="col-3">
-            <%= link_to image_tag(view_object.photo.variant(resize: '150x150')), {action: :show_photo} %>
+            <%= link_to image_tag(view_object.photo.variant(:small)), { action: :show_photo } %>
           </div>
         <% end %>
         <%= render 'subscription_buttons', view_object: view_object %>

--- a/app/views/efforts/_show_photo.html.erb
+++ b/app/views/efforts/_show_photo.html.erb
@@ -1,1 +1,1 @@
-<%= link_to image_tag(@effort.photo.variant(resize: '500x500')), {action: :show} %>
+<%= link_to image_tag(@effort.photo.variant(:medium)), { action: :show } %>

--- a/app/views/event_groups/_partner_list.html.erb
+++ b/app/views/event_groups/_partner_list.html.erb
@@ -25,7 +25,7 @@
     <% presenter.partners.each do |partner| %>
       <tr>
         <td><%= partner.name %></td>
-        <td><%= image_tag partner.banner.variant(resize: "364x45") if partner.banner.attached? %></td>
+        <td><%= image_tag partner.banner.variant(:banner_small) if partner.banner.attached? %></td>
         <td><%= link_to partner.banner_link, url_with_protocol(partner.banner_link), target: "_blank" if partner.banner_link %></td>
         <td><%= partner.weight %></td>
         <td>

--- a/app/views/events/_partner_banner.html.erb
+++ b/app/views/events/_partner_banner.html.erb
@@ -1,7 +1,7 @@
 <div class="row header">
   <div class="col-md-6 partner-ad">
     <a href="<%= url_with_protocol(partner.banner_link) %>" target="_blank">
-      <img src="<%= partner.banner.variant(resize: '728x90') if partner.banner.attached? %>">
+      <img src="<%= partner.banner.variant(:banner_large) if partner.banner.attached? %>">
     </a>
   </div>
   <div class="col-md-6">

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -1,14 +1,14 @@
-<%= render 'shared/errors', obj: @partner %>
+<%= render "shared/errors", obj: @partner %>
 
 <div class="row">
   <div class="col-md-12">
-    <%= form_for(@partner, multipart: true, html: {class: 'form-horizontal', role: 'form'}) do |f| %>
+    <%= form_for(@partner, multipart: true, html: { class: "form-horizontal", role: "form" }) do |f| %>
       <div class="form-group required">
         <div class="control-label col-sm-2">
           <%= f.label :name %>
         </div>
         <div class="col-sm-8">
-          <%= f.text_field :name, class: 'form-control', placeholder: 'Partner name', autofocus: true %>
+          <%= f.text_field :name, class: "form-control", placeholder: "Partner name", autofocus: true %>
         </div>
       </div>
 
@@ -17,12 +17,12 @@
           <%= f.label :banner %>
         </div>
         <div class="col-sm-8">
-          <%= f.file_field :banner, class: 'form-control' %>
+          <%= f.file_field :banner, class: "form-control" %>
         </div>
       </div>
 
       <div class="form-group">
-        <%= image_tag @partner.banner.variant(resize: '728x90') if @partner.banner.attached? %>
+        <%= image_tag @partner.banner.variant(:banner_large) if @partner.banner.attached? %>
       </div>
 
       <div class="form-group">
@@ -30,8 +30,8 @@
           <%= f.label :banner_link %>
         </div>
         <div class="col-sm-8">
-          <%= f.text_field :banner_link, class: 'form-control',
-                           placeholder: 'Paste the link that this banner should open' %>
+          <%= f.text_field :banner_link, class: "form-control",
+                           placeholder: "Paste the link that this banner should open" %>
         </div>
       </div>
 
@@ -40,7 +40,7 @@
           <%= f.label :weight %>
         </div>
         <div class="col-sm-8">
-          <%= f.number_field :weight, class: 'form-control' %>
+          <%= f.number_field :weight, class: "form-control" %>
         </div>
       </div>
 
@@ -48,12 +48,12 @@
 
       <div class="form-group">
         <div class="col-sm-offset-2 col-sm-10">
-          <%= f.submit(@partner.new_record? ? 'Create partner' : 'Update partner', class: 'btn btn-primary btn-large') %>
+          <%= f.submit(@partner.new_record? ? "Create partner" : "Update partner", class: "btn btn-primary btn-large") %>
         </div>
       </div>
 
       <div class="col-xs-4 col-xs-offset-2">
-        <span class="brackets"><%= link_to 'Cancel', setup_event_group_path(@partner.event_group_id, display_style: "partners") %></span>
+        <span class="brackets"><%= link_to "Cancel", setup_event_group_path(@partner.event_group_id, display_style: "partners") %></span>
       </div>
     <% end %>
   </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -32,7 +32,7 @@
       </div>
       <% if @presenter.photo.attached? %>
         <div class="col-3">
-          <%= image_tag(@presenter.photo.variant(resize: "150x150")) %>
+          <%= image_tag(@presenter.photo.variant(:small)) %>
         </div>
       <% end %>
       <%= render "subscription_buttons", view_object: @presenter %>


### PR DESCRIPTION
This PR changes all variant syntax over to VIPS-compatible syntax.

It also moves all definitions into pre-defined variants on the models.