### PR TITLE
Cutoff Analysis for Aid Stations

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class CoursesController < ApplicationController
-  before_action :authenticate_user!, except: [:show, :best_efforts, :plan_effort]
+  before_action :authenticate_user!, except: [:show, :best_efforts, :cutoff_analysis, :plan_effort]
   before_action :set_course, except: [:new, :create]
-  after_action :verify_authorized, except: [:show, :best_efforts, :plan_effort]
+  after_action :verify_authorized, except: [:show, :best_efforts, :cutoff_analysis, :plan_effort]
 
   def show
     course = Course.where(id: @course).includes(:splits).first
@@ -83,6 +83,10 @@ class CoursesController < ApplicationController
         render json: {best_effort_segments: segments, html: html, links: {next: @presenter.next_page_url}}
       end
     end
+  end
+
+  def cutoff_analysis
+    @presenter = CourseCutoffAnalysisPresenter.new(@course, view_context)
   end
 
   def plan_effort

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -3,59 +3,65 @@
 module TabsHelper
   def effort_view_tabs(view_object)
     if !view_object.simple? || current_user&.authorized_to_edit?(view_object.effort)
-      items = [{name: "Split times",
-                link: effort_path(view_object.effort),
-                active: action_name == "show"},
-               {name: "Projections",
-                link: projections_effort_path(view_object.effort),
-                active: action_name == "projections",
-                hidden: view_object.simple? || !view_object.in_progress?},
-               {name: "Analyze times",
-                link: analyze_effort_path(view_object.effort),
-                active: action_name == "analyze",
-                hidden: view_object.simple? || view_object.not_analyzable?},
-               {name: "Places + peers",
-                link: place_effort_path(view_object.effort),
-                active: action_name == "place",
-                hidden: view_object.simple? || view_object.not_analyzable?},
-               {name: "Audit",
-                link: audit_effort_path(view_object.effort),
-                active: action_name == "audit",
-                hidden: !current_user&.authorized_to_edit?(view_object.effort)}]
+      items = [{ name: "Split times",
+                 link: effort_path(view_object.effort),
+                 active: action_name == "show" },
+               { name: "Projections",
+                 link: projections_effort_path(view_object.effort),
+                 active: action_name == "projections",
+                 hidden: view_object.simple? || !view_object.in_progress? },
+               { name: "Analyze times",
+                 link: analyze_effort_path(view_object.effort),
+                 active: action_name == "analyze",
+                 hidden: view_object.simple? || view_object.not_analyzable? },
+               { name: "Places + peers",
+                 link: place_effort_path(view_object.effort),
+                 active: action_name == "place",
+                 hidden: view_object.simple? || view_object.not_analyzable? },
+               { name: "Audit",
+                 link: audit_effort_path(view_object.effort),
+                 active: action_name == "audit",
+                 hidden: !current_user&.authorized_to_edit?(view_object.effort) }]
 
       build_view_tabs(items)
     end
   end
 
   def course_view_tabs(view_object)
-    items = [{name: "Splits",
-              link: course_path(view_object.course, display_style: "splits"),
-              active: action_name == "show" && view_object.display_style == "splits"},
-             {name: "Events",
-              link: course_path(view_object.course, display_style: "events"),
-              active: action_name == "show" && view_object.display_style == "events"},
-             {name: "All-time best",
-              link: best_efforts_course_path(view_object.course),
-              active: action_name == "best_efforts"},
-             {name: "Plan my effort",
-              link: plan_effort_course_path(view_object.course),
-              active: action_name == "plan_effort",
-              hidden: view_object.simple?}]
+    items = [
+      { name: "Splits",
+        link: course_path(view_object.course, display_style: "splits"),
+        active: action_name == "show" && view_object.display_style == "splits" },
+      { name: "Events",
+        link: course_path(view_object.course, display_style: "events"),
+        active: action_name == "show" && view_object.display_style == "events" },
+      { name: "All-time best",
+        link: best_efforts_course_path(view_object.course),
+        active: action_name == "best_efforts" },
+      { name: "Plan my effort",
+        link: plan_effort_course_path(view_object.course),
+        active: action_name == "plan_effort",
+        hidden: view_object.simple? },
+      { name: "Cutoff analysis",
+        link: cutoff_analysis_course_path(view_object.course),
+        active: action_name == "cutoff_analysis",
+        hidden: view_object.simple? },
+    ]
 
     build_view_tabs(items)
   end
 
   def setup_view_tabs(presenter)
     items = [
-      {name: "Events",
-       link: setup_event_group_path(presenter.event_group, display_style: "events"),
-       active: action_name == "setup" && presenter.display_style == "events"},
-      {name: "Entrants",
-       link: setup_event_group_path(presenter.event_group, display_style: "entrants"),
-       active: action_name == "setup" && presenter.display_style == "entrants"},
-      {name: "Partners",
-       link: setup_event_group_path(presenter.event_group, display_style: "partners"),
-       active: action_name == "setup" && presenter.display_style == "partners"},
+      { name: "Events",
+        link: setup_event_group_path(presenter.event_group, display_style: "events"),
+        active: action_name == "setup" && presenter.display_style == "events" },
+      { name: "Entrants",
+        link: setup_event_group_path(presenter.event_group, display_style: "entrants"),
+        active: action_name == "setup" && presenter.display_style == "entrants" },
+      { name: "Partners",
+        link: setup_event_group_path(presenter.event_group, display_style: "partners"),
+        active: action_name == "setup" && presenter.display_style == "partners" },
     ]
 
     build_view_tabs(items)

--- a/app/models/interval_split_cutoff_analysis.rb
+++ b/app/models/interval_split_cutoff_analysis.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+class IntervalSplitCutoffAnalysis < ::ApplicationQuery
+  attribute :end_seconds, :integer
+  attribute :finished_count, :integer
+  attribute :start_seconds, :integer
+  attribute :total_count, :integer
+
+  ROW_LIMIT = 300
+
+  # @param [Integer] split_id
+  # @param [Integer,ActiveSupport::Duration] band_width
+  def self.execute_query(split_id:, band_width:)
+    split = Split.find_by(id: split_id)
+    return unless split.present?
+
+    start_split_id = split.course.start_split.id
+    band_width /= 1.second
+    effort_segments = ::EffortSegment.where(begin_split_id: start_split_id, end_split_id: split_id)
+    max = effort_segments.maximum(:elapsed_seconds)
+    min = effort_segments.minimum(:elapsed_seconds)
+    return [] unless max.present? && min.present?
+
+    time_span = max - min
+    return if time_span / band_width > ROW_LIMIT
+
+    super
+  end
+
+  # @param [Integer] split_id
+  # @param [Integer,ActiveSupport::Duration] band_width
+  # @return [String]
+  def self.sql(split_id:, band_width:)
+    band_width /= 1.second
+
+    <<~SQL.squish
+      with
+          course_splits as (
+            select a.id, a.kind
+            from splits s
+            join splits a on a.course_id = s.course_id
+            where s.id = #{split_id}
+          ),
+
+          subject_effort_segments as (
+              select distinct on (effort_id, lap) effort_id, lap, elapsed_seconds
+              from effort_segments
+          where begin_split_id = (select id from course_splits where kind = 0)
+            and end_split_id = #{split_id}
+          order by effort_id, lap, end_bitkey desc
+          ),
+          
+          finish_effort_segments as (
+              select effort_id, lap, elapsed_seconds
+              from effort_segments
+          where begin_split_id = (select id from course_splits where kind = 0)
+            and end_split_id = (select id from course_splits where kind = 1)
+          ),
+          
+          all_effort_segments as (
+              select ses.effort_id, ses.lap, ses.elapsed_seconds, fes.effort_id is not null as finished
+              from subject_effort_segments ses
+                  left join finish_effort_segments fes using (effort_id, lap)
+          ),
+          
+          interval_starts as (
+              select *
+              from generate_series((select min(floor(elapsed_seconds / #{band_width}) * #{band_width}) from subject_effort_segments)::int,
+                                   (select max(floor(elapsed_seconds / #{band_width}) * #{band_width}) + #{band_width} from subject_effort_segments)::int,
+                                   #{band_width}) seconds
+          ),
+
+          intervals as (
+              select seconds as start_seconds, lead(seconds) over(order by seconds) as end_seconds
+              from interval_starts
+          )
+          
+      select i.start_seconds,
+             i.end_seconds,
+             count(case when aes.finished is true then 1 else null end) as finished_count,
+             count(aes.effort_id) as total_count
+      from all_effort_segments aes
+        right join intervals i
+          on aes.elapsed_seconds >= i.start_seconds and aes.elapsed_seconds < i.end_seconds
+      where i.end_seconds is not null
+      group by i.start_seconds, i.end_seconds
+      order by i.start_seconds;
+    SQL
+  end
+end

--- a/app/presenters/course_cutoff_analysis_presenter.rb
+++ b/app/presenters/course_cutoff_analysis_presenter.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class CourseCutoffAnalysisPresenter < BasePresenter
+  include SplitAnalyzable
+  include TimeFormats
+
+  attr_reader :course, :band_width
+
+  delegate :name, :organization, :simple?, to: :course
+
+  def initialize(course, view_context)
+    @course = course
+    @view_context = view_context
+    @parameterized_split_name = view_context.prepared_params[:parameterized_split_name]
+    @band_width = view_context.prepared_params[:band_width]&.to_i || 30.minutes
+  end
+
+  def interval_split_cutoff_analyses
+    @interval_split_cutoff_analyses ||= ::IntervalSplitCutoffAnalysis.execute_query(split: split, band_width: band_width)
+  end
+
+  def chart_data
+    @chart_data ||=
+      [
+        {
+          name: "Finished",
+          data: interval_split_cutoff_analyses.map { |isca| [duration_range_string(isca), isca.finished_count] }
+        },
+        {
+          name: "Unfinished",
+          data: interval_split_cutoff_analyses.map { |isca| [duration_range_string(isca), isca.total_count - isca.finished_count] }
+        },
+      ]
+  end
+
+  def distance
+    split&.distance_from_start
+  end
+
+  def table_title
+    if split.nil?
+      "Unknown split."
+    elsif interval_split_cutoff_analyses.nil?
+      "Too many rows to analyze. Use a lower frequency."
+    elsif interval_split_cutoff_analyses.empty?
+      "No data is available for this aid station."
+    else
+      "Cutoff analysis for #{split_name} in increments of #{band_width / 1.minute} minutes"
+    end
+  end
+
+  def duration_range_string(isca)
+    "#{time_format_hhmm(isca.start_seconds)} to #{time_format_hhmm(isca.end_seconds)}"
+  end
+
+  def split_name
+    split.base_name
+  end
+
+  def suggested_band_widths
+    [1.minute, 2.minutes, 5.minutes, 10.minutes, 15.minutes, 30.minutes, 60.minutes]
+  end
+
+  private
+
+  attr_reader :parameterized_split_name
+
+  def split
+    @split ||= course.splits.find_by(parameterized_base_name: parameterized_split_name) || course.ordered_splits.second
+  end
+
+  def split_analyzable
+    course
+  end
+
+  def localized_time(datetime)
+    I18n.localize(datetime.in_time_zone(event_group.home_time_zone), format: :day_and_military)
+  end
+end

--- a/app/views/courses/cutoff_analysis.html.erb
+++ b/app/views/courses/cutoff_analysis.html.erb
@@ -1,0 +1,75 @@
+<% content_for :title do %>
+  <% "OpenSplitTime: Cutoff analysis - #{@presenter.name}" %>
+<% end %>
+
+<header class="ost-header">
+  <div class="container">
+    <div class="ost-heading row">
+      <div class="col">
+        <div class="ost-title">
+          <h1><strong><%= "#{@presenter.name}: Cutoff Analysis" %></strong></h1>
+          <ul class="breadcrumb breadcrumb-ost">
+            <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
+            <li class="breadcrumb-item"><%= link_to @presenter.organization.name, organization_path(@presenter.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to @presenter.name, course_path(@presenter.course) %></li>
+            <li class="breadcrumb-item active">Cutoff Analysis</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <%= course_view_tabs(@presenter) %>
+  </div>
+</header>
+
+<aside class="ost-toolbar">
+  <div class="container">
+    <div class="row">
+      <div class="col form-inline">
+        <div class="dropdown float-left-button">
+          <div class="btn-group btn-group-ost pull-right">
+            <%= prior_next_nav_button(@presenter, :prior) %>
+            <%= split_name_dropdown(@presenter) %>
+            <%= prior_next_nav_button(@presenter, :next) %>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="dropdown float-left-button">
+          <%= traffic_band_width_dropdown(@presenter) %>
+        </div>
+      </div>
+    </div>
+  </div>
+</aside>
+
+<article class="ost-article container">
+  <h4><%= @presenter.table_title %></h4>
+  <br/>
+
+  <% if @presenter.interval_split_cutoff_analyses.present? %>
+    <div>
+      <%= column_chart @presenter.chart_data, stacked: true %>
+    </div>
+
+    <table class="table table-condensed table-striped" style="width:80%">
+      <thead>
+      <tr>
+        <th>Elapsed Time</th>
+        <th class="text-center">Total Efforts</th>
+        <th class="text-center">Finished Efforts</th>
+      </tr>
+      </thead>
+      <tbody>
+      <% @presenter.interval_split_cutoff_analyses.each do |isca| %>
+        <tr>
+          <td><%= @presenter.duration_range_string(isca) %></td>
+          <td class="text-center"><%= isca.total_count %></td>
+          <td class="text-center"><%= isca.finished_count %></td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <h5>No efforts have been measured at this aid station.</h5>
+  <% end %>
+</article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,8 +60,11 @@ Rails.application.routes.draw do
   resources :aid_stations, only: [:show, :create, :update, :destroy]
 
   resources :courses, except: :index do
-    member { get :best_efforts }
-    member { get :plan_effort }
+    member do
+      get :best_efforts
+      get :cutoff_analysis
+      get :plan_effort
+    end
   end
 
   resources :efforts do

--- a/spec/models/interval_split_cutoff_analysis_spec.rb
+++ b/spec/models/interval_split_cutoff_analysis_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IntervalSplitCutoffAnalysis, type: :model do
+  describe ".execute_query" do
+    subject { described_class.execute_query(split: split, band_width: band_width) }
+    let(:band_width) { 1.hour }
+
+    before(:all) { EffortSegment.set_all }
+    after(:all) { EffortSegment.delete_all }
+
+    context "for a split close to the start" do
+      let(:split) { splits(:hardrock_ccw_cunningham) }
+
+      it "returns an array of IntervalSplitCutoffAnalysis objects" do
+        expect(subject.size).to eq(3)
+        expect(subject.map(&:start_seconds)).to eq([3600, 7200, 10800])
+        expect(subject.map(&:end_seconds)).to eq([7200, 10800, 14400])
+        expect(subject.map(&:total_count)).to eq([2, 20, 8])
+        expect(subject.map(&:finished_count)).to eq([2, 18, 5])
+      end
+    end
+
+    context "for a split extending over multiple days" do
+      let(:split) { splits(:hardrock_ccw_telluride) }
+
+      it "returns an array of IntervalSplitCutoffAnalysis objects reflecting multiple days" do
+        expect(subject.size).to eq(19)
+
+        subject_isca = subject[10]
+        expect(subject_isca.start_seconds).to eq(90_000)
+        expect(subject_isca.end_seconds).to eq(93_600)
+        expect(subject_isca.total_count).to eq(4)
+        expect(subject_isca.finished_count).to eq(4)
+      end
+    end
+
+    context "when the query would return too many rows" do
+      let(:split) { splits(:hardrock_ccw_telluride) }
+      let(:band_width) { 1.minute }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR creates a new Cutoff Analysis view, allowing users to determine at what point it is no longer reasonably possible to finish from a given aid station.

This is a basic implementation focused entirely on elapsed time. A future PR should add functionality to add an expected race start, at which point elapsed times would be added to produce easy-to-understand cutoffs in absolute time terms.

Addresses #802