### PR TITLE
Logic to update track_points when course is saved

### DIFF
--- a/app/jobs/sync_track_points_job.rb
+++ b/app/jobs/sync_track_points_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class SyncTrackPointsJob < ApplicationJob
+  MAX_POINTS = 1000
+
+  queue_as :default
+
+  def perform(course)
+    if course.gpx.attached?
+      doc = Nokogiri::XML(course.gpx.download)
+      points = doc.xpath('//xmlns:trkpt')
+      json_points = points.map { |trkpt| { lat: trkpt.xpath('@lat').to_s.to_f, lon: trkpt.xpath('@lon').to_s.to_f } }
+      filtered_json_points = filter(json_points)
+
+      course.update!(track_points: filtered_json_points)
+    else
+      course.update!(track_points: [])
+    end
+  end
+
+  private
+
+  def filter(points)
+    points_size = points.size
+    return points if points_size <= MAX_POINTS
+
+    trim_factor = points_size / MAX_POINTS.to_f
+    indexes_to_save = (0..MAX_POINTS).map { |i| (i * trim_factor).round(0) }.to_set
+    indexes_to_save << points_size - 1 # Ensure the last point is always included
+
+    points.select.with_index { |_, i| i.in?(indexes_to_save) }
+  end
+end

--- a/app/jobs/sync_track_points_job.rb
+++ b/app/jobs/sync_track_points_job.rb
@@ -1,33 +1,12 @@
 # frozen_string_literal: true
 
 class SyncTrackPointsJob < ApplicationJob
-  MAX_POINTS = 1000
-
   queue_as :default
 
-  def perform(course)
-    if course.gpx.attached?
-      doc = Nokogiri::XML(course.gpx.download)
-      points = doc.xpath('//xmlns:trkpt')
-      json_points = points.map { |trkpt| { lat: trkpt.xpath('@lat').to_s.to_f, lon: trkpt.xpath('@lon').to_s.to_f } }
-      filtered_json_points = filter(json_points)
+  def perform(course_id)
+    course = ::Course.find_by(id: course_id)
+    return if course.nil?
 
-      course.update!(track_points: filtered_json_points)
-    else
-      course.update!(track_points: [])
-    end
-  end
-
-  private
-
-  def filter(points)
-    points_size = points.size
-    return points if points_size <= MAX_POINTS
-
-    trim_factor = points_size / MAX_POINTS.to_f
-    indexes_to_save = (0..MAX_POINTS).map { |i| (i * trim_factor).round(0) }.to_set
-    indexes_to_save << points_size - 1 # Ensure the last point is always included
-
-    points.select.with_index { |_, i| i.in?(indexes_to_save) }
+    ::Interactors::SetTrackPoints.perform!(course)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -79,6 +79,6 @@ class Course < ApplicationRecord
   def sync_track_points
     return unless attachment_changes["gpx"].present?
 
-    ::SyncTrackPointsJob.perform_later(self)
+    ::SyncTrackPointsJob.perform_later(id)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -24,6 +24,8 @@ class Course < ApplicationRecord
   scope :standard_includes, -> { includes(:splits) }
   scope :with_policy_scope_attributes, -> { all }
 
+  after_commit :sync_track_points, on: [:create, :update]
+
   validates_presence_of :name, :organization
   validates_uniqueness_of :name, case_sensitive: false
   validates :gpx,
@@ -60,17 +62,6 @@ class Course < ApplicationRecord
     @distance ||= finish_split.distance_from_start if finish_split.present?
   end
 
-  def track_points
-    return [] unless gpx.attached?
-
-    @track_points ||=
-      begin
-        doc = Nokogiri::XML(gpx.download)
-        trackpoints = doc.xpath('//xmlns:trkpt')
-        trackpoints.map { |trkpt| { lat: trkpt.xpath('@lat').to_s.to_f, lon: trkpt.xpath('@lon').to_s.to_f } }
-      end
-  end
-
   def vert_gain
     @vert_gain ||= finish_split.vert_gain_from_start if finish_split.present?
   end
@@ -81,5 +72,13 @@ class Course < ApplicationRecord
 
   def simple?
     splits_count < 3
+  end
+
+  private
+
+  def sync_track_points
+    return unless attachment_changes["gpx"].present?
+
+    ::SyncTrackPointsJob.perform_later(self)
   end
 end

--- a/app/services/interactors/errors.rb
+++ b/app/services/interactors/errors.rb
@@ -118,6 +118,11 @@ module Interactors
        detail: {messages: ["#{raw_time} does not have a new_split_time"]}}
     end
 
+    def nokogiri_parse_error(exception)
+      {title: "An error occurred while attempting to parse the file",
+       detail: {exception: exception}}
+    end
+
     def raw_time_mismatch_error
       {title: "Raw times do not match",
        detail: {messages: ["One or more raw times is not related to the provided event group"]}}

--- a/app/services/interactors/set_track_points.rb
+++ b/app/services/interactors/set_track_points.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Interactors
+  class SetTrackPoints
+    include Interactors::Errors
+
+    MAX_POINTS = 1000
+
+    def self.perform!(course)
+      new(course).perform!
+    end
+
+    def initialize(course)
+      @course = course
+      @response = ::Interactors::Response.new([])
+    end
+
+    def perform!
+      if course.gpx.attached?
+        doc = Nokogiri::XML(course.gpx.download)
+        points = doc.xpath('//xmlns:trkpt')
+        json_points = points.map { |trkpt| { lat: trkpt.xpath('@lat').to_s.to_f, lon: trkpt.xpath('@lon').to_s.to_f } }
+        filtered_json_points = filter(json_points)
+
+        errors << resource_error_object(course) unless course.update(track_points: filtered_json_points)
+      else
+        errors << resource_error_object(course) unless course.update(track_points: [])
+      end
+
+    rescue ActiveRecord::RecordInvalid => e
+      response.errors << active_record_error(e)
+    rescue Nokogiri::ParseException => e
+      response.errors << nokogiri_parse_error(e)
+    ensure
+      response
+    end
+
+    private
+
+    attr_reader :course, :response
+
+    def filter(points)
+      points_size = points.size
+      return points if points_size <= MAX_POINTS
+
+      trim_factor = points_size / MAX_POINTS.to_f
+      indexes_to_save = (0..MAX_POINTS).map { |i| (i * trim_factor).round(0) }.to_set
+      indexes_to_save << points_size - 1 # Ensure the last point is always included
+
+      points.select.with_index { |_, i| i.in?(indexes_to_save) }
+    end
+  end
+end

--- a/lib/tasks/temp/set_track_points.rake
+++ b/lib/tasks/temp/set_track_points.rake
@@ -1,0 +1,25 @@
+# This is a temporary rake task that should be deleted
+# once it has been run in all environments.
+
+require "active_record"
+require "active_record/errors"
+
+namespace :temp do
+  desc "sets track points for all courses"
+  task set_track_points: :environment do
+    Rails.application.eager_load!
+
+    ::Course.find_each do |course|
+      identifier = "#{course.name} (#{course.id})"
+      puts "Setting track points for #{identifier}"
+      result = ::Interactors::SetTrackPoints.perform!(course)
+
+      if result.errors.present?
+        puts "Could not set track points for #{identifier}"
+        pp result.errors
+      end
+    end
+
+    puts "Finished updating track points for all courses"
+  end
+end

--- a/spec/jobs/sync_track_points_job_spec.rb
+++ b/spec/jobs/sync_track_points_job_spec.rb
@@ -3,25 +3,26 @@
 require "rails_helper"
 
 RSpec.describe SyncTrackPointsJob do
-  subject { described_class.new(course) }
-  let(:course) { build(:course) }
+  include ActiveJob::TestHelper
 
-  context "when no gpx file is attached" do
-    it "sets track_points to an empty array" do
-      subject.perform_now
-      expect(course.track_points).to eq([])
-    end
+  subject(:job) { described_class.perform_later(course.id) }
+  let(:course) { courses(:sum_100k_course) }
+
+  it "queues the job" do
+    expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
   end
 
-  context "when a gpx file is attached" do
-    let(:course) { create(:course, :with_gpx) }
+  it "uses the default queue" do
+    expect(SyncTrackPointsJob.new.queue_name).to eq("default")
+  end
 
-    it "sets track_points to an array of lat/lon points" do
-      expect(course.track_points).to be_nil
-      subject.perform_now
-      expect(course.track_points.size).to eq(113)
-      expect(course.track_points.first).to eq({ "lat" => 39.6270910, "lon" => -104.9042260 })
-      expect(course.track_points.last).to eq({ "lat" => 39.6238040, "lon" => -104.8933630 })
-    end
+  it "executes perform" do
+    expect(::Interactors::SetTrackPoints).to receive(:perform!).with(course)
+    perform_enqueued_jobs { job }
+  end
+
+  after do
+    clear_enqueued_jobs
+    clear_performed_jobs
   end
 end

--- a/spec/jobs/sync_track_points_job_spec.rb
+++ b/spec/jobs/sync_track_points_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SyncTrackPointsJob do
+  subject { described_class.new(course) }
+  let(:course) { build(:course) }
+
+  context "when no gpx file is attached" do
+    it "sets track_points to an empty array" do
+      subject.perform_now
+      expect(course.track_points).to eq([])
+    end
+  end
+
+  context "when a gpx file is attached" do
+    let(:course) { create(:course, :with_gpx) }
+
+    it "sets track_points to an array of lat/lon points" do
+      expect(course.track_points).to be_nil
+      subject.perform_now
+      expect(course.track_points.size).to eq(113)
+      expect(course.track_points.first).to eq({ "lat" => 39.6270910, "lon" => -104.9042260 })
+      expect(course.track_points.last).to eq({ "lat" => 39.6238040, "lon" => -104.8933630 })
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -169,19 +169,20 @@ RSpec.describe Course, type: :model do
   end
 
   describe "#track_points" do
-    context "when a gpx file is attached" do
-      let(:course) { create(:course, :with_gpx) }
+    let(:course) { create(:course, :with_gpx) }
+    context "when track points have been set" do
+      before { ::Interactors::SetTrackPoints.perform!(course) }
+
       it "returns an array of hashes containing lat/lon points" do
         expect(course.track_points.count).to eq(113)
-        expect(course.track_points.first).to eq(lat: 39.627091, lon: -104.904226)
-        expect(course.track_points.last).to eq(lat: 39.623804, lon: -104.893363)
+        expect(course.track_points.first).to eq("lat" => 39.627091, "lon" => -104.904226)
+        expect(course.track_points.last).to eq("lat" => 39.623804, "lon" => -104.893363)
       end
     end
 
-    context "when no gpx file is attached" do
-      let(:course) { create(:course) }
-      it "returns an empty array" do
-        expect(course.track_points).to eq([])
+    context "when no track points have been set" do
+      it "returns nil" do
+        expect(course.track_points).to be_nil
       end
     end
   end

--- a/spec/services/interactors/set_track_points_spec.rb
+++ b/spec/services/interactors/set_track_points_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::Interactors::SetTrackPoints do
+  subject { described_class.new(course) }
+  let(:course) { create(:course) }
+
+  context "when no gpx file is attached" do
+    it "sets track_points to an empty array" do
+      expect(course.track_points).to be_nil
+      subject.perform!
+      expect(course.track_points).to eq([])
+    end
+  end
+
+  context "when a gpx file is attached" do
+    let(:course) { create(:course, :with_gpx) }
+
+    it "sets track_points to an array of lat/lon points" do
+      expect(course.track_points).to be_nil
+      subject.perform!
+      expect(course.track_points.size).to eq(113)
+      expect(course.track_points.first).to eq({ "lat" => 39.6270910, "lon" => -104.9042260 })
+      expect(course.track_points.last).to eq({ "lat" => 39.6238040, "lon" => -104.8933630 })
+    end
+  end
+end


### PR DESCRIPTION
This PR deletes the existing `track_points` method in the Course model and replaces it with a callback that kicks off a job that will parse the GPX file and save out track points to a JSON column on the courses table.