### PR TITLE
Set a delay on processing Sync Track Points Job

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -77,11 +77,6 @@ class Course < ApplicationRecord
   private
 
   def sync_track_points
-    Rails.logger.info "=============================================================="
-    Rails.logger.info attachment_changes
-    Rails.logger.info attachment_changes["gpx"].present?
-    Rails.logger.info "=============================================================="
-
     return unless attachment_changes["gpx"].present?
 
     ::SyncTrackPointsJob.set(wait: 5.seconds).perform_later(id)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -77,8 +77,13 @@ class Course < ApplicationRecord
   private
 
   def sync_track_points
+    Rails.logger.info "=============================================================="
+    Rails.logger.info attachment_changes
+    Rails.logger.info attachment_changes["gpx"].present?
+    Rails.logger.info "=============================================================="
+
     return unless attachment_changes["gpx"].present?
 
-    ::SyncTrackPointsJob.perform_later(id)
+    ::SyncTrackPointsJob.set(wait: 5.seconds).perform_later(id)
   end
 end

--- a/app/services/interactors/set_track_points.rb
+++ b/app/services/interactors/set_track_points.rb
@@ -17,13 +17,26 @@ module Interactors
 
     def perform!
       if course.gpx.attached?
+
+        Rails.logger.info "=============================================================="
+        Rails.logger.info "gpx is attached"
+
         doc = Nokogiri::XML(course.gpx.download)
+
+        Rails.logger.info "Filename: #{course.gpx.blob.filename}"
+        Rails.logger.info "=============================================================="
+
         points = doc.xpath('//xmlns:trkpt')
         json_points = points.map { |trkpt| { lat: trkpt.xpath('@lat').to_s.to_f, lon: trkpt.xpath('@lon').to_s.to_f } }
         filtered_json_points = filter(json_points)
 
         errors << resource_error_object(course) unless course.update(track_points: filtered_json_points)
       else
+
+        Rails.logger.info "=============================================================="
+        Rails.logger.info "gpx is not attached"
+        Rails.logger.info "=============================================================="
+
         errors << resource_error_object(course) unless course.update(track_points: [])
       end
 

--- a/app/services/interactors/set_track_points.rb
+++ b/app/services/interactors/set_track_points.rb
@@ -17,14 +17,7 @@ module Interactors
 
     def perform!
       if course.gpx.attached?
-
-        Rails.logger.info "=============================================================="
-        Rails.logger.info "gpx is attached"
-
         doc = Nokogiri::XML(course.gpx.download)
-
-        Rails.logger.info "Filename: #{course.gpx.blob.filename}"
-        Rails.logger.info "=============================================================="
 
         points = doc.xpath('//xmlns:trkpt')
         json_points = points.map { |trkpt| { lat: trkpt.xpath('@lat').to_s.to_f, lon: trkpt.xpath('@lon').to_s.to_f } }
@@ -32,11 +25,6 @@ module Interactors
 
         errors << resource_error_object(course) unless course.update(track_points: filtered_json_points)
       else
-
-        Rails.logger.info "=============================================================="
-        Rails.logger.info "gpx is not attached"
-        Rails.logger.info "=============================================================="
-
         errors << resource_error_object(course) unless course.update(track_points: [])
       end
 


### PR DESCRIPTION
Currently, uploaded GPX files are not being parsed into track_points files. This may be because the Sidekiq worker is picking up the job faster than the GPX blob can be uploaded to S3.

This PR introduces a short delay before running the Sync Track Points job.