### PR TITLE
Lottery sync

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -210,7 +210,7 @@ class EventGroupsController < ApplicationController
 
     response = ::Interactors::SyncLotteryEntrants.perform!(@event_group)
     set_flash_message(response)
-    redirect_to setup_event_group_path(@event_group)
+    redirect_to setup_event_group_path(@event_group, display_style: :entrants)
   end
 
   # GET /event_groups/1/assign_bibs

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -204,6 +204,15 @@ class EventGroupsController < ApplicationController
     end
   end
 
+  # POST /event_groups/1/sync_lottery_entrants
+  def sync_lottery_entrants
+    authorize @event_group
+
+    response = ::Interactors::SyncLotteryEntrants.perform!(@event_group)
+    set_flash_message(response)
+    redirect_to setup_event_group_path(@event_group)
+  end
+
   # GET /event_groups/1/assign_bibs
   def assign_bibs
     authorize @event_group

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -9,7 +9,7 @@ module DropdownHelper
     content_tag container_tag, class: [container_class, options[:class]].join(" ") do
       toggle_tag = options[:button] ? :button : :a
       toggle_class = (options[:button] ? "btn btn-outline-secondary" : "") + " dropdown-toggle"
-      concat content_tag(toggle_tag, class: toggle_class, data: {toggle: "dropdown"}) {
+      concat content_tag(toggle_tag, class: toggle_class, data: { toggle: "dropdown" }) {
         active_name = items.find { |item| item[:active] }&.dig(:name)
         safe_concat [title, active_name].compact.join(" / ")
         safe_concat "&nbsp;"
@@ -24,7 +24,7 @@ module DropdownHelper
             active = item[:active] ? "active" : nil
             disabled = item[:disabled] ? "disabled" : nil
             html_class = ["dropdown-item", active, disabled, item[:class]].compact.join(" ")
-            concat link_to item[:name], item[:link], {class: html_class}.merge(item.slice(:method, :data))
+            concat link_to item[:name], item[:link], { class: html_class }.merge(item.slice(:method, :data))
           end
         end
       }
@@ -33,27 +33,27 @@ module DropdownHelper
 
   def admin_dropdown_menu(view_object)
     dropdown_items = [
-      {name: "Construction",
-       link: setup_event_group_path(view_object.event_group),
-       active: action_name == "setup"},
-      {name: "Staging",
-       link: "#{event_staging_app_path(view_object.event)}#/#{event_staging_app_page(view_object)}",
-       active: action_name == "app"},
-      {name: "Reconcile",
-       link: reconcile_event_group_path(view_object.event_group),
-       active: action_name == "reconcile"},
-      {name: "Roster",
-       link: roster_event_group_path(view_object.event_group),
-       active: action_name == "roster" && !params[:problem]},
-      {name: "Problems",
-       link: roster_event_group_path(view_object.event_group, problem: true),
-       active: action_name == "roster" && params[:problem]},
-      {name: "Stats",
-       link: stats_event_group_path(view_object.event_group),
-       active: controller_name == "event_groups" && action_name == "stats"},
-      {name: "Finish Line",
-       link: finish_line_event_group_path(view_object.event_group),
-       active: controller_name == "event_groups" && action_name == "finish_line"},
+      { name: "Construction",
+        link: setup_event_group_path(view_object.event_group),
+        active: action_name == "setup" },
+      { name: "Staging",
+        link: "#{event_staging_app_path(view_object.event)}#/#{event_staging_app_page(view_object)}",
+        active: action_name == "app" },
+      { name: "Reconcile",
+        link: reconcile_event_group_path(view_object.event_group),
+        active: action_name == "reconcile" },
+      { name: "Roster",
+        link: roster_event_group_path(view_object.event_group),
+        active: action_name == "roster" && !params[:problem] },
+      { name: "Problems",
+        link: roster_event_group_path(view_object.event_group, problem: true),
+        active: action_name == "roster" && params[:problem] },
+      { name: "Stats",
+        link: stats_event_group_path(view_object.event_group),
+        active: controller_name == "event_groups" && action_name == "stats" },
+      { name: "Finish Line",
+        link: finish_line_event_group_path(view_object.event_group),
+        active: controller_name == "event_groups" && action_name == "finish_line" },
     ]
     build_dropdown_menu("Admin", dropdown_items, class: "nav-item")
   end
@@ -64,7 +64,7 @@ module DropdownHelper
         name: "Hardrock",
         link: auto_assign_bibs_event_group_path(view_object.event_group, strategy: :hardrock),
         method: :patch,
-        data: {confirm: "Assign bib numbers beginning at 1 to prior-year finishers in order of finish rank, and to other entrants beginning at 100 in alphabetical name order. Proceed?"}
+        data: { confirm: "Assign bib numbers beginning at 1 to prior-year finishers in order of finish rank, and to other entrants beginning at 100 in alphabetical name order. Proceed?" }
       },
     ]
     build_dropdown_menu("Auto Assign", dropdown_items, button: true)
@@ -72,122 +72,122 @@ module DropdownHelper
 
   def live_dropdown_menu(view_object)
     dropdown_items = [
-      {name: "Time Entry",
-       link: live_entry_live_event_group_path(view_object.event_group),
-       active: action_name == "live_entry",
-       visible: view_object.available_live},
-      {name: "Drops",
-       link: drop_list_event_group_path(view_object.event_group),
-       active: action_name == "drop_list"},
-      {name: "Progress",
-       link: progress_report_live_event_path(view_object.event),
-       active: action_name == "progress_report"},
-      {name: "Aid Stations",
-       link: aid_station_report_live_event_path(view_object.event),
-       active: action_name == "aid_station_report"},
-      {name: "Aid Detail",
-       link: aid_station_detail_live_event_path(view_object.event),
-       active: action_name == "aid_station_detail"}
+      { name: "Time Entry",
+        link: live_entry_live_event_group_path(view_object.event_group),
+        active: action_name == "live_entry",
+        visible: view_object.available_live },
+      { name: "Drops",
+        link: drop_list_event_group_path(view_object.event_group),
+        active: action_name == "drop_list" },
+      { name: "Progress",
+        link: progress_report_live_event_path(view_object.event),
+        active: action_name == "progress_report" },
+      { name: "Aid Stations",
+        link: aid_station_report_live_event_path(view_object.event),
+        active: action_name == "aid_station_report" },
+      { name: "Aid Detail",
+        link: aid_station_detail_live_event_path(view_object.event),
+        active: action_name == "aid_station_detail" }
     ]
     build_dropdown_menu("Live", dropdown_items, class: "nav-item")
   end
 
   def results_dropdown_menu(view_object)
     dropdown_items = [
-      {name: "Full",
-       link: spread_event_path(view_object.event),
-       active: action_name == "spread"},
-      {name: "Summary",
-       link: summary_event_path(view_object.event),
-       active: action_name == "summary" && !(params[:finished] == "true")},
-      {name: "Finishers",
-       link: summary_event_path(view_object.event, finished: true),
-       active: action_name == "summary" && params[:finished] == "true"},
-      {name: "Podium",
-       link: podium_event_path(view_object.event),
-       active: action_name == "podium"},
-      {name: "Follow",
-       link: follow_event_group_path(view_object.event_group),
-       active: action_name == "follow"},
-      {name: "Traffic",
-       link: traffic_event_group_path(view_object.event_group),
-       active: action_name == "traffic"}
+      { name: "Full",
+        link: spread_event_path(view_object.event),
+        active: action_name == "spread" },
+      { name: "Summary",
+        link: summary_event_path(view_object.event),
+        active: action_name == "summary" && !(params[:finished] == "true") },
+      { name: "Finishers",
+        link: summary_event_path(view_object.event, finished: true),
+        active: action_name == "summary" && params[:finished] == "true" },
+      { name: "Podium",
+        link: podium_event_path(view_object.event),
+        active: action_name == "podium" },
+      { name: "Follow",
+        link: follow_event_group_path(view_object.event_group),
+        active: action_name == "follow" },
+      { name: "Traffic",
+        link: traffic_event_group_path(view_object.event_group),
+        active: action_name == "traffic" }
     ]
     build_dropdown_menu("Results", dropdown_items, class: "nav-item")
   end
 
   def raw_times_dropdown_menu(view_object)
     dropdown_items = [
-      {name: "List",
-       link: raw_times_event_group_path(view_object.event_group),
-       active: action_name == "raw_times"},
-      {name: "Splits",
-       link: split_raw_times_event_group_path(view_object.event_group),
-       active: action_name == "split_raw_times"}
+      { name: "List",
+        link: raw_times_event_group_path(view_object.event_group),
+        active: action_name == "raw_times" },
+      { name: "Splits",
+        link: split_raw_times_event_group_path(view_object.event_group),
+        active: action_name == "split_raw_times" }
     ]
     build_dropdown_menu("Raw Times", dropdown_items, class: "nav-item")
   end
 
   def check_in_filter_dropdown
-    items = [{icon_name: "exclamation-circle", type: :solid, text: "Problems", problem: true},
-             {icon_name: "question-circle", type: :solid, text: "Unreconciled", unreconciled: true},
-             {icon_name: "square", type: :regular, text: "Not checked", checked_in: false, started: false},
-             {icon_name: "check-square", type: :regular, text: "Checked in", checked_in: true, started: false},
-             {icon_name: "caret-square-right", type: :regular, text: "Started", started: true},
-             {icon_name: "asterisk", type: :solid, text: "All"}]
+    items = [{ icon_name: "exclamation-circle", type: :solid, text: "Problems", problem: true },
+             { icon_name: "question-circle", type: :solid, text: "Unreconciled", unreconciled: true },
+             { icon_name: "square", type: :regular, text: "Not checked", checked_in: false, started: false },
+             { icon_name: "check-square", type: :regular, text: "Checked in", checked_in: true, started: false },
+             { icon_name: "caret-square-right", type: :regular, text: "Started", started: true },
+             { icon_name: "asterisk", type: :solid, text: "All" }]
 
     dropdown_items = items.map do |item|
-      {name: fa_icon(item[:icon_name], text: item[:text], type: item[:type]),
-       link: request.params.merge(
-         checked_in: item[:checked_in],
-         started: item[:started],
-         unreconciled: item[:unreconciled],
-         problem: item[:problem],
-         filter: {search: ""},
-         page: nil
-       ),
-       active: params[:checked_in]&.to_boolean == item[:checked_in] &&
-         params[:started]&.to_boolean == item[:started] &&
-         params[:unreconciled]&.to_boolean == item[:unreconciled] &&
-         params[:problem]&.to_boolean == item[:problem]}
+      { name: fa_icon(item[:icon_name], text: item[:text], type: item[:type]),
+        link: request.params.merge(
+          checked_in: item[:checked_in],
+          started: item[:started],
+          unreconciled: item[:unreconciled],
+          problem: item[:problem],
+          filter: { search: "" },
+          page: nil
+        ),
+        active: params[:checked_in]&.to_boolean == item[:checked_in] &&
+          params[:started]&.to_boolean == item[:started] &&
+          params[:unreconciled]&.to_boolean == item[:unreconciled] &&
+          params[:problem]&.to_boolean == item[:problem] }
     end
 
     build_dropdown_menu(nil, dropdown_items, button: true)
   end
 
   def raw_time_filter_dropdown
-    items = [{icon_name: "hand-paper", type: :solid, text: "Stopped", stopped: true, reviewed: nil, matched: nil},
-             {icon_name: "cloud-download-alt", type: :solid, text: "Reviewed", stopped: nil, reviewed: true, matched: nil},
-             {icon_name: "cloud-upload-alt", type: :solid, text: "Unreviewed", stopped: nil, reviewed: false, matched: nil},
-             {icon_name: "check-square", type: :solid, text: "Matched", stopped: nil, reviewed: nil, matched: true},
-             {icon_name: "square", type: :solid, text: "Unmatched", stopped: nil, reviewed: nil, matched: false},
-             {icon_name: "asterisk", type: :solid, text: "All", stopped: nil, reviewed: nil, matched: nil}]
+    items = [{ icon_name: "hand-paper", type: :solid, text: "Stopped", stopped: true, reviewed: nil, matched: nil },
+             { icon_name: "cloud-download-alt", type: :solid, text: "Reviewed", stopped: nil, reviewed: true, matched: nil },
+             { icon_name: "cloud-upload-alt", type: :solid, text: "Unreviewed", stopped: nil, reviewed: false, matched: nil },
+             { icon_name: "check-square", type: :solid, text: "Matched", stopped: nil, reviewed: nil, matched: true },
+             { icon_name: "square", type: :solid, text: "Unmatched", stopped: nil, reviewed: nil, matched: false },
+             { icon_name: "asterisk", type: :solid, text: "All", stopped: nil, reviewed: nil, matched: nil }]
 
     dropdown_items = items.map do |item|
-      {name: fa_icon(item[:icon_name], text: item[:text], type: item[:type]),
-       link: request.params.merge(
-         stopped: item[:stopped],
-         reviewed: item[:reviewed],
-         matched: item[:matched],
-         page: nil
-       ),
-       active: params[:stopped]&.to_boolean == item[:stopped] &&
-         params[:reviewed]&.to_boolean == item[:reviewed] &&
-         params[:matched]&.to_boolean == item[:matched]}
+      { name: fa_icon(item[:icon_name], text: item[:text], type: item[:type]),
+        link: request.params.merge(
+          stopped: item[:stopped],
+          reviewed: item[:reviewed],
+          matched: item[:matched],
+          page: nil
+        ),
+        active: params[:stopped]&.to_boolean == item[:stopped] &&
+          params[:reviewed]&.to_boolean == item[:reviewed] &&
+          params[:matched]&.to_boolean == item[:matched] }
     end
 
     build_dropdown_menu(nil, dropdown_items, button: true)
   end
 
   def summary_filter_dropdown
-    items = [{text: "All", finished: nil},
-             {text: "Finished", finished: true},
-             {text: "Unfinished", finished: false}]
+    items = [{ text: "All", finished: nil },
+             { text: "Finished", finished: true },
+             { text: "Unfinished", finished: false }]
 
     dropdown_items = items.map do |item|
-      {name: item[:text],
-       link: request.params.merge(finished: item[:finished], page: nil),
-       active: params[:finished]&.to_boolean == item[:finished]}
+      { name: item[:text],
+        link: request.params.merge(finished: item[:finished], page: nil),
+        active: params[:finished]&.to_boolean == item[:finished] }
     end
 
     build_dropdown_menu(nil, dropdown_items, button: true)
@@ -195,116 +195,116 @@ module DropdownHelper
 
   def explore_dropdown_menu(view_object)
     dropdown_items = [
-      {name: "Plan my effort",
-       link: plan_effort_course_path(view_object.course)},
-      {name: "All-time best",
-       link: best_efforts_course_path(view_object.course)},
-      {name: "Cutoff analysis",
-       link: cutoff_analysis_course_path(view_object.course)},
+      { name: "Plan my effort",
+        link: plan_effort_course_path(view_object.course) },
+      { name: "All-time best",
+        link: best_efforts_course_path(view_object.course) },
+      { name: "Cutoff analysis",
+        link: cutoff_analysis_course_path(view_object.course) },
     ]
     build_dropdown_menu("Explore", dropdown_items, button: true)
   end
 
   def effort_actions_dropdown_menu(view_object)
     dropdown_items = [
-      {name: "Set Data Status",
-       link: set_data_status_effort_path(view_object.effort),
-       method: :patch},
-      {role: :separator},
-      {name: "Edit Times of Day",
-       link: edit_split_times_effort_path(view_object.effort, display_style: :military_time)},
-      {name: "Edit Dates and Times",
-       link: edit_split_times_effort_path(view_object.effort, display_style: :absolute_time_local)},
-      {name: "Edit Elapsed Times",
-       link: edit_split_times_effort_path(view_object.effort, display_style: :elapsed_time)},
-      {role: :separator},
-      {name: "Edit Entrant",
-       link: edit_effort_path(view_object.effort)},
-      {name: "Rebuild Times",
-       link: rebuild_effort_path(view_object.effort),
-       method: :patch,
-       data: {confirm: "This will delete all split times and attempt to rebuild them from the " +
-         "#{pluralize(view_object.raw_times_count, 'raw time')} related to this effort. This action cannot be undone. Proceed?"},
-       visible: view_object.multiple_laps? && view_object.raw_times_count.positive?},
-      {role: :separator},
-      {name: "Delete Entrant",
-       link: effort_path(view_object.effort),
-       method: :delete,
-       data: {confirm: "This action cannot be undone. Proceed?"},
-       class: "text-danger"}
+      { name: "Set Data Status",
+        link: set_data_status_effort_path(view_object.effort),
+        method: :patch },
+      { role: :separator },
+      { name: "Edit Times of Day",
+        link: edit_split_times_effort_path(view_object.effort, display_style: :military_time) },
+      { name: "Edit Dates and Times",
+        link: edit_split_times_effort_path(view_object.effort, display_style: :absolute_time_local) },
+      { name: "Edit Elapsed Times",
+        link: edit_split_times_effort_path(view_object.effort, display_style: :elapsed_time) },
+      { role: :separator },
+      { name: "Edit Entrant",
+        link: edit_effort_path(view_object.effort) },
+      { name: "Rebuild Times",
+        link: rebuild_effort_path(view_object.effort),
+        method: :patch,
+        data: { confirm: "This will delete all split times and attempt to rebuild them from the " +
+          "#{pluralize(view_object.raw_times_count, 'raw time')} related to this effort. This action cannot be undone. Proceed?" },
+        visible: view_object.multiple_laps? && view_object.raw_times_count.positive? },
+      { role: :separator },
+      { name: "Delete Entrant",
+        link: effort_path(view_object.effort),
+        method: :delete,
+        data: { confirm: "This action cannot be undone. Proceed?" },
+        class: "text-danger" }
     ]
     build_dropdown_menu("Actions", dropdown_items, button: true)
   end
 
   def event_series_actions_dropdown_menu(view_object)
     dropdown_items = [
-      {name: "Edit",
-       link: edit_event_series_path(view_object.event_series)},
-      {role: :separator},
-      {name: "Delete event series",
-       link: event_series_path(view_object.event_series),
-       method: :delete,
-       data: {confirm: "This action cannot be undone. Proceed?"},
-       class: "text-danger"}
+      { name: "Edit",
+        link: edit_event_series_path(view_object.event_series) },
+      { role: :separator },
+      { name: "Delete event series",
+        link: event_series_path(view_object.event_series),
+        method: :delete,
+        data: { confirm: "This action cannot be undone. Proceed?" },
+        class: "text-danger" }
     ]
     build_dropdown_menu("Actions", dropdown_items, button: true)
   end
 
   def person_actions_dropdown_menu(view_object)
     dropdown_items = [
-      {name: "Edit",
-       link: edit_person_path(view_object.person)},
-      {name: "Merge with",
-       link: merge_person_path(view_object.person)},
-      {role: :separator},
-      {name: "Delete person",
-       link: person_path(view_object.person),
-       method: :delete,
-       data: {confirm: "This action cannot be undone. Proceed?"},
-       class: "text-danger"}
+      { name: "Edit",
+        link: edit_person_path(view_object.person) },
+      { name: "Merge with",
+        link: merge_person_path(view_object.person) },
+      { role: :separator },
+      { name: "Delete person",
+        link: person_path(view_object.person),
+        method: :delete,
+        data: { confirm: "This action cannot be undone. Proceed?" },
+        class: "text-danger" }
     ]
     build_dropdown_menu("Actions", dropdown_items, button: true)
   end
 
   def gender_dropdown_menu(view_object)
     dropdown_items = %w[combined male female].map do |gender|
-      {name: gender.titleize,
-       link: request.params.merge(filter: {gender: gender}, page: nil),
-       active: view_object.gender_text == gender}
+      { name: gender.titleize,
+        link: request.params.merge(filter: { gender: gender }, page: nil),
+        active: view_object.gender_text == gender }
     end
     build_dropdown_menu(nil, dropdown_items, button: true)
   end
 
   def display_style_dropdown_menu(view_object)
     dropdown_items = view_object.display_style_hash.map do |style, text|
-      {name: text,
-       link: request.params.merge(display_style: style),
-       active: view_object.display_style.to_s == style.to_s}
+      { name: text,
+        link: request.params.merge(display_style: style),
+        active: view_object.display_style.to_s == style.to_s }
     end
     build_dropdown_menu(nil, dropdown_items, button: true)
   end
 
   def event_actions_dropdown(event)
     dropdown_items = [
-      {name: "Edit/Delete Event",
-       link: edit_event_group_event_path(event.event_group, event),
-       data: {"turbo-frame" => "_top"}},
-      {name: "Establish Drops",
-       link: set_stops_event_path(event),
-       method: :put,
-       data: {confirm: "NOTE: For every effort that is unfinished, this will flag the effort as having stopped " +
-         "at the last aid station for which times are available. Are you sure you want to proceed?"}},
-      {name: "Shift start time",
-       link: edit_start_time_event_path(event),
-       visible: current_user.admin?,
-       data: {"turbo-frame" => "_top"}},
-      {role: :separator},
-      {name: "Export Finishers List",
-       link: export_event_path(event, format: :csv, export_format: :finishers)},
-      {name: "Export to ITRA",
-       link: export_event_path(event, format: :csv, export_format: :itra)},
-      {name: "Export to Ultrasignup",
-       link: export_event_path(event, format: :csv, export_format: :ultrasignup)}
+      { name: "Edit/Delete Event",
+        link: edit_event_group_event_path(event.event_group, event),
+        data: { "turbo-frame" => "_top" } },
+      { name: "Establish Drops",
+        link: set_stops_event_path(event),
+        method: :put,
+        data: { confirm: "NOTE: For every effort that is unfinished, this will flag the effort as having stopped " +
+          "at the last aid station for which times are available. Are you sure you want to proceed?" } },
+      { name: "Shift start time",
+        link: edit_start_time_event_path(event),
+        visible: current_user.admin?,
+        data: { "turbo-frame" => "_top" } },
+      { role: :separator },
+      { name: "Export Finishers List",
+        link: export_event_path(event, format: :csv, export_format: :finishers) },
+      { name: "Export to ITRA",
+        link: export_event_path(event, format: :csv, export_format: :itra) },
+      { name: "Export to Ultrasignup",
+        link: export_event_path(event, format: :csv, export_format: :ultrasignup) }
     ]
     build_dropdown_menu("Actions", dropdown_items, button: true)
   end
@@ -322,71 +322,78 @@ module DropdownHelper
       "by email and SMS text when new times are added. Are you sure you want to proceed?"
 
     dropdown_items = [
-      {name: "Edit/Delete Group",
-       link: edit_organization_event_group_path(view_object.organization, view_object.event_group)},
-      {name: "Duplicate Group",
-       link: new_duplicate_event_group_path(existing_id: view_object.event_group.id)},
-      {role: :separator},
-      {name: "Make Public",
-       link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: {concealed: false}),
-       data: {confirm: make_public_text},
-       disabled: !view_object.concealed?,
-       method: :put},
-      {name: "Make Private",
-       link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: {concealed: true}),
-       data: {confirm: make_private_text},
-       disabled: view_object.concealed?,
-       method: :put},
-      {role: :separator},
-      {name: "Enable Live",
-       link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: {available_live: true}),
-       data: {confirm: enable_live_text},
-       disabled: view_object.available_live?,
-       method: :put},
-      {name: "Disable Live",
-       link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: {available_live: false}),
-       data: {confirm: disable_live_text},
-       disabled: !view_object.available_live?,
-       method: :put},
-      {role: :separator},
-      {name: "Add/Remove Stewards",
-       link: organization_path(view_object.organization, display_style: "stewards")}
+      { name: "Edit/Delete Group",
+        link: edit_organization_event_group_path(view_object.organization, view_object.event_group) },
+      { name: "Duplicate Group",
+        link: new_duplicate_event_group_path(existing_id: view_object.event_group.id) },
+      { role: :separator },
+      { name: "Make Public",
+        link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { concealed: false }),
+        data: { confirm: make_public_text },
+        disabled: !view_object.concealed?,
+        method: :put },
+      { name: "Make Private",
+        link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { concealed: true }),
+        data: { confirm: make_private_text },
+        disabled: view_object.concealed?,
+        method: :put },
+      { role: :separator },
+      { name: "Enable Live",
+        link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { available_live: true }),
+        data: { confirm: enable_live_text },
+        disabled: view_object.available_live?,
+        method: :put },
+      { name: "Disable Live",
+        link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { available_live: false }),
+        data: { confirm: disable_live_text },
+        disabled: !view_object.available_live?,
+        method: :put },
+      { role: :separator },
+      { name: "Add/Remove Stewards",
+        link: organization_path(view_object.organization, display_style: "stewards") }
     ]
     build_dropdown_menu("Group Actions", dropdown_items, button: true)
   end
 
   def setup_entrants_import_dropdown(view_object)
+    sync_text = <<~STR
+      This will add all accepted entrants from related lotteries and will permanently delete all withdrawn entrants and 
+      others who do not match the list of accepted lottery entrants. This action cannot be undone. Proceed?
+    STR
     dropdown_items = [
-      {name: "From lottery",
-       link: choose_lottery_entrants_event_group_path(view_object.event_group)},
-      {name: "From CSV file",
-       link: new_import_job_path(import_job: {parent_type: "EventGroup", parent_id: view_object.event_group.id, format: :event_group_entrants})},
-      {role: :separator},
-      {name: "Download CSV template",
-       link: efforts_path(filter: {id: 0}, format: :csv)},
+      { name: "Sync from lottery",
+        link: sync_lottery_entrants_event_group_path(view_object.event_group),
+        data: { confirm: sync_text },
+        disabled: view_object.event_group.events.pluck(:lottery_id).compact.empty?,
+        method: :post },
+      { name: "Import from CSV file",
+        link: new_import_job_path(import_job: { parent_type: "EventGroup", parent_id: view_object.event_group.id, format: :event_group_entrants }) },
+      { role: :separator },
+      { name: "Download CSV template",
+        link: efforts_path(filter: { id: 0 }, format: :csv) },
     ]
     build_dropdown_menu("Import", dropdown_items, button: true)
   end
 
   def roster_actions_dropdown(view_object)
     dropdown_items = [
-      {name: "Reconcile efforts",
-       link: reconcile_event_group_path(view_object.event_group)},
-      {name: "Set data status",
-       link: set_data_status_event_group_path(view_object.event_group),
-       method: :patch},
-      {role: :separator},
-      {name: "Import entrants",
-       link: new_import_job_path(import_job: {parent_type: "EventGroup", parent_id: view_object.event_group.id, format: :event_group_entrants})}
+      { name: "Reconcile efforts",
+        link: reconcile_event_group_path(view_object.event_group) },
+      { name: "Set data status",
+        link: set_data_status_event_group_path(view_object.event_group),
+        method: :patch },
+      { role: :separator },
+      { name: "Import entrants",
+        link: new_import_job_path(import_job: { parent_type: "EventGroup", parent_id: view_object.event_group.id, format: :event_group_entrants }) }
     ]
     build_dropdown_menu("Actions", dropdown_items, button: true)
   end
 
   def split_name_dropdown(view_object, param: :parameterized_split_name)
     dropdown_items = view_object.ordered_split_names.map do |split_name|
-      {name: split_name,
-       link: request.params.merge(param => split_name.parameterize),
-       active: split_name.parameterize == view_object.split_name&.parameterize}
+      { name: split_name,
+        link: request.params.merge(param => split_name.parameterize),
+        active: split_name.parameterize == view_object.split_name&.parameterize }
     end
 
     build_dropdown_menu(nil, dropdown_items, button: true)
@@ -394,13 +401,13 @@ module DropdownHelper
 
   def split_name_filter_dropdown(view_object, param: :parameterized_split_name)
     default_item_filter = (request.params[:filter] || {}).except(param)
-    default_item = {name: "All Splits",
-                    link: request.params.merge(filter: default_item_filter, page: nil),
-                    active: view_object.split_name.parameterize == "all-splits"}
+    default_item = { name: "All Splits",
+                     link: request.params.merge(filter: default_item_filter, page: nil),
+                     active: view_object.split_name.parameterize == "all-splits" }
     dropdown_items = view_object.ordered_split_names.map do |split_name|
-      {name: split_name,
-       link: request.params.deep_merge(filter: {param => split_name.parameterize}, page: nil),
-       active: split_name.parameterize == view_object.split_name.parameterize}
+      { name: split_name,
+        link: request.params.deep_merge(filter: { param => split_name.parameterize }, page: nil),
+        active: split_name.parameterize == view_object.split_name.parameterize }
     end
     dropdown_items.unshift(default_item)
 
@@ -409,18 +416,18 @@ module DropdownHelper
 
   def sub_split_kind_dropdown(view_object)
     dropdown_items = view_object.sub_split_kinds.map do |kind|
-      {name: kind.titleize,
-       link: request.params.merge(sub_split_kind: kind.parameterize),
-       active: kind.parameterize == view_object.sub_split_kind.parameterize}
+      { name: kind.titleize,
+        link: request.params.merge(sub_split_kind: kind.parameterize),
+        active: kind.parameterize == view_object.sub_split_kind.parameterize }
     end
     build_dropdown_menu(nil, dropdown_items, button: true)
   end
 
   def traffic_band_width_dropdown(view_object)
     dropdown_items = view_object.suggested_band_widths.map do |band_width|
-      {name: pluralize(band_width / 1.minute, "minute"),
-       link: request.params.merge(band_width: band_width),
-       active: band_width == view_object.band_width}
+      { name: pluralize(band_width / 1.minute, "minute"),
+        link: request.params.merge(band_width: band_width),
+        active: band_width == view_object.band_width }
     end
     build_dropdown_menu(nil, dropdown_items, button: true)
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,6 +20,7 @@ class Event < ApplicationRecord
 
   belongs_to :course
   belongs_to :event_group
+  belongs_to :lottery
   belongs_to :results_template
   has_many :event_series_events, dependent: :destroy
   has_many :event_series, through: :event_series_events

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,7 +20,7 @@ class Event < ApplicationRecord
 
   belongs_to :course
   belongs_to :event_group
-  belongs_to :lottery
+  belongs_to :lottery, optional: true
   belongs_to :results_template
   has_many :event_series_events, dependent: :destroy
   has_many :event_series, through: :event_series_events

--- a/app/parameters/event_parameters.rb
+++ b/app/parameters/event_parameters.rb
@@ -2,8 +2,21 @@
 
 class EventParameters < BaseParameters
   def self.permitted
-    [:id, :slug, :course_id, :event_group_id, :short_name, :scheduled_start_time, :beacon_url, :available_live,
-     :laps_required, :scheduled_start_time_local, :results_template_id, :notice_text]
+    [
+      :id,
+      :slug,
+      :course_id,
+      :event_group_id,
+      :short_name,
+      :scheduled_start_time,
+      :beacon_url,
+      :available_live,
+      :laps_required,
+      :scheduled_start_time_local,
+      :results_template_id,
+      :notice_text,
+      :lottery_id,
+    ]
   end
 
   def self.permitted_query

--- a/app/policies/event_group_policy.rb
+++ b/app/policies/event_group_policy.rb
@@ -56,6 +56,10 @@ class EventGroupPolicy < ApplicationPolicy
     user.authorized_to_edit?(event_group)
   end
 
+  def sync_lottery_entrants?
+    user.authorized_to_edit?(event_group)
+  end
+
   def assign_bibs?
     user.authorized_to_edit?(event_group)
   end

--- a/app/services/interactors/errors.rb
+++ b/app/services/interactors/errors.rb
@@ -58,6 +58,11 @@ module Interactors
        detail: {messages: ["Event group for #{resource_1} does not match the event group for #{resource_2}"]}}
     end
 
+    def events_not_linked_error
+      {title: "Events not linked to lotteries",
+       detail: {messages: ["No events have been linked to a lottery. Link an event to a lottery and try again."]}}
+    end
+
     def finish_split_missing_error
       {title: "Finish split missing",
        detail: {messages: ["The event associated with the provided effort has no finish split"]}}

--- a/app/services/interactors/sync_lottery_entrants.rb
+++ b/app/services/interactors/sync_lottery_entrants.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Interactors
+  class SyncLotteryEntrants
+    include ::Interactors::Errors
+
+    RELEVANT_ATTRIBUTES = [
+      "first_name",
+      "last_name",
+      "gender",
+      "birthdate",
+      "city",
+      "state_code",
+      "country_code",
+    ].freeze
+
+    def self.perform!(event_group)
+      new(event_group).perform!
+    end
+
+    def initialize(event_group)
+      @event_group = event_group
+      @response = ::Interactors::Response.new([])
+      @time = Time.current
+      validate_setup
+    end
+
+    def perform!
+      events.each do |event|
+        find_and_create_entrants(event)
+        delete_obsolete_entrants(event)
+      end
+
+      response
+    end
+
+    private
+
+    attr_reader :event_group, :response, :time
+
+    def find_and_create_entrants(event)
+      accepted_entrants = event.lottery.divisions.flat_map(&:accepted_entrants)
+                               .sort_by { |entrant| [entrant.last_name, entrant.first_name] }
+
+      accepted_entrants.find_each do |entrant|
+        unique_key = { first_name: entrant.first_name, last_name: entrant.last_name, birthdate: entrant.birthdate }
+        effort = event.efforts.find_or_initialize_by(unique_key)
+        RELEVANT_ATTRIBUTES.each { |attr| effort.send("#{attr}=", entrant.send(attr)) }
+        response.errors << resource_error_object(effort) unless effort.save
+        effort.update_attribute(:synced_at, time)
+      end
+    end
+
+    def delete_obsolete_entrants(event)
+      obsolete_entrants = event.efforts.where.not(synced_at: time)
+      obsolete_entrants.find_each(&:destroy)
+    end
+
+    def events
+      @events ||= event_group.events.where.not(lottery_id: nil)
+    end
+
+    def validate_setup
+      errors << events_not_linked_error unless events.present?
+    end
+  end
+end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -12,10 +12,10 @@
   <div data-event-setup-target="formData"
        data-event-group-name="<%= presenter.event_group.name %>"
        data-pref-distance-unit="<%= presenter.pref_distance_unit %>"></div>
-  <%= turbo_frame_tag :course_info, data: {"event-setup-target" => "courseInfoFrame"} do %>
+  <%= turbo_frame_tag :course_info, data: { "event-setup-target" => "courseInfoFrame" } do %>
     <div class="row">
       <div class="col-12">
-        <%= form_with(model: presenter.course, html: {class: "form-horizontal", role: "form"}) do |form| %>
+        <%= form_with(model: presenter.course, html: { class: "form-horizontal", role: "form" }) do |form| %>
           <div class="card card-body bg-light border-0">
             <div class="row">
               <div class="form-group col">
@@ -23,10 +23,10 @@
                 <span class="has-tooltip" tabindex="-1" data-toggle="tooltip" data-placement="bottom" data-original-title="Each event is run on a course. Your courses can be reused in future events."><i class="fas fa-question-circle"></i></span>
                 <%= form.select :id, options_for_select(presenter.courses_for_select, presenter.event.course_id),
                                 {},
-                                {autofocus: true,
-                                 class: "form-control dropdown-select-field",
-                                 data: {"event-setup-target" => "courseSelector",
-                                        action: "event-setup#fillDistance event-setup#toggleCourseForm event-setup#setCourseId"}} %>
+                                { autofocus: true,
+                                  class: "form-control dropdown-select-field",
+                                  data: { "event-setup-target" => "courseSelector",
+                                          action: "event-setup#fillDistance event-setup#toggleCourseForm event-setup#setCourseId" } } %>
               </div>
             </div>
 
@@ -81,17 +81,20 @@
   <div class="row">
     <div class="col-12">
       <%= form_with(model: [presenter.event_group, presenter.event],
-                    data: {remote: false, turbo: false},
-                    html: {class: "form-horizontal", role: "form"}) do |form| %>
+                    data: { remote: false, turbo: false },
+                    html: { class: "form-horizontal", role: "form" }) do |form| %>
         <div class="card card-body bg-light border-0">
           <div class="row">
             <div class="form-group col">
               <div class="row">
-                <%= form.hidden_field :course_id, data: {"event-setup-target" => "courseIdField"} %>
+                <%= form.hidden_field :course_id, data: { "event-setup-target" => "courseIdField" } %>
                 <div class="col">
                   <%= form.label :laps_required, class: 'required' %>
-                  <%= form.select :laps_required, (1..20).map { |n| [n, n] }.unshift(['Unlimited', 0]), {},
-                                  class: "form-control dropdown-select-field", data: {'event-setup-target' => 'lapDropdown', action: 'event-setup#fillDistance'} %>
+                  <%= form.select :laps_required,
+                                  (1..20).map { |n| [n, n] }.unshift(['Unlimited', 0]),
+                                  {},
+                                  class: "form-control dropdown-select-field",
+                                  data: { 'event-setup-target' => 'lapDropdown', action: 'event-setup#fillDistance' } %>
                 </div>
                 <div class="col">
                   <%= form.label :course_distance %>
@@ -115,7 +118,7 @@
                 <div class="col">
                   <%= form.label :short_name %>
                   <span class="has-tooltip" tabindex="-1" data-toggle="tooltip" data-placement="bottom" data-original-title="If you will have more than one event in this group, give each a short name (like '50K' or '24-hour') to distinguish them"><i class="fas fa-question-circle"></i></span>
-                  <%= form.text_field :short_name, class: "form-control", placeholder: "Short name", data: {"event-setup-target" => "eventShortName", action: 'keyup->event-setup#fillEventName'} %>
+                  <%= form.text_field :short_name, class: "form-control", placeholder: "Short name", data: { "event-setup-target" => "eventShortName", action: 'keyup->event-setup#fillEventName' } %>
                 </div>
                 <div class="col">
                   <%= form.label :full_name %>
@@ -131,6 +134,27 @@
             </div>
           </div>
         </div>
+
+        <br/>
+
+        <% if event.organization.lotteries.exists? %>
+          <div class="card card-body bg-light border-0">
+            <div class="row">
+              <div class="form-group col">
+                <div class="row">
+                  <div class="col">
+                    <%= form.label :linked_lottery %>
+                    <span class="has-tooltip" tabindex="-1" data-toggle="tooltip" data-placement="bottom" data-original-title="If entrants to this event were chosen in an OpenSplitTime lottery, choose the lottery from this dropdown. Otherwise, leave this selection blank."><i class="fas fa-question-circle"></i></span>
+                    <%= form.select :lottery_id,
+                                    options_for_select(event.organization.lotteries.pluck(:name, :id), event.lottery_id),
+                                    { prompt: "Select a lottery" },
+                                    class: "form-control dropdown-select-field" %>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
 
         <br/>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,7 @@ Rails.application.routes.draw do
       get :traffic
       post :create_people
       post :load_lottery_entrants
+      post :sync_lottery_entrants
       patch :set_data_status
       patch :assign_entrant_photos
       patch :auto_assign_bibs

--- a/spec/services/interactors/sync_lottery_entrants_spec.rb
+++ b/spec/services/interactors/sync_lottery_entrants_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Interactors::SyncLotteryEntrants do
+  describe ".perform!" do
+    subject { described_class.new(event_group) }
+    let(:event_group) { create(:event_group, organization: organizations(:hardrock)) }
+    let(:event) { create(:event, event_group: event_group, course: courses(:hardrock_cw), lottery_id: lottery_id) }
+    let(:lottery_id) { nil }
+    let(:lottery) { lotteries(:lottery_with_tickets_and_draws) }
+
+    context "when no events are linked to a lottery" do
+      it "returns a descriptive error" do
+        response = subject.perform!
+        expect(response).not_to be_successful
+        expect(response.errors.first.dig(:detail, :messages).first).to include("No events have been linked to a lottery")
+      end
+    end
+
+    context "when a single event is linked to a lottery" do
+      let(:lottery_id) { lottery.id }
+      let(:resulting_effort_ids) { event.reload.efforts.pluck(:id) }
+
+      context "when the event has no existing efforts" do
+        it "adds all accepted lottery entrants to the event" do
+          expect(event.efforts.count).to eq(0)
+          subject.perform!
+          expect(event.efforts.count).to eq(5)
+        end
+      end
+
+      context "when the event has existing efforts that do not match the lottery entrants" do
+        let!(:effort_1) { create(:effort, event: event) }
+        let!(:effort_2) { create(:effort, event: event) }
+
+        it "destroys existing efforts and adds accepted lottery entrants" do
+          expect(event.efforts.count).to eq(2)
+          subject.perform!
+          expect(event.efforts.count).to eq(5)
+
+          expect(effort_1.id).not_to be_in(resulting_effort_ids)
+          expect(effort_2.id).not_to be_in(resulting_effort_ids)
+        end
+      end
+
+      context "when the event has existing efforts some of which match the lottery entrants" do
+        let(:entrant_1) { lottery_divisions(:lottery_division_1).accepted_entrants.first }
+        let(:entrant_2) { lottery_divisions(:lottery_division_1).accepted_entrants.second }
+        let!(:effort_1) { create(:effort, event: event, first_name: entrant_1.first_name, last_name: entrant_1.last_name, birthdate: entrant_1.birthdate) }
+        let!(:effort_2) { create(:effort, event: event, first_name: entrant_2.first_name, last_name: entrant_2.last_name, birthdate: entrant_2.birthdate) }
+        let!(:effort_3) { create(:effort, event: event) }
+
+        it "matches and creates entrants as expected" do
+          expect(event.efforts.count).to eq(3)
+          subject.perform!
+          expect(event.efforts.count).to eq(5)
+
+          expect(effort_1.id).to be_in(resulting_effort_ids)
+          expect(effort_2.id).to be_in(resulting_effort_ids)
+          expect(effort_3.id).not_to be_in(resulting_effort_ids)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR replaces the existing `load_lottery_entrants` endpoint with a new `sync_lottery_entrants` endpoint. The new endpoint uses the persisted `lottery_id` for each event to determine where to source the incoming entrants. 

This is a one-click solution to lottery syncing, but it has some weaknesses, namely:

- It operates synchronously, which can lead to long response times
- It does not give much information about the lottery that is about to be synced

A future PR should perhaps incorporate an interim view that shows which lotteries relate to which events and allows the user to modify those assignments before committing to the sync action.

Addresses a portion of #808