### PR TITLE
Upgrade Node version to v16 & improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ Getting Started
 5. `$ rbenv install <current ruby version>`
 6. `$ rbenv rehash` then restart the terminal session
 
-**Rails and Gems**
+**Rails, Gems, Databases**
 
 1. `$ gem install bundler` You should not need to `sudo` this. If it says "permission denied" [rbenv is not setup correctly](https://github.com/rbenv/rbenv/issues/670)
 2. `$ gem install rails`
 3. Install Postgres:
 
 > ### Using Homebrew on MacOS
-> `$ brew install postgres`
+> `$ brew install postgres redis`
 
 > ### Using Debian/Ubuntu
-> 1. `$ sudo apt install postgresql libpq-dev`
+> 1. `$ sudo apt install postgresql libpq-dev redis-server`
 > 2. Setup your user (same as login) `$ sudo -u postgres createuser --interactive`
 
 4. `$ bundle install`
@@ -98,7 +98,7 @@ v1.13.0 instead.
 
 **Database**
 
-1. Start your local DB `$ brew services restart postgres` or run the Postgres App
+1. Start your local DB `$ brew services restart postgres && brew services restart redis` or run the Postgres App
 2. `$ rails db:setup` to create the database
 3. `$ rails db:from_fixtures` to load seed data from test fixtures files
 4. `$ rails s` to start the server
@@ -116,9 +116,9 @@ After you setup/seed your database, you should have four test users:
 | user  | fifthuser@example.com  | password |
 ```
 
-**Sidekiq and Redis**
+**Sidekiq**
 
-OpenSplitTime relies on Sidekiq for background jobs, and Sidekiq needs Redis. Install Redis using the simple instructions you'll find at [redis.io](https://redis.io). Run your Sidekiq server from the command line:
+OpenSplitTime relies on Sidekiq for background jobs, and Sidekiq needs Redis. Make sure your Redis server (installed above) is started. Run your Sidekiq server from the command line:
 
 `$ sidekiq`
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ Getting Started
 **Rails, Gems, Databases**
 
 1. `$ gem install bundler` You should not need to `sudo` this. If it says "permission denied" [rbenv is not setup correctly](https://github.com/rbenv/rbenv/issues/670)
-2. `$ gem install rails`
-3. Install Postgres:
+2. Install Postgres:
 
 > ### Using Homebrew on MacOS
 > `$ brew install postgres redis`

--- a/README.md
+++ b/README.md
@@ -67,33 +67,13 @@ Getting Started
 
 **Javascript Runtime + Yarn**
 
-1. Install Node.js
-
-> ### On MacOS
-> Download the package installer from nodejs.org. Use the LTS version (v10.16.0 as of mid-2019)
-
-> ### Using Debian/Ubuntu
-> 1. Configure repository `wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -`
-> 3. Install Node.js `sudo apt-get install -y nodejs`
+1. Install Node.js v16 (the latest LTS as of mid-2022). We recommend using [`nvm`](https://github.com/nvm-sh/nvm). Otherwise:
+- Using MacOS: You can download the package installer from nodejs.org.
+- Using Debian/Ubuntu: `wget -qO- https://deb.nodesource.com/setup_16.x | sudo -E bash - && sudo apt-get install -y nodejs`
 
 2. Install Yarn
 
-> ### Using Homebrew on MacOS
-> Use the yarn install script so that you can specify the version you want. The newest versions of yarn (as of mid-2019) 
-depend on Nodejs v12 and will install it as a dependency even though you have already installed Nodejs v10. Specify
-v1.13.0 instead.
-> 1. `curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0`
-> 2. Restart your terminal session
-
-> ### Using Debian/Ubuntu
-> 1. Configure yarn repository:
-> 2. `curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -`
-> 3. `echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list`
-> 4. `sudo apt-get update && sudo apt-get install yarn`
-> 5. `$ cd` into your local `OpenSplitTime` directory
-> 6. Update dependancies `$ yarn`
->
-> *If you have any issues, refer to [yarn's website](https://yarnpkg.com/lang/en/docs/install)*
+After ensuring you're using the right version of Node.js (with `node --version`): `npm install -g yarn`
 
 **Database**
 


### PR DESCRIPTION
I couldn't install Node v10 because I'm using an ARM (M1) Mac. Good news is that upgrading to v16, the latest LTS, seems to work fine :) v10 hasn't been supported since April 2021, so I guess this is a welcome change. Please verify though, I just see the homepage rendering fine with no 404's. Not sure if there are more complicated assets going on.

I use `nvm` and I think instructing people to use that would be a good recommendation. It outsources install instructions, too, in addition to letting people easily manage multiple versions on their computers. There are other similar solutions `asdf` but people who use those tools can figure it out themselves. 

I tried to update the Ubuntu/Debian instructions but I'm not sure how to make sure the Redis server is started, so I didn't include that. Feel free to add commits to this branch with those. (And feel free, in general, to tweak in anyway you see fit.)

Cheers!