### PR TITLE
Event 'spread' design tweaks

### DIFF
--- a/app/assets/stylesheets/pages/_spread.scss
+++ b/app/assets/stylesheets/pages/_spread.scss
@@ -4,4 +4,12 @@ body.events.spread {
     .container {
 	max-width: 100%;
     }
+
+    tbody tr.status {
+	height: 1.5em;
+	font-size: 0.9em;
+	font-variant: small-caps;
+	background: lightgray;
+    }
+
 }

--- a/app/assets/stylesheets/pages/_spread.scss
+++ b/app/assets/stylesheets/pages/_spread.scss
@@ -1,3 +1,7 @@
 body.events.spread {
     overflow-x: visible;
+
+    .container {
+	max-width: 100%;
+    }
 }

--- a/app/assets/stylesheets/pages/_spread.scss
+++ b/app/assets/stylesheets/pages/_spread.scss
@@ -1,15 +1,10 @@
 body.events.spread {
     overflow-x: visible;
 
-    .container {
-	max-width: 100%;
-    }
-
     tbody tr.status {
 	height: 1.5em;
 	font-size: 0.9em;
 	font-variant: small-caps;
 	background: lightgray;
     }
-
 }

--- a/app/models/concerns/rankable.rb
+++ b/app/models/concerns/rankable.rb
@@ -8,6 +8,11 @@
 module Rankable
   extend ActiveSupport::Concern
 
+  FINISHED = "Finished"
+  IN_PROGRESS = "In Progress"
+  DROPPED = "Dropped"
+  NOT_STARTED = "Not Started"
+
   # @return [String (frozen)]
   def display_overall_rank
     beyond_start? ? overall_rank : "--"
@@ -21,13 +26,13 @@ module Rankable
   # @return [String (frozen)]
   def effort_status
     if finished?
-      "Finished"
+      FINISHED
     elsif dropped?
-      "Dropped"
+      DROPPED
     elsif in_progress?
-      "In Progress"
+      IN_PROGRESS
     else
-      "Not Started"
+      NOT_STARTED
     end
   end
 end

--- a/app/presenters/event_spread_display.rb
+++ b/app/presenters/event_spread_display.rb
@@ -24,12 +24,13 @@ class EventSpreadDisplay < EventWithEffortsPresenter
   end
 
   def grouped_effort_times_rows
-    result = effort_times_rows.group_by(&:effort_status)
-    if event.laps_unlimited? && result[Rankable::IN_PROGRESS].any? then
-      { "Started" => result.slice(Rankable::FINISHED, Rankable::IN_PROGRESS, Rankable::DROPPED).values.flatten,
-        "Not Started" => result[Rankable::NOT_STARTED] }
+    if event.laps_unlimited? && !event.finished?
+      effort_times_rows.flatten.group_by(&:started?).then do |grouped_results|
+        {"Started" => grouped_results[true].sort_by { |row| -row.effort.laps_finished },
+         "Not Started" => grouped_results[false]}
+      end
     else
-      result
+      effort_times_rows.group_by(&:effort_status)
     end
   end
 

--- a/app/presenters/event_spread_display.rb
+++ b/app/presenters/event_spread_display.rb
@@ -28,7 +28,7 @@ class EventSpreadDisplay < EventWithEffortsPresenter
   end
 
   def lap_splits
-    @lp_splits ||= event.required_lap_splits.presence || event.lap_splits_through(highest_lap)
+    @lap_splits ||= event.required_lap_splits.presence || event.lap_splits_through(highest_lap)
   end
 
   def partner_with_banner

--- a/app/presenters/event_spread_display.rb
+++ b/app/presenters/event_spread_display.rb
@@ -25,7 +25,7 @@ class EventSpreadDisplay < EventWithEffortsPresenter
 
   def grouped_effort_times_rows
     result = effort_times_rows.group_by(&:effort_status)
-    if event.laps_required == 0 && result[Rankable::IN_PROGRESS].any? then
+    if event.laps_unlimited? && result[Rankable::IN_PROGRESS].any? then
       { "Started" => result.slice(Rankable::FINISHED, Rankable::IN_PROGRESS, Rankable::DROPPED).values.flatten,
         "Not Started" => result[Rankable::NOT_STARTED] }
     else

--- a/app/presenters/event_spread_display.rb
+++ b/app/presenters/event_spread_display.rb
@@ -25,9 +25,9 @@ class EventSpreadDisplay < EventWithEffortsPresenter
 
   def grouped_effort_times_rows
     result = effort_times_rows.group_by(&:effort_status)
-    if event.laps_required == 0 && result["In Progress"].any? then
-      { "Started" => result.slice("Finished", "In Progress", "Dropped").values.flatten,
-        "Not Started" => result["Not Started"] }
+    if event.laps_required == 0 && result[Rankable::IN_PROGRESS].any? then
+      { "Started" => result.slice(Rankable::FINISHED, Rankable::IN_PROGRESS, Rankable::DROPPED).values.flatten,
+        "Not Started" => result[Rankable::NOT_STARTED] }
     else
       result
     end

--- a/app/presenters/event_spread_display.rb
+++ b/app/presenters/event_spread_display.rb
@@ -24,7 +24,13 @@ class EventSpreadDisplay < EventWithEffortsPresenter
   end
 
   def grouped_effort_times_rows
-    effort_times_rows.group_by(&:effort_status)
+    result = effort_times_rows.group_by(&:effort_status)
+    if event.laps_required == 0 && result["In Progress"].any? then
+      { "Started" => result.slice("Finished", "In Progress", "Dropped").values.flatten,
+        "Not Started" => result["Not Started"] }
+    else
+      result
+    end
   end
 
   def lap_splits

--- a/app/presenters/event_spread_display.rb
+++ b/app/presenters/event_spread_display.rb
@@ -23,22 +23,12 @@ class EventSpreadDisplay < EventWithEffortsPresenter
     {elapsed: "Elapsed", ampm: "AM/PM", military: "24-Hour", segment: "Segment"}
   end
 
-  def effort_times_rows
-    @effort_times_rows ||=
-      filtered_ranked_efforts.map do |effort|
-        EffortTimesRow.new(effort: effort,
-                           lap_splits: lap_splits,
-                           split_times: split_times_by_effort.fetch(effort.id, []),
-                           display_style: display_style)
-      end
-  end
-
-  def effort_times_row_ids
-    effort_times_rows.map(&:id)
+  def grouped_effort_times_rows
+    effort_times_rows.group_by(&:effort_status)
   end
 
   def lap_splits
-    @lap_splits ||= event.required_lap_splits.presence || event.lap_splits_through(highest_lap)
+    @lp_splits ||= event.required_lap_splits.presence || event.lap_splits_through(highest_lap)
   end
 
   def partner_with_banner
@@ -105,5 +95,15 @@ class EventSpreadDisplay < EventWithEffortsPresenter
 
   def split_times_by_effort
     @split_times_by_effort ||= split_times.group_by { |st| st[:effort_id] }
+  end
+
+  def effort_times_rows
+    @effort_times_rows ||=
+      filtered_ranked_efforts.map do |effort|
+        EffortTimesRow.new(effort: effort,
+                           lap_splits: lap_splits,
+                           split_times: split_times_by_effort.fetch(effort.id, []),
+                           display_style: display_style)
+      end
   end
 end

--- a/app/view_models/effort_times_row.rb
+++ b/app/view_models/effort_times_row.rb
@@ -88,6 +88,10 @@ class EffortTimesRow
     time_clusters.map(&:stopped_here_flags)
   end
 
+  def finish_time
+    effort.finish_split_time&.formatted_time_hhmmss
+  end
+
   alias stopped stopped?
   alias dropped dropped?
   alias finished finished?

--- a/app/views/events/_spread_row.html.erb
+++ b/app/views/events/_spread_row.html.erb
@@ -2,9 +2,9 @@
   <td><%= "#{row.display_overall_rank}/#{row.display_gender_rank}" %></td>
   <td><%= row.bib_number %></td>
   <td class="text-nowrap"><strong><%= link_to row.full_name, effort_path(row.effort) %></strong></td>
+  <td class="text-nowrap"><%= row.finish_time %></td>
   <td class="text-nowrap"><%= row.bio_historic %></td>
   <td class="text-nowrap"><%= row.flexible_geolocation %></td>
-  <td class="text-nowrap"><%= row.effort_status %></td>
   <% spread_relevant_elements(row.time_clusters).each do |cluster| %>
     <td class="text-nowrap text-center">
       <%= time_cluster_display_data(cluster, display_style) %>

--- a/app/views/events/_spread_row.html.erb
+++ b/app/views/events/_spread_row.html.erb
@@ -1,0 +1,18 @@
+<tr id="<%= "effort_#{row.id}" %>">
+  <td><%= "#{row.display_overall_rank}/#{row.display_gender_rank}" %></td>
+  <td><%= row.bib_number %></td>
+  <td class="text-nowrap"><strong><%= link_to row.full_name, effort_path(row.effort) %></strong></td>
+  <td class="text-nowrap"><%= row.bio_historic %></td>
+  <td class="text-nowrap"><%= row.flexible_geolocation %></td>
+  <td class="text-nowrap"><%= row.effort_status %></td>
+  <% spread_relevant_elements(row.time_clusters).each do |cluster| %>
+    <td class="text-nowrap text-center">
+      <%= time_cluster_display_data(cluster, display_style) %>
+    </td>
+  <% end %>
+  <% if show_segment_totals %>
+    <td class="text-center text-nowrap">
+      <%= clustered_segment_total_data(row) %>
+    </td>
+  <% end %>
+</tr>

--- a/app/views/events/spread.html.erb
+++ b/app/views/events/spread.html.erb
@@ -63,7 +63,7 @@
     <table class="table table-sm table-striped">
       <thead>
       <tr>
-        <th>O/G<br/><%= link_to_reversing_sort_heading('Place', :overall_rank, @presenter.existing_sort) %></th>
+        <th title="Overall/group">O/G<br/><%= link_to_reversing_sort_heading('Place', :overall_rank, @presenter.existing_sort) %></th>
         <th><%= link_to_reversing_sort_heading('Bib', :bib_number, @presenter.existing_sort) %></th>
         <th><%= link_to_reversing_sort_heading('Name', 'last_name,first_name', @presenter.existing_sort) %></th>
         <th><%= link_to_reversing_sort_heading('Finish time', :finish_split, @presenter.existing_sort) %> </th>

--- a/app/views/events/spread.html.erb
+++ b/app/views/events/spread.html.erb
@@ -85,7 +85,7 @@
       <% @presenter.grouped_effort_times_rows.each do |status_text, rows| %>
         <tbody>
           <% if rows.any? %>
-            <tr class="status"> <th colspan="999" scope="rowgroup"> <%= status_text %> </th> </tr>
+            <tr class="status"> <th colspan="100%" scope="rowgroup"> <%= status_text %> </th> </tr>
           <% end %>
 
           <%=

--- a/app/views/events/spread.html.erb
+++ b/app/views/events/spread.html.erb
@@ -58,7 +58,7 @@
   <%= render 'partner_banner', partner: @presenter.partner_with_banner, organization_name: @presenter.organization_name %>
 <% end %>
 
-<article class="ost-article container">
+<article class="ost-article container-fluid">
   <% cache @presenter.cache_key do %>
     <table class="table table-sm table-striped">
       <thead>

--- a/app/views/events/spread.html.erb
+++ b/app/views/events/spread.html.erb
@@ -66,9 +66,9 @@
         <th>O/G<br/><%= link_to_reversing_sort_heading('Place', :overall_rank, @presenter.existing_sort) %></th>
         <th><%= link_to_reversing_sort_heading('Bib', :bib_number, @presenter.existing_sort) %></th>
         <th><%= link_to_reversing_sort_heading('Name', 'last_name,first_name', @presenter.existing_sort) %></th>
+        <th><%= link_to_reversing_sort_heading('Finish time', :finish_split, @presenter.existing_sort) %> </th>
         <th><%= link_to_reversing_sort_heading('Category', 'gender,age', @presenter.existing_sort) %></th>
         <th><%= link_to_reversing_sort_heading('From', :state_code, @presenter.existing_sort) %></th>
-        <th>Status</th>
         <% spread_relevant_elements(@presenter.split_header_data).each do |header| %>
           <th class="text-nowrap text-center">
             <%= clustered_header(header) %>

--- a/app/views/events/spread.html.erb
+++ b/app/views/events/spread.html.erb
@@ -82,28 +82,25 @@
       </tr>
       </thead>
 
-      <tbody>
-      <% @presenter.effort_times_rows.each do |row| %>
-        <tr id="<%= "effort_#{row.id}" %>">
-          <td><%= "#{row.display_overall_rank}/#{row.display_gender_rank}" %></td>
-          <td><%= row.bib_number %></td>
-          <td class="text-nowrap"><strong><%= link_to row.full_name, effort_path(row.effort) %></strong></td>
-          <td class="text-nowrap"><%= row.bio_historic %></td>
-          <td class="text-nowrap"><%= row.flexible_geolocation %></td>
-          <td class="text-nowrap"><%= row.effort_status %></td>
-          <% spread_relevant_elements(row.time_clusters).each do |cluster| %>
-            <td class="text-nowrap text-center">
-              <%= time_cluster_display_data(cluster, @presenter.display_style) %>
-            </td>
+      <% @presenter.grouped_effort_times_rows.each do |status_text, rows| %>
+        <tbody>
+          <% if rows.any? %>
+            <tr class="status"> <th colspan="999" scope="rowgroup"> <%= status_text %> </th> </tr>
           <% end %>
-          <% if @presenter.show_segment_totals? %>
-            <td class="text-center text-nowrap">
-              <%= clustered_segment_total_data(row) %>
-            </td>
-          <% end %>
-        </tr>
+
+          <%=
+            render(
+              partial: "events/spread_row",
+              collection: rows,
+              as: :row,
+              locals: {
+                show_segment_totals: @presenter.show_segment_totals?,
+                display_style: @presenter.display_style
+              }
+            )
+          %>
+        </tbody>
       <% end %>
-      </tbody>
     </table>
   <% end %>
 </article>


### PR DESCRIPTION
Some screenshots (taken on a 4k monitor).

Before:
![Screenshot 2022-08-01 at 18-32-27 OpenSplitTime Full results - Hardrock 2016](https://user-images.githubusercontent.com/632942/182262477-16d32b97-5355-4bd9-ab4c-275e1db0ec15.png)


After:
![Screenshot 2022-08-01 at 18-31-59 OpenSplitTime Full results - Hardrock 2016](https://user-images.githubusercontent.com/632942/182262473-21ff557b-e99d-4ea9-9fb1-a3feb637be8a.png)



1. Allow the page to be full-width instead of inside a container. The table is often very wide, with a horizontal scroll, so we should minimize the amount of wasted space. In the example above, you can see that there's not even a horizontal scroll for this event. This doesn't look as good for events with fewer split times, admittedly. But most events have many aid stations, so I think this is an OK trade-off. We could use breakpoints (or Ruby logic based on the # of splits) to make this more sophisticated, if desired. [Before](https://user-images.githubusercontent.com/632942/182262601-5b2b7cb6-449e-426c-b185-e5e6cb559fec.png). [After](https://user-images.githubusercontent.com/632942/182262603-ed89cfa1-c1ab-4832-ae4a-4b98807ac3c5.png).


2. Separate results into groups by status. So, the results clearly show who has Finished, and who has not yet. When I was following along with Hardrock this year, I was checking to see who had finished already, and this change makes that very clear. It should be fine during and after the event, since we won't show the "In progress" label when no athletes are left in progress.

3. Show finish time. Since the status is grouped now, it doesn't need to be displayed. Using that screen real-estate, we can show the finish time for athletes who have finished. This was the impetus behind these design tweaks :) Especially when there's a horizontal scroll, we should surface the finish time as close to the athlete's name as possible once they're finished, I think.



Some concerns:
1. The grouping into status [doesn't really make a ton of sense for timed events (or backyard/last-person-running style)](https://user-images.githubusercontent.com/632942/182262924-eb09219a-14c6-4dd8-9c78-14d4bfa0a9a6.png). Any ideas for how to handle that?
2. The order I see is "Finished", "In Progress", "Dropped", "Not started". This is the ideal ordering but I don't list it anywhere. I guess it might be due to an existing ordering happening, in which case it's fine. This ordering is basically contingent on the order it sees the results in. Is that OK? (An bug I'm concerned about is somehow getting a 'Dropped' Effort first and that getting the first key in the results hash, which would be displayed at the top.). It's a simple change to explicitly list the order.
3. I added some local variables to the partial instead of relying on the `@presenter` instance variable being available. I see that as a global state anti-pattern that has bit me too many times, but the code is certainly shorter without extracting those.)
4. It's hard to see on the screenshots but I still need to add some whitespace to the right side of the Combined & AM/PM filters so they're not right at the edge of the screen.
5. I'm not sold on the design. In particular, I think the group label rows can be improved, but this demonstrates the structure at least. 
6. I'm happy to add tests for this too, just want to be sure these changes are desired before spending that time.