### PR TITLE
Increase default per page from 25 to 50 for best efforts view

### DIFF
--- a/app/presenters/best_efforts_display.rb
+++ b/app/presenters/best_efforts_display.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class BestEffortsDisplay < BasePresenter
+  DEFAULT_PER_PAGE = 50
+  FIRST_PAGE = 1
+
   attr_reader :course, :view_context, :request
 
   delegate :name, :simple?, :ordered_splits_without_finish, :ordered_splits_without_start, :organization,
@@ -73,11 +76,11 @@ class BestEffortsDisplay < BasePresenter
   end
 
   def page
-    params[:page]&.to_i || 1
+    params[:page]&.to_i || FIRST_PAGE
   end
 
   def per_page
-    params[:per_page]&.to_i || 25
+    params[:per_page]&.to_i || DEFAULT_PER_PAGE
   end
 
   def split1


### PR DESCRIPTION
Based on queries run directly against the production database, loading 50 best effort segments at a time seems to take about the same amount of time as running 25 at a time. But jumping to 100 slows down noticeably.

This PR bumps the default per_page query from 25 to 50, which seems to be about the sweet spot.

Related to #818, though this is really just a UX optimization.