### PR TITLE
Render failed effort create/update with 422

### DIFF
--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -46,7 +46,7 @@ class EffortsController < ApplicationController
     if @effort.save
       redirect_to setup_event_group_path(@effort.event_group, display_style: :entrants)
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 
@@ -78,7 +78,7 @@ class EffortsController < ApplicationController
       end
     else
       @effort = effort
-      render "edit"
+      render "edit", status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
Turbo needs failed create and update responses to be rendered with status: 422 (unprocessable_entity).

This MR adds that status to failed effort creates and updates.