### PR TITLE
Return status 422 with all failed create/update actions

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -40,7 +40,7 @@ class CoursesController < ApplicationController
         redirect_to course_path(@course)
       end
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 
@@ -50,7 +50,7 @@ class CoursesController < ApplicationController
     if @course.update(permitted_params)
       redirect_to @course, notice: "Course updated"
     else
-      render "edit"
+      render "edit", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/duplicate_event_groups_controller.rb
+++ b/app/controllers/duplicate_event_groups_controller.rb
@@ -17,7 +17,7 @@ class DuplicateEventGroupsController < ApplicationController
     if @duplicate_event_group.valid?
       redirect_to setup_event_group_path(@duplicate_event_group.new_event_group)
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -41,7 +41,7 @@ class EventGroupsController < ApplicationController
     if @event_group.save
       redirect_to setup_event_group_path(@event_group)
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/event_series_controller.rb
+++ b/app/controllers/event_series_controller.rb
@@ -35,7 +35,7 @@ class EventSeriesController < ApplicationController
     if @event_series.save
       redirect_to @event_series
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 
@@ -46,7 +46,7 @@ class EventSeriesController < ApplicationController
     if @event_series.update(permitted_params)
       redirect_to @event_series
     else
-      render "edit"
+      render "edit", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -44,7 +44,7 @@ class EventsController < ApplicationController
       redirect_to setup_event_group_path(@event_group)
     else
       @presenter = ::EventSetupPresenter.new(@event, params, current_user)
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/import_jobs_controller.rb
+++ b/app/controllers/import_jobs_controller.rb
@@ -37,12 +37,12 @@ class ImportJobsController < ApplicationController
         redirect_to import_jobs_path
       else
         flash[:danger] = "Unable to create import job: #{@import_job.errors.full_messages.join(', ')}"
-        render "new"
+        render "new", status: :unprocessable_entity
       end
     rescue Aws::Errors::NoSuchEndpointError => e
       flash[:danger] = "Unable to create import job: #{e}"
       @import_job.failed!
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/lotteries_controller.rb
+++ b/app/controllers/lotteries_controller.rb
@@ -45,7 +45,7 @@ class LotteriesController < ApplicationController
     if @lottery.save
       redirect_to setup_organization_lottery_path(@organization, @lottery)
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 
@@ -55,7 +55,7 @@ class LotteriesController < ApplicationController
     if @lottery.update(permitted_params)
       redirect_to setup_organization_lottery_path(@organization, @lottery), notice: "Lottery updated"
     else
-      render "edit"
+      render "edit", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/lottery_divisions_controller.rb
+++ b/app/controllers/lottery_divisions_controller.rb
@@ -24,7 +24,7 @@ class LotteryDivisionsController < ApplicationController
     if @lottery_division.save
       redirect_to setup_organization_lottery_path(@organization, @lottery)
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 
@@ -34,7 +34,7 @@ class LotteryDivisionsController < ApplicationController
     if @lottery_division.update(permitted_params)
       redirect_to setup_organization_lottery_path(@organization, @lottery)
     else
-      render "edit"
+      render "edit", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/lottery_entrants_controller.rb
+++ b/app/controllers/lottery_entrants_controller.rb
@@ -29,7 +29,7 @@ class LotteryEntrantsController < ApplicationController
     if @lottery_entrant.save
       redirect_to setup_organization_lottery_path(@lottery_entrant.organization, @lottery_entrant.lottery, entrant_id: @lottery_entrant.id)
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/lottery_simulation_runs_controller.rb
+++ b/app/controllers/lottery_simulation_runs_controller.rb
@@ -31,7 +31,7 @@ class LotterySimulationRunsController < ApplicationController
       flash[:success] = "Simulation run in progress."
       redirect_to organization_lottery_lottery_simulation_runs_path(@organization, @lottery)
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -41,7 +41,7 @@ class OrganizationsController < ApplicationController
     if @organization.save
       redirect_to @organization
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 
@@ -51,7 +51,7 @@ class OrganizationsController < ApplicationController
     if @organization.update(permitted_params)
       redirect_to @organization
     else
-      render "edit"
+      render "edit", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -22,7 +22,7 @@ class PartnersController < ApplicationController
     if @partner.save
       redirect_to partner_event_group_path
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 
@@ -32,7 +32,7 @@ class PartnersController < ApplicationController
     if @partner.update(permitted_params)
       redirect_to partner_event_group_path
     else
-      render "edit"
+      render "edit", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -36,7 +36,7 @@ class PeopleController < ApplicationController
     if @person.save
       redirect_to session.delete(:return_to) || @person
     else
-      render "new"
+      render "new", status: :unprocessable_entity
     end
   end
 
@@ -46,7 +46,7 @@ class PeopleController < ApplicationController
     if @person.update(permitted_params)
       redirect_to @person
     else
-      render "edit"
+      render "edit", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/splits_controller.rb
+++ b/app/controllers/splits_controller.rb
@@ -40,11 +40,11 @@ class SplitsController < ApplicationController
       redirect_to split_path(@split)
     else
       if @event
-        render "new", event_id: @event.id
+        render "new", event_id: @event.id, status: :unprocessable_entity
       elsif @course
-        render "new", course_id: @course.id
+        render "new", course_id: @course.id, status: :unprocessable_entity
       else
-        render "new"
+        render "new", status: :unprocessable_entity
       end
     end
   end
@@ -56,7 +56,7 @@ class SplitsController < ApplicationController
       redirect_to split_path(@split)
     else
       @course = Course.friendly.find(@split.course_id) if @split.course_id
-      render "edit"
+      render "edit", status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
This PR updates all (non-API) controllers to respond with status: 422 on an unsuccessful create or update. This is in line with modern Rails/Turbo practice.