### PR TITLE
Start times manager

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -283,6 +283,17 @@ class EventGroupsController < ApplicationController
     @presenter = ::EventGroupSetupPresenter.new(@event_group, prepared_params, current_user)
   end
 
+  # GET /event_groups/1/manage_start_times_edit_actual
+  def manage_start_times_edit_actual
+    authorize @event_group
+
+    render partial: "form_start_time_actual", locals: {
+      event_id: params[:event_id],
+      scheduled_start_time: params[:scheduled_start_time].to_datetime,
+      effort_ids: params[:effort_ids],
+    }
+  end
+
   def set_data_status
     authorize @event_group
 

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -276,6 +276,13 @@ class EventGroupsController < ApplicationController
     redirect_to manage_entrant_photos_event_group_path(@event_group)
   end
 
+  # GET /event_groups/1/manage_start_times
+  def manage_start_times
+    authorize @event_group
+
+    @presenter = ::EventGroupSetupPresenter.new(@event_group, prepared_params, current_user)
+  end
+
   def set_data_status
     authorize @event_group
 

--- a/app/policies/event_group_policy.rb
+++ b/app/policies/event_group_policy.rb
@@ -88,6 +88,10 @@ class EventGroupPolicy < ApplicationPolicy
     user.authorized_to_edit?(event_group)
   end
 
+  def manage_start_times?
+    user.authorized_to_edit?(event_group)
+  end
+
   def roster?
     user.authorized_to_edit?(event_group)
   end

--- a/app/policies/event_group_policy.rb
+++ b/app/policies/event_group_policy.rb
@@ -92,6 +92,10 @@ class EventGroupPolicy < ApplicationPolicy
     user.authorized_to_edit?(event_group)
   end
 
+  def manage_start_times_edit_actual?
+    user.authorized_to_edit?(event_group)
+  end
+
   def roster?
     user.authorized_to_edit?(event_group)
   end

--- a/app/presenters/event_group_setup_presenter.rb
+++ b/app/presenters/event_group_setup_presenter.rb
@@ -7,6 +7,7 @@ class EventGroupSetupPresenter < BasePresenter
   delegate :available_live?,
            :concealed?,
            :first_event,
+           :home_time_zone,
            :multiple_events?,
            :name,
            :organization,

--- a/app/services/interactors/start_efforts.rb
+++ b/app/services/interactors/start_efforts.rb
@@ -37,13 +37,16 @@ module Interactors
     attr_reader :efforts, :start_time, :current_user_id, :errors, :saved_split_times
 
     def start_effort(effort)
-      return if effort.split_times.any?(&:starting_split_time?)
+      split_time = SplitTime.find_or_initialize_by(
+        effort_id: effort.id,
+        lap: 1,
+        split_id: effort.start_split_id,
+        bitkey: SubSplit::IN_BITKEY,
+      )
 
-      time_point = TimePoint.new(1, effort.start_split_id, SubSplit::IN_BITKEY)
-      split_time = SplitTime.new(effort_id: effort.id,
-                                 time_point: time_point,
-                                 absolute_time: effort_start_time(effort),
-                                 created_by: current_user_id)
+      split_time.absolute_time = effort_start_time(effort)
+      split_time.created_by = current_user_id
+
       if split_time.save
         saved_split_times << split_time
       else
@@ -79,11 +82,12 @@ module Interactors
         errors << efforts_not_provided_error
         return
       end
+
       errors << multiple_event_groups_error(event_group_ids) if event_group_ids.uniq.many?
       errors << invalid_start_time_error(start_time) if invalid_start_time?
       errors << invalid_start_time_error(start_time || "nil") unless converted_start_time ||
-                                                                     efforts.all?(&:scheduled_start_time?) ||
-                                                                     efforts.all?(&:event)
+        efforts.all?(&:scheduled_start_time?) ||
+        efforts.all?(&:event)
     end
 
     def event_group_ids

--- a/app/views/event_groups/_entrants_roster.html.erb
+++ b/app/views/event_groups/_entrants_roster.html.erb
@@ -13,6 +13,7 @@
                 <%= link_to "Reconcile", reconcile_event_group_path(@presenter.event_group), class: "dropdown-item" %>
                 <%= link_to "Assign Bibs", assign_bibs_event_group_path(@presenter.event_group), class: "dropdown-item" %>
                 <%= link_to "Manage Photos", manage_entrant_photos_event_group_path(@presenter.event_group), class: "dropdown-item" %>
+                <%= link_to "Manage Start Times", manage_start_times_event_group_path(@presenter.event_group), class: "dropdown-item" %>
                 <div class="dropdown-divider"></div>
                 <%= link_to "Export", efforts_path(filter: { event_id: @presenter.events.ids }, format: :csv), class: "dropdown-item" %>
                 <div class="dropdown-divider"></div>

--- a/app/views/event_groups/_form_start_time_actual.html.erb
+++ b/app/views/event_groups/_form_start_time_actual.html.erb
@@ -1,0 +1,24 @@
+<%= turbo_frame_tag [event_id, scheduled_start_time.to_i] do %>
+  <%= form_with(url: start_efforts_event_group_path(@event_group, filter: { id: effort_ids }),
+                method: :patch,
+                data: { turbo: false }) do |f| %>
+    <div class="row">
+      <div class="col-12 col-md-7">
+        <%= f.label :actual, class: "font-weight-bold" %>
+        <%= f.text_field :actual_start_time,
+                         value: l(scheduled_start_time.in_time_zone(@event_group.home_time_zone), format: :datetime_input),
+                         class: "form-control",
+                         autofocus: true %>
+      </div>
+
+      <div class="col-12 col-md-5 text-end">
+        <br/>
+        <%= button_tag type: "submit", class: "btn btn-outline-primary align-top" do %>
+          <%= fa_icon("check-circle") %>
+        <% end %>
+
+        <%= link_to fa_icon("times-circle"), manage_start_times_event_group_path(@event_group), class: "btn btn-outline-secondary" %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/event_groups/manage_start_times.html.erb
+++ b/app/views/event_groups/manage_start_times.html.erb
@@ -1,0 +1,71 @@
+<% content_for :title do %>
+  <% "OpenSplitTime: Manage Start Times - #{@presenter.event_group.name}" %>
+<% end %>
+
+<%= render "shared/mode_widget", event_group: @presenter.event_group %>
+
+<header class="ost-header">
+  <div class="container">
+    <div class="ost-heading row">
+      <div class="col">
+        <div class="ost-title">
+          <h1>
+            <strong><%= name_with_concealed_indicator(@presenter) %></strong>
+            <%= construction_status_badge(@presenter.status) %>
+          </h1>
+          <ul class="breadcrumb breadcrumb-ost">
+            <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
+            <li class="breadcrumb-item"><%= link_to @presenter.organization.name, organization_path(@presenter.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to @presenter.event_group.name, event_group_path(@presenter.event_group) %></li>
+            <li class="breadcrumb-item"><%= link_to "Setup", setup_event_group_path(@presenter.event_group, display_style: :entrants) %></li>
+            <li class="breadcrumb-item">Manage Start Times</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+
+<article class="ost-article container">
+  <div class="row">
+    <div class="col-12">
+      <% @presenter.events.order(:scheduled_start_time).each do |event| %>
+        <div class="row my-3 px-2 pt-2 pb-0 bg-light border-bottom border-secondary">
+          <h3 class="font-weight-bold"><%= event.short_name %></h3>
+        </div>
+        <% event.efforts.order(:bib_number).group_by(&:assumed_start_time_local).each do |start_time, efforts| %>
+          <div class="row my-3 px-2 pt-2 pb-1 bg-light">
+            <div class="col-6">
+              <span class="font-weight-bold"><%= l(start_time, format: :datetime_input) %></span>
+            </div>
+            <div class="col-3">
+              <span class="font-weight-bold">Scheduled</span>
+            </div>
+            <div class="col-3">
+              <span class="font-weight-bold">Actual</span>
+            </div>
+          </div>
+          <% efforts.each do |effort| %>
+            <div class="card my-1">
+              <div class="card-body px-3 py-2">
+                <div class="row">
+                  <div class="col-6">
+                    <span><%= "#{effort.full_name} ##{effort.bib_number}" %></span>
+                  </div>
+                  <div class="col-3">
+                    <span><%= l(effort.assumed_start_time_local, format: :datetime_input) %></span>
+                  </div>
+                  <div class="col-3">
+                    <% if effort.actual_start_time.present? %>
+                      <span><%= l(effort.actual_start_time_local, format: :datetime_input) %></span>
+                    <% end %>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</article>

--- a/app/views/event_groups/manage_start_times.html.erb
+++ b/app/views/event_groups/manage_start_times.html.erb
@@ -33,30 +33,38 @@
         <div class="row my-3 px-2 pt-2 pb-0 bg-light border-bottom border-secondary">
           <h3 class="font-weight-bold"><%= event.short_name %></h3>
         </div>
-        <% event.efforts.order(:bib_number).group_by(&:assumed_start_time_local).each do |start_time, efforts| %>
+        <% event.efforts.order(:bib_number).group_by(&:assumed_start_time).each do |start_time, efforts| %>
           <div class="row my-3 px-2 pt-2 pb-1 bg-light">
-            <div class="col-6">
-              <span class="font-weight-bold"><%= l(start_time, format: :datetime_input) %></span>
+            <div class="col-4">
+              <span class="font-weight-bold"><%= l(start_time.in_time_zone(@presenter.home_time_zone), format: :datetime_input) %></span>
             </div>
-            <div class="col-3">
+            <div class="col-4">
               <span class="font-weight-bold">Scheduled</span>
             </div>
-            <div class="col-3">
-              <span class="font-weight-bold">Actual</span>
-              <span><%= link_to "Change", start_efforts_event_group_path(@event_group) %></span>
+            <div class="col-4">
+              <%= turbo_frame_tag [event.id, start_time.to_i] do %>
+                <span class="font-weight-bold">Actual</span>
+                <span class="mx-2">
+                <%= link_to(
+                      fa_icon("pencil-alt"),
+                      manage_start_times_edit_actual_event_group_path(@event_group, event_id: event.id, scheduled_start_time: start_time, effort_ids: efforts.map(&:id)),
+                      class: "btn btn-sm btn-outline-primary"
+                    ) %>
+                </span>
+              <% end %>
             </div>
           </div>
           <% efforts.each do |effort| %>
             <div class="card my-1">
               <div class="card-body px-3 py-2">
                 <div class="row">
-                  <div class="col-6">
+                  <div class="col-4">
                     <span><%= "#{effort.full_name} ##{effort.bib_number}" %></span>
                   </div>
-                  <div class="col-3">
+                  <div class="col-4">
                     <span><%= l(effort.assumed_start_time_local, format: :datetime_input) %></span>
                   </div>
-                  <div class="col-3">
+                  <div class="col-4">
                     <% if effort.actual_start_time.present? %>
                       <span><%= l(effort.actual_start_time_local, format: :datetime_input) %></span>
                     <% end %>

--- a/app/views/event_groups/manage_start_times.html.erb
+++ b/app/views/event_groups/manage_start_times.html.erb
@@ -43,6 +43,7 @@
             </div>
             <div class="col-3">
               <span class="font-weight-bold">Actual</span>
+              <span><%= link_to "Change", start_efforts_event_group_path(@event_group) %></span>
             </div>
           </div>
           <% efforts.each do |effort| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,7 @@ Rails.application.routes.draw do
       get :follow
       get :link_lotteries
       get :manage_entrant_photos
+      get :manage_start_times
       get :raw_times
       get :reconcile
       get :roster

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,7 @@ Rails.application.routes.draw do
       get :link_lotteries
       get :manage_entrant_photos
       get :manage_start_times
+      get :manage_start_times_edit_actual
       get :raw_times
       get :reconcile
       get :roster

--- a/spec/services/interactors/start_efforts_spec.rb
+++ b/spec/services/interactors/start_efforts_spec.rb
@@ -112,15 +112,18 @@ RSpec.describe Interactors::StartEfforts do
         let(:subject_efforts) { [efforts(:sum_55k_not_started), efforts(:sum_100k_progress_cascade)] }
         let(:start_time) { "2017-09-23 08:00:00" }
 
-        it "creates starting split_times only for the effort that needs one, and returns a successful response" do
-          effort_2_start_time = subject_efforts.second.starting_split_time.absolute_time
+        it "creates or updates starting split times as needed" do
           expect { subject.perform! }.to change { SplitTime.count }.by(1)
 
           subject_efforts.each(&:reload)
           split_times = subject_efforts.map(&:starting_split_time)
           expect(split_times).to all be_present
           expect(split_times.first.absolute_time).to eq(start_time.in_time_zone(home_time_zone))
-          expect(split_times.second.absolute_time).to eq(effort_2_start_time)
+          expect(split_times.second.absolute_time).to eq(start_time.in_time_zone(home_time_zone))
+        end
+
+        it "returns a successful response" do
+          expect(subject.perform!).to be_successful
         end
       end
     end

--- a/spec/system/manage_start_times_spec.rb
+++ b/spec/system/manage_start_times_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Manage start times", type: :system do
+  let(:page_path) { manage_start_times_event_group_path(event_group) }
+
+  let(:owner) { users(:fourth_user) }
+  let(:steward) { users(:fifth_user) }
+  let(:admin) { users(:admin_user) }
+
+  before do
+    organization.update(created_by: owner.id)
+    organization.stewards << steward
+  end
+
+  let(:organization) { organizations(:running_up_for_air) }
+  let(:event_group) { event_groups(:rufa_2017) }
+  let(:event) { events(:rufa_2017_12h) }
+  let(:scheduled_start_time) { "2017-02-11 07:00:00".in_time_zone(event_group.home_time_zone) }
+  let(:updated_actual_start_time_text) { "02/11/2017 07:01:23" }
+
+  scenario "The user is a visitor" do
+    verify_unable_to_visit_page
+  end
+
+  scenario "The user is a steward" do
+    login_as steward, scope: :user
+    verify_manage_start_times_flow
+  end
+
+  scenario "The user owns the organization" do
+    login_as owner, scope: :user
+    verify_manage_start_times_flow
+  end
+
+  scenario "The user is an admin" do
+    login_as admin, scope: :user
+    verify_manage_start_times_flow
+  end
+
+  private
+
+  def verify_unable_to_visit_page
+    visit page_path
+    expect(page).to have_current_path(root_path)
+  end
+
+  def verify_manage_start_times_flow
+    visit page_path
+    expect(page).to have_text "Manage Start Times"
+    turbo_frame = find("turbo-frame", id: "#{event.id}_#{scheduled_start_time.to_i}")
+    edit_button = turbo_frame.find("a")
+
+    # Test the cancel button
+    edit_button.click
+    fill_in "actual_start_time", with: updated_actual_start_time_text
+    cancel_button = turbo_frame.find_link(href: page_path)
+
+    expect { cancel_button.click }.not_to change { SplitTime.count }
+    efforts = event.efforts.where(scheduled_start_time: scheduled_start_time)
+    efforts.each do |effort|
+      if effort.name.include?("Not Started")
+        expect(effort.actual_start_time).to be_nil
+      else
+        expect(effort.actual_start_time).to eq(scheduled_start_time)
+      end
+    end
+
+    # Test the submit button
+    edit_button.click
+    fill_in "actual_start_time", with: updated_actual_start_time_text
+    submit_button = turbo_frame.find('button[type="submit"]')
+
+    expect { submit_button.click }.to change { SplitTime.count }.by(1)
+    efforts = event.efforts.where(scheduled_start_time: scheduled_start_time)
+    efforts.each { |effort| expect(effort.actual_start_time).to eq(updated_actual_start_time_text.in_time_zone(event_group.home_time_zone)) }
+  end
+end


### PR DESCRIPTION
Currently, once runners are started, there is no way to change start times in bulk.

This PR adds a Start Times Manager view that provides the ability to change start times for a group of runners. Runners are grouped by event and by scheduled start time. 

Begins to address #599 