### PR TITLE
Manage Start Times | Group efforts by actual start time

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -289,7 +289,7 @@ class EventGroupsController < ApplicationController
 
     render partial: "form_start_time_actual", locals: {
       event_id: params[:event_id],
-      scheduled_start_time: params[:scheduled_start_time].to_datetime,
+      actual_start_time: params[:actual_start_time]&.to_datetime,
       effort_ids: params[:effort_ids],
     }
   end

--- a/app/views/event_groups/_form_start_time_actual.html.erb
+++ b/app/views/event_groups/_form_start_time_actual.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag [event_id, scheduled_start_time.to_i] do %>
+<%= turbo_frame_tag [event_id, actual_start_time.to_i] do %>
   <%= form_with(url: start_efforts_event_group_path(@event_group, filter: { id: effort_ids }),
                 method: :patch,
                 data: { turbo: false }) do |f| %>
@@ -6,7 +6,7 @@
       <div class="col-12 col-md-7">
         <%= f.label :actual, class: "font-weight-bold" %>
         <%= f.text_field :actual_start_time,
-                         value: l(scheduled_start_time.in_time_zone(@event_group.home_time_zone), format: :datetime_input),
+                         value: actual_start_time.present? ? l(actual_start_time.in_time_zone(@event_group.home_time_zone), format: :datetime_input) : nil,
                          class: "form-control",
                          autofocus: true %>
       </div>

--- a/app/views/event_groups/manage_start_times.html.erb
+++ b/app/views/event_groups/manage_start_times.html.erb
@@ -33,10 +33,10 @@
         <div class="row my-3 px-2 pt-2 pb-0 bg-light border-bottom border-secondary">
           <h3 class="font-weight-bold"><%= event.short_name %></h3>
         </div>
-        <% event.efforts.order(:bib_number).group_by(&:assumed_start_time).each do |start_time, efforts| %>
+        <% event.efforts.roster_subquery.order(:actual_start_time, :bib_number).group_by(&:actual_start_time).each do |start_time, efforts| %>
           <div class="row my-3 px-2 pt-2 pb-1 bg-light">
             <div class="col-4">
-              <span class="font-weight-bold"><%= l(start_time.in_time_zone(@presenter.home_time_zone), format: :datetime_input) %></span>
+              <span class="font-weight-bold"><%= start_time.present? ? "Started #{l(start_time.in_time_zone(@presenter.home_time_zone), format: :datetime_input)}" : "Not started" %></span>
             </div>
             <div class="col-4">
               <span class="font-weight-bold">Scheduled</span>
@@ -47,7 +47,7 @@
                 <span class="mx-2">
                 <%= link_to(
                       fa_icon("pencil-alt"),
-                      manage_start_times_edit_actual_event_group_path(@event_group, event_id: event.id, scheduled_start_time: start_time, effort_ids: efforts.map(&:id)),
+                      manage_start_times_edit_actual_event_group_path(@event_group, event_id: event.id, actual_start_time: start_time, effort_ids: efforts.map(&:id)),
                       class: "btn btn-sm btn-outline-primary"
                     ) %>
                 </span>

--- a/spec/system/manage_start_times_spec.rb
+++ b/spec/system/manage_start_times_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Manage start times", type: :system do
     fill_in "actual_start_time", with: updated_actual_start_time_text
     cancel_button = turbo_frame.find_link(href: page_path)
 
-    expect { submit_button.click }.not_to change { SplitTime.count }
+    expect { cancel_button.click }.not_to change { SplitTime.count }
     efforts = event.efforts.roster_subquery.where(actual_start_time: actual_start_time)
     efforts.each { |effort| expect(effort.actual_start_time).to eq(actual_start_time) }
 
@@ -98,7 +98,7 @@ RSpec.describe "Manage start times", type: :system do
     fill_in "actual_start_time", with: updated_actual_start_time_text
     submit_button = turbo_frame.find('button[type="submit"]')
 
-    expect { cancel_button.click }.to change { SplitTime.count }.by(1)
+    expect { submit_button.click }.to change { SplitTime.count }.by(1)
     efforts = event.efforts.roster_subquery.where(actual_start_time: actual_start_time)
     efforts.each { |effort| expect(effort.actual_start_time).to eq(updated_actual_start_time_text.in_time_zone(event_group.home_time_zone)) }
   end


### PR DESCRIPTION
In the PR that introduced Manage Start Times (#827), start times are grouped by scheduled start time, and all adjustments must be made to the group based on scheduled start time. The problem with this is that there will generally be unstarted efforts (DNS) that have the same scheduled start time as started efforts, and these DNS efforts will inadvertently be started when using the Manage Start Times view.

This PR changes the view to group efforts by actual start time instead, allowing the RD to change start times for just those efforts that were started at a particular time.