### PR TITLE
Use matchable bib number when rebuilding efforts

### DIFF
--- a/app/services/interactors/rebuild_effort_times.rb
+++ b/app/services/interactors/rebuild_effort_times.rb
@@ -85,8 +85,10 @@ module Interactors
     end
 
     def ordered_raw_times
-      @raw_times = RawTime.where(event_group_id: event_group.id, bib_number: effort.bib_number).with_relation_ids
-          .select(&:absolute_time).sort_by(&:absolute_time)
+      @raw_times = RawTime.where(event_group_id: event_group.id, matchable_bib_number: effort.bib_number)
+                          .with_relation_ids
+                          .select(&:absolute_time)
+                          .sort_by(&:absolute_time)
     end
 
     def validate_setup


### PR DESCRIPTION
We need to account for possible leading zeros when matching bib numbers in an effort rebuild. This PR changes the logic to look at `matchable_bib_number` instead of `bib_number` when selecting raw times for an effort rebuild.

Resolves #831 