### PR TITLE
Rework RawTime.with_relation_ids query

### DIFF
--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -38,7 +38,7 @@ class RawTime < ApplicationRecord
   }
 
   def self.with_relation_ids(args = {})
-    query = RawTimeQuery.with_relations(args)
+    query = RawTimeQuery.with_relations(self, args)
     find_by_sql(query)
   end
 


### PR DESCRIPTION
This PR makes some improvements to the `with_relation_ids` query:

- Ignores which aid stations are enabled and just assigns a split_id if there is a match
- Uses proper scoping in preparation for moving to a subquery approach that returns an ActiveRecord Relation

Should resolve #833 