### PR TITLE
Filter by event id and actual start time instead of effort ids

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -290,7 +290,6 @@ class EventGroupsController < ApplicationController
     render partial: "form_start_time_actual", locals: {
       event_id: params[:event_id],
       actual_start_time: params[:actual_start_time]&.to_datetime,
-      effort_ids: params[:effort_ids],
     }
   end
 

--- a/app/views/event_groups/_form_start_time_actual.html.erb
+++ b/app/views/event_groups/_form_start_time_actual.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag [event_id, actual_start_time.to_i] do %>
-  <%= form_with(url: start_efforts_event_group_path(@event_group, filter: { id: effort_ids }),
+  <%= form_with(url: start_efforts_event_group_path(@event_group, filter: { event_id: event_id, actual_start_time: actual_start_time }),
                 method: :patch,
                 data: { turbo: false }) do |f| %>
     <div class="row">

--- a/app/views/event_groups/manage_start_times.html.erb
+++ b/app/views/event_groups/manage_start_times.html.erb
@@ -47,7 +47,7 @@
                 <span class="mx-2">
                 <%= link_to(
                       fa_icon("pencil-alt"),
-                      manage_start_times_edit_actual_event_group_path(@event_group, event_id: event.id, actual_start_time: start_time, effort_ids: efforts.map(&:id)),
+                      manage_start_times_edit_actual_event_group_path(@event_group, event_id: event.id, actual_start_time: start_time),
                       class: "btn btn-sm btn-outline-primary"
                     ) %>
                 </span>


### PR DESCRIPTION
This PR changes the logic in the Manage Start Times flow to filter by event id and actual start time instead of effort ids in the form partial.

Should address #835 