### PR TITLE
Restrict Node to v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.7.4",
     "webpack-dev-server": "^4.5.0"
+  },
+  "engines": {
+    "node": "16.x"
   }
 }


### PR DESCRIPTION
Builds are currently failing on Heroku because Node 18.x doesn't like the version of webpack we are running.

This PR restricts Node to 16.x.

This failure highlights the need to move OpenSplitTime off of webpacker and onto jsbundling-rails with webpack or, better yet, with esbuild.