### PR TITLE
Add finish count to the course group best efforts export

### DIFF
--- a/app/controllers/course_group_best_efforts_controller.rb
+++ b/app/controllers/course_group_best_efforts_controller.rb
@@ -25,7 +25,7 @@ class CourseGroupBestEffortsController < ApplicationController
     authorize @organization
 
     @presenter = ::CourseGroupBestEffortsDisplay.new(@course_group, view_context)
-    sql_string = @presenter.filtered_segments_unpaginated.to_sql
+    sql_string = @presenter.filtered_segments_unpaginated.finish_count_subquery.to_sql
 
     ::ExportAsyncJob.perform_later(current_user.id, controller_name, "BestEffortSegment", sql_string)
 

--- a/app/models/best_effort_segment.rb
+++ b/app/models/best_effort_segment.rb
@@ -20,6 +20,7 @@ class BestEffortSegment < ::ApplicationRecord
           end_split_id: segment.end_id,
           end_bitkey: segment.end_bitkey)
   }
+  scope :finish_count_subquery, -> { from(::BestEffortSegmentQuery.finish_count_subquery(self)) }
 
   def elapsed_time
     ::TimeConversion.seconds_to_hms(elapsed_seconds)

--- a/app/parameters/best_effort_segment_parameters.rb
+++ b/app/parameters/best_effort_segment_parameters.rb
@@ -15,6 +15,7 @@ class BestEffortSegmentParameters < BaseParameters
       course_name
       year_and_lap
       elapsed_time
+      finish_count
     ]
   end
 end

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class BaseQuery
+  def self.full_sql_for_existing_scope(scope)
+    scope.connection.unprepared_statement { scope.reorder(nil).to_sql }
+  end
+
   def self.sql_safe_integer_list(array)
     array.flatten.compact.map(&:to_i).join(",")
   end

--- a/app/queries/best_effort_segment_query.rb
+++ b/app/queries/best_effort_segment_query.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class BestEffortSegmentQuery < BaseQuery
+  # @param [ActiveRecord::ActiveRecordRelation] existing_scope
+  # @return [String]
+  def self.finish_count_subquery(existing_scope)
+    existing_scope_subquery = full_sql_for_existing_scope(existing_scope)
+
+    <<~SQL.squish
+      (with existing_scope as (
+              #{existing_scope_subquery}
+            ),
+
+      effort_counts as (
+        select person_id, count(*) as finish_count
+        from existing_scope
+        group by person_id
+      )
+
+      select existing_scope.*, effort_counts.finish_count
+      from existing_scope
+        join effort_counts using (person_id)) best_effort_segments
+    SQL
+  end
+end

--- a/app/queries/effort_query.rb
+++ b/app/queries/effort_query.rb
@@ -155,10 +155,6 @@ class EffortQuery < BaseQuery
     scope.connection.unprepared_statement { scope.reorder(nil).select("id").to_sql }
   end
 
-  def self.full_sql_for_existing_scope(scope)
-    scope.connection.unprepared_statement { scope.reorder(nil).to_sql }
-  end
-
   def self.permitted_column_names
     EffortParameters.enriched_query
   end


### PR DESCRIPTION
This PR adds a finish count to the course group best efforts export. 

The operation is pretty expensive, so let's not add it to the course group best efforts index view at this point.