### PR TITLE
Use rank instead of row_number in DatabaseRankable module

### DIFF
--- a/app/models/concerns/database_rankable.rb
+++ b/app/models/concerns/database_rankable.rb
@@ -8,14 +8,14 @@ module DatabaseRankable
       raise ArgumentError, "One or more ranking attributes must be provided" unless attributes.present?
 
       order_string = attributes.join(", ")
-      select("*, row_number() over (order by #{order_string}) as overall_rank, row_number() over (partition by gender order by #{order_string}) as gender_rank")
+      select("*, rank() over (order by #{order_string}) as overall_rank, rank() over (partition by gender order by #{order_string}) as gender_rank")
     }
 
     scope :with_overall_gender_and_event_rank, lambda { |*attributes|
       raise ArgumentError, "One or more ranking attributes must be provided" unless attributes.present?
 
       order_string = attributes.join(", ")
-      select("*, row_number() over (order by #{order_string}) as overall_rank, row_number() over (partition by gender order by #{order_string}) as gender_rank, row_number() over (partition by event_id order by #{order_string}) as event_rank")
+      select("*, rank() over (order by #{order_string}) as overall_rank, rank() over (partition by gender order by #{order_string}) as gender_rank, rank() over (partition by event_id order by #{order_string}) as event_rank")
     }
   end
 end


### PR DESCRIPTION
Currently, the Best Efforts views are showing identical times with different overall ranks:

![Screenshot 2022-11-20 at 7 24 48 AM](https://user-images.githubusercontent.com/14797300/202907708-851145cd-0115-4e6f-8355-0f75bf0bf523.png)

This is inconsistent with how we are displaying overall ranks on the event spread view.

![Screenshot 2022-11-20 at 7 27 25 AM](https://user-images.githubusercontent.com/14797300/202907855-e61b0bcb-80bf-45c3-acb8-b0a0eb4e3b94.png)

This PR changes the `DatabaseRankable` module to use `rank()` instead of `row_number()`, making these rankings consistent.