### PR TITLE
Create links to course group finishers view

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -200,16 +200,24 @@ module DropdownHelper
     ]
 
     view_object.course_groups.each do |course_group|
+      item = { role: :separator }
+      dropdown_items << item
+
       item = { name: "All-time best (#{course_group.name})",
                link: organization_course_group_best_efforts_path(view_object.organization, course_group) }
       dropdown_items << item
+
+      item = { name: "All finishers (#{course_group.name})",
+               link: organization_course_group_finishers_path(view_object.organization, course_group) }
+      dropdown_items << item
     end
 
-    dropdown_items += [{ role: :separator },
-     { name: "Plan my effort",
-       link: plan_effort_course_path(view_object.course) },
-     { name: "Cutoff analysis",
-       link: cutoff_analysis_course_path(view_object.course) },
+    dropdown_items += [
+      { role: :separator },
+      { name: "Plan my effort",
+        link: plan_effort_course_path(view_object.course) },
+      { name: "Cutoff analysis",
+        link: cutoff_analysis_course_path(view_object.course) },
     ]
     build_dropdown_menu("Explore", dropdown_items, button: true)
   end

--- a/app/views/course_groups/show.html.erb
+++ b/app/views/course_groups/show.html.erb
@@ -28,8 +28,11 @@
     <div class="row">
       <div class="form-inline">
         <div>
-          <%= link_to "All-time Finishers",
+          <%= link_to "All-time best",
                       organization_course_group_best_efforts_path(@presenter.organization, @presenter.course_group),
+                      class: "btn btn-primary" %>
+          <%= link_to "All finishers",
+                      organization_course_group_finishers_path(@presenter.organization, @presenter.course_group),
                       class: "btn btn-primary" %>
           <% if current_user&.authorized_to_edit?(@presenter.course_group) %>
             <%= course_group_actions_dropdown_menu(@presenter) %>

--- a/app/views/organizations/_course_groups_list.html.erb
+++ b/app/views/organizations/_course_groups_list.html.erb
@@ -14,8 +14,11 @@
       </td>
       <td><%= course_group.courses.pluck(:name).join(", ") %></td>
       <td class="text-right">
-        <%= link_to "All-time Finishers",
+        <%= link_to "All-time best",
                     organization_course_group_best_efforts_path(course_group.organization, course_group),
+                    class: "btn btn-primary" %>
+        <%= link_to "All finishers",
+                    organization_course_group_finishers_path(course_group.organization, course_group),
                     class: "btn btn-primary" %>
       </td>
     </tr>


### PR DESCRIPTION
This PR adds links to the Course Group Finishers page from the Event Spread view, the Course Group Show view, and the Organization > Courses view.

Resolves #864