### PR TITLE
Return to organization page from event group setup when no events are present

### DIFF
--- a/app/views/shared/_mode_widget.html.erb
+++ b/app/views/shared/_mode_widget.html.erb
@@ -8,7 +8,7 @@
       </div>
       <div class="col text-right">
         <%= link_to "Return to monitor mode",
-                    event_group.persisted? ? roster_event_group_path(event_group) : organization_path(event_group.organization),
+                    event_group.persisted? && event_group.events.exists? ? roster_event_group_path(event_group) : organization_path(event_group.organization),
                     class: "btn btn-outline-light" %>
       </div>
     </div>


### PR DESCRIPTION
Currently, the "Return to monitor mode" button is broken when no events are present on an event group.

This PR links that button to the organizations/show page when no events are present.

Resolved #869 