### PR TITLE
Add entrant ids to lottery simulation results

### DIFF
--- a/app/models/lottery_simulation.rb
+++ b/app/models/lottery_simulation.rb
@@ -5,16 +5,25 @@ class LotterySimulation < ApplicationRecord
 
   def build
     results_array = simulation_run.divisions.ordered_by_name.map do |division|
+      accepted_male_ids = ::LotteryEntrant.from(division.accepted_entrants, :lottery_entrants).male.order(:drawn_at).pluck(:id)
+      accepted_female_ids = ::LotteryEntrant.from(division.accepted_entrants, :lottery_entrants).female.order(:drawn_at).pluck(:id)
+      wait_list_male_ids = ::LotteryEntrant.from(division.wait_list_entrants, :lottery_entrants).male.order(:drawn_at).pluck(:id)
+      wait_list_female_ids = ::LotteryEntrant.from(division.wait_list_entrants, :lottery_entrants).female.order(:drawn_at).pluck(:id)
+
       [
         division.name,
         {
           accepted: {
-            male: ::LotteryEntrant.from(division.accepted_entrants, :lottery_entrants).male.count,
-            female: ::LotteryEntrant.from(division.accepted_entrants, :lottery_entrants).female.count,
+            male: accepted_male_ids.size,
+            male_entrant_ids: accepted_male_ids,
+            female: accepted_female_ids.size,
+            female_entrant_ids: accepted_female_ids,
           },
           wait_list: {
-            male: ::LotteryEntrant.from(division.wait_list_entrants, :lottery_entrants).male.count,
-            female: ::LotteryEntrant.from(division.wait_list_entrants, :lottery_entrants).female.count,
+            male: wait_list_male_ids.size,
+            male_entrant_ids: wait_list_male_ids,
+            female: wait_list_female_ids.size,
+            female_entrant_ids: wait_list_female_ids,
           }
         }
       ]

--- a/spec/lib/simulations/runner_spec.rb
+++ b/spec/lib/simulations/runner_spec.rb
@@ -17,16 +17,46 @@ RSpec.describe LotterySimulations::Runner do
       let(:expected_results) do
         {
           "Elses" => {
-            "accepted" => {"male" => anything, "female" => anything},
-            "wait_list" => {"male" => anything, "female" => anything},
+            "accepted" => {
+              "male" => anything,
+              "male_entrant_ids" => anything,
+              "female" => anything,
+              "female_entrant_ids" => anything,
+            },
+            "wait_list" => {
+              "male" => anything,
+              "male_entrant_ids" => anything,
+              "female" => anything,
+              "female_entrant_ids" => anything,
+            },
           },
           "Never Ever Evers" => {
-            "accepted" => {"male" => anything, "female" => anything},
-            "wait_list" => {"male" => anything, "female" => anything},
+            "accepted" => {
+              "male" => anything,
+              "male_entrant_ids" => anything,
+              "female" => anything,
+              "female_entrant_ids" => anything,
+            },
+            "wait_list" => {
+              "male" => anything,
+              "male_entrant_ids" => anything,
+              "female" => anything,
+              "female_entrant_ids" => anything,
+            },
           },
           "Veterans" => {
-            "accepted" => {"male" => anything, "female" => anything},
-            "wait_list" => {"male" => anything, "female" => anything},
+            "accepted" => {
+              "male" => anything,
+              "male_entrant_ids" => anything,
+              "female" => anything,
+              "female_entrant_ids" => anything,
+            },
+            "wait_list" => {
+              "male" => anything,
+              "male_entrant_ids" => anything,
+              "female" => anything,
+              "female_entrant_ids" => anything,
+            },
           },
         }
       end
@@ -42,8 +72,8 @@ RSpec.describe LotterySimulations::Runner do
           # Mysteriously, expect(simulation.results).to eq(expected_results) does not work here
           lottery.divisions.each do |division|
             expect(simulation.results[division.name].keys).to eq(expected_results[division.name].keys)
-            expect(simulation.results.dig(division.name, "accepted").keys).to eq(expected_results.dig(division.name, "accepted").keys)
-            expect(simulation.results.dig(division.name, "wait_list").keys).to eq(expected_results.dig(division.name, "wait_list").keys)
+            expect(simulation.results.dig(division.name, "accepted").keys).to match_array(expected_results.dig(division.name, "accepted").keys)
+            expect(simulation.results.dig(division.name, "wait_list").keys).to match_array(expected_results.dig(division.name, "wait_list").keys)
           end
         end
       end

--- a/spec/models/lottery_simulation_spec.rb
+++ b/spec/models/lottery_simulation_spec.rb
@@ -16,16 +16,46 @@ RSpec.describe LotterySimulation, type: :model do
         let(:expected_results) do
           {
             "Elses" => {
-              "accepted" => {"male" => 0, "female" => 2},
-              "wait_list" => {"male" => 0, "female" => 0},
+              "accepted" => {
+                "male" => 0,
+                "male_entrant_ids" => [],
+                "female" => 2,
+                "female_entrant_ids" => [27, 24],
+              },
+              "wait_list" => {
+                "male" => 0,
+                "male_entrant_ids" => [],
+                "female" => 0,
+                "female_entrant_ids" => [],
+              },
             },
             "Never Ever Evers" => {
-              "accepted" => {"male" => 1, "female" => 2},
-              "wait_list" => {"male" => 1, "female" => 1},
+              "accepted" => {
+                "male" => 1,
+                "male_entrant_ids" => [9],
+                "female" => 2,
+                "female_entrant_ids" => [13, 7],
+              },
+              "wait_list" => {
+                "male" => 1,
+                "male_entrant_ids" => [4],
+                "female" => 1,
+                "female_entrant_ids" => [11],
+              },
             },
             "Veterans" => {
-              "accepted" => {"male" => 0, "female" => 0},
-              "wait_list" => {"male" => 0, "female" => 0},
+              "accepted" => {
+                "male" => 0,
+                "male_entrant_ids" => [],
+                "female" => 0,
+                "female_entrant_ids" => [],
+              },
+              "wait_list" => {
+                "male" => 0,
+                "male_entrant_ids" => [],
+                "female" => 0,
+                "female_entrant_ids" => []
+              },
             },
           }
         end
@@ -46,16 +76,46 @@ RSpec.describe LotterySimulation, type: :model do
         let(:expected_results) do
           {
             "Elses" => {
-              "accepted" => {"male" => 0, "female" => 0},
-              "wait_list" => {"male" => 0, "female" => 0},
+              "accepted" => {
+                "male" => 0,
+                "male_entrant_ids" => [],
+                "female" => 0,
+                "female_entrant_ids" => [],
+              },
+              "wait_list" => {
+                "male" => 0,
+                "male_entrant_ids" => [],
+                "female" => 0,
+                "female_entrant_ids" => [],
+              },
             },
             "Never Ever Evers" => {
-              "accepted" => {"male" => 0, "female" => 0},
-              "wait_list" => {"male" => 0, "female" => 0},
+              "accepted" => {
+                "male" => 0,
+                "male_entrant_ids" => [],
+                "female" => 0,
+                "female_entrant_ids" => [],
+              },
+              "wait_list" => {
+                "male" => 0,
+                "male_entrant_ids" => [],
+                "female" => 0,
+                "female_entrant_ids" => [],
+              },
             },
             "Veterans" => {
-              "accepted" => {"male" => 0, "female" => 0},
-              "wait_list" => {"male" => 0, "female" => 0},
+              "accepted" => {
+                "male" => 0,
+                "male_entrant_ids" => [],
+                "female" => 0,
+                "female_entrant_ids" => [],
+              },
+              "wait_list" => {
+                "male" => 0,
+                "male_entrant_ids" => [],
+                "female" => 0,
+                "female_entrant_ids" => []
+              },
             },
           }
         end


### PR DESCRIPTION
Currently, for lottery simulation runs, we are persisting only the counts for male and female accepted and waitlisted entrants.

This PR adds logic to persist the entrant ids for each of those categories.