### PR TITLE
Make lottery partner banners visible when lottery is live

### DIFF
--- a/app/models/lottery.rb
+++ b/app/models/lottery.rb
@@ -11,6 +11,7 @@ class Lottery < ApplicationRecord
   has_many :entrants, through: :divisions
   has_many :tickets, class_name: "LotteryTicket", dependent: :destroy
   has_many :draws, class_name: "LotteryDraw", dependent: :destroy
+  has_many :partners, as: :partnerable
   has_many :simulation_runs, class_name: "LotterySimulationRun", dependent: :destroy
 
   strip_attributes collapse_spaces: true
@@ -89,5 +90,9 @@ class Lottery < ApplicationRecord
 
     ticket_hashes = generate_ticket_hashes(beginning_reference_number: beginning_reference_number)
     LotteryTicket.insert_all(ticket_hashes)
+  end
+
+  def pick_partner_with_banner
+    partners.with_banners.flat_map { |partner| [partner] * partner.weight }.sample
   end
 end

--- a/app/presenters/lottery_presenter.rb
+++ b/app/presenters/lottery_presenter.rb
@@ -82,6 +82,14 @@ class LotteryPresenter < BasePresenter
     end
   end
 
+  def partner_with_banner
+    @partner_with_banner ||= lottery.pick_partner_with_banner
+  end
+
+  def show_partner_banners?
+    lottery.live? && partner_with_banner.present?
+  end
+
   def tickets_not_generated?
     @tickets_not_generated ||= lottery_tickets.empty?
   end

--- a/app/views/lotteries/_partner_banner.html.erb
+++ b/app/views/lotteries/_partner_banner.html.erb
@@ -1,0 +1,3 @@
+<div class="fixed-bottom text-center bg-light py-2">
+  <%= link_to image_tag(partner.banner.variant(:banner_small)), url_with_protocol(partner.banner_link), target: "_blank" %>
+</div>

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -55,7 +55,9 @@
 <article class="ost-article container">
   <% case @presenter.display_style %>
   <% when "entrants" %>
-    <h4 class="mt-5"><strong><%= "Lottery Entrants" %></strong><small class="text-muted"><%= " #{pluralize_with_delimiter(@presenter.lottery_entrants.count, 'total entrant')}" %></small></h4>
+    <h4 class="mt-5">
+      <strong><%= "Lottery Entrants" %></strong><small class="text-muted"><%= " #{pluralize_with_delimiter(@presenter.lottery_entrants.count, 'total entrant')}" %></small>
+    </h4>
     <hr/>
     <aside class="ost-toolbar">
       <div class="container">
@@ -79,7 +81,7 @@
         <div class="row">
           <div class="col text-center" data-infinite-scroll-target="link">
             <% if @presenter.next_page_url.present? %>
-              <%= link_to "Show More", @presenter.next_page_url, data: {action: "infinite-scroll#loadFromClick"} %>
+              <%= link_to "Show More", @presenter.next_page_url, data: { action: "infinite-scroll#loadFromClick" } %>
             <% else %>
               <p>End of List</p>
             <% end %>
@@ -165,3 +167,7 @@
     <% end %>
   <% end %>
 </article>
+
+<% if @presenter.show_partner_banners? %>
+  <%= render "partner_banner", partner: @presenter.partner_with_banner %>
+<% end %>


### PR DESCRIPTION
This PR contains the most basic code needed to get lottery partners showing on the live draws page.

Addresses a portion of #873 