### PR TITLE
Partnerable module and lottery partner CRUD

### DIFF
--- a/app/controllers/lotteries/partners_controller.rb
+++ b/app/controllers/lotteries/partners_controller.rb
@@ -2,14 +2,18 @@
 
 module Lotteries
   class PartnersController < ::PartnersController
+    def index
+      @presenter = ::LotteryPresenter.new(@partnerable, view_context)
+    end
+
     private
 
     def partnerable_path
-      setup_organization_lottery_path(@partner.organization, @partner.partnerable)
+      organization_lottery_partners_path(@partner.organization, @partner.partnerable)
     end
 
     def set_partnerable
-      @partnerable = ::Lottery.find(params[:lottery_id])
+      @partnerable = ::Lottery.friendly.find(params[:lottery_id])
     end
   end
 end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -2,22 +2,20 @@
 
 class PartnersController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_partner, except: [:new, :create]
+  before_action :set_partner, except: [:index, :new, :create]
   before_action :set_partnerable
+  before_action :authorize_organization
   after_action :verify_authorized
 
   def new
     @partner = @partnerable.partners.new
-    authorize @partner
   end
 
   def edit
-    authorize @partner
   end
 
   def create
     @partner = @partnerable.partners.new(permitted_params)
-    authorize @partner
 
     if @partner.save
       redirect_to partnerable_path
@@ -27,8 +25,6 @@ class PartnersController < ApplicationController
   end
 
   def update
-    authorize @partner
-
     if @partner.update(permitted_params)
       redirect_to partnerable_path
     else
@@ -37,14 +33,16 @@ class PartnersController < ApplicationController
   end
 
   def destroy
-    authorize @partner
-
     @partner.destroy
     flash[:success] = "Partner deleted."
     redirect_to partnerable_path
   end
 
   private
+
+  def authorize_organization
+    authorize @partnerable.organization, policy_class: ::PartnerPolicy
+  end
 
   def partnerable_path
     raise NotImplementedError, "partnerable_path must be implemented"

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -22,4 +22,26 @@ module PartnersHelper
                class: "btn btn-primary has-tooltip"}
     link_to fa_icon("pencil-alt"), url, options
   end
+
+  def link_to_lottery_partner_delete(partner)
+    url = organization_lottery_partner_path(partner.organization, partner.partnerable, partner)
+    tooltip = "Delete partner"
+    options = {method: :delete,
+               data: {confirm: "This cannot be undone. Continue?",
+                      toggle: :tooltip,
+                      placement: :bottom,
+                      "original-title" => tooltip},
+               class: "btn btn-danger has-tooltip"}
+    link_to fa_icon("trash"), url, options
+  end
+
+  def link_to_lottery_partner_edit(partner)
+    url = edit_organization_lottery_partner_path(partner.organization, partner.partnerable, partner)
+    tooltip = "Edit partner"
+    options = {data: {toggle: :tooltip,
+                      placement: :bottom,
+                      "original-title" => tooltip},
+               class: "btn btn-primary has-tooltip"}
+    link_to fa_icon("pencil-alt"), url, options
+  end
 end

--- a/app/models/concerns/partnerable.rb
+++ b/app/models/concerns/partnerable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Partnerable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :partners, as: :partnerable
+  end
+
+  def pick_partner_with_banner
+    partners.with_banners.flat_map { |partner| [partner] * partner.weight }.sample
+  end
+end

--- a/app/models/event_group.rb
+++ b/app/models/event_group.rb
@@ -11,6 +11,7 @@ class EventGroup < ApplicationRecord
   include Delegable
   include Concealable
   include Auditable
+  include Partnerable
   extend FriendlyId
 
   strip_attributes collapse_spaces: true
@@ -20,7 +21,6 @@ class EventGroup < ApplicationRecord
   has_many :events, dependent: :destroy
   has_many :efforts, through: :events
   has_many :raw_times, dependent: :destroy
-  has_many :partners, as: :partnerable
   belongs_to :organization
 
   has_many_attached :entrant_photos do |photo|
@@ -74,10 +74,6 @@ class EventGroup < ApplicationRecord
 
   def permit_notifications?
     visible? && available_live?
-  end
-
-  def pick_partner_with_banner
-    partners.with_banners.flat_map { |partner| [partner] * partner.weight }.sample
   end
 
   def split_times

--- a/app/models/lottery.rb
+++ b/app/models/lottery.rb
@@ -5,13 +5,13 @@ class Lottery < ApplicationRecord
   include Delegable
   include Concealable
   include CapitalizeAttributes
+  include Partnerable
 
   belongs_to :organization
   has_many :divisions, class_name: "LotteryDivision", dependent: :destroy
   has_many :entrants, through: :divisions
   has_many :tickets, class_name: "LotteryTicket", dependent: :destroy
   has_many :draws, class_name: "LotteryDraw", dependent: :destroy
-  has_many :partners, as: :partnerable
   has_many :simulation_runs, class_name: "LotterySimulationRun", dependent: :destroy
 
   strip_attributes collapse_spaces: true
@@ -90,9 +90,5 @@ class Lottery < ApplicationRecord
 
     ticket_hashes = generate_ticket_hashes(beginning_reference_number: beginning_reference_number)
     LotteryTicket.insert_all(ticket_hashes)
-  end
-
-  def pick_partner_with_banner
-    partners.with_banners.flat_map { |partner| [partner] * partner.weight }.sample
   end
 end

--- a/app/policies/partner_policy.rb
+++ b/app/policies/partner_policy.rb
@@ -6,14 +6,19 @@ class PartnerPolicy < ApplicationPolicy
     end
   end
 
-  attr_reader :partner
+  attr_reader :organization
 
-  def post_initialize(partner)
-    @partner = partner
+  def post_initialize(organization)
+    verify_authorization_was_delegated(organization, ::Partner)
+    @organization = organization
+  end
+
+  def index?
+    user.authorized_to_edit?(organization) || user.authorized_for_lotteries?(organization)
   end
 
   def new?
-    user.authorized_to_edit?(partner.partnerable) || user.authorized_for_lotteries?(partner.partnerable)
+    index?
   end
 
   def create?

--- a/app/presenters/lottery_presenter.rb
+++ b/app/presenters/lottery_presenter.rb
@@ -3,7 +3,8 @@
 class LotteryPresenter < BasePresenter
   DEFAULT_SORT_HASH = { division_name: :asc, last_name: :asc }.freeze
 
-  attr_reader :lottery, :params, :action_name
+  attr_reader :lottery, :params
+  delegate :action_name, :controller_name, to: :view_context
 
   delegate :concealed?, :divisions, :draws, :entrants, :name, :organization, :scheduled_start_date, :status,
            :tickets, :to_param, to: :lottery
@@ -13,9 +14,6 @@ class LotteryPresenter < BasePresenter
     @lottery = lottery
     @view_context = view_context
     @params = view_context.prepared_params
-    @current_user = view_context.current_user
-    @action_name = view_context.action_name
-    @request = view_context.request
   end
 
   def ordered_divisions
@@ -48,6 +46,10 @@ class LotteryPresenter < BasePresenter
 
   def next_page_url
     view_context.url_for(request.params.merge(page: page + 1)) if records_from_context_count == per_page
+  end
+
+  def partners
+    @partners ||= lottery.partners.order(:name)
   end
 
   def records_from_context
@@ -104,7 +106,8 @@ class LotteryPresenter < BasePresenter
 
   private
 
-  attr_reader :view_context, :current_user, :request
+  attr_reader :view_context
+  delegate :current_user, :request, to: :view_context, private: true
 
   def lottery_entrants_filtered
     lottery_entrants

--- a/app/views/lotteries/_admin_tabs.html.erb
+++ b/app/views/lotteries/_admin_tabs.html.erb
@@ -1,14 +1,14 @@
 <ul class="nav nav-tabs nav-tabs-ost" data-turbo="false">
-  <%= content_tag :li, class: "nav-item #{'active' if presenter.action_name == 'setup'}" do
-    link_to "Setup", setup_organization_lottery_path(presenter.organization, presenter.lottery)
-  end %>
-  <%= content_tag :li, class: "nav-item #{'active' if presenter.action_name == 'draw_tickets'}" do
-    link_to "Draw Tickets", draw_tickets_organization_lottery_path(presenter.organization, presenter.lottery)
-  end %>
-  <%= content_tag :li, class: "nav-item #{'active' if presenter.action_name == 'withdraw_entrants'}" do
-    link_to "Withdraw Entrants", withdraw_entrants_organization_lottery_path(presenter.organization, presenter.lottery)
-  end %>
-  <%= content_tag :li, class: "nav-item #{'active' if presenter.controller_name == 'partners'}" do
-    link_to "Partners", organization_lottery_partners_path(presenter.organization, presenter.lottery)
-  end %>
+  <%= content_tag :li, class: "nav-item #{'active' if presenter.action_name == 'setup'}" do %>
+    <%= link_to "Setup", setup_organization_lottery_path(presenter.organization, presenter.lottery) %>
+  <% end %>
+  <%= content_tag :li, class: "nav-item #{'active' if presenter.action_name == 'draw_tickets'}" do %>
+    <%= link_to "Draw Tickets", draw_tickets_organization_lottery_path(presenter.organization, presenter.lottery) %>
+  <% end %>
+  <%= content_tag :li, class: "nav-item #{'active' if presenter.action_name == 'withdraw_entrants'}" do %>
+    <%= link_to "Withdraw Entrants", withdraw_entrants_organization_lottery_path(presenter.organization, presenter.lottery) %>
+  <% end %>
+  <%= content_tag :li, class: "nav-item #{'active' if presenter.controller_name == 'partners'}" do %>
+    <%= link_to "Partners", organization_lottery_partners_path(presenter.organization, presenter.lottery) %>
+  <% end %>
 </ul>

--- a/app/views/lotteries/_admin_tabs.html.erb
+++ b/app/views/lotteries/_admin_tabs.html.erb
@@ -8,4 +8,7 @@
   <%= content_tag :li, class: "nav-item #{'active' if presenter.action_name == 'withdraw_entrants'}" do
     link_to "Withdraw Entrants", withdraw_entrants_organization_lottery_path(presenter.organization, presenter.lottery)
   end %>
+  <%= content_tag :li, class: "nav-item #{'active' if presenter.controller_name == 'partners'}" do
+    link_to "Partners", organization_lottery_partners_path(presenter.organization, presenter.lottery)
+  end %>
 </ul>

--- a/app/views/lotteries/partners/_partner_list.html.erb
+++ b/app/views/lotteries/partners/_partner_list.html.erb
@@ -1,0 +1,46 @@
+<%# Requires parameter presenter %>
+
+<aside class="ost-toolbar">
+  <div class="container">
+    <div class="row">
+      <div class="col">
+        <%= link_to fa_icon("plus", text: "Add a partner"),
+                    new_organization_lottery_partner_path(presenter.organization, presenter.lottery),
+                    id: "add-partner",
+                    class: "btn btn-success" %>
+      </div>
+    </div>
+  </div>
+</aside>
+
+<% if presenter.partners.present? %>
+  <table class="table table-condensed table-striped">
+    <thead>
+    <tr>
+      <th>Name</th>
+      <th>Banner</th>
+      <th>Banner Link</th>
+      <th>Weight</th>
+      <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% presenter.partners.each do |partner| %>
+      <tr>
+        <td><%= partner.name %></td>
+        <td><%= image_tag partner.banner.variant(:banner_small) if partner.banner.attached? %></td>
+        <td><%= link_to partner.banner_link, url_with_protocol(partner.banner_link), target: "_blank" if partner.banner_link %></td>
+        <td><%= partner.weight %></td>
+        <td>
+          <%= link_to_lottery_partner_edit(partner) %>
+          <%= link_to_lottery_partner_delete(partner) %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+
+<% else %>
+  <br/>
+  <h5>No partners have been added yet.</h5>
+<% end %>

--- a/app/views/lotteries/partners/index.html.erb
+++ b/app/views/lotteries/partners/index.html.erb
@@ -1,0 +1,37 @@
+<% content_for :title do %>
+  <% "OpenSplitTime: Partners for Lottery - #{@presenter.name}" %>
+<% end %>
+
+<header class="ost-header">
+  <div class="container">
+    <div class="ost-heading row">
+      <div class="col">
+        <div class="ost-title">
+          <h1>
+            <strong><%= name_with_concealed_indicator(@presenter) %></strong>
+            <%= lottery_status_badge(@presenter.status) %>
+          </h1>
+          <ul class="breadcrumb breadcrumb-ost">
+            <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
+            <li class="breadcrumb-item"><%= link_to @presenter.organization.name, organization_lotteries_path(@presenter.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to "Lotteries", organization_lotteries_path(@presenter.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to @presenter.name, organization_lottery_path(@presenter.organization, @presenter.lottery) %></li>
+            <li class="breadcrumb-item">Draw Tickets</li>
+          </ul>
+        </div>
+        <div class="ost-subtitle">
+          <p><%= l(@presenter.scheduled_start_date, format: :full_with_weekday) %></p>
+        </div>
+      </div>
+      <aside class="col-auto">
+        <%= link_to "Public", organization_lottery_path(@presenter.organization, @presenter.lottery), class: "btn btn-outline-secondary" %>
+      </aside>
+    </div>
+    <!-- Navigation -->
+    <%= render partial: "lotteries/admin_tabs", locals: { presenter: @presenter } %>
+  </div>
+</header>
+
+<article class="ost-article container">
+  <%= render "partner_list", presenter: @presenter %>
+</article>

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row">
   <div class="col-md-12">
-    <%= form_for([@partner.partnerable, @partner], multipart: true, html: { class: "form-horizontal", role: "form" }) do |f| %>
+    <%= form_for([@partner.organization, @partner.partnerable, @partner], multipart: true, html: { class: "form-horizontal", role: "form" }) do |f| %>
       <div class="form-group required">
         <div class="control-label col-sm-2">
           <%= f.label :name %>
@@ -51,7 +51,7 @@
       </div>
 
       <div class="col-xs-4 col-xs-offset-2">
-        <span class="brackets"><%= link_to "Cancel", polymorphic_path([:setup, @partner.partnerable], display_style: "partners") %></span>
+        <span class="brackets"><%= link_to "Cancel", polymorphic_path([@partner.organization, @partner.partnerable, :partners]) %></span>
       </div>
     <% end %>
   </div>

--- a/app/views/partners/edit.html.erb
+++ b/app/views/partners/edit.html.erb
@@ -15,7 +15,7 @@
           <ul class="breadcrumb breadcrumb-ost">
             <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
             <li class="breadcrumb-item"><%= link_to @partnerable.organization.name, organization_path(@partnerable.organization) %></li>
-            <li class="breadcrumb-item"><%= link_to @partnerable.name, polymorphic_path(@partnerable) %></li>
+            <li class="breadcrumb-item"><%= link_to @partnerable.name, polymorphic_path([@partnerable.organization, @partnerable]) %></li>
             <li class="breadcrumb-item">Partners</li>
             <li class="breadcrumb-item">Edit</li>
           </ul>

--- a/app/views/partners/new.html.erb
+++ b/app/views/partners/new.html.erb
@@ -15,7 +15,7 @@
           <ul class="breadcrumb breadcrumb-ost">
             <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
             <li class="breadcrumb-item"><%= link_to @partnerable.organization.name, organization_path(@partnerable.organization) %></li>
-            <li class="breadcrumb-item"><%= link_to @partnerable.name, polymorphic_path(@partnerable) %></li>
+            <li class="breadcrumb-item"><%= link_to @partnerable.name, polymorphic_path([@partnerable.organization, @partnerable]) %></li>
             <li class="breadcrumb-item">Partners</li>
             <li class="breadcrumb-item">New</li>
           </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,7 +184,7 @@ Rails.application.routes.draw do
         member { post :draw }
       end
       resources :lottery_simulation_runs, only: [:index, :show, :new, :create, :destroy]
-      resources :partners, except: [:index, :show], module: "lotteries"
+      resources :partners, except: [:show], module: "lotteries"
     end
   end
 


### PR DESCRIPTION
This PR introduces a `Partnerable` module and adds routes, controller, and views for lottery partner CRUD actions.

In the process, this PR breaks lottery CRUD for event groups. We will need a follow-up PR to bring event groups in line with the more straightforward pattern used here.