### PR TITLE
Move event_series routes under organizations namespace

### DIFF
--- a/app/controllers/event_series_controller.rb
+++ b/app/controllers/event_series_controller.rb
@@ -1,9 +1,9 @@
 class EventSeriesController < ApplicationController
-  before_action :authenticate_user!, except: [:show]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_organization
-  before_action :authorize_organization
+  before_action :authorize_organization, except: [:index, :show]
   before_action :set_event_series, except: [:index, :new, :create]
-  after_action :verify_authorized, except: [:show]
+  after_action :verify_authorized, except: [:index, :show]
 
   def index
     @presenter = ::OrganizationPresenter.new(@organization, view_context)

--- a/app/controllers/event_series_controller.rb
+++ b/app/controllers/event_series_controller.rb
@@ -1,84 +1,84 @@
 class EventSeriesController < ApplicationController
   before_action :authenticate_user!, except: [:show]
-  before_action :set_event_series, except: [:new, :create]
+  before_action :set_organization
+  before_action :authorize_organization
+  before_action :set_event_series, except: [:index, :new, :create]
   after_action :verify_authorized, except: [:show]
 
+  def index
+    @presenter = ::OrganizationPresenter.new(@organization, view_context)
+  end
+
   def show
-    event_series = EventSeries.where(id: @event_series).includes(:organization, :results_template, events: :efforts).first
-    @presenter = EventSeriesPresenter.new(event_series, params, current_user)
+    event_series = @organization.event_series.where(id: @event_series).includes(events: :efforts).first
+    @presenter = ::EventSeriesPresenter.new(event_series, view_context)
   end
 
   def new
-    organization = Organization.where(id: Organization.friendly.find(params[:organization]))
-        .includes(event_groups: {events: :efforts}).first
+    organization = ::Organization.where(id: @organization.id).includes(event_groups: { events: :efforts }).first
 
-    if organization
-      @event_series = EventSeries.new(organization: organization, results_template: ResultsTemplate.default)
-      authorize @event_series
-    else
-      flash[:warning] = "A new event series must be created using an existing organization"
-      redirect_to organizations_path
-    end
+    @event_series = organization.event_series.new(results_template: ::ResultsTemplate.default)
   end
 
   def edit
-    authorize @event_series
-    @event_series = EventSeries.where(id: @event_series).includes(:organization, events: :efforts).first
+    @event_series = @organization.event_series.where(id: @event_series).includes(events: :efforts).first
   end
 
   def create
     convert_checkbox_event_ids
 
-    @event_series = EventSeries.new(permitted_params)
-    authorize @event_series
+    @event_series = @organization.event_series.new(permitted_params)
 
     if @event_series.save
-      redirect_to @event_series
+      redirect_to organization_event_series_path(@organization, @event_series)
     else
       render "new", status: :unprocessable_entity
     end
   end
 
   def update
-    authorize @event_series
     convert_checkbox_event_ids
 
     if @event_series.update(permitted_params)
-      redirect_to @event_series
+      redirect_to organization_event_series_path(@organization, @event_series)
     else
       render "edit", status: :unprocessable_entity
     end
   end
 
   def destroy
-    authorize @event_series
-
     if @event_series.destroy
       flash[:success] = "Event series deleted."
-      redirect_to_organization
     else
       flash[:danger] = @event_series.errors.full_messages.join("\n")
-      redirect_to_organization
     end
+
+    redirect_to_organization
   end
 
   private
 
-  def convert_checkbox_event_ids
-    if params.dig(:event_series, :event_ids).is_a?(ActionController::Parameters)
-      params[:event_series][:event_ids] = params.dig(:event_series, :event_ids).select { |_, value| value == "1" }.keys
-    end
+  def authorize_organization
+    authorize @organization, policy_class: ::EventSeriesPolicy
   end
 
-  def set_event_series
-    @event_series = EventSeries.friendly.find(params[:id])
+  def convert_checkbox_event_ids
+    event_id_params = params.dig(:event_series, :event_ids)
 
-    if request.path != event_series_path(@event_series)
-      redirect_numeric_to_friendly(@event_series, params[:id])
+    if event_id_params.is_a?(ActionController::Parameters)
+      params[:event_series][:event_ids] = event_id_params.select { |_, value| value == "1" }.keys
     end
   end
 
   def redirect_to_organization
-    redirect_to organization_path(@event_series.organization, display_style: :event_series)
+    redirect_to organization_event_series_index_path(@organization)
+  end
+
+  def set_event_series
+    @event_series = @organization.event_series.friendly.find(params[:id])
+  end
+
+  def set_organization
+    @organization = policy_scope(::Organization).friendly.find(params[:organization_id])
   end
 end

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -256,10 +256,10 @@ module DropdownHelper
   def event_series_actions_dropdown_menu(view_object)
     dropdown_items = [
       { name: "Edit",
-        link: edit_event_series_path(view_object.event_series) },
+        link: edit_organization_event_series_path(view_object.organization, view_object.event_series) },
       { role: :separator },
       { name: "Delete event series",
-        link: event_series_path(view_object.event_series),
+        link: organization_event_series_path(view_object.organization, view_object.event_series),
         method: :delete,
         data: { confirm: "This action cannot be undone. Proceed?" },
         class: "text-danger" }

--- a/app/parameters/event_series_parameters.rb
+++ b/app/parameters/event_series_parameters.rb
@@ -2,6 +2,6 @@
 
 class EventSeriesParameters < BaseParameters
   def self.permitted
-    [:id, :name, :slug, :organization_id, :results_template_id, :scoring_method, {event_ids: []}]
+    [:id, :name, :slug, :results_template_id, :scoring_method, {event_ids: []}]
   end
 end

--- a/app/policies/event_series_policy.rb
+++ b/app/policies/event_series_policy.rb
@@ -14,17 +14,30 @@ class EventSeriesPolicy < ApplicationPolicy
     end
   end
 
-  attr_reader :event_series
+  attr_reader :organization
 
-  def post_initialize(event_series)
-    @event_series = event_series
+  def post_initialize(organization)
+    verify_authorization_was_delegated(organization, ::EventSeries)
+    @organization = organization
   end
 
   def new?
-    event_series.organization && user.authorized_to_edit?(event_series.organization)
+    user.authorized_to_edit?(organization)
+  end
+
+  def edit?
+    new?
   end
 
   def create?
-    event_series.organization && user.authorized_to_edit?(event_series.organization)
+    new?
+  end
+
+  def update?
+    new?
+  end
+
+  def destroy?
+    new?
   end
 end

--- a/app/presenters/event_series_presenter.rb
+++ b/app/presenters/event_series_presenter.rb
@@ -3,13 +3,13 @@
 class EventSeriesPresenter < BasePresenter
   attr_reader :event_series
 
-  delegate :name, :organization, to: :event_series
+  delegate :name, :organization, :scoring_method, to: :event_series
   delegate :results_categories, to: :completed_template
 
-  def initialize(event_series, params, current_user)
+  def initialize(event_series, view_context)
     @event_series = event_series || []
-    @params = params
-    @current_user = current_user
+    @view_context = view_context
+    @params = view_context.prepared_params
   end
 
   def organization_name
@@ -34,10 +34,11 @@ class EventSeriesPresenter < BasePresenter
 
   private
 
-  attr_reader :params, :current_user
+  attr_reader :params, :view_context
 
-  delegate :results_template, :scoring_method, to: :event_series
-  delegate :podium_size, :point_system, to: :results_template
+  delegate :results_template, to: :event_series, private: true
+  delegate :podium_size, :point_system, to: :results_template, private: true
+  delegate :current_user, to: :view_context, private: true
 
   def completed_template
     @completed_template ||= Results::FillEventSeriesTemplate.perform(event_series)

--- a/app/views/event_series/_event_series_list.html.erb
+++ b/app/views/event_series/_event_series_list.html.erb
@@ -9,7 +9,7 @@
   <tbody>
   <% @presenter.event_series.each do |series| %>
       <tr>
-        <td><%= link_to series.name, event_series_path(series) %></td>
+        <td><%= link_to series.name, organization_event_series_path(@presenter.organization, series) %></td>
         <td><%= @presenter.event_date_range(series) %></td>
       </tr>
   <% end %>

--- a/app/views/event_series/_form.html.erb
+++ b/app/views/event_series/_form.html.erb
@@ -1,12 +1,10 @@
-<%= render 'shared/errors', obj: @event_series %>
+<%= render "shared/errors", obj: @event_series %>
 
 <div class="row">
   <div class="col-md-12">
-    <%= form_with(model: @event_series,
+    <%= form_with(model: [@event_series.organization, @event_series],
                   local: true,
-                  html: {class: "form-horizontal", role: "form"}) do |f| %>
-
-      <%= f.hidden_field :organization_id, value: @event_series.organization.id %>
+                  html: { class: "form-horizontal", role: "form" }) do |f| %>
 
       <div class="form-group">
         <div class="control-label col-sm-2">
@@ -29,7 +27,7 @@
               </h5>
             </div>
             <div class="card-body" data-results-template-target="categories">
-              <%= render 'results_templates/categories_card', template: @event_series.results_template %>
+              <%= render "results_templates/categories_card", template: @event_series.results_template %>
             </div>
           </div>
         </div>
@@ -41,7 +39,7 @@
         </div>
         <div class="col-sm-8">
           <%= collection_select(:event_series, :scoring_method, EventSeries.scoring_methods.keys, :to_sym, :titleize,
-                                {prompt: false}, {class: "form-control dropdown-select-field"}) %>
+                                { prompt: false }, { class: "form-control dropdown-select-field" }) %>
         </div>
       </div>
 
@@ -62,14 +60,14 @@
 
       <div class="form-group">
         <div class="col">
-          <%= f.submit(@event_series.new_record? ? 'Create Event Series' : 'Update Event Series', class: 'btn btn-primary btn-large') %>
+          <%= f.submit(@event_series.new_record? ? "Create Event Series" : "Update Event Series", class: "btn btn-primary btn-large") %>
         </div>
       </div>
       <div class="col">
         <span class="brackets">
-          <%= link_to 'Cancel', @event_series.new_record? ?
-                                    organization_path(@event_series.organization, display_style: 'event_series') :
-                                    event_series_path(@event_series) %>
+          <%= link_to "Cancel", @event_series.new_record? ?
+                                  organization_event_series_index_path(@event_series.organization) :
+                                  organization_event_series_path(@event_series.organization, @event_series) %>
         </span>
       </div>
     <% end %>

--- a/app/views/event_series/edit.html.erb
+++ b/app/views/event_series/edit.html.erb
@@ -9,9 +9,10 @@
         <div class="ost-title">
           <h1><strong>Edit Event Series - <%= @event_series.name %></strong></h1>
           <ul class="breadcrumb breadcrumb-ost">
-            <li class="breadcrumb-item"><%= link_to 'Organizations', organizations_path %></li>
-            <li class="breadcrumb-item"><%= link_to @event_series.organization.name, organization_path(@event_series.organization, display_style: :event_series) %></li>
-            <li class="breadcrumb-item"><%= link_to @event_series.name, event_series_path(@event_series) %></li>
+            <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
+            <li class="breadcrumb-item"><%= link_to @event_series.organization.name, organization_path(@event_series.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to "Event Series", organization_event_series_index_path(@event_series.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to @event_series.name, organization_event_series_path(@event_series.organization, @event_series) %></li>
             <li class="breadcrumb-item active">Edit</li>
           </ul>
         </div>
@@ -21,10 +22,10 @@
 </header>
 
 <article class="ost-article container">
-  <%= render 'form' %>
+  <%= render "form" %>
   <hr>
-  <%= link_to 'Delete', event_series_path(@event_series),
+  <%= link_to "Delete", organization_event_series_path(@event_series.organization, @event_series),
               method: :delete,
-              data: {confirm: 'Are you sure?'},
+              data: {confirm: "Are you sure?"},
               class: "btn btn-danger" %>
 </article>

--- a/app/views/event_series/index.html.erb
+++ b/app/views/event_series/index.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title do %>
+  <% "OpenSplitTime: Event Series - #{@presenter.name}" %>
+<% end %>
+
+<header class="ost-header">
+  <div class="container">
+    <%= render "organizations/organization_heading" %>
+    <!-- Navigation -->
+    <%= render "organizations/organization_tabs" %>
+  </div>
+</header>
+
+<% if current_user&.authorized_to_edit?(@presenter.organization) %>
+  <aside class="ost-toolbar">
+    <div class="container">
+      <div class="row">
+        <div class="col offset-md-6 col-md-6">
+          <%= link_to fa_icon("plus", text: "Add"),
+                      new_organization_event_series_path(organization: @presenter.organization),
+                      id: "add-event-series",
+                      class: "btn btn-success" %>
+        </div>
+      </div>
+    </div>
+  </aside>
+<% end %>
+
+<article class="ost-article container">
+  <% if @presenter.event_series.present? %>
+    <%= render "event_series_list", event_series: @presenter.event_series %>
+  <% else %>
+    <h4>No event series are associated with this organization.</h4>
+  <% end %>
+</article>

--- a/app/views/event_series/new.html.erb
+++ b/app/views/event_series/new.html.erb
@@ -9,8 +9,9 @@
         <div class="ost-title">
           <h1><strong>New Event Series</strong></h1>
           <ul class="breadcrumb breadcrumb-ost">
-            <li class="breadcrumb-item"><%= link_to 'Organizations', organizations_path %></li>
-            <li class="breadcrumb-item"><%= link_to @event_series.organization.name, organization_path(@event_series.organization, display_style: :event_series) %></li>
+            <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
+            <li class="breadcrumb-item"><%= link_to @event_series.organization.name, organization_path(@event_series.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to "Event Series", organization_event_series_index_path(@event_series.organization) %></li>
             <li class="breadcrumb-item active">New</li>
           </ul>
         </div>
@@ -20,5 +21,5 @@
 </header>
 
 <article class="ost-article container">
-  <%= render 'form' %>
+  <%= render "form" %>
 </article>

--- a/app/views/event_series/show.html.erb
+++ b/app/views/event_series/show.html.erb
@@ -13,7 +13,8 @@
           <h1><strong><%= "#{@presenter.name} Results" %></strong></h1>
           <ul class="breadcrumb">
             <li class="breadcrumb-item"><%= link_to 'Organizations', organizations_path %></li>
-            <li class="breadcrumb-item"><%= link_to @presenter.organization.name, organization_path(@presenter.organization, display_style: :event_series) %></li>
+            <li class="breadcrumb-item"><%= link_to @presenter.organization.name, organization_path(@presenter.organization) %></li>
+            <li class="breadcrumb-item"><%= link_to "Event Series", organization_event_series_index_path(@presenter.organization) %></li>
             <li class="breadcrumb-item active"><%= "#{@presenter.name} Results" %></li>
           </ul>
         </div>

--- a/app/views/organizations/_organization_tabs.html.erb
+++ b/app/views/organizations/_organization_tabs.html.erb
@@ -1,12 +1,12 @@
 <ul class="nav nav-tabs nav-tabs-ost">
+  <%= content_tag :li, class: "nav-item #{'active' if @presenter.controller_name == 'organizations'}" do %>
+    <%= link_to "Events", organization_path(@presenter.organization) %>
+  <% end %>
   <%= content_tag :li, class: "nav-item #{'active' if @presenter.controller_name == 'courses'}" do %>
     <%= link_to "Courses", organization_courses_path(@presenter.organization) %>
   <% end %>
-  <%= content_tag :li, class: "nav-item #{'active' if @presenter.controller_name == 'organizations' && @presenter.display_style == 'events'}" do %>
-    <%= link_to "Events", organization_path(@presenter.organization, display_style: :events) %>
-  <% end %>
-  <%= content_tag :li, class: "nav-item #{'active' if @presenter.controller_name == 'organizations' && @presenter.display_style == 'event_series'}" do %>
-    <%= link_to "Event Series", organization_path(@presenter.organization, display_style: :event_series) %>
+  <%= content_tag :li, class: "nav-item #{'active' if @presenter.controller_name == 'event_series'}" do %>
+    <%= link_to "Event Series", organization_event_series_index_path(@presenter.organization) %>
   <% end %>
   <% if @presenter.lotteries.present? || current_user&.authorized_for_lotteries?(@presenter.organization) %>
     <%= content_tag :li, class: "nav-item #{'active' if @presenter.controller_name == 'lotteries'}" do %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -13,54 +13,29 @@
   </div>
 </header>
 
-<% case @presenter.display_style %>
-<% when "event_series" %>
-  <% if current_user&.authorized_to_edit?(@presenter.organization) %>
-    <aside class="ost-toolbar">
-      <div class="container">
-        <div class="row">
-          <div class="col offset-md-6 col-md-6">
-            <%= link_to fa_icon("plus", text: "Add"), new_event_series_path(organization: @presenter.organization), id: "add-event-series", class: "btn btn-success" %>
-          </div>
+<% if current_user&.authorized_to_edit?(@presenter.organization) %>
+  <aside class="ost-toolbar">
+    <div class="container">
+      <div class="row">
+        <div class="col">
+          <%= link_to fa_icon("plus", text: "New event group"), new_organization_event_group_path(@presenter.organization), id: "add-event-group", class: "btn btn-success" %>
         </div>
       </div>
-    </aside>
-  <% end %>
-
-  <article class="ost-article container">
-    <% if @presenter.event_series.present? %>
-      <%= render "event_series_list", event_series: @presenter.event_series %>
-    <% else %>
-      <h4>No event series are associated with this organization.</h4>
-    <% end %>
-  </article>
-
-<% else %>
-
-  <% if current_user&.authorized_to_edit?(@presenter.organization) %>
-    <aside class="ost-toolbar">
-      <div class="container">
-        <div class="row">
-          <div class="col">
-            <%= link_to fa_icon("plus", text: "New event group"), new_organization_event_group_path(@presenter.organization), id: "add-event-group", class: "btn btn-success" %>
-          </div>
-        </div>
-      </div>
-    </aside>
-  <% end %>
-
-  <article class="ost-article container">
-    <% if current_user&.authorized_to_edit?(@presenter.organization) && @presenter.concealed_event_groups.exists? %>
-      <div class="p-3 border border-primary">
-        <h3>Under Construction</h3>
-        <%= render "event_groups/list_event_groups", presenter: @presenter, event_groups: @presenter.concealed_event_groups %>
-      </div>
-    <% end %>
-
-    <% if @presenter.visible_event_groups.exists? %>
-      <%= render "event_groups/list_event_groups", presenter: @presenter, event_groups: @presenter.visible_event_groups %>
-    <% else %>
-      <h4>No events exist yet</h4>
-    <% end %>
-  </article>
+    </div>
+  </aside>
 <% end %>
+
+<article class="ost-article container">
+  <% if current_user&.authorized_to_edit?(@presenter.organization) && @presenter.concealed_event_groups.exists? %>
+    <div class="p-3 border border-primary">
+      <h3>Under Construction</h3>
+      <%= render "event_groups/list_event_groups", presenter: @presenter, event_groups: @presenter.concealed_event_groups %>
+    </div>
+  <% end %>
+
+  <% if @presenter.visible_event_groups.exists? %>
+    <%= render "event_groups/list_event_groups", presenter: @presenter, event_groups: @presenter.visible_event_groups %>
+  <% else %>
+    <h4>No events exist yet</h4>
+  <% end %>
+</article>

--- a/app/views/stewardships/index.html.erb
+++ b/app/views/stewardships/index.html.erb
@@ -11,31 +11,29 @@
 </header>
 
 <article class="ost-article container">
-  <article class="ost-article container">
-    <div class="card">
-      <h4 class="card-header">Owner</h4>
-      <div class="card-body">
-        <h5><%= "#{@presenter.organization.owner_full_name} (#{@presenter.organization.owner_email})" %></h5>
-      </div>
+  <div class="card">
+    <h4 class="card-header">Owner</h4>
+    <div class="card-body">
+      <h5><%= "#{@presenter.organization.owner_full_name} (#{@presenter.organization.owner_email})" %></h5>
     </div>
-    <br/>
+  </div>
+  <br/>
 
-    <div class="card">
-      <h4 class="card-header">
-        <div class="row">
-          <div class="col-md">Stewards</div>
-          <div class="col-md float-right">
-            <%= render "user_lookup" %>
-          </div>
+  <div class="card">
+    <h4 class="card-header">
+      <div class="row">
+        <div class="col-md">Stewards</div>
+        <div class="col-md float-right">
+          <%= render "user_lookup" %>
         </div>
-      </h4>
-      <div class="card-body">
-        <% if @presenter.stewards.present? %>
-          <%= render "stewards_list", stewards: @presenter.stewards %>
-        <% else %>
-          <h4>No stewards have been added to this organization.</h4>
-        <% end %>
       </div>
+    </h4>
+    <div class="card-body">
+      <% if @presenter.stewards.present? %>
+        <%= render "stewards_list", stewards: @presenter.stewards %>
+      <% else %>
+        <h4>No stewards have been added to this organization.</h4>
+      <% end %>
     </div>
-  </article>
+  </div>
 </article>

--- a/app/views/users/my_stuff.html.erb
+++ b/app/views/users/my_stuff.html.erb
@@ -56,7 +56,7 @@
         <div class="card-body">
           <% @presenter.recent_event_series(10).each do |series| %>
             <h4 class="card-text">
-              <strong><%= link_to series.name, event_series_path(series) %></strong>
+              <strong><%= link_to series.name, organization_event_series_path(series.organization, series) %></strong>
             </h4>
           <% end %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,8 +126,6 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :event_series, only: [:show, :new, :create, :edit, :update, :destroy]
-
   resources :events, only: [:show] do
     member do
       get :admin
@@ -167,6 +165,7 @@ Rails.application.routes.draw do
     end
 
     resources :event_groups, except: [:index, :show]
+    resources :event_series
 
     resources :lotteries do
       member { get :draw_tickets }

--- a/spec/system/visit_event_series_spec.rb
+++ b/spec/system/visit_event_series_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "visit an event series page" do
       let(:subject_series) { event_series(:d30_short_series) }
 
       scenario "Visit the page" do
-        visit event_series_path(subject_series)
+        visit organization_event_series_path(organization, subject_series)
         verify_page_header
         verify_event_links
       end


### PR DESCRIPTION
This PR continues in the effort to move organization-related routes under the `organizations` route namespace.