### PR TITLE
Autofocus in login modal

### DIFF
--- a/app/javascript/controllers/autofocus_controller.js
+++ b/app/javascript/controllers/autofocus_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+import { useIntersection } from 'stimulus-use'
+
+export default class extends Controller {
+    options = {
+        threshold: 1
+    }
+
+    connect() {
+        useIntersection(this, this.options)
+    }
+
+    appear(_entry) {
+        this.element.focus()
+    }
+}

--- a/app/views/devise/sessions/_form.html.erb
+++ b/app/views/devise/sessions/_form.html.erb
@@ -4,25 +4,25 @@
              data: {action: "ajax:success->login#reloadPage ajax:error->login#showErrors"}) do |f| %>
   <div class="form-group">
     <%= f.label :email %>
-    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
+    <%= f.email_field :email, autocomplete: "email", class: "form-control", data: { controller: :autofocus } %>
   </div>
 
   <div class="form-group">
     <%= f.label :password %>
-    <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control' %>
+    <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
   </div>
 
   <% if devise_mapping.rememberable? %>
     <div class="form-group form-check">
-      <%= f.check_box :remember_me, class: 'form-check-input' %>
-      <%= f.label :remember_me, class: 'form-check-label' do %>
-        <%= resource.class.human_attribute_name('remember_me') %>
+      <%= f.check_box :remember_me, class: "form-check-input" %>
+      <%= f.label :remember_me, class: "form-check-label" do %>
+        <%= resource.class.human_attribute_name("remember_me") %>
       <% end %>
     </div>
   <% end %>
 
   <div class="form-group">
-    <%= f.submit t('devise.sessions.new.sign_in'), id: 'log-in-modal-submit', class: 'btn btn-primary',
-                 data: {action: 'click->login#hideErrors', turbo: false} %>
+    <%= f.submit t("devise.sessions.new.sign_in"), id: "log-in-modal-submit", class: "btn btn-primary",
+                 data: {action: "click->login#hideErrors", turbo: false} %>
   </div>
 <% end %>

--- a/app/views/devise/sessions/_new.html.erb
+++ b/app/views/devise/sessions/_new.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h3 class="modal-title"><strong><%= t('devise.sessions.new.sign_in').titleize %></strong></h3>
+        <h3 class="modal-title"><strong><%= t("devise.sessions.new.sign_in").titleize %></strong></h3>
         <button type="button" class="close" data-dismiss="modal" tabindex="-1">
           <span>&times;</span>
         </button>
@@ -34,8 +34,8 @@
             <% end %>
             <hr class="hr-text" data-content="or">
             <p class="text-center">Log in with Email</p>
-            <%= render 'devise/sessions/form', modal: true %>
-            <%= render 'devise/shared/modal_links' %>
+            <%= render "devise/sessions/form", modal: true %>
+            <%= render "devise/shared/modal_links" %>
           </div>
         </div>
       </div>

--- a/app/views/layouts/_progress.html.erb
+++ b/app/views/layouts/_progress.html.erb
@@ -1,5 +1,0 @@
-<%# Live updating progress bar %>
-<div class="progress d-none" id="progress-bar-with-messages">
-  <div class="progress-bar" id='realtime-progress-bar' role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;"></div>
-  <div class="progress-bar-title" id="progress-bar-title">0%</div>
-</div>


### PR DESCRIPTION
Adds a stimulus controller to force autofocus on the email field when the login modal appears.

Resolves #907 