### PR TITLE
Move pagination methods into Base Presenter

### DIFF
--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class BasePresenter
+  DEFAULT_PER_PAGE = 50
+  FIRST_PAGE = 1
+
   def initialize(_args)
     raise NotImplementedError, "#{self.class.name} is an abstract class."
   end
@@ -29,11 +32,11 @@ class BasePresenter
   end
 
   def page
-    params[:page]
+    params[:page]&.to_i || FIRST_PAGE
   end
 
   def per_page
-    params[:per_page] || 200
+    params[:per_page]&.to_i || DEFAULT_PER_PAGE
   end
 
   def request_params_digest

--- a/app/presenters/course_best_efforts_display.rb
+++ b/app/presenters/course_best_efforts_display.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CourseBestEffortsDisplay < BasePresenter
-  DEFAULT_PER_PAGE = 50
-  FIRST_PAGE = 1
-
   attr_reader :course, :view_context, :request
 
   delegate :name, :simple?, :ordered_splits_without_finish, :ordered_splits_without_start, :organization,
@@ -73,14 +70,6 @@ class CourseBestEffortsDisplay < BasePresenter
 
   def ordered_splits
     @ordered_splits ||= course.ordered_splits
-  end
-
-  def page
-    params[:page]&.to_i || FIRST_PAGE
-  end
-
-  def per_page
-    params[:per_page]&.to_i || DEFAULT_PER_PAGE
   end
 
   def split1

--- a/app/presenters/course_group_best_efforts_display.rb
+++ b/app/presenters/course_group_best_efforts_display.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class CourseGroupBestEffortsDisplay < BasePresenter
-  DEFAULT_PER_PAGE = 50
-  FIRST_PAGE = 1
-
   attr_reader :course_group, :view_context, :request
 
   delegate :name, :organization, :to_param, to: :course_group
@@ -58,14 +55,6 @@ class CourseGroupBestEffortsDisplay < BasePresenter
 
   def next_page_url
     view_context.url_for(request.params.merge(page: page + 1)) if filtered_segments_count == per_page
-  end
-
-  def page
-    params[:page]&.to_i || FIRST_PAGE
-  end
-
-  def per_page
-    params[:per_page]&.to_i || DEFAULT_PER_PAGE
   end
 
   private

--- a/app/presenters/course_group_finishers_display.rb
+++ b/app/presenters/course_group_finishers_display.rb
@@ -2,8 +2,6 @@
 
 class CourseGroupFinishersDisplay < BasePresenter
   DEFAULT_ORDER = { last_name: :asc, first_name: :asc, finish_count: :desc }
-  DEFAULT_PER_PAGE = 50
-  FIRST_PAGE = 1
 
   attr_reader :course_group, :view_context, :request
 
@@ -54,14 +52,6 @@ class CourseGroupFinishersDisplay < BasePresenter
 
   def next_page_url
     view_context.url_for(request.params.merge(page: page + 1)) if filtered_finishers_count == per_page
-  end
-
-  def page
-    params[:page]&.to_i || FIRST_PAGE
-  end
-
-  def per_page
-    params[:per_page]&.to_i || DEFAULT_PER_PAGE
   end
 
   private

--- a/app/presenters/event_group_roster_presenter.rb
+++ b/app/presenters/event_group_roster_presenter.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class EventGroupRosterPresenter < BasePresenter
-  DEFAULT_PER_PAGE = 50
-  FIRST_PAGE = 1
-
   attr_reader :event_group
   delegate :available_live, :concealed?, :multiple_events?, :name, :organization, :scheduled_start_time_local,
            :to_param, :unreconciled_efforts, to: :event_group
@@ -58,14 +55,6 @@ class EventGroupRosterPresenter < BasePresenter
 
   def next_page_url
     view_context.url_for(request.params.merge(page: page + 1)) if filtered_roster_efforts_count == per_page
-  end
-
-  def page
-    params[:page]&.to_i || FIRST_PAGE
-  end
-
-  def per_page
-    params[:per_page]&.to_i || DEFAULT_PER_PAGE
   end
 
   def events

--- a/app/presenters/event_spread_display.rb
+++ b/app/presenters/event_spread_display.rb
@@ -96,7 +96,7 @@ class EventSpreadDisplay < EventWithEffortsPresenter
   end
 
   def per_page
-    params[:per_page] || ranked_efforts.size
+    params[:per_page]&.to_i || ranked_efforts.size
   end
 
   def split_times

--- a/app/presenters/lottery_presenter.rb
+++ b/app/presenters/lottery_presenter.rb
@@ -117,14 +117,6 @@ class LotteryPresenter < BasePresenter
     @tickets_not_generated ||= lottery_tickets.empty?
   end
 
-  def page
-    params[:page]&.to_i || 1
-  end
-
-  def per_page
-    params[:per_page]&.to_i || 25
-  end
-
   private
 
   attr_reader :view_context

--- a/app/presenters/organizations_presenter.rb
+++ b/app/presenters/organizations_presenter.rb
@@ -11,14 +11,6 @@ class OrganizationsPresenter < BasePresenter
     view_context.url_for(request.params.merge(page: page + 1)) if records_from_context_count == per_page
   end
 
-  def page
-    params[:page]&.to_i || 1
-  end
-
-  def per_page
-    params[:per_page]&.to_i || 25
-  end
-
   def records_from_context
     @records_from_context ||= OrganizationPolicy::Scope.new(current_user, Organization)
         .viewable


### PR DESCRIPTION
We have a lot of duplicate code for pagination in presenters. 

This PR concentrates logic for `page` and `per_page` into the Base Presenter.