### PR TITLE
Use infinite scrolling for event group setup entrants

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -72,6 +72,11 @@ class EventGroupsController < ApplicationController
   def setup
     authorize @event_group
     @presenter = ::EventGroupSetupPresenter.new(@event_group, view_context)
+
+    respond_to do |format|
+      format.html
+      format.turbo_stream { render "setup", locals: { presenter: @presenter } }
+    end
   end
 
   def efforts

--- a/app/presenters/event_group_setup_presenter.rb
+++ b/app/presenters/event_group_setup_presenter.rb
@@ -61,6 +61,10 @@ class EventGroupSetupPresenter < BasePresenter
                             .paginate(page: page, per_page: per_page)
   end
 
+  def filtered_efforts_count
+    @filtered_efforts_count ||= filtered_efforts.size
+  end
+
   def event_group_name
     event_group.name
   end
@@ -71,6 +75,10 @@ class EventGroupSetupPresenter < BasePresenter
 
   def events
     @events ||= event_group.events.order(:scheduled_start_time)
+  end
+
+  def next_page_url
+    view_context.url_for(request.params.merge(page: page + 1)) if filtered_efforts_count == per_page
   end
 
   def organization_name
@@ -84,7 +92,7 @@ class EventGroupSetupPresenter < BasePresenter
   private
 
   attr_reader :params, :view_context
-  delegate :current_user, to: :view_context, private: true
+  delegate :current_user, :request, to: :view_context, private: true
 
   def default_display_style
     "events"

--- a/app/views/efforts/_entrant_for_setup.html.erb
+++ b/app/views/efforts/_entrant_for_setup.html.erb
@@ -1,0 +1,20 @@
+<%# locals: (effort:, presenter:) -%>
+
+<tr>
+  <td class="text-center">
+    <%= effort.unreconciled? ? fa_icon("check-circle", type: :regular, class: "text-danger") : fa_icon("check-circle", type: :solid, class: "text-success") %>
+  </td>
+  <% if presenter.multiple_events? %>
+    <td><%= effort.event.guaranteed_short_name %></td>
+  <% end %>
+  <td><%= effort.full_name %></td>
+  <td class="text-center"><%= effort.bib_number %></td>
+  <td><%= effort.bio_historic %></td>
+  <td><%= effort.flexible_geolocation %></td>
+  <td><%= "#{day_time_military_format(effort.assumed_start_time_local)} (#{offset_format_xxhyym(effort.scheduled_start_offset)})" %></td>
+  <td><%= [effort.emergency_contact, effort.emergency_phone].compact.join(" / ") %></td>
+  <td class="text-center">
+    <%= link_to_effort_edit(effort) %>
+    <%= link_to_effort_delete(effort) %>
+  </td>
+</tr>

--- a/app/views/event_groups/_entrants_roster.html.erb
+++ b/app/views/event_groups/_entrants_roster.html.erb
@@ -82,29 +82,15 @@
           <th></th>
         </tr>
         </thead>
-        <tbody>
-        <% presenter.filtered_efforts.each do |effort| %>
-          <tr>
-            <td class="text-center">
-              <%= effort.unreconciled? ? fa_icon("check-circle", type: :regular, class: "text-danger") : fa_icon("check-circle", type: :solid, class: "text-success") %>
-            </td>
-            <% if presenter.multiple_events? %>
-              <td><%= effort.event.guaranteed_short_name %></td>
-            <% end %>
-            <td><%= effort.full_name %></td>
-            <td class="text-center"><%= effort.bib_number %></td>
-            <td><%= effort.bio_historic %></td>
-            <td><%= effort.flexible_geolocation %></td>
-            <td><%= "#{day_time_military_format(effort.assumed_start_time_local)} (#{offset_format_xxhyym(effort.scheduled_start_offset)})" %></td>
-            <td><%= [effort.emergency_contact, effort.emergency_phone].compact.join(" / ") %></td>
-            <td class="text-center">
-              <%= link_to_effort_edit(effort) %>
-              <%= link_to_effort_delete(effort) %>
-            </td>
-          </tr>
-        <% end %>
+        <tbody id="entrants">
+        <%= render partial: "efforts/entrant_for_setup",
+                   collection: presenter.filtered_efforts,
+                   as: :effort,
+                   locals: { presenter: presenter } %>
         </tbody>
       </table>
+
+      <%= render "shared/pager", next_page_url: @presenter.next_page_url %>
 
     <% elsif presenter.event_group_efforts.exists? %>
       <h5>No results match that search.</h5>

--- a/app/views/event_groups/setup.turbo_stream.erb
+++ b/app/views/event_groups/setup.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.append "entrants",
+                        partial: "efforts/entrant_for_setup",
+                        collection: presenter.filtered_efforts,
+                        as: :effort,
+                        locals: { presenter: presenter } %>
+
+<%= turbo_stream.replace "pager",
+                         partial: "shared/pager",
+                         locals: { next_page_url: presenter.next_page_url } %>

--- a/app/views/shared/_strong_confirm_modal.html.erb
+++ b/app/views/shared/_strong_confirm_modal.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (message:, path_on_confirm:, required_pattern:, strong_confirm_id: -%>
+
 <aside id="<%= strong_confirm_id %>" class="modal fade" role="dialog" data-controller="confirm">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -12,8 +14,26 @@
         <p>To proceed, please type <strong><%= required_pattern %></strong> below and click the Delete button.</p>
       </div>
       <div class="modal-footer">
-        <%= text_field_tag "confirm", nil, class: "form-control col", autofocus: true, tabindex: 1, data: {action: "keyup->confirm#compare", "confirm-target" => "pattern", "pattern-required" => required_pattern} %>
-        <%= link_to "Permanently Delete", path_on_confirm, tabindex: -1, class: "btn btn-block btn-danger font-weight-bold disabled", method: :delete, data: {"confirm-target" => "deleteButton", action: "click->confirm#onClickDelete"} %>
+        <%= text_field_tag "confirm",
+                           nil,
+                           class: "form-control col",
+                           autofocus: true,
+                           tabindex: 1,
+                           data: {
+                             action: "keyup->confirm#compare",
+                             "confirm-target" => "pattern",
+                             "pattern-required" => required_pattern,
+                           } %>
+        <%= button_to "Permanently Delete",
+                      path_on_confirm,
+                      tabindex: -1,
+                      class: "btn btn-block btn-danger font-weight-bold disabled",
+                      method: :delete,
+                      data: {
+                        "confirm-target" => "deleteButton",
+                        action: "click->confirm#onClickDelete",
+                        turbo: false,
+                      } %>
       </div>
     </div>
   </div>

--- a/spec/system/edit_event_flow_spec.rb
+++ b/spec/system/edit_event_flow_spec.rb
@@ -79,14 +79,14 @@ RSpec.describe "visit the edit event page and make changes", type: :system, js: 
     click_link "Delete this event"
     modal = page.find("aside")
     expect(modal).to have_content("Are you absolutely sure?")
-    expect(modal).to have_link("Permanently Delete", class: "disabled")
+    expect(modal).to have_button("Permanently Delete", class: "disabled")
 
     fill_in "confirm", with: event.name.upcase
-    expect(modal).not_to have_link("Permanently Delete", class: "disabled")
-    expect(modal).to have_link("Permanently Delete")
+    expect(modal).not_to have_button("Permanently Delete", class: "disabled")
+    expect(modal).to have_button("Permanently Delete")
 
     expect do
-      click_link "Permanently Delete"
+      click_button "Permanently Delete"
       expect(page).to have_current_path(setup_event_group_path(event_group))
     end.to change { Event.count }.by(-1)
   end

--- a/spec/system/edit_event_group_flow_spec.rb
+++ b/spec/system/edit_event_group_flow_spec.rb
@@ -87,17 +87,17 @@ RSpec.describe "visit the edit event group page and make changes", type: :system
     click_link "Delete all time records"
     modal = page.find("aside")
     expect(modal).to have_content("Are you absolutely sure?")
-    expect(modal).to have_link("Permanently Delete", class: "disabled")
+    expect(modal).to have_button("Permanently Delete", class: "disabled")
 
     fill_in "confirm", with: "#{event_group.name.upcase} TIMES"
-    expect(modal).not_to have_link("Permanently Delete", class: "disabled")
-    expect(modal).to have_link("Permanently Delete")
+    expect(modal).not_to have_button("Permanently Delete", class: "disabled")
+    expect(modal).to have_button("Permanently Delete")
 
     split_time_count = event_group.split_times.count
     raw_time_count = event_group.raw_times.count
 
     expect do
-      click_link "Permanently Delete"
+      click_button "Permanently Delete"
       expect(page).not_to have_current_path(edit_organization_event_group_path(organization, event_group))
     end.to change { SplitTime.count }.by(-split_time_count).and change { RawTime.count }.by (-raw_time_count)
 
@@ -108,14 +108,14 @@ RSpec.describe "visit the edit event group page and make changes", type: :system
     click_link "Delete this event group"
     modal = page.find("aside")
     expect(modal).to have_content("Are you absolutely sure?")
-    expect(modal).to have_link("Permanently Delete", class: "disabled")
+    expect(modal).to have_button("Permanently Delete", class: "disabled")
 
     fill_in "confirm", with: event_group.name.upcase
-    expect(modal).not_to have_link("Permanently Delete", class: "disabled")
-    expect(modal).to have_link("Permanently Delete")
+    expect(modal).not_to have_button("Permanently Delete", class: "disabled")
+    expect(modal).to have_button("Permanently Delete")
 
     expect do
-      click_link "Permanently Delete"
+      click_button "Permanently Delete"
       expect(page).not_to have_current_path(edit_organization_event_group_path(organization, event_group))
     end.to change { EventGroup.count }.by(-1)
     expect(page).to have_current_path(event_groups_path)


### PR DESCRIPTION
When we moved from standard pagination to infinite scrolling, the Event Group Setup > Entrants view was missed. 

This PR adds infinite scrolling for that view.

Resolves #924 