### PR TITLE
Add scheduled_start_time_local to runsignup sync

### DIFF
--- a/app/services/interactors/sync_runsignup_participants.rb
+++ b/app/services/interactors/sync_runsignup_participants.rb
@@ -7,14 +7,15 @@ module Interactors
     RELEVANT_ATTRIBUTES = [
       "first_name",
       "last_name",
-      "gender",
       "birthdate",
+      "gender",
+      "bib_number",
       "city",
       "state_code",
       "country_code",
-      "bib_number",
       "email",
       "phone",
+      "scheduled_start_time_local",
     ].freeze
 
     def self.perform!(event, current_user)

--- a/lib/runsignup/get_participants.rb
+++ b/lib/runsignup/get_participants.rb
@@ -58,6 +58,14 @@ module Runsignup
       @credentials ||= user.credentials["runsignup"] || {}
     end
 
+    def event_start_time
+      return @event_start_time if defined?(@event_start_time)
+
+      events = ::Runsignup::GetEvents.perform(race_id: race_id, user: user)
+      event = events.find { |event| event.id == event_id }
+      @event_start_time = event&.start_time
+    end
+
     def participant_from_raw(raw_participant)
       ::Runsignup::Participant.new(
         first_name: raw_participant.dig("user", "first_name"),
@@ -70,6 +78,7 @@ module Runsignup
         state_code: raw_participant.dig("user", "address", "state"),
         country_code: raw_participant.dig("user", "address", "country_code"),
         bib_number: raw_participant.dig("bib_num"),
+        scheduled_start_time_local: event_start_time,
       )
     end
 

--- a/lib/runsignup/participant.rb
+++ b/lib/runsignup/participant.rb
@@ -10,6 +10,7 @@ module Runsignup
     :country_code,
     :email,
     :phone,
+    :scheduled_start_time_local,
     keyword_init: true
   )
 end


### PR DESCRIPTION
We need to pull the start time from the runsignup event so as to set `scheduled_start_time` on synced efforts in OST.