### PR TITLE
Touch event group and events after bulk deleting times

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -148,6 +148,10 @@ class User < ApplicationRecord
     avatar.present?
   end
 
+  def has_credentials_for?(source_name)
+    credentials.present? && credentials[source_name.to_s].present?
+  end
+
   def from_omniauth?
     provider? && uid?
   end

--- a/app/presenters/event_group_setup_presenter.rb
+++ b/app/presenters/event_group_setup_presenter.rb
@@ -92,7 +92,7 @@ class EventGroupSetupPresenter < BasePresenter
   end
 
   def all_runsignup_events
-    return [] unless runsignup_race_id.present?
+    return [] unless runsignup_race_id.present? && current_user.has_credentials_for?(:runsignup)
 
     @all_runsignup_events ||= ::Runsignup::GetEvents.perform(race_id: runsignup_race_id, user: current_user)
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -257,4 +257,37 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "#has_credentials_for?" do
+    let(:user) { users(:third_user) }
+    let(:result) { user.has_credentials_for?(source_name) }
+    let(:source_name) { "partner_service" }
+    let(:test_credentials) { nil }
+
+    before { allow(user).to receive(:credentials).and_return(test_credentials) }
+
+    context "when credentials are nil" do
+      it { expect(result).to eq(false) }
+    end
+
+    context "when credentials are empty" do
+      let(:test_credentials) { {} }
+      it { expect(result).to eq(false) }
+    end
+
+    context "when credentials exist but do not include the requested key" do
+      let(:test_credentials) { { "other_service" => { "api_key" => "1234", "api_secret" => "2345"} } }
+      it { expect(result).to eq(false) }
+    end
+
+    context "when credentials exist for the requested key" do
+      let(:test_credentials) { { "partner_service" => { "api_key" => "1234", "api_secret" => "2345"} } }
+      it { expect(result).to eq(true) }
+
+      context "when the key is a symbol" do
+        let(:source_name) { :partner_service }
+        it { expect(result).to eq(true) }
+      end
+    end
+  end
 end

--- a/spec/services/interactors/bulk_delete_event_group_times_spec.rb
+++ b/spec/services/interactors/bulk_delete_event_group_times_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Interactors::BulkDeleteEventGroupTimes do
+  subject { described_class.new(event_group) }
+  let(:event_group) { event_groups(:sum) }
+
+  describe "#perform!" do
+    context "when no errors occur" do
+      it "deletes all split times" do
+        expect(event_group.split_times.count).to be_positive
+        expect { subject.perform! }.to change { event_group.split_times.count }.from(anything).to(0)
+      end
+
+      it "deletes all raw times" do
+        expect(event_group.raw_times.count).to be_positive
+        expect { subject.perform! }.to change { event_group.raw_times.count }.from(anything).to(0)
+      end
+
+      it "touches the event group and each event" do
+        subject.perform!
+        expect(event_group.reload.updated_at).to be_within(1.second).of(Time.current)
+        event_group.events.each { |event| expect(event.reload.updated_at).to be_within(1.second).of(Time.current) }
+      end
+
+      it "returns a response with a descriptive message" do
+        raw_times_count = event_group.raw_times.count
+        split_times_count = event_group.split_times.count
+        response = subject.perform!
+
+        expect(response).to be_a(Interactors::Response)
+        expect(response).to be_successful
+        expect(response.message).to include("Deleted")
+        expect(response.message).to include("#{raw_times_count} raw times")
+        expect(response.message).to include("#{split_times_count} split times")
+      end
+    end
+
+    context "when an error occurs" do
+      before { allow_any_instance_of(ActiveRecord::Relation).to receive(:delete_all).and_raise ActiveRecord::ActiveRecordError, "a thing happened" }
+
+      it "does not delete split times or raw times" do
+        expect { subject.perform! }.to not_change { event_group.split_times.count }
+                                         .and not_change { event_group.raw_times.count }
+      end
+
+      it "returns a response with errors" do
+        response = subject.perform!
+        expect(response).not_to be_successful
+        expect(response.errors).to be_present
+        expect(response.errors.first[:detail].to_s).to include("a thing happened")
+      end
+    end
+  end
+end

--- a/spec/support/matchers/not_change.rb
+++ b/spec/support/matchers/not_change.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
After bulk deletion of times, the spread view does not update because the cache remains intact.

This PR touches the event group and its events after bulk deletion, which will bust the cache.