### PR TITLE
Validate presence of entered_time on raw times

### DIFF
--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -32,7 +32,7 @@ class RawTime < ApplicationRecord
 
   after_create_commit :broadcast_raw_time_create
 
-  validates_presence_of :event_group, :split_name, :bitkey, :bib_number, :source
+  validates_presence_of :entered_time, :event_group, :split_name, :bitkey, :bib_number, :source
   validates :bib_number, length: { maximum: 6 }, format: { with: /\A[\d*]+\z/, message: "may contain only digits and asterisks" }
 
   scope :with_policy_scope_attributes, lambda {

--- a/app/services/raw_times/set_absolute_time_and_lap.rb
+++ b/app/services/raw_times/set_absolute_time_and_lap.rb
@@ -17,7 +17,6 @@ module RawTimes
     def perform
       raw_times.each do |raw_time|
         set_lap_simple(raw_time)
-        set_entered_from_absolute_time(raw_time) if raw_time.absolute_time.present? # See note below
         set_absolute_from_entered_time(raw_time) unless raw_time.absolute_time.present?
         set_lap_using_time(raw_time) unless raw_time.lap.present?
       end
@@ -35,20 +34,6 @@ module RawTimes
       elsif single_lap_event_group? || single_lap_event?(raw_time)
         raw_time.lap = 1
       end
-    end
-
-    # Versions of OST Remote prior to July 2020 set absolute_time directly,
-    # making it necessary to copy absolute_time to entered_time
-    # if absolute_time exists.
-    #
-    # This method can be removed once OST Remote sets entered_time
-    # instead of absolute_time (and there has been plenty of time for
-    # users to upgrade). January 2021 should be about right.
-    #
-    # See also the RowifyRawTimes class.
-    #
-    def set_entered_from_absolute_time(raw_time)
-      raw_time.entered_time = raw_time.absolute_time
     end
 
     def set_absolute_from_entered_time(raw_time)

--- a/app/services/rowify_raw_times.rb
+++ b/app/services/rowify_raw_times.rb
@@ -20,7 +20,6 @@ class RowifyRawTimes
 
   def build
     add_lap_to_raw_times
-    add_entered_time_from_absolute # See note below
     raw_time_pairs = RawTimePairer.pair(event_group: event_group, raw_times: raw_times).map(&:compact)
     raw_time_pairs.map(&method(:build_time_row))
   end
@@ -51,14 +50,6 @@ class RowifyRawTimes
                             subject_value: subject_value,
                             split_id: raw_time.split_id,
                             bitkey: raw_time.bitkey)
-  end
-
-  # This should be removed after OST Remote changes are
-  # well baked, circa January 2021.
-  def add_entered_time_from_absolute
-    raw_times.reject(&:entered_time).each do |rt|
-      rt.entered_time = rt.military_time(home_time_zone)
-    end
   end
 
   def build_time_row(raw_time_pair)

--- a/spec/factories/raw_time.rb
+++ b/spec/factories/raw_time.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :raw_time do
     event_group
+    entered_time { "12:34:56" }
     split_name { "#{FFaker::Name.first_name} #{FFaker::Name.first_name}".parameterize }
     bitkey { [SubSplit::IN_BITKEY, SubSplit::OUT_BITKEY].sample }
     bib_number { rand(1..999).to_s }

--- a/spec/jobs/process_imported_raw_times_job_spec.rb
+++ b/spec/jobs/process_imported_raw_times_job_spec.rb
@@ -106,27 +106,6 @@ RSpec.describe ProcessImportedRawTimesJob do
       end
     end
 
-    context "when raw times have absolute times but no entered times" do
-      let(:raw_time_1) do
-        create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: "in",
-                          absolute_time: absolute_time_in, entered_time: nil, with_pacer: "true", stopped_here: "false", source: source)
-      end
-      let(:raw_time_2) do
-        create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: "out",
-                          absolute_time: absolute_time_out, entered_time: nil, with_pacer: "true", stopped_here: "true", source: source)
-      end
-
-      include_examples "processes raw times as expected"
-
-      it "sets entered times without changing absolute times" do
-        perform_process
-        raw_times.each(&:reload)
-
-        expect(raw_times.map(&:absolute_time)).to eq([absolute_time_in, absolute_time_out])
-        expect(raw_times.map { |rt| time_zone.parse(rt.entered_time) }).to eq([absolute_time_in, absolute_time_out])
-      end
-    end
-
     context "when raw times have entered times but no absolute times" do
       let(:raw_time_1) do
         create(:raw_time, event_group: event_group, bib_number: bib_number, split_name: split_name, sub_split_kind: "in",

--- a/spec/services/interactors/rebuild_effort_times_spec.rb
+++ b/spec/services/interactors/rebuild_effort_times_spec.rb
@@ -38,8 +38,15 @@ RSpec.describe Interactors::RebuildEffortTimes do
         end
 
         ordered_split_times[1..-1].map do |st|
-          RawTime.create!(event_group: effort.event_group, bib_number: effort.bib_number, split_name: st.split.base_name,
-                          absolute_time: st.absolute_time, bitkey: st.bitkey, source: "rebuild_effort_test")
+          RawTime.create!(
+            event_group: effort.event_group,
+            bib_number: effort.bib_number,
+            split_name: st.split.base_name,
+            entered_time: st.absolute_time,
+            absolute_time: st.absolute_time,
+            bitkey: st.bitkey,
+            source: "rebuild_effort_test",
+          )
         end
       end
 
@@ -77,9 +84,16 @@ RSpec.describe Interactors::RebuildEffortTimes do
           st = ordered_split_times[3]
           duplicate_time = st.absolute_time + 1.minute
           earlier_creation_time = st.created_at - 1.minute
-          RawTime.create!(event_group: effort.event_group, bib_number: effort.bib_number, split_name: st.split.base_name,
-                          absolute_time: duplicate_time, bitkey: st.bitkey, source: "rebuild_effort_test",
-                          created_at: earlier_creation_time)
+          RawTime.create!(
+            event_group: effort.event_group,
+            bib_number: effort.bib_number,
+            split_name: st.split.base_name,
+            entered_time: duplicate_time,
+            absolute_time: duplicate_time,
+            bitkey: st.bitkey,
+            source: "rebuild_effort_test",
+            created_at: earlier_creation_time,
+          )
         end
 
         it "reorders the split_times, retaining sub_split integrity and skipping the duplicate time" do

--- a/spec/services/raw_times/set_absolute_time_and_lap_spec.rb
+++ b/spec/services/raw_times/set_absolute_time_and_lap_spec.rb
@@ -40,8 +40,7 @@ RSpec.describe ::RawTimes::SetAbsoluteTimeAndLap do
       shared_examples "sets lap and time for a single-lap event" do
         context "when absolute time is present" do
           let(:absolute_time) { "2020-04-04 07:30:00-0600" }
-          it "sets entered time and lap" do
-            expect(resulting_raw_time.entered_time.to_datetime).to eq(absolute_time.to_datetime)
+          it "sets the lap" do
             expect(resulting_raw_time.lap).to eq(1)
           end
         end
@@ -99,9 +98,6 @@ RSpec.describe ::RawTimes::SetAbsoluteTimeAndLap do
 
         context "when absolute time is present" do
           let(:absolute_time) { "2017-02-11 11:55:00-0600" }
-          it "sets entered time" do
-            expect(resulting_raw_time.entered_time.to_datetime).to eq(absolute_time.to_datetime)
-          end
 
           include_examples "uses FindExpectedLap to set the lap"
         end
@@ -146,9 +142,6 @@ RSpec.describe ::RawTimes::SetAbsoluteTimeAndLap do
 
         context "when absolute time is present" do
           let(:absolute_time) { "2017-02-11 11:55:00-0600" }
-          it "sets entered time" do
-            expect(resulting_raw_time.entered_time.to_datetime).to eq(absolute_time.to_datetime)
-          end
 
           include_examples "uses entered lap to set the lap"
         end

--- a/spec/services/raw_times/set_absolute_time_and_lap_spec.rb
+++ b/spec/services/raw_times/set_absolute_time_and_lap_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ::RawTimes::SetAbsoluteTimeAndLap do
   end
 
   let(:entered_lap) { nil }
-  let(:entered_time) { nil }
+  let(:entered_time) { "2020-04-04 07:30:00-0600" }
   let(:absolute_time) { nil }
   let(:effort) { event.efforts.order(:bib_number).first }
   let(:bib_number) { effort.bib_number.to_s }


### PR DESCRIPTION
Prior to mid-2020, OST Remote submitted raw times with an `absolute_time` attribute, while the Live Entry screen submitted raw times with an `entered_time` attribute. 

Since mid-2020, OST Remote has used `entered_time` (with a full timestamp) and Live Entry continues to use `entered_time` (with a military time), and `absolute_time` is always derived.

This PR validates `entered_time` on the RawTime model. It also removes some existing tests and tweaks existing specs to reflect the universal provision of `entered_time` on raw times from whatever source.