### PR TITLE
Register selenium drivers using :options instead of :capabilities

### DIFF
--- a/spec/support/basic_configure.rb
+++ b/spec/support/basic_configure.rb
@@ -1,4 +1,4 @@
-# Noel Rappin at https://medium.com/table-xi/a-quick-guide-to-rails-system-tests-in-rspec-b6e9e8a8b5f6
+# frozen_string_literal: true
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
@@ -6,6 +6,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    driven_by :selenium_chrome_headless
+    driven_by :chrome_headless
   end
 end

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -1,3 +1,29 @@
 Capybara.configure do |config|
   config.default_max_wait_time = 4
 end
+
+# chrome_headless is the default driver for system tests
+Capybara.register_driver :chrome_headless do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(
+    args: %w[headless disable-gpu no-sandbox window-size=1024,768],
+    )
+  Capybara::Selenium::Driver.new app,
+                                 browser: :chrome,
+                                 clear_session_storage: true,
+                                 clear_local_storage: true,
+                                 options: options
+end
+
+# chrome_visible can be used for debugging by changing the argument
+# passed to `driven_by` in spec/support/basic_configure.rb from
+# :chrome_headless to :chrome_visible
+Capybara.register_driver :chrome_visible do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(
+    args: %w[disable-gpu no-sandbox window-size=1024,768],
+  )
+  Capybara::Selenium::Driver.new app,
+                                 browser: :chrome,
+                                 clear_session_storage: true,
+                                 clear_local_storage: true,
+                                 options: options
+end

--- a/spec/system/edit_event_flow_spec.rb
+++ b/spec/system/edit_event_flow_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "visit the edit event page and make changes", type: :system, js: 
 
   def verify_confirm_and_delete
     click_link "Delete this event"
-    modal = page.find("aside")
+    modal = page.find(:css, "aside.modal")
     expect(modal).to have_content("Are you absolutely sure?")
     expect(modal).to have_button("Permanently Delete", class: "disabled")
 

--- a/spec/system/edit_event_group_flow_spec.rb
+++ b/spec/system/edit_event_group_flow_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "visit the edit event group page and make changes", type: :system
 
   def verify_confirm_and_delete_times
     click_link "Delete all time records"
-    modal = page.find("aside")
+    modal = page.find(:css, "aside.modal")
     expect(modal).to have_content("Are you absolutely sure?")
     expect(modal).to have_button("Permanently Delete", class: "disabled")
 
@@ -106,7 +106,7 @@ RSpec.describe "visit the edit event group page and make changes", type: :system
 
   def verify_confirm_and_delete
     click_link "Delete this event group"
-    modal = page.find("aside")
+    modal = page.find(:css, "aside.modal")
     expect(modal).to have_content("Are you absolutely sure?")
     expect(modal).to have_button("Permanently Delete", class: "disabled")
 


### PR DESCRIPTION
This PR adds custom selenium drivers to avoid the deprecation warnings we are seeing when running system tests.