### PR TITLE
Only show cutoff analysis if visible events exist

### DIFF
--- a/app/models/concerns/course_analysis_methods.rb
+++ b/app/models/concerns/course_analysis_methods.rb
@@ -15,7 +15,7 @@ module CourseAnalysisMethods
   end
 
   def default_time_zone
-    event.home_time_zone
+    event&.home_time_zone
   end
 
   def start_time

--- a/app/presenters/course_cutoff_analysis_presenter.rb
+++ b/app/presenters/course_cutoff_analysis_presenter.rb
@@ -9,7 +9,7 @@ class CourseCutoffAnalysisPresenter < BasePresenter
   DEFAULT_DISPLAY_STYLE = :absolute
 
   attr_reader :course
-  delegate :name, :organization, :simple?, to: :course
+  delegate :events, :name, :organization, :simple?, to: :course
 
   def initialize(course, view_context)
     @course = course
@@ -83,6 +83,10 @@ class CourseCutoffAnalysisPresenter < BasePresenter
     else
       "Cutoff analysis for #{split_name} in increments of #{band_width / 1.minute} minutes"
     end
+  end
+
+  def visible_events_exist?
+    events.visible.exists?
   end
 
   private

--- a/app/views/courses/cutoff_analysis.html.erb
+++ b/app/views/courses/cutoff_analysis.html.erb
@@ -35,7 +35,7 @@
   <h4><%= @presenter.table_title %></h4>
   <br/>
 
-  <% if @presenter.interval_split_cutoff_analyses.present? %>
+  <% if @presenter.visible_events_exist? && @presenter.interval_split_cutoff_analyses.present? %>
     <div>
       <%= column_chart @presenter.chart_data, stacked: true %>
     </div>

--- a/spec/system/cutoff_analysis_flow_spec.rb
+++ b/spec/system/cutoff_analysis_flow_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Visit the cutoff analysis page", js: true do
+  let(:course) { courses(:hardrock_ccw) }
+  let(:first_split_name) { course.splits.intermediate.first.base_name }
+
+  before(:all) { EffortSegment.set_all }
+  after(:all) { EffortSegment.delete_all }
+
+  scenario "Visitor visits the page with existing data" do
+    visit_page
+
+    expect(page).to have_content(course.name)
+    expect(page).to have_content("Cutoff analysis for #{first_split_name}")
+    table = page.find("article").find("table")
+    expect(table.all(:css, "tbody tr").size).to eq(5)
+  end
+
+  context "when no events exist" do
+    before do
+      Notification.delete_all
+      RawTime.delete_all
+      SplitTime.delete_all
+      Effort.delete_all
+      AidStation.delete_all
+      Event.delete_all
+    end
+
+    scenario "Visitor visits the page" do
+      visit_page
+
+      expect(page).to have_content(course.name)
+      expect(page).to have_content("No efforts have been measured at this aid station")
+    end
+  end
+
+  context "when no events are visible" do
+    before { course.events.flat_map(&:event_group).each { |event_group| event_group.update_column(:concealed, true) } }
+
+    scenario "Visitor visits the page" do
+      visit_page
+
+      expect(page).to have_content(course.name)
+      expect(page).to have_content("No efforts have been measured at this aid station")
+    end
+  end
+
+  def visit_page
+    visit cutoff_analysis_organization_course_path(course.organization, course)
+  end
+end


### PR DESCRIPTION
Restricts display of cutoff analysis to courses having visible events.

Resolves #945 