### PR TITLE
Make OstConfig the source of truth for redis URL

### DIFF
--- a/config/initializers/01_ost_config.rb
+++ b/config/initializers/01_ost_config.rb
@@ -95,6 +95,14 @@ module OstConfig
     3.days
   end
 
+  def self.redis_url
+    if Rails.env.production? && base_uri == "ost-stage.herokuapp.com"
+      ENV["REDIS_TLS_URL"] || ENV["REDIS_URL"]
+    else
+      ENV["REDIS_URL"]
+    end
+  end
+
   def self.scout_apm_sample_rate
     ENV["SCOUT_APM_SAMPLE_RATE"]&.to_f || 1.0
   end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-$redis = Redis.new(url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })
+$redis = Redis.new(url: OstConfig.redis_url, ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,7 @@
 
 Sidekiq.configure_server do |config|
   config.redis = {
-    url: ENV["REDIS_URL"],
+    url: OstConfig.redis_url,
     ssl_params: {
       verify_mode: OpenSSL::SSL::VERIFY_NONE
     }
@@ -11,7 +11,7 @@ end
 
 Sidekiq.configure_client do |config|
   config.redis = {
-    url: ENV["REDIS_URL"],
+    url: OstConfig.redis_url,
     ssl_params: {
       verify_mode: OpenSSL::SSL::VERIFY_NONE
     }
@@ -19,4 +19,3 @@ Sidekiq.configure_client do |config|
 end
 
 # Sidekiq::Cron::Job.load_from_hash YAML.load_file("config/schedule.yml") if Rails.env.production?
-


### PR DESCRIPTION
We had some trouble this morning with a Redis upgrade on Heroku, as described in #949 

Part of the trouble was that we had no way to test the app's ability to communicate with Redis over TLS/SSL because the staging environment uses a `mini` instance of heroku-redis, which does not require TLS. In order to use TLS on a `mini` instance, we have to talk to redis on `REDIS_TLS_URL` instead of `REDIS_URL`.

This PR moves the source of truth for talking to Redis into the OstConfig class. For the staging environment it favors `REDIS_TLS_URL` and for every other environment it uses `REDIS_URL`.