### PR TITLE
Reference `files` instead of `file` for entrant import

### DIFF
--- a/app/parameters/import_job_parameters.rb
+++ b/app/parameters/import_job_parameters.rb
@@ -3,7 +3,7 @@
 class ImportJobParameters < BaseParameters
   def self.permitted
     [
-      :file,
+      :files,
       :format,
       :parent_id,
       :parent_type

--- a/app/views/import_jobs/_form.html.erb
+++ b/app/views/import_jobs/_form.html.erb
@@ -6,7 +6,7 @@
       <div class="form-row">
         <div class="form-group col-md-4">
           <%= f.label :file_name %>
-          <%= f.file_field :file, class: "form-control", autofocus: true %>
+          <%= f.file_field :files, class: "form-control", autofocus: true %>
         </div>
         <%= f.hidden_field :parent_type %>
         <%= f.hidden_field :parent_id %>


### PR DESCRIPTION
This PR updates the Import Jobs form to correctly submit `files` instead of a single `file`.

Resolves #951 