### PR TITLE
Don't create records before testing sitemap generator

### DIFF
--- a/spec/lib/sitemap_generator/interpreter_spec.rb
+++ b/spec/lib/sitemap_generator/interpreter_spec.rb
@@ -8,9 +8,6 @@ RSpec.describe SitemapGenerator::Interpreter do
       allow(SitemapGenerator::Sitemap).to receive(:ping_search_engines).and_return true
       allow(SitemapGenerator::Sitemap).to receive(:create).and_yield
 
-      FactoryBot.create_list(:organization, 5)
-      FactoryBot.create_list(:person, 3)
-
       expect { described_class.run }.not_to raise_error
     end
   end


### PR DESCRIPTION
The sitemap generator spec was written before we had fixtures in place, so we created some Organization and Person records so there was something to generate. But this test can occasionally fail because of organization name collisions.

Now that we have fixtures, there is no need for record creation before that spec runs. This PR removes the record creation.