### PR TITLE
Bump devise to 4.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "chartkick"
 gem "coverband"
 gem "dalli"
 gem "data_migrate"
-gem "devise", "< 4.9" # Remove this restriction once we are tested with hotwire
+gem "devise"
 gem "devise-bootstrap-views"
 gem "ffaker"
 gem "font_awesome5_rails", ">= 1.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
       rake (> 10, < 14)
       ruby-statistics (>= 2.1)
       thor (>= 0.19, < 2)
-    devise (4.8.1)
+    devise (4.9.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -605,7 +605,7 @@ DEPENDENCIES
   dalli
   data_migrate
   derailed_benchmarks
-  devise (< 4.9)
+  devise
   devise-bootstrap-views
   factory_bot_rails (~> 5.2, >= 5.2.0)
   ffaker

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -253,6 +253,10 @@ Devise.setup do |config|
     manager.failure_app = CustomFailure
   end
 
+  # Match the behavior expected by Turbo
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
+
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.

--- a/spec/requests/modal_login_spec.rb
+++ b/spec/requests/modal_login_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe "Modal login", type: :request do
     let(:email) { invalid_email }
     let(:password) { valid_password }
 
-    it "returns 403 but does not attempt to redirect to the sign_in page" do
+    it "returns 422 but does not attempt to redirect to the sign_in page" do
       make_request
 
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(422)
       expect(response.body).to include("Invalid email or password.")
       expect(response).not_to redirect_to("/users/sign_in")
     end
@@ -42,10 +42,10 @@ RSpec.describe "Modal login", type: :request do
     let(:email) { valid_email }
     let(:password) { invalid_password }
 
-    it "returns 403 but does not attempt to redirect to the sign_in page" do
+    it "returns 422 but does not attempt to redirect to the sign_in page" do
       make_request
 
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(422)
       expect(response.body).to include("Invalid email or password.")
       expect(response).not_to redirect_to("/users/sign_in")
     end


### PR DESCRIPTION
Removes the version restriction on Devise gem and sets configs to match expected Hotwire/Turbo status codes.