### PR TITLE
Remove raw times from list using turbo stream

### DIFF
--- a/app/controllers/raw_times_controller.rb
+++ b/app/controllers/raw_times_controller.rb
@@ -18,7 +18,10 @@ class RawTimesController < ApplicationController
     authorize @raw_time
 
     @raw_time.destroy
-    redirect_to request.referrer
+    respond_to do |format|
+      format.html { redirect_to request.referrer }
+      format.turbo_stream { render turbo_stream: turbo_stream.remove(@raw_time) }
+    end
   end
 
   private


### PR DESCRIPTION
Currently, we are adding new raw times to the Raw Times > List view using turbo stream, but we are requiring a page load to reflect deletions.

This PR removes raw times from the list when they are deleted.

Resolves #967