### PR TITLE
Initialize tooltips individually

### DIFF
--- a/app/assets/javascripts/event-stage.js
+++ b/app/assets/javascripts/event-stage.js
@@ -758,9 +758,6 @@
                     }
                 } );
                 eventStage.dataTables.onDataChange.call( this );
-                $( this.$el ).on( 'mouseover', '[data-bs-toggle="tooltip"]', function() {
-                    $( this ).tooltip( 'show' );
-                } );
             },
             init: function() {
                 Vue.component( 'data-tables', {

--- a/app/assets/javascripts/new_live_entry.js
+++ b/app/assets/javascripts/new_live_entry.js
@@ -1,10 +1,10 @@
 (function ($) {
 
     var timeIcons = {
-        'exists': '&nbsp;<span class="fas fa-exclamation-circle" data-bs-toggle="tooltip" title="Data Already Exists"></span>',
-        'good': '&nbsp;<span class="fas fa-check-circle text-success" data-bs-toggle="tooltip" title="Time Appears Good"></span>',
-        'questionable': '&nbsp;<span class="fas fa-question-circle text-warning" data-bs-toggle="tooltip" title="Time Appears Questionable"></span>',
-        'bad': '&nbsp;<span class="fas fa-times-circle text-danger" data-bs-toggle="tooltip" title="Time Appears Bad"></span>'
+        'exists': '&nbsp;<span class="fas fa-exclamation-circle" data-controller="tooltip" title="Data Already Exists"></span>',
+        'good': '&nbsp;<span class="fas fa-check-circle text-success" data-controller="tooltip" title="Time Appears Good"></span>',
+        'questionable': '&nbsp;<span class="fas fa-question-circle text-warning" data-controller="tooltip" title="Time Appears Questionable"></span>',
+        'bad': '&nbsp;<span class="fas fa-times-circle text-danger" data-controller="tooltip" title="Time Appears Bad"></span>'
     };
 
     /**
@@ -407,8 +407,6 @@
                     insertMode: false,
                     showMaskOnHover: false,
                 };
-
-                $('#js-add-effort-form [data-bs-toggle="tooltip"]').tooltip({container: 'body'});
 
                 $('#js-time-in').inputmask("datetime", timeMaskOptions);
                 $('#js-time-out').inputmask("datetime", timeMaskOptions);
@@ -831,9 +829,6 @@
                 liveEntry.timeRowsTable.timeRowControls();
 
                 $('[data-bs-toggle="popover"]').popover();
-                liveEntry.timeRowsTable.$dataTable.on('mouseover', '[data-bs-toggle="tooltip"]', function () {
-                    $(this).tooltip('show');
-                });
 
                 // Attach add listener
                 $('#js-add-to-cache').on('click', function (event) {
@@ -994,9 +989,9 @@
 
             buildTrHtml: function (rawTimeRow) {
                 var bibIcons = {
-                    'good': '&nbsp;<span class="fas fa-check-circle text-success" data-bs-toggle="tooltip" title="Bib Found"></span>',
-                    'questionable': '&nbsp;<span class="fas fa-question-circle text-warning" data-bs-toggle="tooltip" title="Bib In Wrong Event"></span>',
-                    'bad': '&nbsp;<span class="fas fa-times-circle text-danger" data-bs-toggle="tooltip" title="Bib Not Found"></span>'
+                    'good': '&nbsp;<span class="fas fa-check-circle text-success" data-controller="tooltip" title="Bib Found"></span>',
+                    'questionable': '&nbsp;<span class="fas fa-question-circle text-warning" data-controller="tooltip" title="Bib In Wrong Event"></span>',
+                    'bad': '&nbsp;<span class="fas fa-times-circle text-danger" data-controller="tooltip" title="Bib Not Found"></span>'
                 };
                 var inRawTime = liveEntry.rawTimeFromRow(rawTimeRow, 'in');
                 var outRawTime = liveEntry.rawTimeFromRow(rawTimeRow, 'out');

--- a/app/helpers/badge_helper.rb
+++ b/app/helpers/badge_helper.rb
@@ -5,7 +5,7 @@ module BadgeHelper
     color = options[:color] || "primary"
     tooltip_text = options[:tooltip_text]
     css_class = "badge bg-#{color} align-top"
-    tooltip_data = tooltip_text.present? ? { "bs-toggle": "tooltip", "bs-original-title": tooltip_text } : {}
+    tooltip_data = tooltip_text.present? ? { controller: :tooltip, bs_original_title: tooltip_text } : {}
 
     content_tag(:span,
                 text,
@@ -30,7 +30,7 @@ module BadgeHelper
                 status.titleize,
                 style: "font-size:0.8rem;",
                 class: "badge bg-#{color} align-top",
-                data: { "bs-toggle": "tooltip", "bs-original-title": tooltip_text })
+                data: { controller: :tooltip, bs_original_title: tooltip_text })
   end
 
   def lottery_status_badge(status)
@@ -52,7 +52,7 @@ module BadgeHelper
                 status.titleize,
                 style: "font-size:0.8rem;",
                 class: "badge bg-#{color} align-top",
-                data: { "bs-toggle": "tooltip", "bs-original-title": tooltip_text })
+                data: { controller: :tooltip, bs_original_title: tooltip_text })
   end
 
   def waitlist_badge

--- a/app/helpers/concealed_helper.rb
+++ b/app/helpers/concealed_helper.rb
@@ -7,6 +7,6 @@ module ConcealedHelper
 
     concat name.html_safe
     concat " "
-    fa_icon(icon_name, data: { "bs-toggle": "tooltip", "bs-original-title": tooltip_text })
+    fa_icon(icon_name, data: { controller: :tooltip, bs_original_title: tooltip_text })
   end
 end

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -4,8 +4,8 @@ module CoursesHelper
   def link_to_course_edit(course)
     url = edit_organization_course_path(course.organization, course)
     tooltip = "Edit this course"
-    options = { data: { bs_toggle: :tooltip,
-                        bs_placement: :bottom,
+    options = { data: { controller: :tooltip,
+                        bs_placement: :top,
                         bs_original_title: tooltip },
                 class: "btn btn-primary btn-sm" }
     link_to fa_icon("pencil-alt"), url, options

--- a/app/helpers/data_status_helper.rb
+++ b/app/helpers/data_status_helper.rb
@@ -16,6 +16,6 @@ module DataStatusHelper
     fa_icon(attributes[:icon],
             class: attributes[:class],
             text: time,
-            data: { "bs-toggle": "tooltip", "bs-original-title": tooltip_title })
+            data: { controller: :tooltip, bs_original_title: tooltip_title })
   end
 end

--- a/app/helpers/datetimepicker_helper.rb
+++ b/app/helpers/datetimepicker_helper.rb
@@ -22,13 +22,13 @@ module DatetimepickerHelper
                                  value: object.send(method)&.strftime(strftime_format),
                                  placeholder: placeholder_format,
                                  class: "form-control datetimepicker-input",
-                                 data: {"bs-target": "##{html_id}"}
+                                 data: { bs_target: "##{html_id}" }
 
-    append = content_tag(:div, nil, class: "input-group-text", data: {"bs-target": "##{html_id}", "bs-toggle": "datetimepicker"}) do
+    append = content_tag(:div, nil, class: "input-group-text", data: { bs_target: "##{html_id}", bs_toggle: "datetimepicker" }) do
       content_tag(:span, nil, class: "far fa-calendar-alt")
     end
 
-    content_tag(:div, nil, class: "input-group date", id: html_id, data: {"target-input" => "nearest"}) do
+    content_tag(:div, nil, class: "input-group date", id: html_id, data: { "target-input" => "nearest" }) do
       text_field + append
     end
   end

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -9,7 +9,7 @@ module DropdownHelper
     content_tag container_tag, class: [container_class, options[:class]].join(" ") do
       toggle_tag = options[:button] ? :button : :a
       toggle_class = (options[:button] ? "btn btn-outline-secondary" : "") + " dropdown-toggle"
-      concat content_tag(toggle_tag, class: toggle_class, data: { "bs-toggle": "dropdown" }) {
+      concat content_tag(toggle_tag, class: toggle_class, data: { bs_toggle: "dropdown" }) {
         active_name = items.find { |item| item[:active] }&.dig(:name)
         safe_concat [title, active_name].compact.join(" / ")
         safe_concat "&nbsp;"

--- a/app/helpers/efforts_helper.rb
+++ b/app/helpers/efforts_helper.rb
@@ -46,22 +46,22 @@ module EffortsHelper
   def link_to_effort_delete(effort)
     url = effort_path(effort)
     tooltip = "Delete effort"
-    options = {method: :delete,
-               data: {confirm: "This cannot be undone. Continue?",
-                      "bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
-               class: "btn btn-danger"}
+    options = { method: :delete,
+                data: { confirm: "This cannot be undone. Continue?",
+                        controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: tooltip },
+                class: "btn btn-danger" }
     link_to fa_icon("trash"), url, options
   end
 
   def link_to_effort_edit(effort)
     url = edit_effort_path(effort)
     tooltip = "Edit effort"
-    options = {data: {"bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
-               class: "btn btn-primary"}
+    options = { data: { controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: tooltip },
+                class: "btn btn-primary" }
     link_to fa_icon("pencil-alt"), url, options
   end
 
@@ -70,11 +70,11 @@ module EffortsHelper
       row.time_data_statuses.each_with_index do |data_status, i|
         new_data_status = data_status == "confirmed" ? "" : "confirmed"
         button_class = data_status == "confirmed" ? "success" : "outline-secondary"
-        effort_data = {split_times_attributes: {id: row.split_time_ids[i], data_status: new_data_status}}
+        effort_data = { split_times_attributes: { id: row.split_time_ids[i], data_status: new_data_status } }
         url = update_split_times_effort_path(effort, effort: effort_data)
-        options = {method: :patch,
-                   disabled: row.split_time_ids[i].blank?,
-                   class: "btn btn-#{button_class}"}
+        options = { method: :patch,
+                    disabled: row.split_time_ids[i].blank?,
+                    class: "btn btn-#{button_class}" }
         concat link_to fa_icon("thumbs-up"), url, options
         concat " "
       end
@@ -85,10 +85,10 @@ module EffortsHelper
     if row.split_time_ids.compact.present?
       row.split_time_ids.each do |id|
         url = delete_split_times_effort_path(effort, split_time_ids: [id])
-        options = {method: :delete,
-                   disabled: id.blank?,
-                   data: {confirm: "This action cannot be undone. OK to proceed?"},
-                   class: "btn btn-danger"}
+        options = { method: :delete,
+                    disabled: id.blank?,
+                    data: { confirm: "This action cannot be undone. OK to proceed?" },
+                    class: "btn btn-danger" }
         concat link_to fa_icon("trash"), url, options
         concat " "
       end
@@ -97,10 +97,10 @@ module EffortsHelper
 
   def link_to_start_effort(view_object)
     time = view_object.assumed_start_time_local
-    button_tag "Start effort", class: "btn btn-success", data: {action: "click->roster#showModal",
-                                                                title: "Start Effort",
-                                                                time: time.to_s,
-                                                                displaytime: l(time, format: :datetime_input)}
+    button_tag "Start effort", class: "btn btn-success", data: { action: "click->roster#showModal",
+                                                                 title: "Start Effort",
+                                                                 time: time.to_s,
+                                                                 displaytime: l(time, format: :datetime_input) }
   end
 
   def effort_start_time_string(presenter)

--- a/app/helpers/event_groups_helper.rb
+++ b/app/helpers/event_groups_helper.rb
@@ -5,27 +5,29 @@ module EventGroupsHelper
     if view_object.ready_efforts.present?
       content_tag :div, class: "btn-group" do
         concat content_tag(:button, class: "btn btn-success dropdown-toggle start-ready-efforts",
-                                    data: {"bs-toggle": :dropdown}) {
-                 safe_concat "Start entrants"
-                 safe_concat "&nbsp;"
-                 concat content_tag(:span, "", class: "caret")
-               }
+                           data: { bs_toggle: :dropdown }) {
+          safe_concat "Start entrants"
+          safe_concat "&nbsp;"
+          concat content_tag(:span, "", class: "caret")
+        }
 
         concat content_tag(:div, class: "dropdown-menu") {
           view_object.ready_efforts.count_by(&:assumed_start_time_local).sort.each do |time, effort_count|
             display_time = l(time, format: :full_day_military_and_zone)
             concat content_tag(:div, "(#{effort_count}) scheduled at #{display_time}",
-                               {class: "dropdown-item", data: {action: "click->roster#showModal",
-                                                               title: "Start #{pluralize(effort_count, 'Entrant')}",
-                                                               time: time.in_time_zone("UTC").to_s,
-                                                               displaytime: l(time, format: :datetime_input)}})
+                               { class: "dropdown-item",
+                                 data: { action: "click->roster#showModal",
+                                         title: "Start #{pluralize(effort_count, 'Entrant')}",
+                                         time: time.in_time_zone("UTC").to_s,
+                                         displaytime: l(time, format: :datetime_input) }
+                               })
           end
         }
       end
     else
       link_to "Nothing to start", "#", disabled: true,
-                                       data: {confirm: "No entrants are ready to start. Reload the page to check again."},
-                                       class: "start-ready-efforts btn btn-md btn-success"
+              data: { confirm: "No entrants are ready to start. Reload the page to check again." },
+              class: "start-ready-efforts btn btn-md btn-success"
     end
   end
 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -6,7 +6,7 @@ module EventsHelper
     tooltip = "Delete this event"
     options = { data: { turbo_confirm: "This will delete the event, together with all related entrants. Are you sure you want to proceed?",
                         turbo_method: :delete,
-                        bs_toggle: :tooltip,
+                        controller: :tooltip,
                         bs_placement: :bottom,
                         bs_original_title: tooltip },
                 class: "btn btn-danger" }
@@ -16,7 +16,7 @@ module EventsHelper
   def link_to_event_edit(event)
     url = edit_event_group_event_path(event.event_group, event)
     tooltip = "Edit this event"
-    options = { data: { bs_toggle: :tooltip,
+    options = { data: { controller: :tooltip,
                         bs_placement: :bottom,
                         bs_original_title: tooltip },
                 class: "btn btn-primary" }
@@ -27,7 +27,7 @@ module EventsHelper
     link_to fa_icon("sign-in-alt"),
             reassign_event_group_event_path(event.event_group, event, event: { event_group_id: desired_event_group.id }),
             data: {
-              bs_toggle: "tooltip",
+              controller: :tooltip,
               bs_placement: "bottom",
               bs_original_title: "Join #{event.name} into the #{desired_event_group.name} group",
               turbo_method: :patch,
@@ -40,7 +40,7 @@ module EventsHelper
     link_to fa_icon("sign-out-alt"),
             reassign_event_group_event_path(current_event_group, event, event: { event_group_id: nil }),
             data: {
-              bs_toggle: "tooltip",
+              controller: :tooltip,
               bs_placement: "bottom",
               bs_original_title: "Remove #{event.name} from the #{current_event_group.name} group",
               turbo_method: :patch,

--- a/app/helpers/lottery_helper.rb
+++ b/app/helpers/lottery_helper.rb
@@ -7,9 +7,9 @@ module LotteryHelper
     options = {method: :delete,
                data: {confirm: "This will delete the division, together with all related entrants. Are you sure you want to proceed?",
                       turbo: false,
-                      "bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
+                      controller: :tooltip,
+                      bs_placement: :bottom,
+                      bs_original_title: tooltip},
                class: "btn btn-danger btn-sm"}
     link_to fa_icon("trash"), url, options
   end
@@ -17,9 +17,9 @@ module LotteryHelper
   def link_to_division_edit(division)
     url = edit_organization_lottery_lottery_division_path(division.organization, division.lottery, division)
     tooltip = "Edit this division"
-    options = {data: {"bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
+    options = {data: {controller: :tooltip,
+                      bs_placement: :bottom,
+                      bs_original_title: tooltip},
                class: "btn btn-primary btn-sm"}
     link_to fa_icon("pencil-alt"), url, options
   end
@@ -30,9 +30,9 @@ module LotteryHelper
     options = {method: :delete,
                data: {confirm: "This will delete the entrant and cannot be undone. Are you sure you want to proceed?",
                       turbo: false,
-                      "bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
+                      controller: :tooltip,
+                      bs_placement: :bottom,
+                      bs_original_title: tooltip},
                class: "btn btn-danger btn-sm"}
     link_to fa_icon("trash"), url, options
   end
@@ -40,9 +40,9 @@ module LotteryHelper
   def link_to_entrant_edit(entrant)
     url = edit_organization_lottery_lottery_entrant_path(entrant.organization, entrant.lottery, entrant)
     tooltip = "Edit this entrant"
-    options = {data: {"bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
+    options = {data: {controller: :tooltip,
+                      bs_placement: :bottom,
+                      bs_original_title: tooltip},
                class: "btn btn-primary btn-sm"}
     link_to fa_icon("pencil-alt"), url, options
   end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -10,9 +10,9 @@ module NavigationHelper
             data: { controller: "navigation animation",
                     action: "click->animation#spinIcon keyup@document->navigation#evaluateKeyup",
                     "navigation-target" => "refreshButton",
-                    "bs-toggle": "tooltip",
-                    placement: :bottom,
-                    "bs-original-title": tooltip_title }
+                    controller: :tooltip,
+                    bs_placement: :bottom,
+                    bs_original_title: tooltip_title }
   end
 
   def prior_next_nav_button(view_object, prior_or_next, param: :parameterized_split_name)
@@ -29,9 +29,9 @@ module NavigationHelper
             data: { controller: "navigation",
                     action: "keyup@document->navigation#evaluateKeyup",
                     "navigation-target" => "#{prior_or_next}Button",
-                    "bs-toggle": "tooltip",
-                    placement: :bottom,
-                    "bs-original-title": tooltip_title },
+                    controller: :tooltip,
+                    bs_placement: :bottom,
+                    bs_original_title: tooltip_title },
             disabled: target.blank?
   end
 end

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -6,9 +6,9 @@ module PartnersHelper
     tooltip = "Delete partner"
     options = {method: :delete,
                data: {confirm: "This cannot be undone. Continue?",
-                      "bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
+                      controller: :tooltip,
+                      bs_placement: :bottom,
+                      bs_original_title: tooltip},
                class: "btn btn-danger"}
     link_to fa_icon("trash"), url, options
   end
@@ -16,9 +16,9 @@ module PartnersHelper
   def link_to_event_group_partner_edit(partner)
     url = edit_organization_event_group_partner_path(partner.organization, partner.partnerable, partner)
     tooltip = "Edit partner"
-    options = {data: {"bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
+    options = {data: {controller: :tooltip,
+                      bs_placement: :bottom,
+                      bs_original_title: tooltip},
                class: "btn btn-primary"}
     link_to fa_icon("pencil-alt"), url, options
   end
@@ -28,9 +28,9 @@ module PartnersHelper
     tooltip = "Delete partner"
     options = {method: :delete,
                data: {confirm: "This cannot be undone. Continue?",
-                      "bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
+                      controller: :tooltip,
+                      bs_placement: :bottom,
+                      bs_original_title: tooltip},
                class: "btn btn-danger"}
     link_to fa_icon("trash"), url, options
   end
@@ -38,9 +38,9 @@ module PartnersHelper
   def link_to_lottery_partner_edit(partner)
     url = edit_organization_lottery_partner_path(partner.organization, partner.partnerable, partner)
     tooltip = "Edit partner"
-    options = {data: {"bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
+    options = {data: {controller: :tooltip,
+                      bs_placement: :bottom,
+                      bs_original_title: tooltip},
                class: "btn btn-primary"}
     link_to fa_icon("pencil-alt"), url, options
   end

--- a/app/helpers/raw_times_helper.rb
+++ b/app/helpers/raw_times_helper.rb
@@ -28,10 +28,12 @@ module RawTimesHelper
       tooltip_text = "This raw time has not been reviewed by a human. Click to mark it as having been reviewed."
       button_class = "outline-secondary"
     end
-    url = raw_time_path(raw_time, raw_time: {reviewed_by: reviewed_by, reviewed_at: reviewed_at}, referrer_path: request.params)
-    options = {method: :patch,
-               data: {"bs-toggle": :tooltip, placement: :bottom, "bs-original-title": tooltip_text},
-               class: "btn btn-#{button_class} click-spinner"}
+    url = raw_time_path(raw_time, raw_time: { reviewed_by: reviewed_by, reviewed_at: reviewed_at }, referrer_path: request.params)
+    options = { method: :patch,
+                data: { controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: tooltip_text },
+                class: "btn btn-#{button_class} click-spinner" }
 
     link_to fa_icon("glasses"), url, options
   end
@@ -39,74 +41,74 @@ module RawTimesHelper
   def link_to_raw_time_delete(raw_time)
     url = raw_time_path(raw_time, referrer_path: request.params)
     tooltip = "Delete raw time"
-    options = {method: :delete,
-               data: {confirm: "We recommend that you keep a complete list of all time records, even those that are duplicated or incorrect. Are you sure you want to delete this record?",
-                      "bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
-               class: "btn btn-danger"}
+    options = { method: :delete,
+                data: { confirm: "We recommend that you keep a complete list of all time records, even those that are duplicated or incorrect. Are you sure you want to delete this record?",
+                        controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: tooltip },
+                class: "btn btn-danger" }
     link_to fa_icon("trash"), url, options
   end
 
   def link_to_raw_time_match(split_time, raw_time_id, icon)
     if split_time.persisted?
-      url = split_time_path(split_time, split_time: {matching_raw_time_id: raw_time_id})
+      url = split_time_path(split_time, split_time: { matching_raw_time_id: raw_time_id })
       tooltip = icon == :link ? "Match this raw time" : "Set this as the governing time"
-      options = {method: :patch,
-                 data: {"bs-toggle": :tooltip,
-                        placement: :bottom,
-                        "bs-original-title": tooltip},
-                 id: "match-raw-time-#{raw_time_id}",
-                 class: "btn btn-sm btn-success"}
+      options = { method: :patch,
+                  data: { controller: :tooltip,
+                          bs_placement: :bottom,
+                          bs_original_title: tooltip },
+                  id: "match-raw-time-#{raw_time_id}",
+                  class: "btn btn-sm btn-success" }
     else
       url = create_split_time_from_raw_time_effort_path(split_time.effort_id, raw_time_id: raw_time_id, lap: split_time.lap)
       tooltip = "Create a split time from this raw time"
-      options = {method: :post,
-                 data: {"bs-toggle": :tooltip,
-                        placement: :bottom,
-                        "bs-original-title": tooltip},
-                 id: "match-raw-time-#{raw_time_id}",
-                 class: "btn btn-sm btn-success"}
+      options = { method: :post,
+                  data: { controller: :tooltip,
+                          bs_placement: :bottom,
+                          bs_original_title: tooltip },
+                  id: "match-raw-time-#{raw_time_id}",
+                  class: "btn btn-sm btn-success" }
     end
 
     link_to fa_icon(icon), url, options
   end
 
   def link_to_raw_time_unmatch(raw_time_id)
-    url = raw_time_path(raw_time_id, raw_time: {split_time_id: nil})
+    url = raw_time_path(raw_time_id, raw_time: { split_time_id: nil })
     tooltip = "Un-match this raw time"
-    options = {method: :patch,
-               data: {"bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": tooltip},
-               id: "unmatch-raw-time-#{raw_time_id}",
-               class: "btn btn-sm btn-danger"}
+    options = { method: :patch,
+                data: { controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: tooltip },
+                id: "unmatch-raw-time-#{raw_time_id}",
+                class: "btn btn-sm btn-danger" }
 
     link_to fa_icon(:unlink), url, options
   end
 
   def link_to_raw_time_associate(raw_time_id)
-    url = raw_time_path(raw_time_id, raw_time: {disassociated_from_effort: false})
+    url = raw_time_path(raw_time_id, raw_time: { disassociated_from_effort: false })
     tooltip = "Associate this raw time with this effort"
-    options = {method: :patch,
-               data: {"bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "original_title" => tooltip},
-               id: "associate-raw-time-#{raw_time_id}",
-               class: "btn btn-sm btn-success"}
+    options = { method: :patch,
+                data: { controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: tooltip },
+                id: "associate-raw-time-#{raw_time_id}",
+                class: "btn btn-sm btn-success" }
 
     link_to fa_icon(:plus_square), url, options
   end
 
   def link_to_raw_time_disassociate(raw_time_id)
-    url = raw_time_path(raw_time_id, raw_time: {disassociated_from_effort: true})
+    url = raw_time_path(raw_time_id, raw_time: { disassociated_from_effort: true })
     tooltip = "Disassociate this raw time from this effort"
-    options = {method: :patch,
-               data: {"bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "original_title" => tooltip},
-               id: "disassociate-raw-time-#{raw_time_id}",
-               class: "btn btn-sm btn-danger"}
+    options = { method: :patch,
+                data: { controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: tooltip },
+                id: "disassociate-raw-time-#{raw_time_id}",
+                class: "btn btn-sm btn-danger" }
 
     link_to fa_icon(:minus_square), url, options
   end

--- a/app/helpers/time_cluster_helper.rb
+++ b/app/helpers/time_cluster_helper.rb
@@ -21,7 +21,10 @@ module TimeClusterHelper
 
       if cluster.show_stop_indicator?
         concat " "
-        concat fa_icon("hand-paper", class: "text-danger", data: {"bs-toggle": "tooltip", "bs-original-title": "Stopped Here"})
+        concat fa_icon("hand-paper",
+                       class: "text-danger",
+                       data: { controller: :tooltip,
+                               bs_original_title: "Stopped Here" })
       end
     end
   end

--- a/app/helpers/toggle_helper.rb
+++ b/app/helpers/toggle_helper.rb
@@ -39,7 +39,9 @@ module ToggleHelper
     url = update_all_efforts_event_group_path(view_object.event_group, efforts: { checked_in: true }, button: :check_in_all)
     options = { method: "patch",
                 data: { confirm: "This will check in all entrants, making them eligible to start. Do you want to proceed?",
-                        "bs-toggle": :tooltip, placement: :bottom, "bs-original-title": "Check in all" },
+                        controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: "Check in all" },
                 class: "btn btn-success click-spinner" }
     link_to fa_icon("check-square", text: "All", type: :regular), url, options
   end
@@ -48,7 +50,9 @@ module ToggleHelper
     url = update_all_efforts_event_group_path(view_object.event_group, efforts: { checked_in: false }, button: :check_out_all)
     options = { method: "patch",
                 data: { confirm: "This will check out all unstarted entrants, making them ineligible to start. Do you want to proceed?",
-                        "bs-toggle": :tooltip, placement: :bottom, "bs-original-title": "Check out all" },
+                        controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: "Check out all" },
                 class: "btn btn-outline-secondary click-spinner" }
     link_to fa_icon("square", text: "All", type: :regular), url, options
   end
@@ -117,6 +121,8 @@ module ToggleHelper
   def link_to_sign_in(args)
     icon_name = args[:icon_name]
     protocol = args[:protocol]
-    link_to fa_icon(icon_name, text: " #{protocol}"), "#", class: "btn btn-lg btn-outline-secondary", data: { "bs-toggle": "modal", "bs-target": "#log-in-modal" }
+    link_to fa_icon(icon_name, text: " #{protocol}"), "#",
+            class: "btn btn-lg btn-outline-secondary",
+            data: { bs_toggle: "modal", bs_target: "#log-in-modal" }
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -5,9 +5,9 @@ module UsersHelper
     url = user_path(user, referrer_path: request.params)
     options = {method: :delete,
                data: {confirm: "This cannot be undone. Are you sure you want to delete this record?",
-                      "bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": "Delete user"},
+                      controller: :tooltip,
+                      bs_placement: :bottom,
+                      bs_original_title: "Delete user"},
                id: "delete_user_#{user.id}",
                class: "btn btn-danger"}
     link_to fa_icon("trash"), url, options
@@ -16,9 +16,9 @@ module UsersHelper
   def link_to_become_user(user)
     url = admin_impersonate_start_path(user)
     options = {method: :post,
-               data: {"bs-toggle": :tooltip,
-                      placement: :bottom,
-                      "bs-original-title": "Impersonate user"},
+               data: {controller: :tooltip,
+                      bs_placement: :bottom,
+                      bs_original_title: "Impersonate user"},
                id: "impersonate_user_#{user.id}",
                class: "btn btn-warning"}
     link_to fa_icon("theater-masks"), url, options

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+import { Tooltip } from "bootstrap"
+
+export default class extends Controller {
+  connect() {
+    new Tooltip(this.element)
+  }
+
+  disconnect() {
+    const tooltip = Tooltip.getInstance(this.element)
+    tooltip.dispose()
+  }
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -43,14 +43,6 @@ import "bootstrap"
 // Import specific Bootstrap modules
 import { Tooltip } from "bootstrap"
 
-// Initialize tooltips
-document.addEventListener("turbo:load", () => {
-  var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
-  var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
-    return new Tooltip(tooltipTriggerEl)
-  })
-})
-
 // Expand the default allowList for Bootstrap tooltips and popovers
 let myDefaultAllowList = Tooltip.Default.allowList;
 

--- a/app/views/courses/_plan_detail.html.erb
+++ b/app/views/courses/_plan_detail.html.erb
@@ -25,8 +25,8 @@
           <span class="text-danger">
             <%= fa_icon("exclamation-circle",
                         data: {
-                          "bs-toggle": "tooltip",
-                          "bs-original-title": "#{row.base_name} does not exist as an aid station in the upcoming event. It is presented here for reference only."
+                          controller: :tooltip,
+                          bs_original_title: "#{row.base_name} does not exist as an aid station in the upcoming event. It is presented here for reference only."
                         }) %>
           </span>
         <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,21 +1,21 @@
 <div class="mb-3">
   <%- if controller_name != 'sessions' %>
-    <%= link_to t(".sign_in"), '#', data: {"bs-toggle": 'modal', "bs-target": '#log-in-modal'} %><br />
+    <%= link_to t(".sign_in"), '#', data: { bs_toggle: 'modal', bs_target: '#log-in-modal' } %><br/>
   <% end -%>
 
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-    <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
+    <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br/>
   <% end -%>
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-    <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
+    <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br/>
   <% end -%>
 
   <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-    <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+    <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br/>
   <% end -%>
 
   <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-    <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
+    <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br/>
   <% end -%>
 </div>

--- a/app/views/efforts/_start_stop_buttons.html.erb
+++ b/app/views/efforts/_start_stop_buttons.html.erb
@@ -8,24 +8,24 @@
     <%= link_to "Set stop", stop_effort_path(presenter.effort),
                 method: :patch,
                 class: "btn btn-success",
-                data: { "bs-toggle": "tooltip",
-                        placement: :bottom,
-                        "bs-original-title": "Sets a stop on the final split time" } %>
+                data: { controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: "Sets a stop on the final split time" } %>
   <% end %>
   <% if presenter.has_removable_stop? %>
     <%= link_to "Remove stop", stop_effort_path(presenter.effort, status: false),
                 method: :patch,
                 class: "btn btn-success",
-                data: { "bs-toggle": "tooltip",
-                        placement: :bottom,
-                        "bs-original-title": "Removes the stop from all split times" } %>
+                data: { controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: "Removes the stop from all split times" } %>
   <% end %>
   <% if presenter.started? %>
     <%= link_to "Smart stop", smart_stop_effort_path(presenter.effort),
                 method: :patch,
                 class: "btn btn-success",
-                data: { "bs-toggle": "tooltip",
-                        placement: :bottom,
-                        "bs-original-title": "Deletes any hanging split time, fills in a proper final split time if needed, and sets a stop on the final split time" } %>
+                data: { controller: :tooltip,
+                        bs_placement: :bottom,
+                        bs_original_title: "Deletes any hanging split time, fills in a proper final split time if needed, and sets a stop on the final split time" } %>
   <% end %>
 </span>

--- a/app/views/event_groups/_form.html.erb
+++ b/app/views/event_groups/_form.html.erb
@@ -9,7 +9,10 @@
 
       <div class="mb-3 col-12" data-target="eg-form.eventGroupName">
         <label class="form-label required">What will you call your event group?</label>
-        <span tabindex="-1" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-original-title="This is the name for your entire event group. If this is the Great Rocky Run for 2023 and you are running 25- and 50-mile races, the name should be something like '2023 Great Rocky Run'. You'll specify your individual events later."><i class="fas fa-question-circle"></i></span>
+        <span tabindex="-1"
+              data-controller="tooltip"
+              data-bs-placement="bottom"
+              data-bs-original-title="This is the name for your entire event group. If this is the Great Rocky Run for 2023 and you are running 25- and 50-mile races, the name should be something like '2023 Great Rocky Run'. You'll specify your individual events later."><i class="fas fa-question-circle"></i></span>
         <%= form.text_field :name,
                             class: "form-control",
                             placeholder: "Example: #{Date.today.year} #{presenter.organization_name}",
@@ -19,7 +22,10 @@
 
       <div class="mb-3 col-12">
         <label class="required">In what time zone will your event occur?</label>
-        <span tabindex="-1" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-original-title="Choose a timezone for your event. You will add a start time in the next step."><i class="fas fa-question-circle"></i></span>
+        <span tabindex="-1"
+              data-controller="tooltip"
+              data-bs-placement="bottom"
+              data-bs-original-title="Choose a timezone for your event. You will add a start time in the next step."><i class="fas fa-question-circle"></i></span>
         <%= form.collection_select(:home_time_zone, ActiveSupport::TimeZone.all, :name, :name,
                                    { selected: presenter.event_group.home_time_zone || "Mountain Time (US & Canada)" },
                                    { class: "form-control dropdown-select-field" }) %>
@@ -27,7 +33,9 @@
 
       <div class="mb-3 col-12">
         <label class="required">Will you monitor pacers?</label>
-        <span tabindex="-1" data-bs-toggle="tooltip" data-bs-original-title="Choose 'Yes' only if you will actively track pacers using OST Remote."><i class="fas fa-question-circle"></i></span>
+        <span tabindex="-1"
+              data-controller="tooltip"
+              data-bs-original-title="Choose 'Yes' only if you will actively track pacers using OST Remote."><i class="fas fa-question-circle"></i></span>
         <div>
           <div><%= form.radio_button :monitor_pacers, true %> Yes</div>
           <div><%= form.radio_button :monitor_pacers, false %> No</div>
@@ -36,7 +44,9 @@
 
       <div class="mb-3 col-12">
         <label class="required">How will data entry points be grouped in OST Remote?</label>
-        <span tabindex="-1" data-bs-toggle="tooltip" data-bs-original-title="This determines whether data entry points at the same location will be grouped together on the Live Entry screen in OST Remote. If in doubt, choose 'Location Grouped'."><i class="fas fa-question-circle"></i></span>
+        <span tabindex="-1"
+              data-controller="tooltip"
+              data-bs-original-title="This determines whether data entry points at the same location will be grouped together on the Live Entry screen in OST Remote. If in doubt, choose 'Location Grouped'."><i class="fas fa-question-circle"></i></span>
         <div>
           <%= form.select(:data_entry_grouping_strategy,
                           EventGroup.data_entry_grouping_strategies.keys.map { |strategy| [strategy.titleize, strategy] },

--- a/app/views/event_staging/events/_entrants.html.erb
+++ b/app/views/event_staging/events/_entrants.html.erb
@@ -45,8 +45,8 @@
             </tr>
             <template slot="row" scope="vm">
               <td>
-                <i class="fas fa-check-circle" v-show="vm.row.personId" data-bs-toggle="tooltip" title="This effort has been reconciled"></i>
-                <i class="fas fa-question-circle" v-show="!vm.row.personId" data-bs-toggle="tooltip" title="This effort is not reconciled with participants in the database"></i>
+                <i class="fas fa-check-circle" v-show="vm.row.personId" data-controller="tooltip" title="This effort has been reconciled"></i>
+                <i class="fas fa-question-circle" v-show="!vm.row.personId" data-controller="tooltip" title="This effort is not reconciled with participants in the database"></i>
               </td>
               <td>{{ vm.row.firstName }} {{ vm.row.lastName }}</td>
               <td>{{ vm.row.gender === 'male' ? 'M' : 'F' }}</td>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -22,7 +22,10 @@
             <div class="row">
               <div class="mb-3 col">
                 <label class="required">Choose an existing course or create a new course</label>
-                <span tabindex="-1" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-original-title="Each event is run on a course. Your courses can be reused in future events."><i class="fas fa-question-circle"></i></span>
+                <span tabindex="-1"
+                      data-controller="tooltip"
+                      data-bs-placement="bottom"
+                      data-bs-original-title="Each event is run on a course. Your courses can be reused in future events."><i class="fas fa-question-circle"></i></span>
                 <%= form.select :id, options_for_select(presenter.courses_for_select, presenter.event.course_id),
                                 {},
                                 { autofocus: true,
@@ -134,7 +137,10 @@
               <div class="row">
                 <div class="col">
                   <%= form.label :short_name, class: "mb-1" %>
-                  <span tabindex="-1" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-original-title="If you will have more than one event in this group, give each a short name (like '50K' or '24-hour') to distinguish them"><i class="fas fa-question-circle"></i></span>
+                  <span tabindex="-1"
+                        data-controller="tooltip"
+                        data-bs-placement="bottom"
+                        data-bs-original-title="If you will have more than one event in this group, give each a short name (like '50K' or '24-hour') to distinguish them"><i class="fas fa-question-circle"></i></span>
                   <%= form.text_field :short_name,
                                       class: "form-control",
                                       placeholder: "Short name",
@@ -174,7 +180,10 @@
                 <div class="row">
                   <div class="col">
                     <%= form.label :linked_lottery %>
-                    <span tabindex="-1" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-original-title="If entrants to this event were chosen in an OpenSplitTime lottery, choose the lottery from this dropdown. Otherwise, leave this selection blank."><i class="fas fa-question-circle"></i></span>
+                    <span tabindex="-1"
+                          data-controller="tooltip"
+                          data-bs-placement="bottom"
+                          data-bs-original-title="If entrants to this event were chosen in an OpenSplitTime lottery, choose the lottery from this dropdown. Otherwise, leave this selection blank."><i class="fas fa-question-circle"></i></span>
                     <%= form.select :lottery_id,
                                     options_for_select(event.organization.lotteries.pluck(:name, :id).unshift(["None", nil]), event.lottery_id),
                                     {},
@@ -192,7 +201,10 @@
           <div class="row">
             <div class="mb-3 col">
               <%= form.label "Tracking site URL", class: "mb-1" %>
-              <span tabindex="-1" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-original-title="If this event will use an external GPS-based tracking site, you may enter the site URL here to create a convenient link from the event page."><i class="fas fa-question-circle"></i></span>
+              <span tabindex="-1"
+                    data-controller="tooltip"
+                    data-bs-placement="bottom"
+                    data-bs-original-title="If this event will use an external GPS-based tracking site, you may enter the site URL here to create a convenient link from the event page."><i class="fas fa-question-circle"></i></span>
               <%= form.text_field :beacon_url, class: "form-control", placeholder: "example.com/tracking/my-event" %>
             </div>
           </div>
@@ -203,7 +215,10 @@
         <div class="mb-3">
           <div class="control-label col">
             <%= form.label :podium_template, class: "mb-1 required" %>
-            <span tabindex="-1" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-original-title="Select a template for the Results/Podium view. If you aren't sure, choose Simple."><i class="fas fa-question-circle"></i></span>
+            <span tabindex="-1"
+                  data-controller="tooltip"
+                  data-bs-placement="bottom"
+                  data-bs-original-title="Select a template for the Results/Podium view. If you aren't sure, choose Simple."><i class="fas fa-question-circle"></i></span>
           </div>
           <div class="col-sm-8">
             <div class="card" data-controller="results-template">

--- a/app/views/events/_podium_category.html.erb
+++ b/app/views/events/_podium_category.html.erb
@@ -1,7 +1,11 @@
 <thead>
 <tr>
   <th>
-    <span class="collapse-rotate pe-2"><%= link_to fa_icon("caret-right", size: "lg"), "#collapse_#{category.position}", data: {"bs-toggle": "collapse"} %></span>
+    <span class="collapse-rotate pe-2">
+      <%= link_to fa_icon("caret-right", size: "lg"),
+                  "#collapse_#{category.position}",
+                  data: { bs_toggle: "collapse" } %>
+    </span>
     <span><%= "#{'*' if category.fixed_position} #{category.name}" %></span>
   </th>
   <% if @presenter.multiple_laps? %>

--- a/app/views/export_jobs/_export_job.html.erb
+++ b/app/views/export_jobs/_export_job.html.erb
@@ -15,7 +15,7 @@
           <span class="mx-1">
             <% if export_job.file.attached? %>
               <%= link_to fa_icon("download",
-                                  data: { "bs-toggle": "tooltip", "bs-original-title": "Download" }),
+                                  data: { controller: :tooltip, bs_original_title: "Download" }),
                           rails_blob_path(export_job.file, disposition: "attachment") %>
             <% else %>
               <%= fa_icon("download", class: "text-muted") %>
@@ -24,7 +24,7 @@
           <span class="mx-1">
           <%= link_to fa_icon("trash",
                               class: "text-danger",
-                              data: { "bs-toggle": "tooltip", "bs-original-title": "Delete" }),
+                              data: { controller: :tooltip, bs_original_title: "Delete" }),
                       export_job_path(export_job),
                       method: :delete,
                       data: { confirm: "Delete this export?" } %>

--- a/app/views/layouts/_nav_links_for_auth.html.erb
+++ b/app/views/layouts/_nav_links_for_auth.html.erb
@@ -20,7 +20,7 @@
   </li>
 <% else %>
   <li class="nav-item">
-    <%= link_to t("devise.sessions.new.sign_in").titleize, "#", class: "nav-link", data: { "bs-toggle": "modal", "bs-target": "#log-in-modal" } %>
+    <%= link_to t("devise.sessions.new.sign_in").titleize, "#", class: "nav-link", data: { bs_toggle: "modal", bs_target: "#log-in-modal" } %>
   </li>
   <li class="nav-item">
     <%= link_to new_registration_path(resource_name), class: "nav-link" do %>

--- a/app/views/live/event_groups/new_live_entry.html.erb
+++ b/app/views/live/event_groups/new_live_entry.html.erb
@@ -40,9 +40,9 @@
           <div class="input-group">
             <input id="js-bib-number" type="tel" name="bibNumber" class="form-control form-control-sm" autocomplete="off" value="" style="text-align: left;">
             <span class="input-group-text time-status">
-              <span class="fas fa-check-circle good text-success" title="Bib found" data-bs-toggle="tooltip" data-bs-placement="right"></span>
-              <span class="fas fa-question-circle questionable text-warning" title="Bib in wrong event" data-bs-toggle="tooltip" data-bs-placement="right"></span>
-              <span class="fas fa-times-circle bad text-danger" title="Bib not found" data-bs-toggle="tooltip" data-bs-placement="right"></span>
+              <span class="fas fa-check-circle good text-success" title="Bib found" data-controller="tooltip" data-bs-placement="right"></span>
+              <span class="fas fa-question-circle questionable text-warning" title="Bib in wrong event" data-controller="tooltip" data-bs-placement="right"></span>
+              <span class="fas fa-times-circle bad text-danger" title="Bib not found" data-controller="tooltip" data-bs-placement="right"></span>
             </span>
           </div>
         </div>
@@ -61,10 +61,10 @@
           <div class="input-group">
             <input id="js-time-in" type="tel" name="timeIn" class="form-control form-control-sm" value="" placeholder="hh:mm:ss (24hr)">
             <span class="input-group-text time-status">
-              <span class="fas fa-exclamation-circle exists" title="Time for this bib already exists at this station" data-bs-toggle="tooltip" data-bs-placement="right"></span>
-              <span class="fas fa-check-circle good text-success" title="Time appears good" data-bs-toggle="tooltip" data-bs-placement="right"></span>
-              <span class="fas fa-question-circle questionable text-warning" title="Time appears questionable" data-bs-toggle="tooltip" data-bs-placement="right"></span>
-              <span class="fas fa-times-circle bad text-danger" title="Time appears bad" data-bs-toggle="tooltip" data-bs-placement="right"></span>
+              <span class="fas fa-exclamation-circle exists" title="Time for this bib already exists at this station" data-controller="tooltip" data-bs-placement="right"></span>
+              <span class="fas fa-check-circle good text-success" title="Time appears good" data-controller="tooltip" data-bs-placement="right"></span>
+              <span class="fas fa-question-circle questionable text-warning" title="Time appears questionable" data-controller="tooltip" data-bs-placement="right"></span>
+              <span class="fas fa-times-circle bad text-danger" title="Time appears bad" data-controller="tooltip" data-bs-placement="right"></span>
             </span>
           </div>
         </div>
@@ -75,10 +75,10 @@
           <div class="input-group">
             <input id="js-time-out" type="tel" name="timeOut" class="form-control form-control-sm" value="" placeholder="hh:mm:ss (24hr)">
             <span class="input-group-text time-status">
-              <span class="fas fa-exclamation-circle exists" title="Time for this bib already exists at this station" data-bs-toggle="tooltip" data-bs-placement="right"></span>
-              <span class="fas fa-check-circle good text-success" title="Time appears good" data-bs-toggle="tooltip" data-bs-placement="right"></span>
-              <span class="fas fa-question-circle questionable text-warning" title="Time appears questionable" data-bs-toggle="tooltip" data-bs-placement="right"></span>
-              <span class="fas fa-times-circle bad text-danger" title="Time appears bad" data-bs-toggle="tooltip" data-bs-placement="right"></span>
+              <span class="fas fa-exclamation-circle exists" title="Time for this bib already exists at this station" data-controller="tooltip" data-bs-placement="right"></span>
+              <span class="fas fa-check-circle good text-success" title="Time appears good" data-controller="tooltip" data-bs-placement="right"></span>
+              <span class="fas fa-question-circle questionable text-warning" title="Time appears questionable" data-controller="tooltip" data-bs-placement="right"></span>
+              <span class="fas fa-times-circle bad text-danger" title="Time appears bad" data-controller="tooltip" data-bs-placement="right"></span>
             </span>
           </div>
         </div>

--- a/app/views/shared/_strong_confirm_link.html.erb
+++ b/app/views/shared/_strong_confirm_link.html.erb
@@ -1,1 +1,1 @@
-<%= link_to name, "#", options.deep_merge(data: {"bs-toggle": "modal", "bs-target": "##{strong_confirm_id}"}) %>
+<%= link_to name, "#", options.deep_merge(data: { bs_toggle: "modal", bs_target: "##{strong_confirm_id}" }) %>

--- a/app/views/split_times/_projections_list.html.erb
+++ b/app/views/split_times/_projections_list.html.erb
@@ -49,8 +49,8 @@
           <span class="text-danger">
             <%= fa_icon("exclamation-circle",
                         data: {
-                          "bs-toggle": "tooltip",
-                          "bs-original-title": "#{row.base_name} does not exist as an aid station in the upcoming event. It is presented here for reference only."
+                          controller: :tooltip,
+                          bs_original_title: "#{row.base_name} does not exist as an aid station in the upcoming event. It is presented here for reference only."
                         }) %>
           </span>
           <% end %>


### PR DESCRIPTION
Universal tooltip initialization was causing some problems.

This PR adds a Stimulus tooltip controller and uses that controller to initialize and discard tooltips as elements enter and leave the DOM.

Resolves #980