### PR TITLE
Re-enable the new organization view and update documentation

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -34,7 +34,7 @@ class OrganizationsController < ApplicationController
     authorize @organization
 
     if @organization.save
-      redirect_to @organization
+      redirect_to new_organization_event_group_path(@organization)
     else
       render "new", status: :unprocessable_entity
     end

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -7,7 +7,7 @@ module CoursesHelper
     options = { data: { controller: :tooltip,
                         bs_placement: :top,
                         bs_original_title: tooltip },
-                class: "btn btn-primary btn-sm" }
+                class: "btn btn-outline-primary btn-sm" }
     link_to fa_icon("pencil-alt"), url, options
   end
 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -9,7 +9,7 @@ module EventsHelper
                         controller: :tooltip,
                         bs_placement: :bottom,
                         bs_original_title: tooltip },
-                class: "btn btn-danger" }
+                class: "btn btn-outline-danger" }
     link_to fa_icon("trash"), url, options
   end
 
@@ -19,7 +19,7 @@ module EventsHelper
     options = { data: { controller: :tooltip,
                         bs_placement: :bottom,
                         bs_original_title: tooltip },
-                class: "btn btn-primary" }
+                class: "btn btn-outline-primary" }
     link_to fa_icon("pencil-alt"), url, options
   end
 

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -2,10 +2,12 @@
 
 module LinkHelper
   def link_to_monitor_mode(event_group)
-    return_path = if event_group.present? && event_group.persisted? && event_group.events.exists?
+    return_path = if event_group.blank?
+                    organizations_path
+                  elsif event_group.persisted? && event_group.events.exists?
                     roster_event_group_path(event_group)
                   else
-                    organizations_path
+                    organization_path(event_group.organization)
                   end
 
     link_to "Return to monitor mode", return_path, class: "btn btn-outline-light"

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 module LinkHelper
+  def link_to_monitor_mode(event_group)
+    return_path = if event_group.present? && event_group.persisted? && event_group.events.exists?
+                    roster_event_group_path(event_group)
+                  else
+                    organizations_path
+                  end
+
+    link_to "Return to monitor mode", return_path, class: "btn btn-outline-light"
+  end
+
   def link_to_reversing_sort_heading(column_heading, field_name, existing_sort)
     new_sort = field_name.to_s == existing_sort.to_s ? "-#{field_name}" : field_name
     link_to_sort_heading(column_heading, new_sort)

--- a/app/views/docs/visitors/_getting_started_staging_1.html.erb
+++ b/app/views/docs/visitors/_getting_started_staging_1.html.erb
@@ -3,19 +3,20 @@
   <div class="card-body">
     <p>If you are starting from scratch, you've come to the right page. If you are working with an Organization that has
       existing Events, it is probably easier
-      to <%= link_to 'duplicate an event group', docs_getting_started_path(topic: :staging, page: 2) %>
-      or <%= link_to 'create it from within the Organization', docs_getting_started_path(topic: :staging, page: 3) %></p>
-    <p> 1. <%= link_to 'Sign up', new_user_registration_path %>.</p>
-    <p> 2. Create a <%= link_to 'new Event', event_staging_app_path('new') %>.</p>
-    <p> 3. Follow the step-by-step instructions to add splits. You can manually enter information or import a splits CSV
+      to <%= link_to "duplicate an event group", docs_getting_started_path(topic: :staging, page: 2) %>
+      or <%= link_to "create it from within the Organization", docs_getting_started_path(topic: :staging, page: 3) %></p>
+    <p> 1. <%= link_to "Sign up", new_user_registration_path %>.</p>
+    <p> 2. Create a <%= link_to "new Organization", new_organization_path %>.</p>
+    <p> 3. Create a new Event Group.</p>
+    <p> 4. Follow the instructions to add one or more Events and Courses. You can manually enter information or import a splits CSV
       file.</p>
-    <p> 4. Continue to add your entrants' personal information (names, ages, contact info) manually or import a
+    <p> 5. Continue to add your entrants' personal information (names, ages, contact info) manually or import a
       CSV file. To avoid duplication, you will need to reconcile Entrants with our participant database. You can always
       add or change entrant information at any time, including after the event is finished.</p>
-    <p> 5.a. If this is an upcoming event, use the Live features and OST Remote to track your entrants on the course. Your
+    <p> 6.a. If this is an upcoming event, use the Live features and OST Remote to track your entrants on the course. Your
       time data will be available to the public instantly as it is submitted to the database.</p>
     <p>or</p>
-    <p> 5.b. If this is an event that happened in the past and you have the data somewhere in gmail, or sharing a
+    <p> 6.b. If this is an event that happened in the past and you have the data somewhere in gmail, or sharing a
       thumb drive in a drawer with the Sword of Many Truths, or scribbled in a notebook in your basement, dust it off and
       enter it using our handy tools.</p>
   </div>

--- a/app/views/docs/visitors/_getting_started_staging_2.html.erb
+++ b/app/views/docs/visitors/_getting_started_staging_2.html.erb
@@ -11,8 +11,8 @@
       <li>OpenSplitTime will duplicate the Event Group and all Events within the original Event Group, but will not add any
         Entrants. </li>
       <li>Make any changes as necessary. For example, if the start time for your 100K was 6:00 last year but you've moved
-        it to 5:30 this year, you can click Admin > Construction, and then Actions > Edit event.</li>
-      <li>Now <%= link_to 'import your Entrants', docs_getting_started_path(topic: :staging, page: 5) %> and you are ready to go.</li>
+        it to 5:30 this year, you can click Admin > Construction, and then click the pencil to edit your event.</li>
+      <li>Now <%= link_to "import your Entrants", docs_getting_started_path(topic: :staging, page: 5) %> and you are ready to go.</li>
     </ol>
   </div>
 </div>

--- a/app/views/docs/visitors/_getting_started_staging_3.html.erb
+++ b/app/views/docs/visitors/_getting_started_staging_3.html.erb
@@ -4,7 +4,7 @@
     <p>If your new Event Group doesn't share common characteristics with any existing Event Group, follow these steps to
       create a new one:</p>
     <ol>
-      <li>Visit your Organization page, and click "Create New Event".</li>
+      <li>Visit your Organization page, and click "New event group".</li>
       <li>If you are using the same Course as last time, check to make sure all the Splits you need have been associated,
         or click the check mark boxes to add or remove Splits for this event. If you are using a new Course, create it using
         the fields provided.</li>

--- a/app/views/docs/visitors/_getting_started_staging_4.html.erb
+++ b/app/views/docs/visitors/_getting_started_staging_4.html.erb
@@ -14,12 +14,13 @@
   <h4 class="card-header">Split Import Template</h4>
   <div class="card-body">
     <p>
-      First, download a template. After you create your event, go to <strong>Admin > Staging > Splits > Import >
-      Download template</strong>. A blank splits template will be downloaded by your browser. Use this template to add split
-      names, distances, latitude, longitude, and elevation. The "Sub split kinds" column should be either "in" (if you are
-      recording only one time, as runners enter the aid station) or "in out" (if you are recording times both in and out
-      of the aid station). When the spreadsheet is complete, save it back out (remember to save it in CSV format) and then
-      go to <strong>Admin > Staging > Splits > Import > Import splits</strong>.
+      First, download a template. After you create your Course and Event, go to <strong>Admin > Construction</strong>,
+      click the blue pencil icon to edit the Course, and then click <strong>Import > Download template</strong>. A blank
+      splits template will be downloaded by your browser. Use this template to add split names, distances, latitude,
+      longitude, and elevation. The "Sub split kinds" column should be either "in" (if you are recording only one time,
+      as runners enter the aid station) or "in out" (if you are recording times both in and out of the aid station).
+      When the spreadsheet is complete, save it back out (remember to save it in CSV format) and then return to
+      <strong>Admin > Construction > [Setup Course Button] > Import > Import splits</strong>.
     </p>
   </div>
 </div>

--- a/app/views/event_groups/_form.html.erb
+++ b/app/views/event_groups/_form.html.erb
@@ -60,11 +60,11 @@
   <br/>
 
   <div class="mb-3">
-    <%= button_tag(type: :submit, value: "Continue", class: "btn btn-primary") do %>
-      <%= fa_icon "arrow-right", text: "Continue", right: true %>
-    <% end %>
     <%= link_to "Cancel",
                 presenter.event_group.new_record? ? organization_path(presenter.organization) : setup_event_group_path(presenter.event_group),
                 class: "btn btn-outline-secondary" %>
+    <%= button_tag(type: :submit, value: "Continue", class: "btn btn-primary") do %>
+      <%= fa_icon "arrow-right", text: "Continue", right: true %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/event_groups/setup.html.erb
+++ b/app/views/event_groups/setup.html.erb
@@ -44,7 +44,7 @@
         <% else %>
           <div class="callout callout-info">
             <h5>You will need to add an Event before adding Entrants</h5>
-            <p>Click the <strong>Events</strong> tab to add an Event</p>
+            <p>Click the <strong>Setup</strong> tab to add an Event</p>
           </div>
         <% end %>
       </div>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -1,45 +1,26 @@
-<%= render 'shared/errors', obj: @organization %>
+<%= render "shared/errors", obj: @organization %>
 
 <div class="row">
   <div class="col-md-12">
-    <%= form_for(@organization, html: {class: "form-horizontal", role: "form"}) do |f| %>
-      <div class="mb-3">
-        <div class="control-label col-sm-2">
-          <%= f.label :name %>
-        </div>
-        <div class="col-sm-8">
-          <%= f.text_field :name, class: "form-control", placeholder: "Organization name", autofocus: true %>
-        </div>
+    <%= form_with model: @organization do |f| %>
+      <div class="mb-3 col-12">
+        <%= f.label :name, class: "mb-1 required" %>
+        <%= f.text_field :name, class: "form-control", placeholder: "Organization name", autofocus: true %>
+      </div>
+
+      <div class="mb-3 col-12">
+        <%= f.label :description, class: "mb-1" %>
+        <%= f.text_area :description, rows: 4, class: "form-control",
+                        placeholder: "(Optional) Say something about your organization" %>
       </div>
 
       <div class="mb-3">
-        <div class="control-label col-sm-2">
-          <%= f.label :description %>
-        </div>
-        <div class="col-sm-8">
-          <%= f.text_area :description, rows: 4, class: "form-control",
-                          placeholder: "Say something about your organization" %>
-        </div>
-      </div>
-
-      <% if current_user.admin? %>
-        <div class="mb-3">
-          <div class="control-label col-sm-2">
-            <%= f.label :owner %>
-          </div>
-          <div class="col-sm-8">
-            <%= f.text_field :owner_email, class: "form-control", placeholder: "race.director@yourorg.com" %>
-          </div>
-        </div>
-      <% end %>
-
-      <div class="mb-3">
-        <div class="col">
-          <%= f.submit(@organization.new_record? ? "Create Organization" : "Update Organization", class: 'btn btn-primary btn-large') %>
-        </div>
-      </div>
-      <div class="col">
-        [ <%= link_to 'Cancel', @organization.new_record? ? organizations_path : @organization %> ]
+        <%= link_to "Cancel",
+                    @organization.new_record? ? organizations_path : organization_path(@organization),
+                    class: "btn btn-outline-secondary" %>
+        <%= button_tag(type: :submit, value: "Continue", class: "btn btn-primary") do %>
+          <%= fa_icon "arrow-right", text: "Continue", right: true %>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -13,6 +13,11 @@
           </ul>
         </div>
       </div>
+      <% if user_signed_in? %>
+        <div class="col text-end">
+          <%= link_to "Create a new organization", new_organization_path, class: "btn btn-outline-success mt-2" %>
+        </div>
+      <% end %>
     </div>
   </div>
 </header>

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -2,6 +2,8 @@
   <% "OpenSplitTime: New Organization" %>
 <% end %>
 
+<%= render "shared/mode_widget", event_group: nil, organization: @organization %>
+
 <header class="ost-header">
   <div class="container">
     <div class="ost-heading row">
@@ -19,5 +21,5 @@
 </header>
 
 <article class="ost-article container">
-  <%= render 'form' %>
+  <%= render "form" %>
 </article>

--- a/app/views/shared/_mode_widget.html.erb
+++ b/app/views/shared/_mode_widget.html.erb
@@ -1,4 +1,4 @@
-<!-- Mode Selector Widget: Requires local :event_group -->
+<%# locals: (event_group:) -%>
 
 <aside class="bg-primary p-3">
   <div class="container">
@@ -7,9 +7,7 @@
         <h5>You are in Construction Mode</h5>
       </div>
       <div class="col text-end">
-        <%= link_to "Return to monitor mode",
-                    event_group.persisted? && event_group.events.exists? ? roster_event_group_path(event_group) : organization_path(event_group.organization),
-                    class: "btn btn-outline-light" %>
+        <%= link_to_monitor_mode(event_group) %>
       </div>
     </div>
   </div>

--- a/app/views/visitors/index.html.erb
+++ b/app/views/visitors/index.html.erb
@@ -63,6 +63,7 @@
         <strong>All that has now changed.</strong></p>
       <br/>
       <%= link_to "Full Documentation", docs_getting_started_path, class: "btn btn-info cta" %>
+      <%= link_to "Create My First Event", new_organization_path, class: "btn btn-info cta" %>
     </div>
   </div>
   <div class="row fifth">


### PR DESCRIPTION
At some point we disabled the ability to create a new organization except through the Event Staging flow.

This PR re-enables a "New Organization" flow via either the home page or the Organizations index page.