### PR TITLE
Improve Event Group Setup Summary

### DIFF
--- a/app/assets/stylesheets/utilities/_callouts.scss
+++ b/app/assets/stylesheets/utilities/_callouts.scss
@@ -20,15 +20,15 @@
 }
 
 .callout-info {
-    border-left-color: $info;
-    h4 {
-        color: $info;
-    }
+  border-left-color: $info;
+  h4 {
+    color: $info;
+  }
 }
 
 .callout-success {
   border-left-color: $success;
-    h4 {
-        color: $success;
-    }
+  h4 {
+    color: $success;
+  }
 }

--- a/app/assets/stylesheets/utilities/_callouts.scss
+++ b/app/assets/stylesheets/utilities/_callouts.scss
@@ -20,8 +20,15 @@
 }
 
 .callout-info {
-  border-left-color: $info;
+    border-left-color: $info;
     h4 {
         color: $info;
+    }
+}
+
+.callout-success {
+  border-left-color: $success;
+    h4 {
+        color: $success;
     }
 }

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -58,7 +58,11 @@ class EventGroupsController < ApplicationController
     authorize @event_group
 
     @event_group.update(permitted_params)
-    redirect_to setup_event_group_path(@event_group)
+
+    respond_to do |format|
+      format.html { redirect_to setup_event_group_path(@event_group) }
+      format.turbo_stream { @presenter = EventGroupSetupPresenter.new(@event_group, view_context) }
+    end
   end
 
   def destroy

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -11,6 +11,21 @@ module CoursesHelper
     link_to fa_icon("pencil-alt"), url, options
   end
 
+  def link_to_add_course_gpx(event)
+    link_to "Add",
+            new_course_gpx_event_group_event_path(event.event_group, event),
+            data: { turbo_frame: "form_modal" },
+            class: "btn btn-sm btn-outline-success"
+  end
+
+  def link_to_remove_course_gpx(event)
+    link_to "Remove",
+            remove_course_gpx_event_group_event_path(event.event_group, event),
+            method: :delete,
+            class: "btn btn-sm btn-outline-danger",
+            data: { confirm: "This cannot be undone. Proceed?" }
+  end
+
   def segment_start_dropdown(view_object)
     ordered_split_params = view_object.ordered_splits.map(&:to_param)
     items = view_object.ordered_splits_without_finish.map do |split|

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -335,17 +335,6 @@ module DropdownHelper
   end
 
   def event_group_actions_dropdown(view_object)
-    make_public_text = "NOTE: This will make #{view_object.event_group_names} visible to the public, " +
-      "including all related efforts and people. Are you sure you want to proceed?"
-    make_private_text = "NOTE: This will conceal #{view_object.event_group_names} from the public, " +
-      "including all related efforts. Are you sure you want to proceed?"
-    enable_live_text = "NOTE: This will enable live entry actions for #{view_object.event_group_names}, " +
-      "and will also trigger live follower notifications by email and SMS text when new times are added. " +
-      "Are you sure you want to proceed?"
-    disable_live_text = "NOTE: This will suspend all live entry actions for #{view_object.event_group_names}, " +
-      "including any that may be in process, and will disable live follower notifications " +
-      "by email and SMS text when new times are added. Are you sure you want to proceed?"
-
     dropdown_items = [
       { name: "Edit/Delete Group",
         link: edit_organization_event_group_path(view_object.organization, view_object.event_group) },
@@ -354,23 +343,23 @@ module DropdownHelper
       { role: :separator },
       { name: "Make Public",
         link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { concealed: false }),
-        data: { confirm: make_public_text },
+        data: { confirm: I18n.t("event_groups.setup.make_public_confirm", event_group_name: view_object.event_group_name) },
         disabled: !view_object.concealed?,
         method: :put },
       { name: "Make Private",
         link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { concealed: true }),
-        data: { confirm: make_private_text },
+        data: { confirm: I18n.t("event_groups.setup.make_private_confirm", event_group_name: view_object.event_group_name) },
         disabled: view_object.concealed?,
         method: :put },
       { role: :separator },
       { name: "Enable Live",
         link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { available_live: true }),
-        data: { confirm: enable_live_text },
+        data: { confirm: I18n.t("event_groups.setup.enable_live_confirm", event_group_name: view_object.event_group_name) },
         disabled: view_object.available_live?,
         method: :put },
       { name: "Disable Live",
         link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { available_live: false }),
-        data: { confirm: disable_live_text },
+        data: { confirm: I18n.t("event_groups.setup.disable_live_confirm", event_group_name: view_object.event_group_name) },
         disabled: !view_object.available_live?,
         method: :put },
       { role: :separator },

--- a/app/helpers/event_group_setup_widget_helper.rb
+++ b/app/helpers/event_group_setup_widget_helper.rb
@@ -5,7 +5,7 @@ module EventGroupSetupWidgetHelper
     type = presenter.controller_name == "events" && presenter.action_name == "setup_course" && presenter.event == event ? :solid : :regular
     path = setup_course_event_group_event_path(event.event_group, event)
     tooltip = event.course.name
-    icon = fa_icon("check-circle",
+    icon = fa_icon("dot-circle",
                    type: type,
                    size: "2x",
                    data: { controller: "tooltip", bs_original_title: tooltip })
@@ -20,7 +20,7 @@ module EventGroupSetupWidgetHelper
       type = :solid
       tooltip = "Manage your Entrants"
       icon_only = false
-    elsif presenter.event_group.new_record?
+    elsif presenter.event_group.new_record? || presenter.no_persisted_events?
       type = :regular
       tooltip = "You'll be able to add Entrants after your Event Group and Events are created"
       icon_only = true
@@ -48,7 +48,8 @@ module EventGroupSetupWidgetHelper
   def link_to_setup_widget_event_group(presenter)
     type = presenter.controller_name == "event_groups" && presenter.action_name.in?(%w(setup new)) && presenter.display_style != "entrants" ? :solid : :regular
     path = presenter.event_group.new_record? ? new_organization_event_group_path(presenter.organization) : setup_event_group_path(presenter.event_group)
-    icon = fa_icon("check-circle",
+    icon_name = presenter.event_group.new_record? ? "dot-circle" : "check-circle"
+    icon = fa_icon(icon_name,
                    type: type,
                    size: "2x")
 
@@ -102,9 +103,9 @@ module EventGroupSetupWidgetHelper
       type = :solid
       tooltip = ""
       icon_only = false
-    elsif presenter.event_group.new_record?
+    elsif presenter.event_group.new_record? || presenter.no_persisted_events?
       type = :regular
-      tooltip = "You can view a summary here after your Event Group is created"
+      tooltip = "You can view a summary here after your Event Group and Events are created"
       icon_only = true
     else
       type = :regular

--- a/app/helpers/event_groups_helper.rb
+++ b/app/helpers/event_groups_helper.rb
@@ -1,6 +1,38 @@
 # frozen_string_literal: true
 
 module EventGroupsHelper
+  def link_to_event_group_disable_live(view_object)
+    link_to "Disable Live Entry",
+            organization_event_group_path(view_object.organization, view_object.event_group, event_group: { available_live: false }),
+            method: :patch,
+            data: { confirm: t("event_groups.setup.disable_live_confirm", event_group_name: view_object.event_group_name) },
+            class: "btn btn-outline-success"
+  end
+
+  def link_to_event_group_enable_live(view_object)
+    link_to "Enable Live Entry",
+            organization_event_group_path(view_object.organization, view_object.event_group, event_group: { available_live: true }),
+            method: :patch,
+            data: { confirm: t("event_groups.setup.enable_live_confirm", event_group_name: view_object.event_group_name) },
+            class: "btn btn-outline-success"
+  end
+
+  def link_to_event_group_go_public(view_object)
+    link_to "Go Public",
+            organization_event_group_path(view_object.organization, view_object.event_group, event_group: { concealed: false }),
+            method: :patch,
+            data: { confirm: t("event_groups.setup.make_public_confirm", event_group_name: view_object.event_group_name) },
+            class: "btn btn-outline-success"
+  end
+
+  def link_to_event_group_take_private(view_object)
+    link_to "Take Private",
+            organization_event_group_path(view_object.organization, view_object.event_group, event_group: { concealed: true }),
+            method: :patch,
+            data: { confirm: t("event_groups.setup.make_private_confirm", event_group_name: view_object.event_group_name) },
+            class: "btn btn-outline-success"
+  end
+
   def link_to_start_ready_efforts(view_object)
     if view_object.ready_efforts.present?
       content_tag :div, class: "btn-group" do

--- a/app/helpers/event_groups_helper.rb
+++ b/app/helpers/event_groups_helper.rb
@@ -17,7 +17,7 @@ module EventGroupsHelper
             class: "btn btn-outline-success"
   end
 
-  def link_to_event_group_go_public(view_object)
+  def link_to_event_group_make_public(view_object)
     link_to "Go Public",
             organization_event_group_path(view_object.organization, view_object.event_group, event_group: { concealed: false }),
             method: :patch,
@@ -25,7 +25,7 @@ module EventGroupsHelper
             class: "btn btn-outline-success"
   end
 
-  def link_to_event_group_take_private(view_object)
+  def link_to_event_group_make_private(view_object)
     link_to "Take Private",
             organization_event_group_path(view_object.organization, view_object.event_group, event_group: { concealed: true }),
             method: :patch,

--- a/app/presenters/event_group_setup_presenter.rb
+++ b/app/presenters/event_group_setup_presenter.rb
@@ -77,6 +77,10 @@ class EventGroupSetupPresenter < BasePresenter
     @events ||= event_group.events.order(:scheduled_start_time)
   end
 
+  def no_persisted_events?
+    @persisted_events ||= events.none?(&:persisted?)
+  end
+
   def next_page_url
     view_context.url_for(request.params.merge(page: page + 1)) if filtered_efforts_count == per_page
   end

--- a/app/presenters/event_setup_course_presenter.rb
+++ b/app/presenters/event_setup_course_presenter.rb
@@ -28,6 +28,10 @@ class EventSetupCoursePresenter < BasePresenter
     event_group.name
   end
 
+  def no_persisted_events?
+    event_group.events.none?(&:persisted?)
+  end
+
   def event_id
     event.id
   end

--- a/app/presenters/event_setup_presenter.rb
+++ b/app/presenters/event_setup_presenter.rb
@@ -44,6 +44,10 @@ class EventSetupPresenter < BasePresenter
     event_group.name
   end
 
+  def no_persisted_events?
+    event_group.events.none?(&:persisted?)
+  end
+
   def event_name
     event.name
   end

--- a/app/views/event_groups/_setup_header.html.erb
+++ b/app/views/event_groups/_setup_header.html.erb
@@ -5,16 +5,7 @@
     <div class="ost-heading row">
       <div class="col">
         <div class="ost-title">
-          <h1>
-            <span class="fw-bold">
-              <% if presenter.event_group.new_record? %>
-                <%= name_with_concealed_indicator("Your Event Group", true) %>
-              <% else %>
-                <%= name_with_concealed_indicator(presenter.event_group_name, presenter.concealed?) %>
-              <% end %>
-            </span>
-            <span><%= construction_status_badge(presenter.status) %></span>
-          </h1>
+          <%= render "event_groups/setup_header_name_and_indicators", presenter: presenter %>
           <ul class="breadcrumb breadcrumb-ost">
             <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
             <li class="breadcrumb-item"><%= link_to presenter.organization.name, organization_path(presenter.organization) %></li>

--- a/app/views/event_groups/_setup_header_name_and_indicators.html.erb
+++ b/app/views/event_groups/_setup_header_name_and_indicators.html.erb
@@ -1,0 +1,14 @@
+<%# locals: (presenter:) -%>
+
+<div id="setup_header_name_and_indicators">
+  <h1>
+    <span class="fw-bold">
+      <% if presenter.event_group.new_record? %>
+        <%= name_with_concealed_indicator("Your Event Group", true) %>
+      <% else %>
+        <%= name_with_concealed_indicator(presenter.event_group_name, presenter.concealed?) %>
+      <% end %>
+    </span>
+    <span><%= construction_status_badge(presenter.status) %></span>
+  </h1>
+</div>

--- a/app/views/event_groups/_setup_summary_status.html.erb
+++ b/app/views/event_groups/_setup_summary_status.html.erb
@@ -1,0 +1,63 @@
+<%# locals: (presenter:) -%>
+
+<div id="setup_summary_status" class="mb-5">
+  <aside class="col-12">
+    <div class="callout callout-info">
+      <div class="d-inline-flex justify-content-between w-100">
+        <% if presenter.event_group.visible? %>
+          <div>
+            <span class="text-success"><%= fa_icon "check-circle" %></span>
+            <span class="h5 ms-1">Congratulations, your Event Group is public!</span>
+            <p>Results and Follow pages are now available for your entrants to view.</p>
+          </div>
+          <%= link_to "Take Private",
+                      organization_event_group_path(presenter.organization, presenter.event_group, event_group: { concealed: true }),
+                      method: :patch,
+                      data: { confirm: t("event_groups.setup.make_private_confirm", event_group_name: presenter.event_group_name) },
+                      class: "btn btn-outline-success" %>
+        <% else %>
+          <div>
+            <span class="text-info"><%= fa_icon "info-circle" %></span>
+            <span class="h5 ms-1">Your Event Group is still private</span>
+            <p>Once your Events and Courses are ready and you have Entrants loaded, click the "Go Public" button to make
+              your Event Group visible to the public.</p>
+          </div>
+          <%= link_to "Go Public",
+                      organization_event_group_path(presenter.organization, presenter.event_group, event_group: { concealed: false }),
+                      method: :patch,
+                      data: { confirm: t("event_groups.setup.make_public_confirm", event_group_name: presenter.event_group_name) },
+                      class: "btn btn-success" %>
+        <% end %>
+      </div>
+    </div>
+  </aside>
+
+  <aside class="col-12">
+    <div class="callout callout-info">
+      <div class="d-inline-flex justify-content-between w-100">
+        <% if presenter.event_group.available_live? %>
+          <div>
+            <span class="h5 ms-1">Your Event Group is available for Live Entry</span>
+            <p>You can now access the Live Entry view and use OST Remote to record times.</p>
+          </div>
+          <%= link_to "Disable Live Entry",
+                      organization_event_group_path(presenter.organization, presenter.event_group, event_group: { available_live: false }),
+                      method: :patch,
+                      data: { confirm: t("event_groups.setup.disable_live_confirm", event_group_name: presenter.event_group_name) },
+                      class: "btn btn-success" %>
+        <% else %>
+          <div>
+            <span class="h5 ms-1">Your Event Group is not available for Live Entry</span>
+            <p>You will not be able to use the Live Entry view or OST Remote to record times for this Event Group until you make it available by clicking the "Enable Live Entry" button.</p>
+          </div>
+
+          <%= link_to "Enable Live Entry",
+                      organization_event_group_path(presenter.organization, presenter.event_group, event_group: { available_live: true }),
+                      method: :patch,
+                      data: { confirm: t("event_groups.setup.enable_live_confirm", event_group_name: presenter.event_group_name) },
+                      class: "btn btn-outline-success" %>
+        <% end %>
+      </div>
+    </div>
+  </aside>
+</div>

--- a/app/views/event_groups/_setup_summary_status.html.erb
+++ b/app/views/event_groups/_setup_summary_status.html.erb
@@ -11,11 +11,7 @@
             <p>Results and Follow pages are now available for your entrants to view.</p>
           </div>
           <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
-            <%= link_to "Take Private",
-                        organization_event_group_path(presenter.organization, presenter.event_group, event_group: { concealed: true }),
-                        method: :patch,
-                        data: { confirm: t("event_groups.setup.make_private_confirm", event_group_name: presenter.event_group_name) },
-                        class: "btn btn-outline-success" %>
+            <%= link_to_event_group_take_private(presenter) %>
           </div>
         </div>
       <% else %>
@@ -27,11 +23,7 @@
               your Event Group visible to the public.</p>
           </div>
           <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
-            <%= link_to "Go Public",
-                        organization_event_group_path(presenter.organization, presenter.event_group, event_group: { concealed: false }),
-                        method: :patch,
-                        data: { confirm: t("event_groups.setup.make_public_confirm", event_group_name: presenter.event_group_name) },
-                        class: "btn btn-outline-success" %>
+            <%= link_to_event_group_go_public(presenter) %>
           </div>
         </div>
       <% end %>
@@ -47,11 +39,7 @@
             <p>You can now access the Live Entry view and use OST Remote to record times.</p>
           </div>
           <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
-            <%= link_to "Disable Live Entry",
-                        organization_event_group_path(presenter.organization, presenter.event_group, event_group: { available_live: false }),
-                        method: :patch,
-                        data: { confirm: t("event_groups.setup.disable_live_confirm", event_group_name: presenter.event_group_name) },
-                        class: "btn btn-outline-success" %>
+            <%= link_to_event_group_disable_live(presenter) %>
           </div>
         </div>
       <% else %>
@@ -63,11 +51,7 @@
               you make it available by clicking the "Enable Live Entry" button.</p>
           </div>
           <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
-            <%= link_to "Enable Live Entry",
-                        organization_event_group_path(presenter.organization, presenter.event_group, event_group: { available_live: true }),
-                        method: :patch,
-                        data: { confirm: t("event_groups.setup.enable_live_confirm", event_group_name: presenter.event_group_name) },
-                        class: "btn btn-outline-success" %>
+            <%= link_to_event_group_enable_live(presenter) %>
           </div>
         </div>
       <% end %>

--- a/app/views/event_groups/_setup_summary_status.html.erb
+++ b/app/views/event_groups/_setup_summary_status.html.erb
@@ -2,59 +2,44 @@
 
 <div id="setup_summary_status" class="mb-5">
   <aside class="col-12">
-    <div class="callout callout-success">
-      <% if presenter.event_group.visible? %>
-        <div class="row">
-          <div class="col-12 col-md-9">
-            <span class="text-success me-1"><%= fa_icon "check-circle" %></span>
-            <span class="h5">Congratulations, your Event Group is public!</span>
-            <p>Results and Follow pages are now available for your entrants to view.</p>
-          </div>
-          <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
-            <%= link_to_event_group_take_private(presenter) %>
-          </div>
-        </div>
-      <% else %>
-        <div class="row">
-          <div class="col-12 col-md-9">
-            <span class="text-info me-1"><%= fa_icon "info-circle" %></span>
-            <span class="h5">Your Event Group is still private</span>
-            <p>Once your Events and Courses are ready and you have Entrants loaded, click the "Go Public" button to make
-              your Event Group visible to the public.</p>
-          </div>
-          <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
-            <%= link_to_event_group_go_public(presenter) %>
-          </div>
-        </div>
-      <% end %>
-    </div>
+    <% if presenter.event_group.visible? %>
+      <%= render partial: "shared/callout_with_link",
+                 locals: {
+                   icon_color: "success",
+                   icon_name: "check-circle",
+                   main_text: "Congratulations, your Event Group is public!",
+                   detail_text: "Results and Follow pages are now available for your entrants to view.",
+                   link: link_to_event_group_take_private(presenter)
+                 } %>
+    <% else %>
+      <%= render partial: "shared/callout_with_link",
+                 locals: {
+                   icon_color: "warning",
+                   icon_name: "exclamation-circle",
+                   main_text: "Your Event Group is still private",
+                   detail_text: "Once your Events and Courses are ready and you have Entrants loaded, click the \"Go Public\" button to make your Event Group visible to the public.",
+                   link: link_to_event_group_go_public(presenter)
+                 } %>
+    <% end %>
   </aside>
 
   <aside class="col-12">
-    <div class="callout callout-success">
-      <% if presenter.event_group.available_live? %>
-        <div class="row">
-          <div class="col-12 col-md-9">
-            <span class="h5">Your Event Group is available for Live Entry</span>
-            <p>You can now access the Live Entry view and use OST Remote to record times.</p>
-          </div>
-          <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
-            <%= link_to_event_group_disable_live(presenter) %>
-          </div>
-        </div>
-      <% else %>
-        <div class="row">
-          <div class="col-12 col-md-9">
-            <span class="text-warning me-1"><%= fa_icon "exclamation-circle" %></span>
-            <span class="h5">Your Event Group is not yet available for Live Entry</span>
-            <p>You will not be able to use the Live Entry view or OST Remote to record times for this Event Group until
-              you make it available by clicking the "Enable Live Entry" button.</p>
-          </div>
-          <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
-            <%= link_to_event_group_enable_live(presenter) %>
-          </div>
-        </div>
-      <% end %>
-    </div>
+    <% if presenter.event_group.available_live? %>
+      <%= render partial: "shared/callout_with_link",
+                 locals: {
+                   main_text: "Your Event Group is available for Live Entry",
+                   detail_text: "You can now access the Live Entry view and use OST Remote to record times.",
+                   link: link_to_event_group_disable_live(presenter)
+                 } %>
+    <% else %>
+      <%= render partial: "shared/callout_with_link",
+                 locals: {
+                   icon_color: "warning",
+                   icon_name: "exclamation-circle",
+                   main_text: "Your Event Group is not yet available for Live Entry",
+                   detail_text: "You will not be able to use the Live Entry view or OST Remote to record times for this Event Group until you make it available by clicking the \"Enable Live Entry\" button.",
+                   link: link_to_event_group_enable_live(presenter)
+                 } %>
+    <% end %>
   </aside>
 </div>

--- a/app/views/event_groups/_setup_summary_status.html.erb
+++ b/app/views/event_groups/_setup_summary_status.html.erb
@@ -2,62 +2,75 @@
 
 <div id="setup_summary_status" class="mb-5">
   <aside class="col-12">
-    <div class="callout callout-info">
-      <div class="d-inline-flex justify-content-between w-100">
-        <% if presenter.event_group.visible? %>
-          <div>
-            <span class="text-success"><%= fa_icon "check-circle" %></span>
-            <span class="h5 ms-1">Congratulations, your Event Group is public!</span>
+    <div class="callout callout-success">
+      <% if presenter.event_group.visible? %>
+        <div class="row">
+          <div class="col-12 col-md-9">
+            <span class="text-success me-1"><%= fa_icon "check-circle" %></span>
+            <span class="h5">Congratulations, your Event Group is public!</span>
             <p>Results and Follow pages are now available for your entrants to view.</p>
           </div>
-          <%= link_to "Take Private",
-                      organization_event_group_path(presenter.organization, presenter.event_group, event_group: { concealed: true }),
-                      method: :patch,
-                      data: { confirm: t("event_groups.setup.make_private_confirm", event_group_name: presenter.event_group_name) },
-                      class: "btn btn-outline-success" %>
-        <% else %>
-          <div>
-            <span class="text-info"><%= fa_icon "info-circle" %></span>
-            <span class="h5 ms-1">Your Event Group is still private</span>
+          <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
+            <%= link_to "Take Private",
+                        organization_event_group_path(presenter.organization, presenter.event_group, event_group: { concealed: true }),
+                        method: :patch,
+                        data: { confirm: t("event_groups.setup.make_private_confirm", event_group_name: presenter.event_group_name) },
+                        class: "btn btn-outline-success" %>
+          </div>
+        </div>
+      <% else %>
+        <div class="row">
+          <div class="col-12 col-md-9">
+            <span class="text-info me-1"><%= fa_icon "info-circle" %></span>
+            <span class="h5">Your Event Group is still private</span>
             <p>Once your Events and Courses are ready and you have Entrants loaded, click the "Go Public" button to make
               your Event Group visible to the public.</p>
           </div>
-          <%= link_to "Go Public",
-                      organization_event_group_path(presenter.organization, presenter.event_group, event_group: { concealed: false }),
-                      method: :patch,
-                      data: { confirm: t("event_groups.setup.make_public_confirm", event_group_name: presenter.event_group_name) },
-                      class: "btn btn-success" %>
-        <% end %>
-      </div>
+          <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
+            <%= link_to "Go Public",
+                        organization_event_group_path(presenter.organization, presenter.event_group, event_group: { concealed: false }),
+                        method: :patch,
+                        data: { confirm: t("event_groups.setup.make_public_confirm", event_group_name: presenter.event_group_name) },
+                        class: "btn btn-outline-success" %>
+          </div>
+        </div>
+      <% end %>
     </div>
   </aside>
 
   <aside class="col-12">
-    <div class="callout callout-info">
-      <div class="d-inline-flex justify-content-between w-100">
-        <% if presenter.event_group.available_live? %>
-          <div>
-            <span class="h5 ms-1">Your Event Group is available for Live Entry</span>
+    <div class="callout callout-success">
+      <% if presenter.event_group.available_live? %>
+        <div class="row">
+          <div class="col-12 col-md-9">
+            <span class="h5">Your Event Group is available for Live Entry</span>
             <p>You can now access the Live Entry view and use OST Remote to record times.</p>
           </div>
-          <%= link_to "Disable Live Entry",
-                      organization_event_group_path(presenter.organization, presenter.event_group, event_group: { available_live: false }),
-                      method: :patch,
-                      data: { confirm: t("event_groups.setup.disable_live_confirm", event_group_name: presenter.event_group_name) },
-                      class: "btn btn-success" %>
-        <% else %>
-          <div>
-            <span class="h5 ms-1">Your Event Group is not available for Live Entry</span>
-            <p>You will not be able to use the Live Entry view or OST Remote to record times for this Event Group until you make it available by clicking the "Enable Live Entry" button.</p>
+          <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
+            <%= link_to "Disable Live Entry",
+                        organization_event_group_path(presenter.organization, presenter.event_group, event_group: { available_live: false }),
+                        method: :patch,
+                        data: { confirm: t("event_groups.setup.disable_live_confirm", event_group_name: presenter.event_group_name) },
+                        class: "btn btn-outline-success" %>
           </div>
-
-          <%= link_to "Enable Live Entry",
-                      organization_event_group_path(presenter.organization, presenter.event_group, event_group: { available_live: true }),
-                      method: :patch,
-                      data: { confirm: t("event_groups.setup.enable_live_confirm", event_group_name: presenter.event_group_name) },
-                      class: "btn btn-outline-success" %>
-        <% end %>
-      </div>
+        </div>
+      <% else %>
+        <div class="row">
+          <div class="col-12 col-md-9">
+            <span class="text-warning me-1"><%= fa_icon "exclamation-circle" %></span>
+            <span class="h5">Your Event Group is not yet available for Live Entry</span>
+            <p>You will not be able to use the Live Entry view or OST Remote to record times for this Event Group until
+              you make it available by clicking the "Enable Live Entry" button.</p>
+          </div>
+          <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
+            <%= link_to "Enable Live Entry",
+                        organization_event_group_path(presenter.organization, presenter.event_group, event_group: { available_live: true }),
+                        method: :patch,
+                        data: { confirm: t("event_groups.setup.enable_live_confirm", event_group_name: presenter.event_group_name) },
+                        class: "btn btn-outline-success" %>
+          </div>
+        </div>
+      <% end %>
     </div>
   </aside>
 </div>

--- a/app/views/event_groups/_setup_summary_status.html.erb
+++ b/app/views/event_groups/_setup_summary_status.html.erb
@@ -7,18 +7,18 @@
                  locals: {
                    icon_color: "success",
                    icon_name: "check-circle",
-                   main_text: "Congratulations, your Event Group is public!",
-                   detail_text: "Results and Follow pages are now available for your entrants to view.",
-                   link: link_to_event_group_take_private(presenter)
+                   main_text: t("event_groups.setup.group_is_public_main"),
+                   detail_text: t("event_groups.setup.group_is_public_detail"),
+                   link: link_to_event_group_make_private(presenter)
                  } %>
     <% else %>
       <%= render partial: "shared/callout_with_link",
                  locals: {
                    icon_color: "warning",
                    icon_name: "exclamation-circle",
-                   main_text: "Your Event Group is still private",
-                   detail_text: "Once your Events and Courses are ready and you have Entrants loaded, click the \"Go Public\" button to make your Event Group visible to the public.",
-                   link: link_to_event_group_go_public(presenter)
+                   main_text: t("event_groups.setup.group_is_private_main"),
+                   detail_text: t("event_groups.setup.group_is_private_detail"),
+                   link: link_to_event_group_make_public(presenter)
                  } %>
     <% end %>
   </aside>
@@ -27,8 +27,8 @@
     <% if presenter.event_group.available_live? %>
       <%= render partial: "shared/callout_with_link",
                  locals: {
-                   main_text: "Your Event Group is available for Live Entry",
-                   detail_text: "You can now access the Live Entry view and use OST Remote to record times.",
+                   main_text: t("event_groups.setup.group_is_live_main"),
+                   detail_text: t("event_groups.setup.group_is_live_detail"),
                    link: link_to_event_group_disable_live(presenter)
                  } %>
     <% else %>
@@ -36,8 +36,8 @@
                  locals: {
                    icon_color: "warning",
                    icon_name: "exclamation-circle",
-                   main_text: "Your Event Group is not yet available for Live Entry",
-                   detail_text: "You will not be able to use the Live Entry view or OST Remote to record times for this Event Group until you make it available by clicking the \"Enable Live Entry\" button.",
+                   main_text: t("event_groups.setup.group_is_not_live_main"),
+                   detail_text: t("event_groups.setup.group_is_not_live_detail"),
                    link: link_to_event_group_enable_live(presenter)
                  } %>
     <% end %>

--- a/app/views/event_groups/_setup_widget.html.erb
+++ b/app/views/event_groups/_setup_widget.html.erb
@@ -5,7 +5,7 @@
 
     <!-- Event Group Card-->
     <div class="col border-end">
-      <%= render "event_groups/setup_widget_header", title: "Group" %>
+      <%= render "event_groups/setup_widget_header", title: "Overview" %>
       <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_event_group(presenter) %>
     </div>
 

--- a/app/views/event_groups/setup_summary.html.erb
+++ b/app/views/event_groups/setup_summary.html.erb
@@ -7,9 +7,10 @@
 
 <article class="ost-article container">
   <%= render "setup_summary_status", presenter: @presenter %>
-  <div class="card mb-4">
+  <div class="h3 fw-bold">Event Group Summary</div>
+  <div class="card my-3">
     <div class="card-header">
-      <span class="h3">Events and Courses</span>
+      <span class="h4">Events and Courses</span>
     </div>
     <div class="card-body">
       <% @presenter.events.each do |event| %>
@@ -25,9 +26,9 @@
     </div>
   </div>
 
-  <div class="card mb-4">
+  <div class="card my-3">
     <div class="card-header">
-      <span class="h3">Entrants</span><span class="h4 text-muted ms-2"><%= pluralize(@presenter.event_group.efforts.count, "entrant") %></span>
+      <span class="h4">Entrants</span><span class="h4 text-muted ms-2"><%= pluralize(@presenter.event_group.efforts.count, "entrant") %></span>
     </div>
     <div class="card-body">
       <table class="table table-sm">

--- a/app/views/event_groups/setup_summary.html.erb
+++ b/app/views/event_groups/setup_summary.html.erb
@@ -6,14 +6,7 @@
 <%= render "setup_header", presenter: @presenter, breadcrumbs: [] %>
 
 <article class="ost-article container">
-  <div class="row">
-    <div class="col">
-      <div class="callout callout-info">
-        <h5>Here's a summary of your Event Group</h5>
-        <p>Come here anytime for an overview of the Events, Courses, and Entrants for this Event Group.</p>
-      </div>
-    </div>
-  </div>
+  <%= render "setup_summary_status", presenter: @presenter %>
   <div class="card mb-4">
     <div class="card-header">
       <span class="h3">Events and Courses</span>

--- a/app/views/event_groups/update.turbo_stream.erb
+++ b/app/views/event_groups/update.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace "setup_header_name_and_indicators",
+                         partial: "setup_header_name_and_indicators",
+                         locals: { presenter: @presenter } %>
+
+<%= turbo_stream.replace "setup_summary_status",
+                         partial: "setup_summary_status",
+                         locals: { presenter: @presenter } %>

--- a/app/views/events/_course_setup_gpx.html.erb
+++ b/app/views/events/_course_setup_gpx.html.erb
@@ -2,29 +2,22 @@
 
 <%= turbo_frame_tag "course_setup_gpx" do %>
   <aside class="col-12">
-    <div class="callout callout-info">
-      <div class="d-inline-flex justify-content-between w-100">
-        <% if event.course.gpx.attached? %>
-          <div>
-            <span class="text-success"><%= fa_icon "check-circle" %></span>
-            <span class="ms-1">A GPX file has been added for this course.</span>
-          </div>
-          <%= link_to "Remove",
-                      remove_course_gpx_event_group_event_path(event.event_group, event),
-                      method: :delete,
-                      class: "btn btn-sm btn-outline-danger",
-                      data: { confirm: "This cannot be undone. Proceed?" } %>
-        <% else %>
-          <div>
-            <span class="text-info"><%= fa_icon "info-circle" %></span>
-            <span class="ms-1">Add a GPX file to see your course on the map below.</span>
-          </div>
-          <%= link_to "Add",
-                      new_course_gpx_event_group_event_path(event.event_group, event),
-                      data: { turbo_frame: "form_modal" },
-                      class: "btn btn-sm btn-outline-success" %>
-        <% end %>
-      </div>
-    </div>
+    <% if event.course.gpx.attached? %>
+      <%= render partial: "shared/callout_with_link",
+                 locals: {
+                   icon_color: "success",
+                   icon_name: "check-circle",
+                   main_text: t("event_groups.setup.gpx_is_attached"),
+                   link: link_to_remove_course_gpx(event),
+                 } %>
+    <% else %>
+      <%= render partial: "shared/callout_with_link",
+                 locals: {
+                   icon_color: "warning",
+                   icon_name: "info-circle",
+                   main_text: t("event_groups.setup.gpx_is_not_attached"),
+                   link: link_to_add_course_gpx(event),
+                 } %>
+    <% end %>
   </aside>
 <% end %>

--- a/app/views/events/_course_setup_gpx.html.erb
+++ b/app/views/events/_course_setup_gpx.html.erb
@@ -2,9 +2,9 @@
 
 <%= turbo_frame_tag "course_setup_gpx" do %>
   <aside class="col-12">
-    <% if event.course.gpx.attached? %>
-      <div class="callout callout-info">
-        <div class="d-inline-flex justify-content-between w-100">
+    <div class="callout callout-info">
+      <div class="d-inline-flex justify-content-between w-100">
+        <% if event.course.gpx.attached? %>
           <div>
             <span class="text-success"><%= fa_icon "check-circle" %></span>
             <span class="ms-1">A GPX file has been added for this course.</span>
@@ -14,11 +14,7 @@
                       method: :delete,
                       class: "btn btn-sm btn-outline-danger",
                       data: { confirm: "This cannot be undone. Proceed?" } %>
-        </div>
-      </div>
-    <% else %>
-      <div class="callout callout-info">
-        <div class="d-inline-flex justify-content-between w-100">
+        <% else %>
           <div>
             <span class="text-info"><%= fa_icon "info-circle" %></span>
             <span class="ms-1">Add a GPX file to see your course on the map below.</span>
@@ -27,8 +23,8 @@
                       new_course_gpx_event_group_event_path(event.event_group, event),
                       data: { turbo_frame: "form_modal" },
                       class: "btn btn-sm btn-outline-success" %>
-        </div>
+        <% end %>
       </div>
-    <% end %>
+    </div>
   </aside>
 <% end %>

--- a/app/views/shared/_callout_with_link.html.erb
+++ b/app/views/shared/_callout_with_link.html.erb
@@ -3,6 +3,9 @@
 <% callout_color ||= "success" %>
 <% icon_color ||= "success" %>
 <% icon_name ||= nil %>
+<% main_text ||= nil %>
+<% detail_text ||= nil %>
+<% link ||= nil %>
 
 <div class="callout callout-<%= callout_color %>">
   <div class="row">

--- a/app/views/shared/_callout_with_link.html.erb
+++ b/app/views/shared/_callout_with_link.html.erb
@@ -1,0 +1,32 @@
+<%# locals: (callout_color:, icon_color:, icon_name:, main_text:, detail_text:, link: -%>
+
+<% callout_color ||= "success" %>
+<% icon_color ||= "success" %>
+<% icon_name ||= nil %>
+
+<div class="callout callout-<%= callout_color %>">
+  <div class="row">
+    <div class="col-12 col-md-9">
+      <div class="d-block d-md-inline-flex">
+        <% if icon_name.present? %>
+          <div class="text-center py-2 py-md-0 me-md-2">
+            <span class="text-<%= icon_color %> me-1"><%= fa_icon icon_name, type: :regular, size: "2x" %></span>
+          </div>
+        <% end %>
+        <div>
+          <% if main_text.present? %>
+            <div class="h5 fw-bold text-center text-md-start"><%= main_text %></div>
+          <% end %>
+          <% if detail_text.present? %>
+            <p class="text-center text-md-start"><%= detail_text %></p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <% if link.present? %>
+      <div class="col-12 col-md-3 text-center text-md-end pt-3 pt-md-0">
+        <%= link %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -1,0 +1,7 @@
+en:
+  event_groups:
+    setup:
+      enable_live_confirm: "NOTE: This will enable live entry actions for %{event_group_name}, and will also enable live follower notifications by email and SMS text when new times are added. Are you sure you want to proceed?"
+      disable_live_confirm: "NOTE: This will suspend all live entry actions for %{event_group_name}, including any that may be in process, and will disable live follower notifications by email and SMS text when new times are added. Are you sure you want to proceed?"
+      make_public_confirm: "NOTE: This will make %{event_group_name} visible to the public, including all related entrants. Are you sure you want to proceed?"
+      make_private_confirm: "NOTE: This will conceal %{event_group_name} from the public, including all related entrants. Are you sure you want to proceed?"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -15,3 +15,6 @@ en:
       group_is_live_detail: "You can now access the Live Entry view and use OST Remote to record times."
       group_is_not_live_main: "Your Event Group is not yet available for Live Entry"
       group_is_not_live_detail: "You will not be able to use the Live Entry view or OST Remote to record times for this Event Group until you make it available by clicking the \"Enable Live Entry\" button."
+
+      gpx_is_attached: "A GPX file has been added for this course"
+      gpx_is_not_attached: "Add a GPX file to see your course on the map below"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -5,3 +5,13 @@ en:
       disable_live_confirm: "NOTE: This will suspend all live entry actions for %{event_group_name}, including any that may be in process, and will disable live follower notifications by email and SMS text when new times are added. Are you sure you want to proceed?"
       make_public_confirm: "NOTE: This will make %{event_group_name} visible to the public, including all related entrants. Are you sure you want to proceed?"
       make_private_confirm: "NOTE: This will conceal %{event_group_name} from the public, including all related entrants. Are you sure you want to proceed?"
+
+      group_is_public_main: "Congratulations, your Event Group is public!"
+      group_is_public_detail: "Results and Follow pages are now available for your entrants to view."
+      group_is_private_main: "Your Event Group is still private"
+      group_is_private_detail: "Once your Events and Courses are ready and you have Entrants loaded, click the \"Go Public\" button to make your Event Group visible to the public."
+
+      group_is_live_main: "Your Event Group is available for Live Entry"
+      group_is_live_detail: "You can now access the Live Entry view and use OST Remote to record times."
+      group_is_not_live_main: "Your Event Group is not yet available for Live Entry"
+      group_is_not_live_detail: "You will not be able to use the Live Entry view or OST Remote to record times for this Event Group until you make it available by clicking the \"Enable Live Entry\" button."


### PR DESCRIPTION
This PR adds access to Public/Private settings and Live/Not Live settings from the Event Setup Summary page. It also introduces a `callout_with_link` partial that should be reusable in a few places within event and lottery setup.