### PR TITLE
Convert Event Group Setup Entrants to a first-class view

### DIFF
--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -44,7 +44,7 @@ class EffortsController < ApplicationController
     authorize @effort
 
     if @effort.save
-      redirect_to setup_event_group_path(@effort.event_group, display_style: :entrants)
+      redirect_to entrants_event_group_path(@effort.event_group)
     else
       render "new", status: :unprocessable_entity
     end
@@ -63,7 +63,7 @@ class EffortsController < ApplicationController
           when :disassociate
             redirect_to request.referrer
           else
-            redirect_to setup_event_group_path(effort.event_group, display_style: :entrants)
+            redirect_to entrants_event_group_path(effort.event_group)
           end
 
           if new_event_id && new_event_id != effort.event_id
@@ -92,7 +92,7 @@ class EffortsController < ApplicationController
     authorize @effort
 
     @effort.destroy
-    redirect_to setup_event_group_path(@effort.event_group, display_style: :entrants)
+    redirect_to entrants_event_group_path(@effort.event_group)
   end
 
   # DELETE /efforts/1/delete_photo

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -84,6 +84,17 @@ class EventGroupsController < ApplicationController
     end
   end
 
+  # GET /event_groups/1/entrants
+  def entrants
+    authorize @event_group
+    @presenter = ::EventGroupSetupPresenter.new(@event_group, view_context)
+
+    respond_to do |format|
+      format.html
+      format.turbo_stream { render "entrants", locals: { presenter: @presenter } }
+    end
+  end
+
   # GET /event_groups/1/setup_summary
   def setup_summary
     authorize @event_group
@@ -241,7 +252,7 @@ class EventGroupsController < ApplicationController
     response = ::Interactors::BulkSetBibNumbers.perform!(@event_group, bib_assignments)
 
     if response.successful?
-      redirect_to setup_event_group_path(@event_group, display_style: :entrants)
+      redirect_to entrants_event_group_path(@event_group)
     else
       set_flash_message(response)
       redirect_to assign_bibs_event_group_path(@event_group)
@@ -366,7 +377,7 @@ class EventGroupsController < ApplicationController
 
     response = Interactors::BulkDestroyEfforts.perform!(::Effort.where(event: @event_group.events))
     set_flash_message(response) unless response.successful?
-    redirect_to setup_event_group_path(@event_group, display_style: :entrants)
+    redirect_to entrants_event_group_path(@event_group)
   end
 
   def delete_all_times

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -283,7 +283,7 @@ class EventsController < ApplicationController
 
     response = ::Interactors::SyncLotteryEntrants.perform!(@event)
     set_flash_message(response)
-    redirect_to setup_event_group_path(@event.event_group, display_style: :entrants)
+    redirect_to entrants_event_group_path(@event.event_group)
   end
 
   # POST /events/1/sync_entrants
@@ -292,7 +292,7 @@ class EventsController < ApplicationController
 
     response = ::Interactors::SyncRunsignupParticipants.perform!(@event, current_user)
     set_flash_message(response)
-    redirect_to setup_event_group_path(@event.event_group, display_style: :entrants)
+    redirect_to entrants_event_group_path(@event.event_group)
   end
 
   private

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -447,8 +447,4 @@ module DropdownHelper
     end
     build_dropdown_menu(nil, dropdown_items, button: true)
   end
-
-  def event_staging_app_page(view_object)
-    view_object.respond_to?(:display_style) && (view_object.display_style == "splits") ? "splits" : "entrants"
-  end
 end

--- a/app/helpers/event_group_setup_widget_helper.rb
+++ b/app/helpers/event_group_setup_widget_helper.rb
@@ -14,8 +14,7 @@ module EventGroupSetupWidgetHelper
   end
 
   def link_to_setup_widget_entrants(presenter)
-    if presenter.controller_name == "event_groups" &&
-      (presenter.action_name == "setup" && presenter.display_style == "entrants") ||
+    if (presenter.controller_name == "event_groups" && presenter.action_name == "entrants") ||
       presenter.action_name.in?(%w(assign_bibs manage_entrant_photos manage_start_times reconcile))
       type = :solid
       tooltip = "Manage your Entrants"
@@ -40,13 +39,13 @@ module EventGroupSetupWidgetHelper
     if icon_only
       icon
     else
-      path = setup_event_group_path(presenter.event_group, display_style: :entrants)
+      path = entrants_event_group_path(presenter.event_group)
       link_to icon, path
     end
   end
 
   def link_to_setup_widget_event_group(presenter)
-    type = presenter.controller_name == "event_groups" && presenter.action_name.in?(%w(setup new)) && presenter.display_style != "entrants" ? :solid : :regular
+    type = presenter.controller_name == "event_groups" && presenter.action_name.in?(%w(setup new)) ? :solid : :regular
     path = presenter.event_group.new_record? ? new_organization_event_group_path(presenter.organization) : setup_event_group_path(presenter.event_group)
     icon_name = presenter.event_group.new_record? ? "dot-circle" : "check-circle"
     icon = fa_icon(icon_name,

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -89,8 +89,4 @@ module EventsHelper
   def data_status(status_int)
     Effort.data_statuses.key(status_int)
   end
-
-  def event_staging_app_page(view_object)
-    view_object.respond_to?(:display_style) && (view_object.display_style == "splits") ? "splits" : "entrants"
-  end
 end

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -51,22 +51,6 @@ module TabsHelper
     build_view_tabs(items)
   end
 
-  def setup_view_tabs(presenter)
-    items = [
-      { name: "Events",
-        link: setup_event_group_path(presenter.event_group, display_style: "events"),
-        active: action_name == "setup" && presenter.display_style == "events" },
-      { name: "Entrants",
-        link: setup_event_group_path(presenter.event_group, display_style: "entrants"),
-        active: action_name == "setup" && presenter.display_style == "entrants" },
-      { name: "Partners",
-        link: organization_event_group_partners_path(presenter.organization, presenter.event_group),
-        active: controller_name == "partners" },
-    ]
-
-    build_view_tabs(items)
-  end
-
   private
 
   def build_view_tabs(items)

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -45,12 +45,12 @@ class ImportJob < ApplicationRecord
     when "Lottery"
       ::Rails.application.routes.url_helpers.setup_organization_lottery_path(parent.organization, parent)
     when "EventGroup"
-      ::Rails.application.routes.url_helpers.setup_event_group_path(parent, display_style: :entrants)
+      ::Rails.application.routes.url_helpers.entrants_event_group_path(parent)
     when "Event"
       if format == "event_course_splits"
         ::Rails.application.routes.url_helpers.setup_course_event_group_event_path(parent.event_group, parent)
       else
-        ::Rails.application.routes.url_helpers.setup_event_group_path(parent.event_group, display_style: :entrants)
+        ::Rails.application.routes.url_helpers.entrants_event_group_path(parent.event_group)
       end
     else
       raise RuntimeError, "Unknown parent type #{parent_type} for import job #{id}"

--- a/app/policies/event_group_policy.rb
+++ b/app/policies/event_group_policy.rb
@@ -24,6 +24,10 @@ class EventGroupPolicy < ApplicationPolicy
     user.authorized_to_edit?(event_group)
   end
 
+  def entrants?
+    setup?
+  end
+
   def setup_summary?
     setup?
   end

--- a/app/presenters/event_group_setup_presenter.rb
+++ b/app/presenters/event_group_setup_presenter.rb
@@ -41,10 +41,6 @@ class EventGroupSetupPresenter < BasePresenter
     events.map(&:course).uniq
   end
 
-  def display_style
-    params[:display_style].presence || default_display_style
-  end
-
   def event_group_efforts
     event_group.efforts.includes(:event)
   end
@@ -115,8 +111,4 @@ class EventGroupSetupPresenter < BasePresenter
 
   attr_reader :params, :view_context
   delegate :current_user, :request, to: :view_context, private: true
-
-  def default_display_style
-    "events"
-  end
 end

--- a/app/views/efforts/_entrant_for_roster.html.erb
+++ b/app/views/efforts/_entrant_for_roster.html.erb
@@ -1,7 +1,9 @@
 <%# locals: (effort:, presenter:) -%>
 
 <tr id="<%= dom_id effort, :roster_row %>">
-  <td class="text-center"><%= effort.unreconciled? ? "No" : "Yes" %></td>
+  <td class="text-center">
+    <%= effort.unreconciled? ? fa_icon("check-circle", type: :regular, class: "text-danger") : fa_icon("check-circle", type: :solid, class: "text-success") %>
+  </td>
   <% if presenter.multiple_events? %>
     <td><%= effort.event.guaranteed_short_name %></td>
   <% end %>

--- a/app/views/event_groups/_efforts_roster.html.erb
+++ b/app/views/event_groups/_efforts_roster.html.erb
@@ -19,21 +19,14 @@
 
   <article class="ost-article container">
     <% if @presenter.unreconciled_efforts.present? %>
-      <div class="row">
-        <div class="col">
-          <div class="card border-primary">
-            <h4 class="card-header bg-primary text-white"><strong>Note</strong></h4>
-            <div class="card-body">
-              <h5 class="card-text">
-                Unreconciled efforts exist.
-                Please <%= link_to "reconcile", reconcile_event_group_path(@presenter.event_group) %> when you have a
-                moment.
-              </h5>
-            </div>
-          </div>
-        </div>
-      </div>
-      <br/>
+      <%= render partial: "shared/callout_with_link",
+                 locals: {
+                   callout_color: "warning",
+                   icon_color: "warning",
+                   icon_name: "exclamation-triangle",
+                   main_text: "Unreconciled efforts exist; please reconcile when you have a moment",
+                   link: link_to_reconcile_efforts(@presenter.event_group),
+                 } %>
     <% end %>
 
     <% if @presenter.filtered_roster_efforts.present? %>

--- a/app/views/event_groups/_entrants_list.html.erb
+++ b/app/views/event_groups/_entrants_list.html.erb
@@ -35,7 +35,7 @@
           </div>
         </div>
         <div class="col-12 col-md-6">
-          <%= render "effort_lookup_setup", presenter: @presenter %>
+          <%= render "entrants_lookup", presenter: @presenter %>
         </div>
       </div>
     </div>

--- a/app/views/event_groups/_entrants_lookup.html.erb
+++ b/app/views/event_groups/_entrants_lookup.html.erb
@@ -1,14 +1,13 @@
 <%# locals: (presenter:) -%>
 
-<%= form_tag setup_event_group_path(presenter.event_group), method: :get do %>
-  <%= hidden_field_tag "display_style", presenter.display_style %>
+<%= form_tag entrants_event_group_path(presenter.event_group), method: :get do %>
   <div class="input-group">
     <%= text_field_tag "filter[search]",
                        presenter.search_text,
                        placeholder: "Bib #, first name, last name, state, or country",
                        autofocus: true,
                        class: "form-control search-box" %>
-    <%= button_tag(id: "roster-search-submit", type: :submit, class: "btn btn-primary input-group-text") do %>
+    <%= button_tag(id: "entrants-search-submit", type: :submit, class: "btn btn-primary input-group-text") do %>
       <i class="fas fa-search"></i>
     <% end %>
   </div>

--- a/app/views/event_groups/assign_bibs.html.erb
+++ b/app/views/event_groups/assign_bibs.html.erb
@@ -50,7 +50,7 @@
       <div class="col">
         <%= f.submit "Update", class: "btn btn-primary" %>
         <%= link_to "Cancel",
-                    setup_event_group_path(@presenter.event_group, display_style: :entrants),
+                    entrants_event_group_path(@presenter.event_group),
                     class: "btn btn-outline-secondary ms-1" %>
       </div>
     </div>

--- a/app/views/event_groups/entrants.html.erb
+++ b/app/views/event_groups/entrants.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title do %>
+  <% "OpenSplitTime: Event Group Entrants - #{@presenter.event_group.name}" %>
+<% end %>
+
+<%= render "shared/mode_widget", event_group: @presenter.event_group %>
+<%= render "setup_header", presenter: @presenter, breadcrumbs: [] %>
+
+<article class="ost-article container">
+  <div class="row flex-nowrap">
+    <div class="col px-md-4 py-3">
+      <% if @presenter.first_event.present? %>
+        <%= render "entrants_roster", presenter: @presenter %>
+      <% else %>
+        <div class="callout callout-info">
+          <h5>You will need to add an Event before adding Entrants</h5>
+          <p>Click the <strong>Setup</strong> tab to add an Event</p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</article>

--- a/app/views/event_groups/entrants.html.erb
+++ b/app/views/event_groups/entrants.html.erb
@@ -9,7 +9,7 @@
   <div class="row flex-nowrap">
     <div class="col px-md-4 py-3">
       <% if @presenter.first_event.present? %>
-        <%= render "entrants_roster", presenter: @presenter %>
+        <%= render "entrants_list", presenter: @presenter %>
       <% else %>
         <div class="callout callout-info">
           <h5>You will need to add an Event before adding Entrants</h5>

--- a/app/views/event_groups/link_lotteries.html.erb
+++ b/app/views/event_groups/link_lotteries.html.erb
@@ -15,7 +15,7 @@
   <div class="row mb-3">
     <div class="col">
       <%= link_to "Back to setup",
-                  setup_event_group_path(@presenter.event_group, display_style: :entrants),
+                  entrants_event_group_path(@presenter.event_group),
                   class: "btn btn-outline-secondary" %>
     </div>
   </div>

--- a/app/views/event_groups/setup.html.erb
+++ b/app/views/event_groups/setup.html.erb
@@ -5,47 +5,28 @@
 <%= render "shared/mode_widget", event_group: @presenter.event_group %>
 <%= render "setup_header", presenter: @presenter, breadcrumbs: [] %>
 
-<% case @presenter.display_style %>
-<% when "events" %>
-  <article class="ost-article container">
-    <div class="row flex-nowrap">
-      <div class="col px-md-4 py-3">
-        <aside class="ost-toolbar">
-          <div class="container">
-            <div class="row">
-              <div class="col">
-                <% if current_user&.authorized_fully?(@presenter.event_group) %>
-                  <%= link_to fa_icon("plus", text: "Add an event"),
-                              new_event_group_event_path(@presenter.event_group),
-                              id: "add-event",
-                              class: "btn btn-success" %>
-                  <% if @presenter.events.present? %>
-                    <%= event_group_actions_dropdown(@presenter) %>
-                  <% end %>
+<article class="ost-article container">
+  <div class="row flex-nowrap">
+    <div class="col px-md-4 py-3">
+      <aside class="ost-toolbar">
+        <div class="container">
+          <div class="row">
+            <div class="col">
+              <% if current_user&.authorized_fully?(@presenter.event_group) %>
+                <%= link_to fa_icon("plus", text: "Add an event"),
+                            new_event_group_event_path(@presenter.event_group),
+                            id: "add-event",
+                            class: "btn btn-success" %>
+                <% if @presenter.events.present? %>
+                  <%= event_group_actions_dropdown(@presenter) %>
                 <% end %>
-              </div>
+              <% end %>
             </div>
           </div>
-        </aside>
+        </div>
+      </aside>
 
-        <%= render "event_overview_cards", presenter: @presenter %>
-      </div>
+      <%= render "event_overview_cards", presenter: @presenter %>
     </div>
-  </article>
-
-<% when "entrants" %>
-  <article class="ost-article container">
-    <div class="row flex-nowrap">
-      <div class="col px-md-4 py-3">
-        <% if @presenter.first_event.present? %>
-          <%= render "entrants_roster", presenter: @presenter %>
-        <% else %>
-          <div class="callout callout-info">
-            <h5>You will need to add an Event before adding Entrants</h5>
-            <p>Click the <strong>Setup</strong> tab to add an Event</p>
-          </div>
-        <% end %>
-      </div>
-    </div>
-  </article>
-<% end %>
+  </div>
+</article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
       get :assign_bibs
       get :drop_list
       get :efforts
+      get :entrants
       get :export_raw_times
       get :finish_line
       get :follow


### PR DESCRIPTION
Currently, we have an Event Group Setup view that has two display styles, one for Events and one for Entrants.

This PR removes the display style and converts Entrants into its own view.

This PR also conforms the Reconcile UI in the Roster view with the one found in the Entrants view.