### PR TITLE
Use a modal for entrant edit in event group setup

### DIFF
--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -44,7 +44,10 @@ class EffortsController < ApplicationController
     authorize @effort
 
     if @effort.save
-      redirect_to entrants_event_group_path(@effort.event_group)
+      respond_to do |format|
+        format.html { redirect_to entrants_event_group_path(@effort.event_group) }
+        format.turbo_stream { @presenter = EventGroupSetupPresenter.new(@effort.event_group, view_context) }
+      end
     else
       render "new", status: :unprocessable_entity
     end

--- a/app/helpers/efforts_helper.rb
+++ b/app/helpers/efforts_helper.rb
@@ -58,7 +58,8 @@ module EffortsHelper
   def link_to_effort_edit(effort)
     url = edit_effort_path(effort)
     tooltip = "Edit effort"
-    options = { data: { controller: :tooltip,
+    options = { data: { turbo_frame: "form_modal_large",
+                        controller: "tooltip",
                         bs_placement: :bottom,
                         bs_original_title: tooltip },
                 class: "btn btn-primary" }

--- a/app/views/efforts/_entrant_for_setup.html.erb
+++ b/app/views/efforts/_entrant_for_setup.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (effort:, presenter:) -%>
 
-<tr>
+<tr id="<%= dom_id(effort, :event_group_setup) %>">
   <td class="text-center">
     <%= effort.unreconciled? ? fa_icon("check-circle", type: :regular, class: "text-danger") : fa_icon("check-circle", type: :solid, class: "text-success") %>
   </td>

--- a/app/views/efforts/_form.html.erb
+++ b/app/views/efforts/_form.html.erb
@@ -3,7 +3,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-12">
-      <%= form_for(@effort, html: { class: "form-horizontal", role: "form", data: { turbo: false } }) do |f| %>
+      <%= form_for(@effort, html: { class: "form-horizontal", role: "form" }) do |f| %>
         <div class="row">
           <div class="col-md-6 mb-3">
             <%= f.label :event, class: "required" %>
@@ -119,7 +119,10 @@
         <div class="row mb-3">
           <div class="col">
             <%= f.submit(@effort.new_record? ? "Create Entrant" : "Update Entrant", class: "btn btn-primary btn-large") %>
-            <%= link_to "Cancel", request.referrer, class: "btn btn-outline-secondary" %>
+            <%= button_tag "Cancel",
+                           type: :button,
+                           data: { action: "click->form-modal#hide" },
+                           class: "btn btn-outline-secondary" %>
           </div>
         </div>
       <% end %>

--- a/app/views/efforts/create.turbo_stream.erb
+++ b/app/views/efforts/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.prepend("entrants",
+                         partial: "efforts/entrant_for_setup",
+                         locals: { presenter: @presenter, effort: @effort }) %>

--- a/app/views/efforts/edit.html.erb
+++ b/app/views/efforts/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-    <% "OpenSplitTime: Edit Entrant - #{@effort.full_name}" %>
+  <% "OpenSplitTime: Edit Entrant - #{@effort.full_name}" %>
 <% end %>
 
 <%= render "shared/mode_widget", event_group: @effort.event_group %>
@@ -27,5 +27,12 @@
 </header>
 
 <article class="ost-article container">
-  <%= render "form" %>
+  <%= turbo_frame_tag "form_modal_large" do %>
+    <div class="modal-header">
+      <div class="modal-title h4 fw-bold">Edit Entrant - <%= @effort.full_name %></div>
+    </div>
+    <div class="modal-body">
+      <%= render "form" %>
+    </div>
+  <% end %>
 </article>

--- a/app/views/efforts/new.html.erb
+++ b/app/views/efforts/new.html.erb
@@ -26,5 +26,12 @@
 </header>
 
 <article class="ost-article container">
-  <%= render "form" %>
+  <%= turbo_frame_tag "form_modal_large" do %>
+    <div class="modal-header">
+      <div class="modal-title h4 fw-bold">Add an Entrant</div>
+    </div>
+    <div class="modal-body">
+      <%= render "form" %>
+    </div>
+  <% end %>
 </article>

--- a/app/views/efforts/update.turbo_stream.erb
+++ b/app/views/efforts/update.turbo_stream.erb
@@ -7,3 +7,7 @@
 <%= turbo_stream.replace dom_id(effort.event_group, :start_ready_efforts_button),
                         partial: "event_groups/start_ready_efforts_button",
                         locals: { presenter: presenter } %>
+
+<%= turbo_stream.replace dom_id(effort, :event_group_setup),
+                         partial: "efforts/entrant_for_setup",
+                         locals: { presenter: presenter, effort: effort }%>

--- a/app/views/event_groups/_entrants_list.html.erb
+++ b/app/views/event_groups/_entrants_list.html.erb
@@ -4,7 +4,11 @@
       <div class="row">
         <div class="col">
           <div>
-            <%= link_to fa_icon("plus", text: "Add"), new_effort_path(event_id: presenter.first_event.id), id: "add-entrant", class: "btn btn-success" %>
+            <%= link_to fa_icon("plus", text: "Add"),
+                        new_effort_path(event_id: presenter.first_event.id),
+                        data: { turbo_frame: "form_modal_large" },
+                        id: "add-entrant",
+                        class: "btn btn-success" %>
             <div class="btn-group">
               <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="import-dropdown-button" data-bs-toggle="dropdown" aria-expanded="false">
                 Actions


### PR DESCRIPTION
We are using a modal for editing splits in the event course setup view. This PR follows the same pattern for editing entrants in the event group entrants view.