### PR TITLE
Remove the dependent: :destroy option for Effort has_many effort_segments

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -34,7 +34,12 @@ class Effort < ApplicationRecord
 
   belongs_to :event, counter_cache: true, touch: true
   belongs_to :person, optional: true
-  has_many :effort_segments, dependent: :destroy
+
+  # effort_segments are destroyed when the associated split_times are destroyed.
+  # This is accomplished by the :dependent option on the has_many :split_times association.
+  # Do not add a dependent: :destroy option to the has_many :effort_segments association
+  # because it will cause postgres to throw an error when an effort is destroyed.
+  has_many :effort_segments
   has_many :split_times, dependent: :destroy, autosave: true
   has_many :notifications, dependent: :destroy
   has_one_attached :photo do |photo|

--- a/spec/models/effort_spec.rb
+++ b/spec/models/effort_spec.rb
@@ -187,6 +187,37 @@ RSpec.describe Effort, type: :model do
     end
   end
 
+  describe "relations" do
+    describe "destroy dependent effort_segments" do
+      before { EffortSegment.set_for_effort(effort) }
+
+      context "when an effort has no effort_segments" do
+        let(:effort) { efforts(:sum_100k_un_started)}
+
+        it "destroys the effort" do
+          expect { effort.destroy }.to change(Effort, :count).by(-1)
+        end
+
+        it "destroys no effort_segments" do
+          expect { effort.destroy }.not_to change(EffortSegment, :count)
+        end
+      end
+
+      context "when an effort has effort_segments" do
+        let(:effort) { efforts(:hardrock_2014_finished_first) }
+        let(:effort_segments_count) { effort.effort_segments.count }
+
+        it "destroys the effort" do
+          expect { effort.destroy }.to change(Effort, :count).by(-1)
+        end
+
+        it "destroys the effort_segments" do
+          expect { effort.destroy }.to change(EffortSegment, :count).by(-effort_segments_count)
+        end
+      end
+    end
+  end
+
   describe "#current_age_approximate" do
     subject { build_stubbed(:effort, event: event, age: age) }
     let(:event) { build_stubbed(:event, scheduled_start_time: scheduled_start_time) }
@@ -370,8 +401,8 @@ RSpec.describe Effort, type: :model do
 
   describe ".visible" do
     let(:concealed_event_group) { event_groups(:dirty_30) }
-    let(:visible_efforts) { Effort.joins(:event).where.not(events: {event_group_id: concealed_event_group.id}).first(5) }
-    let(:concealed_efforts) { Effort.joins(:event).where(events: {event_group_id: concealed_event_group.id}).first(5) }
+    let(:visible_efforts) { Effort.joins(:event).where.not(events: { event_group_id: concealed_event_group.id }).first(5) }
+    let(:concealed_efforts) { Effort.joins(:event).where(events: { event_group_id: concealed_event_group.id }).first(5) }
 
     before { concealed_event_group.update(concealed: true) }
 


### PR DESCRIPTION
The `effort_segments` table was built as a read-only table without a primary key. Because of this, it doesn't play nice with `dependent: :destroy`. 

This PR removes the `dependent: :destroy` option from that relation. As it turns out, effort segments get destroyed in any case when the related split times are destroyed, through a callback on the SplitTime model.