### PR TITLE
Convert carmen and results templates to Turbo Stream

### DIFF
--- a/app/controllers/carmen_controller.rb
+++ b/app/controllers/carmen_controller.rb
@@ -1,5 +1,7 @@
 class CarmenController < ApplicationController
   def subregion_options
-    render partial: "subregion_select", locals: {model: params[:model], parent_region: params[:parent_region]}
+    respond_to do |format|
+      format.turbo_stream
+    end
   end
 end

--- a/app/controllers/results_templates_controller.rb
+++ b/app/controllers/results_templates_controller.rb
@@ -1,8 +1,10 @@
 class ResultsTemplatesController < ApplicationController
   before_action :set_results_template
 
-  def categories
-    render partial: "categories_card", locals: {template: @results_template}
+  def show
+    respond_to do |format|
+      format.turbo_stream
+    end
   end
 
   private

--- a/app/javascript/controllers/carmen_controller.js
+++ b/app/javascript/controllers/carmen_controller.js
@@ -1,21 +1,19 @@
 import { Controller } from "@hotwired/stimulus"
-import Rails from "@rails/ujs"
+import { get } from "@rails/request.js"
 
 export default class extends Controller {
 
-  static targets = ["countrySelect", "stateSelectWrapper"]
+  static targets = ["countrySelect"]
+  static values = { model: String }
 
   getSubregions() {
     const countryCode = this.countrySelectTarget.value
-    const model = this.data.get("model")
-    const selectWrapper = this.stateSelectWrapperTarget
+    const model = this.modelValue
+    const url = "/carmen/subregion_options?model=" + model + "&parent_region=" + countryCode
+    const options = { responseKind: "turbo-stream" }
 
-    Rails.ajax({
-      type: "GET",
-      url: "/carmen/subregion_options?model=" + model + "&parent_region=" + countryCode,
-      success: function (data, status, xml) {
-        selectWrapper.outerHTML = xml.response
-      }
+    get(url, options).then (response => {
+      if (!response.ok) { console.error(response) }
     })
   }
 }

--- a/app/javascript/controllers/results_template_controller.js
+++ b/app/javascript/controllers/results_template_controller.js
@@ -1,20 +1,19 @@
 import { Controller } from "@hotwired/stimulus"
-import Rails from "@rails/ujs"
+import { get } from "@rails/request.js"
 
 export default class extends Controller {
 
   static targets = ["categories", "dropdown"]
 
   replaceCategories() {
-    let templateId = this.dropdownTarget.value;
-    let categories = this.categoriesTarget;
+    const templateId = this.dropdownTarget.value;
+    const url = "/results_templates/" + templateId
+    const options = {
+      responseKind: "turbo-stream",
+    }
 
-    Rails.ajax({
-      type: "GET",
-      url: "/results_templates/" + templateId + "/categories",
-      success: function (data, status, xml) {
-        categories.innerHTML = xml.response
-      }
+    get(url, options).then (response => {
+      if (!response.ok) { console.error(response) }
     })
   }
 }

--- a/app/javascript/controllers/results_template_controller.js
+++ b/app/javascript/controllers/results_template_controller.js
@@ -3,14 +3,12 @@ import { get } from "@rails/request.js"
 
 export default class extends Controller {
 
-  static targets = ["categories", "dropdown"]
+  static targets = ["dropdown"]
 
   replaceCategories() {
     const templateId = this.dropdownTarget.value;
     const url = "/results_templates/" + templateId
-    const options = {
-      responseKind: "turbo-stream",
-    }
+    const options = { responseKind: "turbo-stream" }
 
     get(url, options).then (response => {
       if (!response.ok) { console.error(response) }

--- a/app/views/carmen/_subregion_select.html.erb
+++ b/app/views/carmen/_subregion_select.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (model:, parent_region:) -%>
 
-<div data-carmen-target="stateSelectWrapper">
+<div id="carmen_subregion_select">
   <% country = Carmen::Country.coded(parent_region) %>
 
   <% if country.nil? %>

--- a/app/views/carmen/subregion_options.turbo_stream.erb
+++ b/app/views/carmen/subregion_options.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "carmen_subregion_select",
+                         partial: "carmen/subregion_select",
+                         locals: { model: params[:model], parent_region: params[:parent_region] } %>

--- a/app/views/efforts/_form.html.erb
+++ b/app/views/efforts/_form.html.erb
@@ -43,7 +43,7 @@
           </div>
         </div>
 
-        <div class="row" data-controller="carmen" data-carmen-model="effort">
+        <div class="row" data-controller="carmen" data-carmen-model-value="effort">
           <div class="col-md-4 mb-3">
             <%= f.label :country_code, "Country", class: "mb-1" %>
             <%= carmen_country_select :effort, :country_code %>

--- a/app/views/event_series/_form.html.erb
+++ b/app/views/event_series/_form.html.erb
@@ -26,7 +26,7 @@
                 <%= results_template_selector(@event_series) %>
               </h5>
             </div>
-            <div class="card-body" data-results-template-target="categories">
+            <div class="card-body">
               <%= render "results_templates/categories_card", template: @event_series.results_template %>
             </div>
           </div>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -229,7 +229,7 @@
                   <%= results_template_selector(presenter.event) %>
                 </h5>
               </div>
-              <div class="card-body" data-results-template-target="categories">
+              <div class="card-body">
                 <%= render "results_templates/categories_card", template: presenter.event.results_template %>
               </div>
             </div>

--- a/app/views/lottery_entrants/_form.html.erb
+++ b/app/views/lottery_entrants/_form.html.erb
@@ -26,7 +26,7 @@
         </div>
       </div>
 
-      <div class="row" data-controller="carmen" data-carmen-model="lottery_entrant">
+      <div class="row" data-controller="carmen" data-carmen-model-value="lottery_entrant">
         <div class="mb-3 col-md-3">
           <%= f.label :city, class: "mb-1" %>
           <%= f.text_field :city, class: "form-control", placeholder: "City" %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -27,7 +27,7 @@
       </div>
     </div>
 
-    <div class="row" data-controller="carmen" data-carmen-model="person">
+    <div class="row" data-controller="carmen" data-carmen-model-value="person">
       <div class="col-md-4 mb-3">
         <%= f.label :country_code, "Country", class: "mb-1" %>
         <%= carmen_country_select :person, :country_code %>

--- a/app/views/results_templates/_categories_card.html.erb
+++ b/app/views/results_templates/_categories_card.html.erb
@@ -1,18 +1,20 @@
-<h5><%= "#{template.podium_size ? pluralize(template.podium_size, 'Participant') : 'Unlimited Participants'} Per Category" %></h5>
-<table>
-  <tbody>
-  <% template.results_template_categories.includes(:results_category).each do |rtc| %>
-    <tr>
-      <td class="text-danger"><%= "#{'*' if rtc.fixed_position}" %></td>
-      <td><%= "#{rtc.position}." %></td>
-      <td><%= "#{rtc.category_name} (#{rtc.category_description})" %></td>
-    </tr>
-  <% end %>
+<div id="results_template_categories_card">
+  <h5><%= "#{template.podium_size ? pluralize(template.podium_size, 'Participant') : 'Unlimited Participants'} Per Category" %></h5>
+  <table>
+    <tbody>
+    <% template.results_template_categories.includes(:results_category).each do |rtc| %>
+      <tr>
+        <td class="text-danger"><%= "#{'*' if rtc.fixed_position}" %></td>
+        <td><%= "#{rtc.position}." %></td>
+        <td><%= "#{rtc.category_name} (#{rtc.category_description})" %></td>
+      </tr>
+    <% end %>
 
-  <% if template.results_template_categories.any?(&:fixed_position?) %>
-    <tr>
-      <td colspan="3" class="text-danger">* Position is fixed</td>
-    </tr>
-  <% end %>
-  </tbody>
-</table>
+    <% if template.results_template_categories.any?(&:fixed_position?) %>
+      <tr>
+        <td colspan="3" class="text-danger">* Position is fixed</td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/results_templates/show.turbo_stream.erb
+++ b/app/views/results_templates/show.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace("results_template_categories_card",
+                         partial: "categories_card",
+                         locals: {template: @results_template}) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -227,9 +227,7 @@ Rails.application.routes.draw do
 
   resources :raw_times, only: [:update, :destroy]
 
-  resources :results_templates, only: [] do
-    member { get :categories }
-  end
+  resources :results_templates, only: [:show]
 
   resources :split_times, only: [:update]
 


### PR DESCRIPTION
We have two dropdown select functions that use Rails.ajax to populate areas on the page, one for Carmen (subregion select after a country is selected) and one for Results Templates (categories display after a template is chosen).

This PR converts both of these over to Turbo.

Addresses a portion of #983