### PR TITLE
Fix devise supporting forms and add system specs

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -12,7 +12,7 @@
   <div class="row justify-content-center">
     <div class="col col-login">
       <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: {method: :post, data: {turbo: false}}) do |f| %>
-        <%= bootstrap_devise_error_messages! %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="form-floating mb-3">
           <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "form-control" %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -12,7 +12,7 @@
   <div class="row justify-content-center">
     <div class="col col-login">
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: {method: :put}) do |f| %>
-        <%= bootstrap_devise_error_messages! %>
+        <%= render "devise/shared/error_messages", resource: resource %>
         <%= f.hidden_field :reset_password_token %>
 
         <div class="form-floating mb-3">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -12,7 +12,7 @@
   <div class="row justify-content-center">
     <div class="col col-login">
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: {method: :post, data: {turbo: false}}) do |f| %>
-        <%= bootstrap_devise_error_messages! %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="form-floating mb-3">
           <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -16,7 +16,7 @@
   <div class="row justify-content-center">
     <div class="col">
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, data: { turbo: false } }) do |f| %>
-        <%= bootstrap_devise_error_messages! %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="form-floating mb-3">
           <%= f.text_field :first_name, autofocus: true, class: "form-control" %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,21 +1,17 @@
 <div class="mb-3">
-  <%- if controller_name != 'sessions' %>
-    <%= link_to t(".sign_in"), '#', data: { bs_toggle: 'modal', bs_target: '#log-in-modal' } %><br/>
+  <%- if devise_mapping.registerable? && controller_name != "registrations" %>
+    <%= link_to t(".sign_up"), new_registration_path(resource_name), data: { turbo_frame: "_top" } %><br/>
   <% end -%>
 
-  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-    <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br/>
+  <%- if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations" %>
+    <%= link_to t(".forgot_your_password"), new_password_path(resource_name), data: { turbo_frame: "_top" } %><br/>
   <% end -%>
 
-  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-    <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br/>
+  <%- if devise_mapping.confirmable? && controller_name != "confirmations" %>
+    <%= link_to t("devise.shared.links.didn_t_receive_confirmation_instructions"), new_confirmation_path(resource_name), data: { turbo_frame: "_top" } %><br/>
   <% end -%>
 
-  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-    <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br/>
-  <% end -%>
-
-  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-    <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br/>
+  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != "unlocks" %>
+    <%= link_to t(".didn_t_receive_unlock_instructions"), new_unlock_path(resource_name), data: { turbo_frame: "_top" } %><br/>
   <% end -%>
 </div>

--- a/app/views/devise/shared/_modal_links.html.erb
+++ b/app/views/devise/shared/_modal_links.html.erb
@@ -1,5 +1,5 @@
 <div class="mb-3">
-  <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br/>
-  <%= link_to t("devise.shared.links.forgot_your_password"), new_password_path(resource_name) %><br/>
-  <%= link_to t('devise.shared.links.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br/>
+  <%= link_to t("devise.shared.links.sign_up"), new_registration_path(resource_name), data: { turbo_frame: "_top" } %><br/>
+  <%= link_to t("devise.shared.links.forgot_your_password"), new_password_path(resource_name), data: { turbo_frame: "_top" } %><br/>
+  <%= link_to t("devise.shared.links.didn_t_receive_confirmation_instructions"), new_confirmation_path(resource_name), data: { turbo_frame: "_top" } %><br/>
 </div>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -12,7 +12,7 @@
   <div class="row justify-content-center">
     <div class="col col-login">
       <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-        <%= bootstrap_devise_error_messages! %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
         <div class="form-floating mb-3">
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>

--- a/spec/system/user_forgot_password_spec.rb
+++ b/spec/system/user_forgot_password_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "User forgot password" do
+  scenario "without email" do
+    visit_page
+    click_button "Send me reset password instructions"
+
+    expect(page).to have_content("Email can't be blank")
+  end
+
+  scenario "with email" do
+    user = users(:third_user)
+
+    visit_page
+    fill_in "Email", with: user.email
+    click_button "Send me reset password instructions"
+
+    expect(page).to have_content I18n.t("devise.passwords.send_instructions")
+  end
+
+  scenario "sign up" do
+    visit_page
+    click_link I18n.t("devise.shared.links.sign_up")
+
+    expect(page).to have_current_path(new_user_registration_path)
+  end
+
+  scenario "didn't receive confirmation instructions" do
+    visit_page
+    click_link I18n.t("devise.shared.links.didn_t_receive_confirmation_instructions")
+
+    expect(page).to have_current_path(new_user_confirmation_path)
+  end
+
+  def visit_page
+    visit new_user_password_path
+  end
+end

--- a/spec/system/user_logs_in_with_modal_spec.rb
+++ b/spec/system/user_logs_in_with_modal_spec.rb
@@ -31,16 +31,42 @@ RSpec.describe "User logs in with modal", type: :system, js: true do
     verify_invalid
   end
 
+  scenario "sign up" do
+    visit organizations_path
+    within(".navbar") { click_link "Log In" }
+    within("#form_modal") { click_link I18n.t("devise.shared.links.sign_up") }
+
+    expect(page).to have_current_path(new_user_registration_path)
+  end
+
+  scenario "forgot password" do
+    visit organizations_path
+    within(".navbar") { click_link "Log In" }
+    within("#form_modal") { click_link I18n.t("devise.shared.links.forgot_your_password") }
+
+    expect(page).to have_current_path(new_user_password_path)
+  end
+
+  scenario "didn't receive confirmation instructions" do
+    visit organizations_path
+    within(".navbar") { click_link "Log In" }
+    within("#form_modal") { click_link I18n.t("devise.shared.links.didn_t_receive_confirmation_instructions") }
+
+    expect(page).to have_current_path(new_user_confirmation_path)
+  end
+
   def login_with_modal(email, password)
-    within(".navbar") do
-      click_link "Log In"
-    end
+    click_login_link
 
     within("#form_modal") do
       fill_in "Email", with: email
       fill_in "Password", with: password
       click_button "Log in"
     end
+  end
+
+  def click_login_link
+    within(".navbar") { click_link "Log In" }
   end
 
   def verify_valid

--- a/spec/system/user_resend_confirmation_instructions_spec.rb
+++ b/spec/system/user_resend_confirmation_instructions_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "User requests resend confirmation instructions" do
+  scenario "without email" do
+    visit_page
+    click_button "Resend confirmation instructions"
+
+    expect(page).to have_content("Email can't be blank")
+  end
+
+  scenario "with email" do
+    user = users(:third_user)
+    user.update(confirmed_at: nil)
+
+    visit_page
+    fill_in "Email", with: user.email
+    click_button "Resend confirmation instructions"
+
+    expect(page).to have_content("You will receive an email with instructions about how to confirm your account in a few minutes.")
+  end
+
+  scenario "sign up" do
+    visit_page
+    click_link I18n.t("devise.shared.links.sign_up")
+
+    expect(page).to have_current_path(new_user_registration_path)
+  end
+
+  scenario "forgot password" do
+    visit_page
+    click_link I18n.t("devise.shared.links.forgot_your_password")
+
+    expect(page).to have_current_path(new_user_password_path)
+  end
+
+  def visit_page
+    visit new_user_confirmation_path
+  end
+end

--- a/spec/system/visitor_signs_up_spec.rb
+++ b/spec/system/visitor_signs_up_spec.rb
@@ -45,8 +45,15 @@ RSpec.describe "Visitor signs up" do
     expect(page).to have_content(:all, "Password is too short")
   end
 
+  scenario "didn't receive confirmation instructions" do
+    visit_page
+    click_link I18n.t("devise.shared.links.didn_t_receive_confirmation_instructions")
+
+    expect(page).to have_current_path(new_user_confirmation_path)
+  end
+
   def sign_up_with(first_name, last_name, email, password, phone = nil)
-    visit new_user_registration_path
+    visit_page
 
     within(".ost-article") do
       fill_in "First name", with: first_name
@@ -57,5 +64,9 @@ RSpec.describe "Visitor signs up" do
       fill_in "Password confirmation", with: password
       click_button "Sign up"
     end
+  end
+
+  def visit_page
+    visit new_user_registration_path
   end
 end


### PR DESCRIPTION
Fixes devise supporting forms and adds a bunch of system specs to make sure we will know if they break in the future.

Also removes the "Log in" link from the bottom of the Sign Up page. This link is not necessary because "Log In" is always visible in the navbar.

Resolves #1014