### PR TITLE
CSS to fix bootstrap popper warning

### DIFF
--- a/app/assets/stylesheets/utilities/_fix_bootstrap_dropdown.scss
+++ b/app/assets/stylesheets/utilities/_fix_bootstrap_dropdown.scss
@@ -1,0 +1,23 @@
+// Dropdowns result in a warning in the console:
+// Popper: CSS "margin" styles cannot be used to apply padding between the popper and its reference element or boundary.
+// https://github.com/twbs/bootstrap/issues/36789#issuecomment-1427003625
+
+.dropdown-menu[data-bs-popper] {
+  top: calc(100% + var(--#{$prefix}dropdown-spacer));
+  margin-top: 0;
+
+  .dropup & {
+    bottom: calc(100% + var(--#{$prefix}dropdown-spacer));
+    margin-bottom: 0;
+  }
+
+  .dropend & {
+    left: calc(100% + var(--#{$prefix}dropdown-spacer));
+    margin-left: 0;
+  }
+
+  .dropstart & {
+    right: calc(100% + var(--#{$prefix}dropdown-spacer));
+    margin-right: 0;
+  }
+}


### PR DESCRIPTION
We are seeing warnings in the browser console related to bootstrap poppers. We are also occasionally seeing dropdowns fail to appear unless the page is reloaded. It's not clear whether the two issues are related.

This PR adds some CSS that eliminates the warning and may or may not eliminate the dropdown issue entirely.

https://github.com/twbs/bootstrap/issues/36789#issuecomment-1427003625