### PR TITLE
Fix the redirect in the subscriptions controller #create action

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -23,7 +23,7 @@ class SubscriptionsController < ApplicationController
       render "replace_button", locals: { subscribable: @subscribable, protocol: protocol }
     else
       flash_protocol_warning
-      redirect_to edit_preferences_user_path(current_user)
+      redirect_to user_settings_preferences_path(current_user)
     end
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -19,11 +19,16 @@ class SubscriptionsController < ApplicationController
     authorize @subscription
 
     if current_user.send(protocol)
-      @subscription.save!
-      render "replace_button", locals: { subscribable: @subscribable, protocol: protocol }
+      if @subscription.save
+        flash.now[:success] = "You have subscribed to #{protocol} notifications for #{@subscribable.full_name}."
+        render "replace_button", locals: { subscribable: @subscribable, protocol: protocol }
+      else
+        flash.now[:danger] = @subscription.errors.full_messages.to_sentence
+        render turbo_stream: turbo_stream.replace("flash", partial: "layouts/flash")
+      end
     else
       flash_protocol_warning
-      redirect_to user_settings_preferences_path(current_user)
+      redirect_to user_settings_preferences_path
     end
   end
 

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -7,6 +7,8 @@ class UserSettingsController < ApplicationController
 
   # GET /user_settings/preferences
   def preferences
+    # Need to hang on to flash messages from the subscriptions controller
+    flash.keep
   end
 
   # GET /user_settings/password

--- a/app/views/subscriptions/replace_button.turbo_stream.erb
+++ b/app/views/subscriptions/replace_button.turbo_stream.erb
@@ -1,5 +1,6 @@
 <%# locals: (subscribable:, protocol:) -%>
 
+<%= turbo_stream.replace("flash", partial: "layouts/flash") %>
 <%= turbo_stream.replace dom_id(subscribable, protocol),
                          partial: "subscription_button",
                          locals: { subscribable: subscribable, protocol: protocol } %>

--- a/spec/system/subscribe_to_effort_notifications_spec.rb
+++ b/spec/system/subscribe_to_effort_notifications_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "User subscribes to an effort's progress notifications", type: :system, js: true do
+  let(:user) { users(:third_user) }
+  let(:effort) { efforts(:sum_100k_progress_cascade) }
+
+  before { effort.update!(topic_resource_key: "anything") }
+
+  scenario "The user is logged in and subscribes to sms without a phone number" do
+    login_as user, scope: :user
+    visit effort_path(effort)
+
+    click_link(href: effort_subscriptions_path(effort, subscription: { protocol: :sms }))
+    accept_confirm
+    expect(page).to have_current_path(user_settings_preferences_path)
+    expect(page).to have_content("Please add a mobile phone number to receive sms text notifications.")
+  end
+
+  scenario "The user is logged in and subscribes to sms with a phone number" do
+    user.update_columns(phone: "1234567890")
+    login_as user, scope: :user
+    visit effort_path(effort)
+
+    click_link(href: effort_subscriptions_path(effort, subscription: { protocol: :sms }))
+    accept_confirm
+    expect(page).to have_current_path(effort_path(effort))
+    expect(page).to have_content("You have subscribed to sms notifications for #{effort.full_name}.")
+  end
+end

--- a/spec/system/subscribe_to_person_notifications_spec.rb
+++ b/spec/system/subscribe_to_person_notifications_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "User subscribes to notifications for a person", type: :system, js: true do
+  let(:user) { users(:third_user) }
+  let(:person) { people(:progress_cascade) }
+
+  before { person.update!(topic_resource_key: "anything") }
+
+  scenario "The user is logged in and subscribes to sms without a phone number" do
+    login_as user, scope: :user
+    visit person_path(person)
+
+    click_link(href: person_subscriptions_path(person, subscription: { protocol: :sms }))
+    accept_confirm
+    expect(page).to have_current_path(user_settings_preferences_path)
+    expect(page).to have_content("Please add a mobile phone number to receive sms text notifications.")
+  end
+
+  scenario "The user is logged in and subscribes to sms with a phone number" do
+    user.update_columns(phone: "1234567890")
+    login_as user, scope: :user
+    visit person_path(person)
+
+    click_link(href: person_subscriptions_path(person, subscription: { protocol: :sms }))
+    accept_confirm
+    expect(page).to have_current_path(person_path(person))
+    expect(page).to have_content("You have subscribed to sms notifications for #{person.full_name}.")
+  end
+end


### PR DESCRIPTION
SubscriptionsController#create is currently sending users to a non-existent path if they attempt to subscribe by SMS text and have no phone number.

This PR directs users to the correct path and uses some Rails magic to keep the flash message alive for the redirect.

Resolves #1019