### PR TITLE
Remove turbo_stream format from EventGroupsController#setup

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -78,11 +78,6 @@ class EventGroupsController < ApplicationController
   def setup
     authorize @event_group
     @presenter = ::EventGroupSetupPresenter.new(@event_group, view_context)
-
-    respond_to do |format|
-      format.html
-      format.turbo_stream { render "setup", locals: { presenter: @presenter } }
-    end
   end
 
   # GET /event_groups/1/entrants


### PR DESCRIPTION
The `turbo_stream` format was used for pagination when the setup view contained (depending on display_style) a list of entrants. 

Now that the list of entrants has its own route, the turbo_stream format is no longer needed here and no corresponding turbo_stream view exists.

This PR removes the `respond_to` block so that the HTML page will always be rendered.

Resolves #1020