### PR TITLE
Don't verify authenticity token in sendgrid events controller

### DIFF
--- a/app/controllers/webhooks/sendgrid_events_controller.rb
+++ b/app/controllers/webhooks/sendgrid_events_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Webhooks::SendgridEventsController < ::ApplicationController
+  skip_before_action :verify_authenticity_token, if: :valid_webhook_token?
+
   def create
     status = :ok
     rows = params.require(:_json)
@@ -36,5 +38,11 @@ class Webhooks::SendgridEventsController < ::ApplicationController
       :type,
       :useragent,
     ]
+  end
+
+  def valid_webhook_token?
+    Rails.logger.info request.headers
+
+    true
   end
 end


### PR DESCRIPTION
We need to disable CSRF checking for the sendgrid webhook endpoint. We'll add security with signature verification at a later date.

Moves us a step closer on #1022 