### PR TITLE
Add nonbinary to best effort segment model

### DIFF
--- a/app/models/best_effort_segment.rb
+++ b/app/models/best_effort_segment.rb
@@ -5,7 +5,7 @@ class BestEffortSegment < ::ApplicationRecord
   include PersonalInfo
   include DatabaseRankable
 
-  enum gender: [:male, :female]
+  enum gender: [:male, :female, :nonbinary]
   belongs_to :course
   belongs_to :effort
   belongs_to :person


### PR DESCRIPTION
This PR adds nonbinary as an option in the BestEffortSegment model, which allows the best efforts display to show nonbinary efforts as such.