### PR TITLE
Tables opt into fixture rake task

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module FixtureHelper
+  FIXTURE_TABLES = [
+    :aid_stations,
+    :course_group_courses,
+    :course_groups,
+    :courses,
+    :credentials,
+    :efforts,
+    :event_groups,
+    :event_series,
+    :event_series_events,
+    :events,
+    :lotteries,
+    :lottery_divisions,
+    :lottery_draws,
+    :lottery_entrants,
+    :lottery_tickets,
+    :notifications,
+    :organizations,
+    :partners,
+    :people,
+    :raw_times,
+    :results_categories,
+    :results_template_categories,
+    :results_templates,
+    :split_times,
+    :splits,
+    :stewardships,
+    :subscriptions,
+    :syncable_relations,
+    :users,
+  ].freeze
+
+  ATTRIBUTES_TO_IGNORE = [
+    :created_at,
+    :confirmation_sent_at,
+    :confirmation_token,
+    :remember_created_at,
+    :reset_password_token,
+    :reset_password_sent_at,
+    :updated_at,
+  ].freeze
+end

--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -42,4 +42,8 @@ module FixtureHelper
     :reset_password_sent_at,
     :updated_at,
   ].freeze
+
+  ATTRIBUTES_TO_PRESERVE = {
+    lottery_draws: [:created_at],
+  }.freeze
 end

--- a/lib/tasks/db/fixtures.rake
+++ b/lib/tasks/db/fixtures.rake
@@ -40,7 +40,10 @@ namespace :db do
                     else
                       "#{table_name.singularize}_#{suffix}"
                     end
-            FixtureHelper::ATTRIBUTES_TO_IGNORE.each { |attr| record.delete(attr.to_s) }
+            FixtureHelper::ATTRIBUTES_TO_IGNORE.each do |attr|
+              next if attr.in? FixtureHelper::ATTRIBUTES_TO_PRESERVE.fetch(table_name.to_sym, [])
+              record.delete(attr.to_s)
+            end
             hash[title] = record
           end
           puts "Writing table '#{table_name}' to '#{file_path}'"

--- a/lib/tasks/db/fixtures.rake
+++ b/lib/tasks/db/fixtures.rake
@@ -2,29 +2,11 @@
 
 # Credit to Yi Zeng, https://yizeng.me/2017/07/16/generate-rails-test-fixtures-yaml-from-database-dump/
 
+require_relative "fixture_helper"
+
 namespace :db do
   desc "Convert development database to Rails test fixtures"
   task to_fixtures: :environment do
-    TABLES_TO_SKIP = %w[
-      active_storage_attachments
-      active_storage_blobs
-      active_storage_variant_records
-      ar_internal_metadata
-      data_migrations
-      delayed_jobs
-      effort_segments
-      export_jobs
-      friendly_id_slugs
-      import_jobs
-      locations
-      lottery_simulations
-      lottery_simulation_runs
-      schema_info
-      schema_migrations
-      shortened_urls
-      versions
-    ].freeze
-
     PRIMARY_KEY_MAP = {
       "effort_segments" => "begin_split_id, begin_bitkey, end_split_id, end_bitkey, effort_id, lap"
     }.freeze
@@ -32,7 +14,7 @@ namespace :db do
     begin
       ActiveRecord::Base.establish_connection
       ActiveRecord::Base.connection.tables.each do |table_name|
-        next if table_name.in?(TABLES_TO_SKIP)
+        next unless table_name.to_sym.in?(FixtureHelper::FIXTURE_TABLES)
 
         counter = 0
         file_path = "#{Rails.root}/spec/fixtures/#{table_name}.yml"
@@ -58,6 +40,7 @@ namespace :db do
                     else
                       "#{table_name.singularize}_#{suffix}"
                     end
+            FixtureHelper::ATTRIBUTES_TO_IGNORE.each { |attr| record.delete(attr.to_s) }
             hash[title] = record
           end
           puts "Writing table '#{table_name}' to '#{file_path}'"
@@ -73,38 +56,17 @@ namespace :db do
   task from_fixtures: :environment do
     process_start_time = Time.current
 
-    TABLES_TO_SKIP = %w[
-      active_storage_attachments
-      active_storage_blobs
-      active_storage_variant_records
-      ar_internal_metadata
-      data_migrations
-      delayed_jobs
-      effort_segments
-      export_jobs
-      friendly_id_slugs
-      import_jobs
-      locations
-      lottery_simulations
-      lottery_simulation_runs
-      schema_info
-      schema_migrations
-      shortened_urls
-      versions
-    ].freeze
-
     begin
       ActiveRecord::Base.establish_connection
-      table_names = ActiveRecord::Base.connection.tables - TABLES_TO_SKIP
       ENV["FIXTURES_PATH"] = "spec/fixtures"
-      ENV["FIXTURES"] = table_names.join(",")
+      ENV["FIXTURES"] = FixtureHelper::FIXTURE_TABLES.join(",")
       ENV["RAILS_ENV"] = "development"
       Rake::Task["db:fixtures:load"].invoke
     ensure
-      ActiveRecord::Base.connection.close if ActiveRecord::Base.connection
+      ActiveRecord::Base.connection&.close
     end
 
     elapsed_time = Time.current - process_start_time
-    puts "\nFinished creating records for #{to_sentence(table_names)} in #{elapsed_time} seconds"
+    puts "\nFinished creating records for #{FixtureHelper::FIXTURE_TABLES.join(', ')} in #{elapsed_time} seconds"
   end
 end

--- a/spec/fixtures/aid_stations.yml
+++ b/spec/fixtures/aid_stations.yml
@@ -3,335 +3,223 @@ aid_station_5:
   id: 5
   event_id: 4
   split_id: 5
-  created_at: 2016-04-18 09:09:56.014295000 Z
-  updated_at: 2016-04-18 09:09:56.014295000 Z
 aid_station_6:
   id: 6
   event_id: 4
   split_id: 6
-  created_at: 2016-04-18 09:09:56.020065000 Z
-  updated_at: 2016-11-14 15:59:38.258874000 Z
 aid_station_12:
   id: 12
   event_id: 4
   split_id: 12
-  created_at: 2016-04-18 09:09:56.050597000 Z
-  updated_at: 2016-11-14 15:59:30.525209000 Z
 aid_station_16:
   id: 16
   event_id: 4
   split_id: 16
-  created_at: 2016-04-18 09:09:56.069840000 Z
-  updated_at: 2016-08-09 08:42:41.925961000 Z
 aid_station_26:
   id: 26
   event_id: 4
   split_id: 26
-  created_at: 2016-04-18 09:09:56.116823000 Z
-  updated_at: 2016-06-19 20:41:39.818650000 Z
 aid_station_32:
   id: 32
   event_id: 4
   split_id: 32
-  created_at: 2016-04-18 09:09:56.150741000 Z
-  updated_at: 2016-06-19 20:41:39.837992000 Z
 aid_station_34:
   id: 34
   event_id: 4
   split_id: 34
-  created_at: 2016-04-18 09:09:56.162233000 Z
-  updated_at: 2016-06-19 20:41:39.841776000 Z
 aid_station_140:
   id: 140
   event_id: 14
   split_id: 46
-  created_at: 2016-05-08 07:14:16.242124000 Z
-  updated_at: 2016-05-08 07:14:16.242124000 Z
 aid_station_141:
   id: 141
   event_id: 14
   split_id: 47
-  created_at: 2016-05-08 07:14:16.243731000 Z
-  updated_at: 2016-05-08 07:14:16.243731000 Z
 aid_station_202:
   id: 202
   event_id: 17
   split_id: 81
-  created_at: 2016-05-23 01:05:15.615672000 Z
-  updated_at: 2016-05-23 01:05:15.615672000 Z
 aid_station_203:
   id: 203
   event_id: 17
   split_id: 82
-  created_at: 2016-05-23 01:05:15.617583000 Z
-  updated_at: 2016-07-01 05:50:35.054723000 Z
 aid_station_208:
   id: 208
   event_id: 17
   split_id: 87
-  created_at: 2016-05-23 01:09:02.029824000 Z
-  updated_at: 2016-07-01 05:50:35.008523000 Z
 aid_station_214:
   id: 214
   event_id: 17
   split_id: 93
-  created_at: 2016-05-23 01:09:02.081070000 Z
-  updated_at: 2016-07-01 05:50:35.021420000 Z
 aid_station_218:
   id: 218
   event_id: 17
   split_id: 97
-  created_at: 2016-05-23 01:09:02.103208000 Z
-  updated_at: 2016-07-01 05:50:35.029118000 Z
 aid_station_222:
   id: 222
   event_id: 17
   split_id: 101
-  created_at: 2016-05-23 01:09:02.125359000 Z
-  updated_at: 2016-07-01 05:50:35.037527000 Z
 aid_station_228:
   id: 228
   event_id: 17
   split_id: 107
-  created_at: 2016-05-23 01:09:02.158422000 Z
-  updated_at: 2016-07-01 05:50:35.051484000 Z
 aid_station_458:
   id: 458
   event_id: 34
   split_id: 135
-  created_at: 2017-01-28 13:22:26.043214000 Z
-  updated_at: 2017-01-28 13:22:26.043214000 Z
 aid_station_459:
   id: 459
   event_id: 34
   split_id: 136
-  created_at: 2017-01-28 13:22:26.067404000 Z
-  updated_at: 2017-01-28 13:22:26.067404000 Z
 aid_station_460:
   id: 460
   event_id: 34
   split_id: 137
-  created_at: 2017-01-28 13:23:10.287671000 Z
-  updated_at: 2017-01-28 13:23:10.287671000 Z
 aid_station_476:
   id: 476
   event_id: 36
   split_id: 137
-  created_at: 2017-03-28 07:18:29.911918000 Z
-  updated_at: 2017-03-28 07:18:29.911918000 Z
 aid_station_477:
   id: 477
   event_id: 36
   split_id: 135
-  created_at: 2017-03-28 07:18:29.943540000 Z
-  updated_at: 2017-03-28 07:18:29.943540000 Z
 aid_station_478:
   id: 478
   event_id: 36
   split_id: 136
-  created_at: 2017-03-28 07:18:29.945487000 Z
-  updated_at: 2017-03-28 07:18:29.945487000 Z
 aid_station_479:
   id: 479
   event_id: 37
   split_id: 81
-  created_at: 2017-04-18 08:19:16.960439000 Z
-  updated_at: 2017-04-18 08:19:16.960439000 Z
 aid_station_482:
   id: 482
   event_id: 37
   split_id: 87
-  created_at: 2017-04-18 08:19:17.003729000 Z
-  updated_at: 2017-04-18 08:19:17.003729000 Z
 aid_station_485:
   id: 485
   event_id: 37
   split_id: 93
-  created_at: 2017-04-18 08:19:17.009424000 Z
-  updated_at: 2017-04-18 08:19:17.009424000 Z
 aid_station_487:
   id: 487
   event_id: 37
   split_id: 97
-  created_at: 2017-04-18 08:19:17.012375000 Z
-  updated_at: 2017-04-18 08:19:17.012375000 Z
 aid_station_489:
   id: 489
   event_id: 37
   split_id: 101
-  created_at: 2017-04-18 08:19:17.015427000 Z
-  updated_at: 2017-04-18 08:19:17.015427000 Z
 aid_station_492:
   id: 492
   event_id: 37
   split_id: 107
-  created_at: 2017-04-18 08:19:17.020122000 Z
-  updated_at: 2017-04-18 08:19:17.020122000 Z
 aid_station_493:
   id: 493
   event_id: 37
   split_id: 82
-  created_at: 2017-04-18 08:19:17.021751000 Z
-  updated_at: 2017-04-18 08:19:17.021751000 Z
 aid_station_513:
   id: 513
   event_id: 4
   split_id: 20
-  created_at: 2017-05-08 11:25:05.108400000 Z
-  updated_at: 2017-05-08 11:25:05.108400000 Z
 aid_station_570:
   id: 570
   event_id: 48
   split_id: 164
-  created_at: 2017-05-28 13:58:46.760875000 Z
-  updated_at: 2017-05-28 13:58:46.760875000 Z
 aid_station_571:
   id: 571
   event_id: 48
   split_id: 165
-  created_at: 2017-05-28 13:58:46.770501000 Z
-  updated_at: 2017-05-28 13:58:46.770501000 Z
 aid_station_572:
   id: 572
   event_id: 48
   split_id: 167
-  created_at: 2017-05-28 13:58:54.441016000 Z
-  updated_at: 2017-05-28 13:58:54.441016000 Z
 aid_station_574:
   id: 574
   event_id: 48
   split_id: 170
-  created_at: 2017-05-28 13:58:57.636311000 Z
-  updated_at: 2017-05-28 13:58:57.636311000 Z
 aid_station_575:
   id: 575
   event_id: 48
   split_id: 168
-  created_at: 2017-05-28 13:58:59.471469000 Z
-  updated_at: 2017-05-28 13:58:59.471469000 Z
 aid_station_576:
   id: 576
   event_id: 48
   split_id: 166
-  created_at: 2017-05-28 13:59:01.411135000 Z
-  updated_at: 2017-05-28 13:59:01.411135000 Z
 aid_station_577:
   id: 577
   event_id: 48
   split_id: 171
-  created_at: 2017-05-31 15:07:01.329496000 Z
-  updated_at: 2017-05-31 15:07:01.329496000 Z
 aid_station_578:
   id: 578
   event_id: 49
   split_id: 173
-  created_at: 2017-06-09 09:51:15.844258000 Z
-  updated_at: 2017-06-09 09:51:15.844258000 Z
 aid_station_579:
   id: 579
   event_id: 49
   split_id: 172
-  created_at: 2017-06-09 09:51:15.921475000 Z
-  updated_at: 2017-06-09 09:51:15.921475000 Z
 aid_station_626:
   id: 626
   event_id: 56
   split_id: 205
-  created_at: 2018-01-18 05:09:16.982509000 Z
-  updated_at: 2018-01-18 05:09:16.982509000 Z
 aid_station_627:
   id: 627
   event_id: 56
   split_id: 204
-  created_at: 2018-01-18 05:09:17.036196000 Z
-  updated_at: 2018-01-18 05:09:17.036196000 Z
 aid_station_629:
   id: 629
   event_id: 56
   split_id: 207
-  created_at: 2018-01-18 05:09:24.981633000 Z
-  updated_at: 2018-01-18 05:09:24.981633000 Z
 aid_station_630:
   id: 630
   event_id: 56
   split_id: 208
-  created_at: 2018-01-18 05:09:24.985718000 Z
-  updated_at: 2018-01-18 05:09:24.985718000 Z
 aid_station_631:
   id: 631
   event_id: 56
   split_id: 209
-  created_at: 2018-01-18 05:09:24.990614000 Z
-  updated_at: 2018-01-18 05:09:24.990614000 Z
 aid_station_632:
   id: 632
   event_id: 56
   split_id: 210
-  created_at: 2018-01-18 05:09:24.994135000 Z
-  updated_at: 2018-01-18 05:09:24.994135000 Z
 aid_station_634:
   id: 634
   event_id: 57
   split_id: 213
-  created_at: 2018-01-18 05:15:20.961165000 Z
-  updated_at: 2018-01-18 05:15:20.961165000 Z
 aid_station_635:
   id: 635
   event_id: 57
   split_id: 212
-  created_at: 2018-01-18 05:15:20.968758000 Z
-  updated_at: 2018-01-18 05:15:20.968758000 Z
 aid_station_636:
   id: 636
   event_id: 57
   split_id: 218
-  created_at: 2018-01-18 05:20:09.897515000 Z
-  updated_at: 2018-01-18 05:20:09.897515000 Z
 aid_station_637:
   id: 637
   event_id: 57
   split_id: 219
-  created_at: 2018-01-18 05:20:09.901899000 Z
-  updated_at: 2018-01-18 05:20:09.901899000 Z
 aid_station_638:
   id: 638
   event_id: 57
   split_id: 220
-  created_at: 2018-01-18 05:20:09.907158000 Z
-  updated_at: 2018-01-18 05:20:09.907158000 Z
 aid_station_639:
   id: 639
   event_id: 57
   split_id: 221
-  created_at: 2018-01-18 05:20:09.910794000 Z
-  updated_at: 2018-01-18 05:20:09.910794000 Z
 aid_station_725:
   id: 725
   event_id: 56
   split_id: 206
-  created_at: 2018-12-15 21:51:03.222083000 Z
-  updated_at: 2018-12-15 21:51:03.222083000 Z
 aid_station_726:
   id: 726
   event_id: 56
   split_id: 211
-  created_at: 2018-12-20 05:24:56.409073000 Z
-  updated_at: 2018-12-20 05:24:56.409073000 Z
 aid_station_753:
   id: 753
   event_id: 70
   split_id: 137
-  created_at: 2019-01-30 17:38:14.249900000 Z
-  updated_at: 2019-01-30 17:38:14.249900000 Z
 aid_station_754:
   id: 754
   event_id: 70
   split_id: 136
-  created_at: 2019-01-30 17:38:14.255012000 Z
-  updated_at: 2019-01-30 17:38:14.255012000 Z
 aid_station_755:
   id: 755
   event_id: 70
   split_id: 135
-  created_at: 2019-01-30 17:38:14.261182000 Z
-  updated_at: 2019-01-30 17:38:14.261182000 Z

--- a/spec/fixtures/course_group_courses.yml
+++ b/spec/fixtures/course_group_courses.yml
@@ -3,11 +3,7 @@ course_group_course_4:
   id: 4
   course_id: 4
   course_group_id: 2
-  created_at: 2022-11-02 04:40:13.159086000 Z
-  updated_at: 2022-11-02 04:40:13.159086000 Z
 course_group_course_6:
   id: 6
   course_id: 12
   course_group_id: 2
-  created_at: 2022-11-02 23:35:37.096406000 Z
-  updated_at: 2022-11-02 23:35:37.096406000 Z

--- a/spec/fixtures/course_groups.yml
+++ b/spec/fixtures/course_groups.yml
@@ -4,5 +4,3 @@ both_directions:
   organization_id: 4
   name: Both Directions
   slug: both-directions
-  created_at: 2022-11-02 04:40:13.150885000 Z
-  updated_at: 2022-11-02 04:40:13.150885000 Z

--- a/spec/fixtures/courses.yml
+++ b/spec/fixtures/courses.yml
@@ -4,8 +4,6 @@ hardrock_ccw:
   name: Hardrock CCW
   description: Counter-clockwise Hardrock 100 course, starting in Silverton, going
     to Sherman, over Handies Peak, to Ouray, Telluride, and back to Silverton
-  created_at: 2016-04-16 19:25:07.637090000 Z
-  updated_at: 2019-01-30 21:32:19.908442000 Z
   created_by: 1
   updated_by: 1
   next_start_time: 2019-07-19 06:00:00.000000000 Z
@@ -17,8 +15,6 @@ ramble_even_course:
   id: 9
   name: Ramble Even Course
   description:
-  created_at: 2016-05-08 07:10:07.192914000 Z
-  updated_at: 2019-01-30 21:32:45.570123000 Z
   created_by: 3
   updated_by: 1
   next_start_time:
@@ -30,8 +26,6 @@ hardrock_cw:
   id: 12
   name: Hardrock CW
   description: Clockwise Hardrock 100 course
-  created_at: 2016-05-23 01:04:57.225296000 Z
-  updated_at: 2019-01-30 21:32:06.354936000 Z
   created_by: 1
   updated_by: 1
   next_start_time: 2016-07-15 12:00:00.000000000 Z
@@ -43,8 +37,6 @@ rufa_course:
   id: 20
   name: RUFA Course
   description: Bottom of Grandeur Peak to top and back
-  created_at: 2017-01-28 13:21:38.623222000 Z
-  updated_at: 2019-01-24 23:58:45.917638000 Z
   created_by: 1
   updated_by: 1
   next_start_time: 2019-02-09 14:00:00.000000000 Z
@@ -56,8 +48,6 @@ d30_50k_course:
   id: 26
   name: D30 50K Course
   description:
-  created_at: 2017-05-23 06:06:29.666791000 Z
-  updated_at: 2019-01-30 21:31:39.197679000 Z
   created_by: 1
   updated_by: 1
   next_start_time: 2017-11-06 06:00:00.000000000 Z
@@ -69,8 +59,6 @@ d30_12m_course:
   id: 27
   name: D30 12M Course
   description:
-  created_at: 2017-06-09 09:51:15.458576000 Z
-  updated_at: 2019-01-30 21:31:14.718422000 Z
   created_by: 1
   updated_by: 1
   next_start_time:
@@ -82,8 +70,6 @@ sum_100k_course:
   id: 31
   name: SUM 100K Course
   description:
-  created_at: 2018-01-18 05:09:16.740608000 Z
-  updated_at: 2019-01-30 21:30:28.251335000 Z
   created_by: 1
   updated_by: 1
   next_start_time:
@@ -95,8 +81,6 @@ sum_55k_course:
   id: 32
   name: SUM 55K Course
   description:
-  created_at: 2018-01-18 05:15:20.742148000 Z
-  updated_at: 2019-01-30 21:44:59.102925000 Z
   created_by: 1
   updated_by: 1
   next_start_time:

--- a/spec/fixtures/credentials.yml
+++ b/spec/fixtures/credentials.yml
@@ -1,11 +1,13 @@
 ---
-runsignup_api_key:
+credential_179223681:
+  id: 179223681
   user_id: 3
   service_identifier: runsignup
   key: api_key
-  value: 1234
-runsignup_api_secret:
+  value: '1234'
+credential_773744130:
+  id: 773744130
   user_id: 3
   service_identifier: runsignup
   key: api_secret
-  value: 2345
+  value: '2345'

--- a/spec/fixtures/efforts.yml
+++ b/spec/fixtures/efforts.yml
@@ -8,8 +8,6 @@ hardrock_2015_tuan_jacobs:
   city:
   state_code: AN
   age: 17
-  created_at: 2016-04-18 09:10:02.632497000 Z
-  updated_at: 2020-09-09 14:53:45.540056000 Z
   created_by: 1
   updated_by: 1
   first_name: Tuan
@@ -50,8 +48,6 @@ hardrock_2015_erich_larson:
   city:
   state_code: MT
   age: 36
-  created_at: 2016-04-18 09:10:02.669411000 Z
-  updated_at: 2020-09-09 14:53:45.600851000 Z
   created_by: 1
   updated_by: 1
   first_name: Erich
@@ -92,8 +88,6 @@ hardrock_2015_leif_carter:
   city:
   state_code:
   age: 55
-  created_at: 2016-04-18 09:10:02.914611000 Z
-  updated_at: 2020-09-09 14:53:45.627299000 Z
   created_by: 1
   updated_by: 1
   first_name: Leif
@@ -134,8 +128,6 @@ hardrock_2015_carmine_adams:
   city:
   state_code: WA
   age: 18
-  created_at: 2016-04-18 09:10:02.994073000 Z
-  updated_at: 2020-09-09 14:53:45.657611000 Z
   created_by: 1
   updated_by: 1
   first_name: Carmine
@@ -176,8 +168,6 @@ hardrock_2015_garry_kuhlman:
   city:
   state_code: MT
   age: 45
-  created_at: 2016-04-18 09:10:03.077148000 Z
-  updated_at: 2020-09-09 14:53:45.685165000 Z
   created_by: 1
   updated_by: 1
   first_name: Garry
@@ -218,8 +208,6 @@ hardrock_2015_darius_jacobson:
   city:
   state_code: CO
   age: 30
-  created_at: 2016-04-18 09:10:03.093446000 Z
-  updated_at: 2020-09-09 14:53:45.715528000 Z
   created_by: 1
   updated_by: 1
   first_name: Darius
@@ -260,8 +248,6 @@ hardrock_2015_santa_green:
   city:
   state_code: CO
   age: 37
-  created_at: 2016-04-18 09:10:03.171265000 Z
-  updated_at: 2020-09-09 14:53:45.745785000 Z
   created_by: 1
   updated_by: 1
   first_name: Santa
@@ -302,8 +288,6 @@ hardrock_2015_gilberto_mckenzie:
   city:
   state_code: WA
   age: 45
-  created_at: 2016-04-18 09:10:03.210408000 Z
-  updated_at: 2020-09-09 14:53:45.775035000 Z
   created_by: 1
   updated_by: 1
   first_name: Gilberto
@@ -344,8 +328,6 @@ hardrock_2015_vince_willms:
   city:
   state_code: CO
   age: 50
-  created_at: 2016-04-18 09:10:03.559700000 Z
-  updated_at: 2020-09-09 14:53:45.802137000 Z
   created_by: 1
   updated_by: 1
   first_name: Vince
@@ -386,8 +368,6 @@ hardrock_2015_cedric_windler:
   city:
   state_code: TN
   age: 36
-  created_at: 2016-04-18 09:10:03.606136000 Z
-  updated_at: 2020-09-09 14:53:45.843863000 Z
   created_by: 1
   updated_by: 1
   first_name: Cedric
@@ -428,8 +408,6 @@ hardrock_2015_chris_rempel:
   city:
   state_code: CO
   age: 26
-  created_at: 2016-04-18 09:10:03.704495000 Z
-  updated_at: 2020-09-09 14:53:45.873705000 Z
   created_by: 1
   updated_by: 1
   first_name: Chris
@@ -470,8 +448,6 @@ hardrock_2015_robby_gerlach:
   city:
   state_code: VA
   age: 45
-  created_at: 2016-04-18 09:10:03.721673000 Z
-  updated_at: 2020-09-09 14:53:45.902174000 Z
   created_by: 1
   updated_by: 1
   first_name: Robby
@@ -512,8 +488,6 @@ hardrock_2015_rachelle_eichmann:
   city:
   state_code: CO
   age: 23
-  created_at: 2016-04-18 09:10:03.755229000 Z
-  updated_at: 2020-09-09 14:53:45.930067000 Z
   created_by: 1
   updated_by: 1
   first_name: Rachelle
@@ -554,8 +528,6 @@ hardrock_2015_elden_morissette:
   city:
   state_code: WI
   age: 42
-  created_at: 2016-04-18 09:10:03.787728000 Z
-  updated_at: 2020-09-09 14:53:45.960285000 Z
   created_by: 1
   updated_by: 1
   first_name: Elden
@@ -596,8 +568,6 @@ hardrock_2015_leroy_leffler:
   city:
   state_code: NM
   age: 48
-  created_at: 2016-04-18 09:10:03.821143000 Z
-  updated_at: 2020-09-09 14:53:45.988739000 Z
   created_by: 1
   updated_by: 1
   first_name: Leroy
@@ -638,8 +608,6 @@ hardrock_2015_samara_vandervort:
   city:
   state_code: CA
   age: 22
-  created_at: 2016-04-18 09:10:03.987419000 Z
-  updated_at: 2020-09-09 14:53:46.018982000 Z
   created_by: 1
   updated_by: 1
   first_name: Samara
@@ -680,8 +648,6 @@ hardrock_2015_robt_wintheiser:
   city:
   state_code: CO
   age: 57
-  created_at: 2016-04-18 09:10:04.337334000 Z
-  updated_at: 2020-09-09 14:53:46.046970000 Z
   created_by: 1
   updated_by: 1
   first_name: Robt
@@ -722,8 +688,6 @@ hardrock_2015_demetrius_moen:
   city:
   state_code: OR
   age: 40
-  created_at: 2016-04-18 09:10:04.367628000 Z
-  updated_at: 2020-09-09 14:53:46.075425000 Z
   created_by: 1
   updated_by: 1
   first_name: Demetrius
@@ -764,8 +728,6 @@ hardrock_2015_vern_buckridge:
   city:
   state_code: TX
   age: 33
-  created_at: 2016-04-18 09:10:04.514797000 Z
-  updated_at: 2020-09-09 14:53:46.106301000 Z
   created_by: 1
   updated_by: 1
   first_name: Vern
@@ -806,8 +768,6 @@ hardrock_2015_donte_spencer:
   city:
   state_code: UT
   age: 30
-  created_at: 2016-04-18 09:10:04.637912000 Z
-  updated_at: 2020-09-09 14:53:46.141007000 Z
   created_by: 1
   updated_by: 1
   first_name: Donte
@@ -848,8 +808,6 @@ hardrock_2015_bruno_fadel:
   city:
   state_code: CA
   age: 27
-  created_at: 2016-04-18 09:10:04.699167000 Z
-  updated_at: 2020-09-09 14:53:46.168238000 Z
   created_by: 1
   updated_by: 1
   first_name: Bruno
@@ -890,8 +848,6 @@ hardrock_2015_gus_walker:
   city:
   state_code: CO
   age: 54
-  created_at: 2016-04-18 09:10:04.715410000 Z
-  updated_at: 2020-09-09 14:53:46.197187000 Z
   created_by: 1
   updated_by: 1
   first_name: Gus
@@ -932,8 +888,6 @@ hardrock_2015_susanna_abshire:
   city:
   state_code: CO
   age: 34
-  created_at: 2016-04-18 09:10:04.780476000 Z
-  updated_at: 2020-09-09 14:53:46.269875000 Z
   created_by: 1
   updated_by: 1
   first_name: Susanna
@@ -974,8 +928,6 @@ hardrock_2015_leandro_cole:
   city:
   state_code: UT
   age: 45
-  created_at: 2016-04-18 09:10:04.842620000 Z
-  updated_at: 2020-09-09 14:53:46.298147000 Z
   created_by: 1
   updated_by: 1
   first_name: Leandro
@@ -1016,8 +968,6 @@ hardrock_2015_benedict_davis:
   city:
   state_code: CO
   age: 32
-  created_at: 2016-04-18 09:10:04.905460000 Z
-  updated_at: 2020-09-09 14:53:46.324434000 Z
   created_by: 1
   updated_by: 1
   first_name: Benedict
@@ -1058,8 +1008,6 @@ hardrock_2015_raphael_swift:
   city:
   state_code: AR
   age: 40
-  created_at: 2016-04-18 09:10:05.014754000 Z
-  updated_at: 2020-09-09 14:53:46.349841000 Z
   created_by: 1
   updated_by: 1
   first_name: Raphael
@@ -1100,8 +1048,6 @@ hardrock_2015_bad_status:
   city:
   state_code: CO
   age: 21
-  created_at: 2016-04-18 09:10:05.047829000 Z
-  updated_at: 2020-09-09 14:53:46.374735000 Z
   created_by: 1
   updated_by: 1
   first_name: Bad
@@ -1142,8 +1088,6 @@ hardrock_2015_irvin_harber:
   city:
   state_code: CO
   age: 19
-  created_at: 2016-04-18 09:10:05.103548000 Z
-  updated_at: 2020-09-09 14:53:46.395706000 Z
   created_by: 1
   updated_by: 1
   first_name: Irvin
@@ -1184,8 +1128,6 @@ hardrock_2015_cassondra_nienow:
   city:
   state_code: OH
   age: 56
-  created_at: 2016-04-18 09:10:05.298384000 Z
-  updated_at: 2020-09-09 14:53:46.420979000 Z
   created_by: 1
   updated_by: 1
   first_name: Cassondra
@@ -1226,8 +1168,6 @@ hardrock_2015_donn_mckenzie:
   city:
   state_code: WY
   age: 16
-  created_at: 2016-04-18 09:10:05.339566000 Z
-  updated_at: 2020-09-09 14:53:46.446814000 Z
   created_by: 1
   updated_by: 1
   first_name: Donn
@@ -1268,8 +1208,6 @@ ramble_finished_first:
   city:
   state_code:
   age: 49
-  created_at: 2016-05-09 01:56:15.125469000 Z
-  updated_at: 2019-02-01 06:38:32.510437000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -1310,8 +1248,6 @@ ramble_finished_second:
   city:
   state_code:
   age: 12
-  created_at: 2016-05-09 01:56:15.230348000 Z
-  updated_at: 2019-02-01 06:38:45.308003000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -1352,8 +1288,6 @@ ramble_start_only:
   city:
   state_code:
   age: 38
-  created_at: 2016-05-09 01:56:15.271716000 Z
-  updated_at: 2019-02-01 06:37:29.491883000 Z
   created_by: 1
   updated_by: 1
   first_name: Start
@@ -1394,8 +1328,6 @@ ramble_not_started:
   city:
   state_code:
   age: 17
-  created_at: 2016-05-09 01:56:15.407929000 Z
-  updated_at: 2019-02-01 06:37:07.323951000 Z
   created_by: 1
   updated_by: 1
   first_name: Not
@@ -1436,8 +1368,6 @@ hardrock_2014_finished_first:
   city:
   state_code: '01'
   age: 19
-  created_at: 2016-05-24 03:02:35.765362000 Z
-  updated_at: 2020-09-09 14:53:46.470415000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -1478,8 +1408,6 @@ hardrock_2014_finished_with_stop:
   city:
   state_code: UT
   age: 40
-  created_at: 2016-05-24 03:02:35.777780000 Z
-  updated_at: 2020-09-09 14:53:46.497693000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -1520,8 +1448,6 @@ hardrock_2014_finished_without_stop:
   city:
   state_code: UT
   age: 25
-  created_at: 2016-05-24 03:02:35.789178000 Z
-  updated_at: 2020-09-09 14:53:46.524465000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -1562,8 +1488,6 @@ hardrock_2014_claudio_wunsch:
   city:
   state_code:
   age: 33
-  created_at: 2016-05-24 03:02:36.044742000 Z
-  updated_at: 2020-09-09 14:53:46.555500000 Z
   created_by: 1
   updated_by: 1
   first_name: Claudio
@@ -1604,8 +1528,6 @@ hardrock_2014_paul_predovic:
   city:
   state_code: ID
   age: 55
-  created_at: 2016-05-24 03:02:36.127624000 Z
-  updated_at: 2020-09-09 14:53:46.581622000 Z
   created_by: 1
   updated_by: 1
   first_name: Paul
@@ -1646,8 +1568,6 @@ hardrock_2014_keith_metz:
   city:
   state_code: UT
   age: 42
-  created_at: 2016-05-24 03:02:36.226666000 Z
-  updated_at: 2020-09-09 14:53:46.611194000 Z
   created_by: 1
   updated_by: 1
   first_name: Keith
@@ -1688,8 +1608,6 @@ hardrock_2014_major_green:
   city:
   state_code: NC
   age: 58
-  created_at: 2016-05-24 03:02:36.242262000 Z
-  updated_at: 2020-09-09 14:53:46.640945000 Z
   created_by: 1
   updated_by: 1
   first_name: Major
@@ -1730,8 +1648,6 @@ hardrock_2014_humberto_adams:
   city:
   state_code: NM
   age: 24
-  created_at: 2016-05-24 03:02:36.472804000 Z
-  updated_at: 2020-09-09 14:53:46.669204000 Z
   created_by: 1
   updated_by: 1
   first_name: Humberto
@@ -1772,8 +1688,6 @@ hardrock_2014_omer_yundt:
   city:
   state_code: CO
   age: 40
-  created_at: 2016-05-24 03:02:36.780679000 Z
-  updated_at: 2020-09-09 14:53:46.697006000 Z
   created_by: 1
   updated_by: 1
   first_name: Omer
@@ -1814,8 +1728,6 @@ hardrock_2014_pat_schaden:
   city:
   state_code: AZ
   age: 53
-  created_at: 2016-05-24 03:02:36.793599000 Z
-  updated_at: 2020-09-09 14:53:46.727556000 Z
   created_by: 1
   updated_by: 1
   first_name: Pat
@@ -1856,8 +1768,6 @@ hardrock_2014_clarence_goyette:
   city:
   state_code: CO
   age: 52
-  created_at: 2016-05-24 03:02:36.820543000 Z
-  updated_at: 2020-09-09 14:53:46.759696000 Z
   created_by: 1
   updated_by: 1
   first_name: Clarence
@@ -1898,8 +1808,6 @@ hardrock_2014_irvin_corkery:
   city:
   state_code: DC
   age: 22
-  created_at: 2016-05-24 03:02:36.844005000 Z
-  updated_at: 2020-09-09 14:53:46.786060000 Z
   created_by: 1
   updated_by: 1
   first_name: Irvin
@@ -1940,8 +1848,6 @@ hardrock_2014_willis_murray:
   city:
   state_code: GA
   age: 16
-  created_at: 2016-05-24 03:02:36.871396000 Z
-  updated_at: 2020-09-09 14:53:46.814201000 Z
   created_by: 1
   updated_by: 1
   first_name: Willis
@@ -1982,8 +1888,6 @@ hardrock_2014_ken_bradtke:
   city:
   state_code: CO
   age: 47
-  created_at: 2016-05-24 03:02:36.906798000 Z
-  updated_at: 2020-09-09 14:53:46.842055000 Z
   created_by: 1
   updated_by: 1
   first_name: Ken
@@ -2024,8 +1928,6 @@ hardrock_2014_progress_sherman:
   city:
   state_code: CO
   age: 36
-  created_at: 2016-05-24 03:02:37.144241000 Z
-  updated_at: 2020-09-09 14:53:46.870316000 Z
   created_by: 1
   updated_by: 1
   first_name: Progress
@@ -2066,8 +1968,6 @@ hardrock_2014_multiple_stops:
   city:
   state_code: HI
   age: 60
-  created_at: 2016-05-24 03:02:37.319538000 Z
-  updated_at: 2020-09-09 14:53:46.895800000 Z
   created_by: 1
   updated_by: 1
   first_name: Multiple
@@ -2108,8 +2008,6 @@ hardrock_2014_without_start:
   city:
   state_code: MT
   age: 49
-  created_at: 2016-05-24 03:02:37.329357000 Z
-  updated_at: 2020-09-09 14:53:46.922513000 Z
   created_by: 1
   updated_by: 1
   first_name: Without
@@ -2150,8 +2048,6 @@ hardrock_2014_drop_ouray:
   city:
   state_code: CA
   age: 40
-  created_at: 2016-05-24 03:02:37.338785000 Z
-  updated_at: 2020-09-09 14:53:46.977479000 Z
   created_by: 1
   updated_by: 1
   first_name: Drop
@@ -2192,8 +2088,6 @@ hardrock_2014_not_started:
   city:
   state_code: CO
   age: 28
-  created_at: 2016-05-24 03:02:37.399692000 Z
-  updated_at: 2020-09-09 14:53:47.001367000 Z
   created_by: 1
   updated_by: 1
   first_name: Not
@@ -2234,8 +2128,6 @@ rufa_2016_finished_first:
   city:
   state_code:
   age: 35
-  created_at: 2017-02-18 07:04:03.460025000 Z
-  updated_at: 2019-02-01 06:13:42.623687000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -2276,8 +2168,6 @@ rufa_2016_finished_second:
   city:
   state_code:
   age: 32
-  created_at: 2017-02-18 07:04:04.964494000 Z
-  updated_at: 2019-02-01 06:33:07.990941000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -2318,8 +2208,6 @@ rufa_2016_progress_lap1:
   city:
   state_code:
   age: 25
-  created_at: 2017-02-18 07:04:23.649965000 Z
-  updated_at: 2019-02-01 06:35:06.886454000 Z
   created_by: 1
   updated_by: 1
   first_name: Progress
@@ -2360,8 +2248,6 @@ rufa_2016_not_started:
   city:
   state_code:
   age: 57
-  created_at: 2017-02-18 07:04:23.903673000 Z
-  updated_at: 2019-02-01 06:34:33.765616000 Z
   created_by: 1
   updated_by: 1
   first_name: Not
@@ -2402,8 +2288,6 @@ rufa_2017_24h_finished_first:
   city:
   state_code: UT
   age: 47
-  created_at: 2017-03-28 07:24:12.485505000 Z
-  updated_at: 2020-09-09 14:53:47.028087000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -2444,8 +2328,6 @@ rufa_2017_24h_progress_lap6:
   city:
   state_code: UT
   age: 33
-  created_at: 2017-03-28 07:24:13.143418000 Z
-  updated_at: 2020-09-09 14:53:47.054889000 Z
   created_by: 1
   updated_by: 1
   first_name: Progress
@@ -2486,8 +2368,6 @@ rufa_2017_24h_multiple_stops:
   city:
   state_code: UT
   age: 43
-  created_at: 2017-03-28 07:24:25.977802000 Z
-  updated_at: 2020-09-09 14:53:47.083534000 Z
   created_by: 1
   updated_by: 1
   first_name: Multiple
@@ -2528,8 +2408,6 @@ rufa_2017_24h_finished_last:
   city:
   state_code: UT
   age: 40
-  created_at: 2017-03-28 07:24:29.153267000 Z
-  updated_at: 2020-09-09 14:53:47.109168000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -2570,8 +2448,6 @@ rufa_2017_24h_not_started:
   city:
   state_code: UT
   age: 30
-  created_at: 2017-03-28 07:24:29.350276000 Z
-  updated_at: 2020-09-09 14:53:47.134401000 Z
   created_by: 1
   updated_by: 1
   first_name: Not
@@ -2612,8 +2488,6 @@ rufa_2017_24h_progress_lap1:
   city:
   state_code: UT
   age: 49
-  created_at: 2017-03-28 07:24:31.338329000 Z
-  updated_at: 2020-09-09 14:53:47.160504000 Z
   created_by: 1
   updated_by: 1
   first_name: Progress
@@ -2654,8 +2528,6 @@ hardrock_2016_lavon_paucek:
   city:
   state_code:
   age: 41
-  created_at: 2017-04-18 09:43:13.944673000 Z
-  updated_at: 2020-09-09 14:53:47.188402000 Z
   created_by: 1
   updated_by: 1
   first_name: Lavon
@@ -2696,8 +2568,6 @@ hardrock_2016_vesta_borer:
   city:
   state_code: UT
   age: 21
-  created_at: 2017-04-18 09:43:17.416478000 Z
-  updated_at: 2020-09-09 14:53:47.215637000 Z
   created_by: 1
   updated_by: 1
   first_name: Vesta
@@ -2738,8 +2608,6 @@ hardrock_2016_kory_kulas:
   city:
   state_code: CA
   age: 42
-  created_at: 2017-04-18 09:43:18.615823000 Z
-  updated_at: 2020-09-09 14:53:47.246315000 Z
   created_by: 1
   updated_by: 1
   first_name: Kory
@@ -2780,8 +2648,6 @@ hardrock_2016_shad_hirthe:
   city:
   state_code: CO
   age: 40
-  created_at: 2017-04-18 09:43:20.572745000 Z
-  updated_at: 2020-09-09 14:53:47.274065000 Z
   created_by: 1
   updated_by: 1
   first_name: Shad
@@ -2822,8 +2688,6 @@ hardrock_2016_douglas_vandervort:
   city:
   state_code: CO
   age: 52
-  created_at: 2017-04-18 09:43:21.759013000 Z
-  updated_at: 2020-09-09 14:53:47.314831000 Z
   created_by: 1
   updated_by: 1
   first_name: Douglas
@@ -2864,8 +2728,6 @@ hardrock_2016_missing_telluride_out:
   city:
   state_code: AK
   age: 20
-  created_at: 2017-04-18 09:43:23.330180000 Z
-  updated_at: 2020-09-09 14:53:47.341782000 Z
   created_by: 1
   updated_by: 1
   first_name: Missing
@@ -2906,8 +2768,6 @@ hardrock_2016_junior_lesch:
   city:
   state_code: NM
   age: 49
-  created_at: 2017-04-18 09:43:24.182361000 Z
-  updated_at: 2020-09-09 14:53:47.370193000 Z
   created_by: 1
   updated_by: 1
   first_name: Junior
@@ -2948,8 +2808,6 @@ hardrock_2016_eddy_goldner:
   city:
   state_code: WA
   age: 18
-  created_at: 2017-04-18 09:43:25.135211000 Z
-  updated_at: 2020-09-09 14:53:47.397367000 Z
   created_by: 1
   updated_by: 1
   first_name: Eddy
@@ -2990,8 +2848,6 @@ hardrock_2016_progress_sherman:
   city:
   state_code: VA
   age: 33
-  created_at: 2017-04-18 09:43:28.206507000 Z
-  updated_at: 2020-09-09 14:53:47.423950000 Z
   created_by: 1
   updated_by: 1
   first_name: Progress
@@ -3032,8 +2888,6 @@ hardrock_2016_benito_moen:
   city:
   state_code: OH
   age: 52
-  created_at: 2017-04-18 09:43:30.366948000 Z
-  updated_at: 2020-09-09 14:53:47.450528000 Z
   created_by: 1
   updated_by: 1
   first_name: Benito
@@ -3074,8 +2928,6 @@ hardrock_2016_kendall_koch:
   city:
   state_code: CO
   age: 40
-  created_at: 2017-04-18 09:43:31.134522000 Z
-  updated_at: 2020-09-09 14:53:47.476060000 Z
   created_by: 1
   updated_by: 1
   first_name: Kendall
@@ -3116,8 +2968,6 @@ hardrock_2016_charlie_mueller:
   city:
   state_code: OR
   age: 27
-  created_at: 2017-04-18 09:43:31.806769000 Z
-  updated_at: 2020-09-09 14:53:47.506844000 Z
   created_by: 1
   updated_by: 1
   first_name: Charlie
@@ -3158,8 +3008,6 @@ hardrock_2016_brinda_fisher:
   city:
   state_code: SC
   age: 22
-  created_at: 2017-04-18 09:43:39.469427000 Z
-  updated_at: 2020-09-09 14:53:47.536118000 Z
   created_by: 1
   updated_by: 1
   first_name: Brinda
@@ -3200,8 +3048,6 @@ hardrock_2016_rene_mclaughlin:
   city:
   state_code: TX
   age: 32
-  created_at: 2017-04-18 09:43:40.343314000 Z
-  updated_at: 2020-09-09 14:53:47.565727000 Z
   created_by: 1
   updated_by: 1
   first_name: Rene
@@ -3242,8 +3088,6 @@ hardrock_2016_dropped_grouse:
   city:
   state_code: CO
   age: 47
-  created_at: 2017-04-18 09:43:43.290742000 Z
-  updated_at: 2020-09-09 14:53:47.596347000 Z
   created_by: 1
   updated_by: 1
   first_name: Dropped
@@ -3284,8 +3128,6 @@ hardrock_2016_mervin_smitham:
   city:
   state_code: NM
   age: 24
-  created_at: 2017-04-18 09:43:43.987125000 Z
-  updated_at: 2020-09-09 14:53:47.652475000 Z
   created_by: 1
   updated_by: 1
   first_name: Mervin
@@ -3326,8 +3168,6 @@ hardrock_2016_rhett_auer:
   city:
   state_code: CO
   age: 41
-  created_at: 2017-04-18 09:43:44.745954000 Z
-  updated_at: 2020-09-09 14:53:47.678332000 Z
   created_by: 1
   updated_by: 1
   first_name: Rhett
@@ -3368,8 +3208,6 @@ hardrock_2016_hoyt_macejkovic:
   city:
   state_code: MD
   age: 55
-  created_at: 2017-04-18 09:43:45.252368000 Z
-  updated_at: 2020-09-09 14:53:47.703989000 Z
   created_by: 1
   updated_by: 1
   first_name: Hoyt
@@ -3410,8 +3248,6 @@ hardrock_2016_start_only:
   city:
   state_code: ME
   age: 26
-  created_at: 2017-04-18 09:43:45.842843000 Z
-  updated_at: 2020-09-09 14:53:47.730783000 Z
   created_by: 1
   updated_by: 1
   first_name: Start
@@ -3452,8 +3288,6 @@ ggd30_50k_finished_first:
   city:
   state_code:
   age: 44
-  created_at: 2017-06-09 08:26:06.148699000 Z
-  updated_at: 2019-02-21 23:11:57.311356000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -3494,8 +3328,6 @@ ggd30_50k_bad_finish:
   city:
   state_code:
   age: 21
-  created_at: 2017-06-09 08:26:07.426849000 Z
-  updated_at: 2019-02-01 06:12:38.529959000 Z
   created_by: 1
   updated_by: 1
   first_name: Bad
@@ -3536,8 +3368,6 @@ ggd30_50k_progress_aid4:
   city:
   state_code:
   age: 35
-  created_at: 2017-06-09 08:26:15.208636000 Z
-  updated_at: 2019-02-01 06:18:53.333713000 Z
   created_by: 1
   updated_by: 1
   first_name: Progress
@@ -3578,8 +3408,6 @@ ggd30_50k_progress_aid3:
   city:
   state_code:
   age: 31
-  created_at: 2017-06-09 08:26:15.541579000 Z
-  updated_at: 2019-02-01 06:18:23.316870000 Z
   created_by: 1
   updated_by: 1
   first_name: Progress
@@ -3620,8 +3448,6 @@ ggd30_50k_drop_aid4:
   city:
   state_code:
   age: 18
-  created_at: 2017-06-09 08:26:16.456387000 Z
-  updated_at: 2019-02-01 06:14:59.563079000 Z
   created_by: 1
   updated_by: 1
   first_name: Drop
@@ -3662,8 +3488,6 @@ ggd30_50k_start_only:
   city:
   state_code:
   age: 31
-  created_at: 2017-06-09 08:26:18.436664000 Z
-  updated_at: 2019-02-01 06:12:38.331033000 Z
   created_by: 1
   updated_by: 1
   first_name: Start
@@ -3704,8 +3528,6 @@ ggd30_50k_not_started:
   city:
   state_code:
   age: 31
-  created_at: 2017-06-09 08:26:18.491140000 Z
-  updated_at: 2019-02-01 06:12:38.385362000 Z
   created_by: 1
   updated_by: 1
   first_name: Not
@@ -3746,8 +3568,6 @@ ggd30_12m_start_only:
   city: Aurora
   state_code: CO
   age: 27
-  created_at: 2017-06-09 09:52:57.315679000 Z
-  updated_at: 2020-09-09 14:53:47.756478000 Z
   created_by: 1
   updated_by: 1
   first_name: Start
@@ -3788,8 +3608,6 @@ ggd30_12m_finished_second:
   city: Boulder
   state_code: CO
   age: 43
-  created_at: 2017-06-09 09:52:57.413084000 Z
-  updated_at: 2020-09-09 14:53:47.784373000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -3830,8 +3648,6 @@ ggd30_12m_finished_first:
   city: LE VIBAL
   state_code: ARA
   age: 23
-  created_at: 2017-06-09 09:52:57.918790000 Z
-  updated_at: 2020-09-09 14:53:47.811020000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -3872,8 +3688,6 @@ ggd30_12m_not_started:
   city: Greeley
   state_code: CO
   age: 22
-  created_at: 2017-06-09 09:52:58.187937000 Z
-  updated_at: 2020-09-09 14:53:47.840370000 Z
   created_by: 1
   updated_by: 1
   first_name: Not
@@ -3914,8 +3728,6 @@ sum_55k_finished_first:
   city:
   state_code: CO
   age: 44
-  created_at: 2018-01-18 05:23:46.230111000 Z
-  updated_at: 2020-09-09 14:53:47.867325000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -3956,8 +3768,6 @@ sum_55k_finished_second:
   city:
   state_code: CO
   age: 44
-  created_at: 2018-01-18 05:23:46.316440000 Z
-  updated_at: 2020-09-09 14:53:47.893185000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -3998,8 +3808,6 @@ sum_55k_not_started:
   city:
   state_code: CO
   age: 36
-  created_at: 2018-01-18 05:23:52.659025000 Z
-  updated_at: 2020-09-09 14:53:47.917249000 Z
   created_by: 1
   updated_by: 1
   first_name: Not
@@ -4040,8 +3848,6 @@ sum_55k_progress_rolling:
   city:
   state_code: CA
   age: 55
-  created_at: 2018-01-18 05:23:52.747120000 Z
-  updated_at: 2020-09-09 14:53:47.939253000 Z
   created_by: 1
   updated_by: 1
   first_name: Progress
@@ -4082,8 +3888,6 @@ sum_55k_drop_bandera:
   city:
   state_code: CO
   age: 19
-  created_at: 2018-01-18 05:23:52.794212000 Z
-  updated_at: 2020-09-09 14:53:47.967862000 Z
   created_by: 1
   updated_by: 1
   first_name: Drop
@@ -4124,8 +3928,6 @@ sum_55k_start_only:
   city:
   state_code: CO
   age: 49
-  created_at: 2018-01-18 05:23:52.832341000 Z
-  updated_at: 2020-09-09 14:53:47.993194000 Z
   created_by: 1
   updated_by: 1
   first_name: Start
@@ -4166,8 +3968,6 @@ sum_100k_drop_anvil:
   city: Akron
   state_code: OH
   age: 28
-  created_at: 2018-02-03 23:41:41.141488000 Z
-  updated_at: 2020-09-09 14:53:48.020672000 Z
   created_by: 1
   updated_by: 1
   first_name: Drop
@@ -4208,8 +4008,6 @@ sum_100k_progress_cascade:
   city: Provo
   state_code: UT
   age: 20
-  created_at: 2018-02-24 22:28:24.196234000 Z
-  updated_at: 2020-09-09 14:53:48.049861000 Z
   created_by: 1
   updated_by: 1
   first_name: Progress
@@ -4250,8 +4048,6 @@ rufa_2017_12h_finished_first:
   city:
   state_code: AZ
   age: 20
-  created_at: 2019-01-30 18:51:23.404239000 Z
-  updated_at: 2020-09-09 14:53:48.078151000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -4292,8 +4088,6 @@ rufa_2017_12h_finished_lap6:
   city:
   state_code: UT
   age: 53
-  created_at: 2019-01-30 18:51:23.828956000 Z
-  updated_at: 2020-09-09 14:53:48.107568000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -4334,8 +4128,6 @@ rufa_2017_12h_progress_lap5_partial:
   city:
   state_code: UT
   age: 28
-  created_at: 2019-01-30 18:51:24.461838000 Z
-  updated_at: 2020-09-09 14:53:48.136697000 Z
   created_by: 1
   updated_by: 1
   first_name: Progress
@@ -4376,8 +4168,6 @@ rufa_2017_12h_progress_lap2:
   city:
   state_code: UT
   age: 24
-  created_at: 2019-01-30 18:51:24.783335000 Z
-  updated_at: 2020-09-09 14:53:48.160574000 Z
   created_by: 1
   updated_by: 1
   first_name: Progress
@@ -4418,8 +4208,6 @@ rufa_2017_12h_start_only:
   city:
   state_code: UT
   age: 44
-  created_at: 2019-01-30 18:51:24.983794000 Z
-  updated_at: 2020-09-09 14:53:48.188176000 Z
   created_by: 1
   updated_by: 1
   first_name: Start
@@ -4460,8 +4248,6 @@ rufa_2017_12h_not_started:
   city:
   state_code: UT
   age: 49
-  created_at: 2019-01-30 18:51:25.331813000 Z
-  updated_at: 2020-09-09 14:53:48.214658000 Z
   created_by: 1
   updated_by: 1
   first_name: Not
@@ -4502,8 +4288,6 @@ sum_100k_un_started:
   city: Fort Collins
   state_code: CO
   age: 29
-  created_at: 2019-01-30 19:51:50.515411000 Z
-  updated_at: 2020-09-09 14:53:48.239975000 Z
   created_by: 1
   updated_by: 1
   first_name: Un
@@ -4544,8 +4328,6 @@ sum_100k_on_dst_change:
   city:
   state_code:
   age:
-  created_at: 2019-02-01 17:50:28.758242000 Z
-  updated_at: 2019-02-21 23:23:43.936495000 Z
   created_by: 1
   updated_by: 1
   first_name: 'On'
@@ -4586,8 +4368,6 @@ sum_100k_across_dst_change:
   city:
   state_code:
   age:
-  created_at: 2019-02-01 17:50:43.430509000 Z
-  updated_at: 2019-02-21 23:23:44.146510000 Z
   created_by: 1
   updated_by: 1
   first_name: Across
@@ -4628,8 +4408,6 @@ ggd30_50k_finished_second:
   city:
   state_code:
   age: 43
-  created_at: 2019-02-21 23:18:43.251040000 Z
-  updated_at: 2019-02-21 23:20:16.853801000 Z
   created_by: 1
   updated_by: 1
   first_name: Finished
@@ -4670,8 +4448,6 @@ ggd30_12m_series_finisher:
   city: Superior
   state_code: CO
   age: 34
-  created_at: 2019-02-21 23:44:48.768830000 Z
-  updated_at: 2020-09-09 14:53:48.292193000 Z
   created_by: 1
   updated_by: 1
   first_name: Series
@@ -4712,8 +4488,6 @@ sum_55k_series_finisher:
   city:
   state_code:
   age: 34
-  created_at: 2019-02-21 23:47:35.929007000 Z
-  updated_at: 2019-02-21 23:49:30.323839000 Z
   created_by: 1
   updated_by: 1
   first_name: Series
@@ -4754,8 +4528,6 @@ sum_55k_slow_finisher:
   city:
   state_code: UT
   age: 64
-  created_at: 2019-02-21 23:54:25.605263000 Z
-  updated_at: 2019-02-21 23:56:29.365474000 Z
   created_by: 1
   updated_by: 1
   first_name: Slow
@@ -4796,8 +4568,6 @@ ggd30_12m_slow_finisher:
   city: Orem
   state_code: UT
   age: 64
-  created_at: 2019-02-21 23:57:44.862099000 Z
-  updated_at: 2019-02-22 00:08:09.025798000 Z
   created_by: 1
   updated_by: 1
   first_name: Slow

--- a/spec/fixtures/event_groups.yml
+++ b/spec/fixtures/event_groups.yml
@@ -5,8 +5,6 @@ ramble:
   organization_id: 6
   available_live: false
   concealed: false
-  created_at: 2017-09-18 04:35:22.344937000 Z
-  updated_at: 2019-01-28 09:54:43.341208000 Z
   created_by: 1
   updated_by: 1
   slug: ramble
@@ -19,8 +17,6 @@ hardrock_2014:
   organization_id: 4
   available_live: false
   concealed: false
-  created_at: 2017-09-18 04:35:22.361380000 Z
-  updated_at: 2019-01-28 08:55:55.574111000 Z
   created_by: 1
   updated_by: 1
   slug: hardrock-2014
@@ -33,8 +29,6 @@ hardrock_2015:
   organization_id: 4
   available_live: true
   concealed: false
-  created_at: 2017-09-18 04:35:22.417957000 Z
-  updated_at: 2019-01-28 08:56:16.148917000 Z
   created_by: 1
   updated_by: 1
   slug: hardrock-2015
@@ -47,8 +41,6 @@ rufa_2016:
   organization_id: 14
   available_live: false
   concealed: false
-  created_at: 2017-09-18 04:35:22.460032000 Z
-  updated_at: 2019-01-31 00:12:13.829169000 Z
   created_by: 1
   updated_by: 1
   slug: rufa-2016
@@ -61,8 +53,6 @@ dirty_30:
   organization_id: 15
   available_live: true
   concealed: false
-  created_at: 2017-09-18 04:35:22.472119000 Z
-  updated_at: 2019-02-01 03:16:00.099678000 Z
   created_by: 1
   updated_by: 1
   slug: dirty-30
@@ -75,8 +65,6 @@ hardrock_2016:
   organization_id: 4
   available_live: true
   concealed: false
-  created_at: 2017-09-18 04:35:22.480615000 Z
-  updated_at: 2019-01-28 08:56:46.152679000 Z
   created_by: 1
   updated_by: 1
   slug: hardrock-2016
@@ -89,8 +77,6 @@ sum:
   organization_id: 15
   available_live: true
   concealed: false
-  created_at: 2018-01-18 05:09:16.755575000 Z
-  updated_at: 2019-01-30 21:36:37.160757000 Z
   created_by: 1
   updated_by: 1
   slug: sum
@@ -103,8 +89,6 @@ rufa_2017:
   organization_id: 14
   available_live: true
   concealed: false
-  created_at: 2019-01-30 23:32:41.392720000 Z
-  updated_at: 2019-01-30 23:44:56.575917000 Z
   created_by: 1
   updated_by: 1
   slug: rufa-2017

--- a/spec/fixtures/event_series.yml
+++ b/spec/fixtures/event_series.yml
@@ -5,8 +5,6 @@ d30_50k_series:
   results_template_id: 7
   name: D30 50K Series
   slug: d30-50k-series
-  created_at: 2019-02-21 23:12:45.586466000 Z
-  updated_at: 2019-02-21 23:12:45.586466000 Z
   scoring_method: 0
 d30_short_series:
   id: 2
@@ -14,6 +12,4 @@ d30_short_series:
   results_template_id: 7
   name: D30 Short Series
   slug: d30-short-series
-  created_at: 2019-02-21 23:28:49.726633000 Z
-  updated_at: 2019-02-21 23:28:49.726633000 Z
   scoring_method: 0

--- a/spec/fixtures/event_series_events.yml
+++ b/spec/fixtures/event_series_events.yml
@@ -3,23 +3,15 @@ event_series_event_1:
   id: 1
   event_id: 48
   event_series_id: 1
-  created_at: 2019-02-21 23:12:45.588834000 Z
-  updated_at: 2019-02-21 23:12:45.588834000 Z
 event_series_event_2:
   id: 2
   event_id: 57
   event_series_id: 1
-  created_at: 2019-02-21 23:12:45.592142000 Z
-  updated_at: 2019-02-21 23:12:45.592142000 Z
 event_series_event_3:
   id: 3
   event_id: 49
   event_series_id: 2
-  created_at: 2019-02-21 23:28:49.728316000 Z
-  updated_at: 2019-02-21 23:28:49.728316000 Z
 event_series_event_4:
   id: 4
   event_id: 57
   event_series_id: 2
-  created_at: 2019-02-21 23:28:49.729758000 Z
-  updated_at: 2019-02-21 23:28:49.729758000 Z

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -3,8 +3,6 @@ hardrock_2015:
   id: 4
   course_id: 4
   historical_name: Hardrock 2015
-  created_at: 2016-04-16 19:25:07.717306000 Z
-  updated_at: 2020-08-08 19:04:59.836439000 Z
   created_by: 1
   updated_by: 1
   scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
@@ -21,8 +19,6 @@ ramble:
   id: 14
   course_id: 9
   historical_name: Ramble
-  created_at: 2016-05-08 07:14:16.236390000 Z
-  updated_at: 2020-08-08 19:04:59.844186000 Z
   created_by: 1
   updated_by: 1
   scheduled_start_time: 2006-09-16 14:00:00.000000000 Z
@@ -39,8 +35,6 @@ hardrock_2014:
   id: 17
   course_id: 12
   historical_name: Hardrock 2014
-  created_at: 2016-05-23 01:05:15.602165000 Z
-  updated_at: 2020-08-08 19:04:59.845718000 Z
   created_by: 1
   updated_by: 1
   scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
@@ -57,8 +51,6 @@ rufa_2016:
   id: 34
   course_id: 20
   historical_name: RUFA 2016
-  created_at: 2017-01-28 13:22:25.985588000 Z
-  updated_at: 2020-08-08 19:04:59.847193000 Z
   created_by: 1
   updated_by: 1
   scheduled_start_time: 2016-02-13 13:00:00.000000000 Z
@@ -75,8 +67,6 @@ rufa_2017_24h:
   id: 36
   course_id: 20
   historical_name: RUFA 2017 24H
-  created_at: 2017-03-28 07:18:29.860735000 Z
-  updated_at: 2020-08-08 19:04:59.848674000 Z
   created_by: 1
   updated_by: 1
   scheduled_start_time: 2017-02-11 13:00:00.000000000 Z
@@ -93,8 +83,6 @@ hardrock_2016:
   id: 37
   course_id: 12
   historical_name: Hardrock 2016
-  created_at: 2017-04-18 08:19:16.928331000 Z
-  updated_at: 2020-08-08 19:04:59.850133000 Z
   created_by: 1
   updated_by: 1
   scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
@@ -111,8 +99,6 @@ ggd30_50k:
   id: 48
   course_id: 26
   historical_name: GGD30 50K
-  created_at: 2017-05-28 13:58:46.392428000 Z
-  updated_at: 2020-08-08 19:04:59.851567000 Z
   created_by: 1
   updated_by: 1
   scheduled_start_time: 2017-06-04 01:00:00.000000000 Z
@@ -129,8 +115,6 @@ ggd30_12m:
   id: 49
   course_id: 27
   historical_name: GGD30 12M
-  created_at: 2017-06-09 09:51:15.491594000 Z
-  updated_at: 2020-08-08 19:04:59.852935000 Z
   created_by: 1
   updated_by: 1
   scheduled_start_time: 2017-06-04 02:00:00.000000000 Z
@@ -147,8 +131,6 @@ sum_100k:
   id: 56
   course_id: 31
   historical_name: SUM 100K
-  created_at: 2018-01-18 05:09:16.764958000 Z
-  updated_at: 2020-08-08 19:04:59.854183000 Z
   created_by: 1
   updated_by: 1
   scheduled_start_time: 2017-09-23 13:00:00.000000000 Z
@@ -165,8 +147,6 @@ sum_55k:
   id: 57
   course_id: 32
   historical_name: SUM 55K
-  created_at: 2018-01-18 05:15:20.769855000 Z
-  updated_at: 2020-08-08 19:04:59.856993000 Z
   created_by: 1
   updated_by: 1
   scheduled_start_time: 2017-09-23 15:00:00.000000000 Z
@@ -183,8 +163,6 @@ rufa_2017_12h:
   id: 70
   course_id: 20
   historical_name: RUFA 2017 12H
-  created_at: 2019-01-30 17:38:14.220608000 Z
-  updated_at: 2020-08-08 19:04:59.858665000 Z
   created_by: 1
   updated_by: 1
   scheduled_start_time: 2017-02-11 14:00:00.000000000 Z

--- a/spec/fixtures/lotteries.yml
+++ b/spec/fixtures/lotteries.yml
@@ -5,8 +5,6 @@ lottery_without_tickets:
   name: Lottery Without Tickets
   scheduled_start_date: '2022-12-06'
   slug: lottery-without-tickets
-  created_at: 2021-09-29 20:39:20.622755000 Z
-  updated_at: 2021-10-02 19:30:32.255267000 Z
   concealed:
   status: 0
 lottery_with_tickets_and_draws:
@@ -15,7 +13,5 @@ lottery_with_tickets_and_draws:
   name: Lottery With Tickets And Draws
   scheduled_start_date: '2020-11-11'
   slug: lottery-with-tickets-and-draws
-  created_at: 2021-09-29 20:44:48.724219000 Z
-  updated_at: 2021-10-02 19:33:57.419309000 Z
   concealed:
   status: 1

--- a/spec/fixtures/lottery_divisions.yml
+++ b/spec/fixtures/lottery_divisions.yml
@@ -3,39 +3,29 @@ lottery_division_1:
   id: 1
   lottery_id: 4
   name: Never Ever Evers
-  created_at: 2021-09-30 00:13:09.163118000 Z
-  updated_at: 2021-10-02 17:51:39.936643000 Z
   maximum_entries: 3
   maximum_wait_list: 2
 lottery_division_2:
   id: 2
   lottery_id: 4
   name: Veterans
-  created_at: 2021-09-30 00:13:21.443479000 Z
-  updated_at: 2021-10-02 16:47:17.875811000 Z
   maximum_entries: 3
   maximum_wait_list: 3
 lottery_division_6:
   id: 6
   lottery_id: 3
   name: Fast People
-  created_at: 2021-09-30 04:10:57.190754000 Z
-  updated_at: 2021-09-30 04:10:57.190754000 Z
   maximum_entries: 5
   maximum_wait_list: 3
 lottery_division_7:
   id: 7
   lottery_id: 3
   name: Slow People
-  created_at: 2021-09-30 04:11:11.363462000 Z
-  updated_at: 2021-09-30 04:11:11.363462000 Z
   maximum_entries: 5
   maximum_wait_list: 3
 lottery_division_8:
   id: 8
   lottery_id: 4
   name: Elses
-  created_at: 2021-09-30 04:16:45.559181000 Z
-  updated_at: 2021-10-02 16:48:16.025070000 Z
   maximum_entries: 3
   maximum_wait_list: 5

--- a/spec/fixtures/lottery_draws.yml
+++ b/spec/fixtures/lottery_draws.yml
@@ -3,34 +3,41 @@ lottery_draw_110:
   id: 110
   lottery_id: 4
   lottery_ticket_id: 18
+  created_at: 2021-10-02 16:24:20.181722000 Z
   position:
 lottery_draw_111:
   id: 111
   lottery_id: 4
   lottery_ticket_id: 10
+  created_at: 2021-10-02 16:29:20.183865000 Z
   position:
 lottery_draw_112:
   id: 112
   lottery_id: 4
   lottery_ticket_id: 17
+  created_at: 2021-10-02 16:43:20.186126000 Z
   position:
 lottery_draw_113:
   id: 113
   lottery_id: 4
   lottery_ticket_id: 13
+  created_at: 2021-10-02 16:46:20.188331000 Z
   position:
 lottery_draw_114:
   id: 114
   lottery_id: 4
   lottery_ticket_id: 9
+  created_at: 2021-10-02 16:45:20.190595000 Z
   position:
 lottery_draw_119:
   id: 119
   lottery_id: 4
   lottery_ticket_id: 3
+  created_at: 2021-10-02 16:28:20.202115000 Z
   position:
 lottery_draw_124:
   id: 124
   lottery_id: 4
   lottery_ticket_id: 6
+  created_at: 2021-10-02 17:25:58.420681000 Z
   position:

--- a/spec/fixtures/lottery_draws.yml
+++ b/spec/fixtures/lottery_draws.yml
@@ -3,48 +3,34 @@ lottery_draw_110:
   id: 110
   lottery_id: 4
   lottery_ticket_id: 18
-  created_at: 2021-10-02 16:24:20.181722000 Z
-  updated_at: 2021-10-02 16:24:20.181722000 Z
   position:
 lottery_draw_111:
   id: 111
   lottery_id: 4
   lottery_ticket_id: 10
-  created_at: 2021-10-02 16:29:20.183865000 Z
-  updated_at: 2021-10-02 16:29:20.183865000 Z
   position:
 lottery_draw_112:
   id: 112
   lottery_id: 4
   lottery_ticket_id: 17
-  created_at: 2021-10-02 16:43:20.186126000 Z
-  updated_at: 2021-10-02 16:43:20.186126000 Z
   position:
 lottery_draw_113:
   id: 113
   lottery_id: 4
   lottery_ticket_id: 13
-  created_at: 2021-10-02 16:46:20.188331000 Z
-  updated_at: 2021-10-02 16:46:20.188331000 Z
   position:
 lottery_draw_114:
   id: 114
   lottery_id: 4
   lottery_ticket_id: 9
-  created_at: 2021-10-02 16:45:20.190595000 Z
-  updated_at: 2021-10-02 16:45:20.190595000 Z
   position:
 lottery_draw_119:
   id: 119
   lottery_id: 4
   lottery_ticket_id: 3
-  created_at: 2021-10-02 16:28:20.202115000 Z
-  updated_at: 2021-10-02 16:28:20.202115000 Z
   position:
 lottery_draw_124:
   id: 124
   lottery_id: 4
   lottery_ticket_id: 6
-  created_at: 2021-10-02 17:25:58.420681000 Z
-  updated_at: 2021-10-02 17:25:58.420681000 Z
   position:

--- a/spec/fixtures/lottery_entrants.yml
+++ b/spec/fixtures/lottery_entrants.yml
@@ -10,8 +10,6 @@ lottery_entrant_4:
   city: Amadashire
   state_code: SC
   country_code: US
-  created_at: 2021-09-30 03:54:51.607806000 Z
-  updated_at: 2021-10-02 16:39:40.754593000 Z
   state_name: South Carolina
   country_name: United States
   pre_selected: false
@@ -29,8 +27,6 @@ lottery_entrant_5:
   city: O'Connertown
   state_code: KY
   country_code: US
-  created_at: 2021-09-30 03:54:51.711874000 Z
-  updated_at: 2021-10-02 16:41:19.088935000 Z
   state_name: Kentucky
   country_name: United States
   pre_selected: false
@@ -48,8 +44,6 @@ lottery_entrant_6:
   city: Port Brandaburgh
   state_code: WI
   country_code: US
-  created_at: 2021-09-30 03:54:51.747905000 Z
-  updated_at: 2021-10-02 16:39:40.762589000 Z
   state_name: Wisconsin
   country_name: United States
   pre_selected: false
@@ -67,8 +61,6 @@ lottery_entrant_7:
   city: West Vicentafurt
   state_code: MS
   country_code: US
-  created_at: 2021-09-30 03:54:51.782475000 Z
-  updated_at: 2021-10-02 16:39:40.765960000 Z
   state_name: Mississippi
   country_name: United States
   pre_selected: false
@@ -86,8 +78,6 @@ lottery_entrant_8:
   city: Caroleeville
   state_code: NM
   country_code: US
-  created_at: 2021-09-30 03:54:51.817823000 Z
-  updated_at: 2021-10-02 16:39:40.771099000 Z
   state_name: New Mexico
   country_name: United States
   pre_selected: false
@@ -105,8 +95,6 @@ lottery_entrant_9:
   city: Hungborough
   state_code: NE
   country_code: US
-  created_at: 2021-09-30 03:54:51.851597000 Z
-  updated_at: 2021-10-02 16:39:40.774279000 Z
   state_name: Nebraska
   country_name: United States
   pre_selected: false
@@ -124,8 +112,6 @@ lottery_entrant_10:
   city: East Lauraport
   state_code: MI
   country_code: US
-  created_at: 2021-09-30 03:54:51.857232000 Z
-  updated_at: 2021-10-02 16:39:40.777393000 Z
   state_name: Michigan
   country_name: United States
   pre_selected: false
@@ -143,8 +129,6 @@ lottery_entrant_11:
   city: Lebsackville
   state_code: IN
   country_code: US
-  created_at: 2021-09-30 03:54:51.872673000 Z
-  updated_at: 2021-10-02 16:39:40.780810000 Z
   state_name: Indiana
   country_name: United States
   pre_selected: false
@@ -162,8 +146,6 @@ lottery_entrant_12:
   city: Lake Nickyberg
   state_code: AL
   country_code: US
-  created_at: 2021-09-30 03:54:51.875905000 Z
-  updated_at: 2021-10-02 16:39:40.783891000 Z
   state_name: Alabama
   country_name: United States
   pre_selected: false
@@ -181,8 +163,6 @@ lottery_entrant_13:
   city: Beerbury
   state_code: PA
   country_code: US
-  created_at: 2021-09-30 03:54:51.878887000 Z
-  updated_at: 2021-10-02 16:39:40.786956000 Z
   state_name: Pennsylvania
   country_name: United States
   pre_selected: false
@@ -200,8 +180,6 @@ lottery_entrant_21:
   city: Port Glennis
   state_code: VA
   country_code: US
-  created_at: 2021-09-30 04:11:51.993457000 Z
-  updated_at: 2021-10-01 05:05:24.169087000 Z
   state_name: Virginia
   country_name: United States
   pre_selected: false
@@ -219,8 +197,6 @@ lottery_entrant_22:
   city: West Rebecka
   state_code: AZ
   country_code: US
-  created_at: 2021-09-30 04:11:51.996405000 Z
-  updated_at: 2021-10-01 05:05:24.173417000 Z
   state_name: Arizona
   country_name: United States
   pre_selected: false
@@ -238,8 +214,6 @@ lottery_entrant_23:
   city: Prohaskaside
   state_code: RI
   country_code: US
-  created_at: 2021-09-30 04:11:51.999359000 Z
-  updated_at: 2021-10-01 05:05:08.196992000 Z
   state_name: Rhode Island
   country_name: United States
   pre_selected: false
@@ -257,8 +231,6 @@ lottery_entrant_24:
   city: Piamouth
   state_code: ND
   country_code: US
-  created_at: 2021-09-30 04:17:29.287393000 Z
-  updated_at: 2021-10-02 16:39:40.790075000 Z
   state_name: North Dakota
   country_name: United States
   pre_selected: false
@@ -276,8 +248,6 @@ lottery_entrant_25:
   city: Lake Antonialand
   state_code: TX
   country_code: US
-  created_at: 2021-09-30 04:17:29.291779000 Z
-  updated_at: 2021-10-02 16:39:40.792948000 Z
   state_name: Texas
   country_name: United States
   pre_selected: false
@@ -295,8 +265,6 @@ lottery_entrant_26:
   city: West Virgenborough
   state_code: CT
   country_code: US
-  created_at: 2021-09-30 04:17:29.295672000 Z
-  updated_at: 2021-10-02 16:39:40.796007000 Z
   state_name: Connecticut
   country_name: United States
   pre_selected: false
@@ -314,8 +282,6 @@ lottery_entrant_27:
   city: North Jessia
   state_code: OR
   country_code: US
-  created_at: 2021-09-30 04:17:29.299192000 Z
-  updated_at: 2021-10-02 16:39:40.798982000 Z
   state_name: Oregon
   country_name: United States
   pre_selected: false
@@ -333,8 +299,6 @@ lottery_entrant_28:
   city: Refugialand
   state_code: AL
   country_code: US
-  created_at: 2021-09-30 04:17:29.302712000 Z
-  updated_at: 2021-10-02 16:39:40.801943000 Z
   state_name: Alabama
   country_name: United States
   pre_selected: false

--- a/spec/fixtures/lottery_tickets.yml
+++ b/spec/fixtures/lottery_tickets.yml
@@ -4,180 +4,128 @@ lottery_ticket_1:
   lottery_entrant_id: 28
   lottery_id: 4
   reference_number: 10000
-  created_at: 2021-10-02 16:41:51.449427000 Z
-  updated_at: 2021-10-02 16:41:51.449430000 Z
 lottery_ticket_2:
   id: 2
   lottery_entrant_id: 5
   lottery_id: 4
   reference_number: 10001
-  created_at: 2021-10-02 16:41:51.449449000 Z
-  updated_at: 2021-10-02 16:41:51.449451000 Z
 lottery_ticket_3:
   id: 3
   lottery_entrant_id: 27
   lottery_id: 4
   reference_number: 10002
-  created_at: 2021-10-02 16:41:51.449414000 Z
-  updated_at: 2021-10-02 16:41:51.449416000 Z
 lottery_ticket_4:
   id: 4
   lottery_entrant_id: 12
   lottery_id: 4
   reference_number: 10003
-  created_at: 2021-10-02 16:41:51.449384000 Z
-  updated_at: 2021-10-02 16:41:51.449386000 Z
 lottery_ticket_5:
   id: 5
   lottery_entrant_id: 6
   lottery_id: 4
   reference_number: 10004
-  created_at: 2021-10-02 16:41:51.449334000 Z
-  updated_at: 2021-10-02 16:41:51.449336000 Z
 lottery_ticket_6:
   id: 6
   lottery_entrant_id: 24
   lottery_id: 4
   reference_number: 10005
-  created_at: 2021-10-02 16:41:51.449394000 Z
-  updated_at: 2021-10-02 16:41:51.449396000 Z
 lottery_ticket_7:
   id: 7
   lottery_entrant_id: 5
   lottery_id: 4
   reference_number: 10006
-  created_at: 2021-10-02 16:41:51.449435000 Z
-  updated_at: 2021-10-02 16:41:51.449437000 Z
 lottery_ticket_8:
   id: 8
   lottery_entrant_id: 25
   lottery_id: 4
   reference_number: 10007
-  created_at: 2021-10-02 16:41:51.449404000 Z
-  updated_at: 2021-10-02 16:41:51.449406000 Z
 lottery_ticket_9:
   id: 9
   lottery_entrant_id: 4
   lottery_id: 4
   reference_number: 10008
-  created_at: 2021-10-02 16:41:51.449305000 Z
-  updated_at: 2021-10-02 16:41:51.449321000 Z
 lottery_ticket_10:
   id: 10
   lottery_entrant_id: 7
   lottery_id: 4
   reference_number: 10009
-  created_at: 2021-10-02 16:41:51.449344000 Z
-  updated_at: 2021-10-02 16:41:51.449346000 Z
 lottery_ticket_11:
   id: 11
   lottery_entrant_id: 5
   lottery_id: 4
   reference_number: 10010
-  created_at: 2021-10-02 16:41:51.449444000 Z
-  updated_at: 2021-10-02 16:41:51.449446000 Z
 lottery_ticket_12:
   id: 12
   lottery_entrant_id: 26
   lottery_id: 4
   reference_number: 10011
-  created_at: 2021-10-02 16:41:51.449409000 Z
-  updated_at: 2021-10-02 16:41:51.449411000 Z
 lottery_ticket_13:
   id: 13
   lottery_entrant_id: 11
   lottery_id: 4
   reference_number: 10012
-  created_at: 2021-10-02 16:41:51.449379000 Z
-  updated_at: 2021-10-02 16:41:51.449381000 Z
 lottery_ticket_14:
   id: 14
   lottery_entrant_id: 8
   lottery_id: 4
   reference_number: 10013
-  created_at: 2021-10-02 16:41:51.449349000 Z
-  updated_at: 2021-10-02 16:41:51.449351000 Z
 lottery_ticket_15:
   id: 15
   lottery_entrant_id: 27
   lottery_id: 4
   reference_number: 10014
-  created_at: 2021-10-02 16:41:51.449418000 Z
-  updated_at: 2021-10-02 16:41:51.449420000 Z
 lottery_ticket_16:
   id: 16
   lottery_entrant_id: 5
   lottery_id: 4
   reference_number: 10015
-  created_at: 2021-10-02 16:41:51.449453000 Z
-  updated_at: 2021-10-02 16:41:51.449455000 Z
 lottery_ticket_17:
   id: 17
   lottery_entrant_id: 9
   lottery_id: 4
   reference_number: 10016
-  created_at: 2021-10-02 16:41:51.449360000 Z
-  updated_at: 2021-10-02 16:41:51.449362000 Z
 lottery_ticket_18:
   id: 18
   lottery_entrant_id: 13
   lottery_id: 4
   reference_number: 10017
-  created_at: 2021-10-02 16:41:51.449389000 Z
-  updated_at: 2021-10-02 16:41:51.449391000 Z
 lottery_ticket_19:
   id: 19
   lottery_entrant_id: 27
   lottery_id: 4
   reference_number: 10018
-  created_at: 2021-10-02 16:41:51.449423000 Z
-  updated_at: 2021-10-02 16:41:51.449424000 Z
 lottery_ticket_20:
   id: 20
   lottery_entrant_id: 11
   lottery_id: 4
   reference_number: 10019
-  created_at: 2021-10-02 16:41:51.449375000 Z
-  updated_at: 2021-10-02 16:41:51.449377000 Z
 lottery_ticket_21:
   id: 21
   lottery_entrant_id: 10
   lottery_id: 4
   reference_number: 10020
-  created_at: 2021-10-02 16:41:51.449370000 Z
-  updated_at: 2021-10-02 16:41:51.449372000 Z
 lottery_ticket_22:
   id: 22
   lottery_entrant_id: 24
   lottery_id: 4
   reference_number: 10021
-  created_at: 2021-10-02 16:41:51.449399000 Z
-  updated_at: 2021-10-02 16:41:51.449401000 Z
 lottery_ticket_23:
   id: 23
   lottery_entrant_id: 5
   lottery_id: 4
   reference_number: 10022
-  created_at: 2021-10-02 16:41:51.449440000 Z
-  updated_at: 2021-10-02 16:41:51.449442000 Z
 lottery_ticket_24:
   id: 24
   lottery_entrant_id: 10
   lottery_id: 4
   reference_number: 10023
-  created_at: 2021-10-02 16:41:51.449365000 Z
-  updated_at: 2021-10-02 16:41:51.449367000 Z
 lottery_ticket_25:
   id: 25
   lottery_entrant_id: 6
   lottery_id: 4
   reference_number: 10024
-  created_at: 2021-10-02 16:41:51.449328000 Z
-  updated_at: 2021-10-02 16:41:51.449331000 Z
 lottery_ticket_26:
   id: 26
   lottery_entrant_id: 6
   lottery_id: 4
   reference_number: 10025
-  created_at: 2021-10-02 16:41:51.449338000 Z
-  updated_at: 2021-10-02 16:41:51.449340000 Z

--- a/spec/fixtures/notifications.yml
+++ b/spec/fixtures/notifications.yml
@@ -5,8 +5,6 @@ notification_1:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:21:09.723887000 Z
-  updated_at: 2019-08-18 02:21:09.723887000 Z
   created_by:
   updated_by:
   kind:
@@ -19,8 +17,6 @@ notification_2:
   distance: 0
   bitkey: 1
   follower_ids: "{4,3}"
-  created_at: 2019-08-18 02:21:39.637953000 Z
-  updated_at: 2019-08-18 02:21:39.637953000 Z
   created_by:
   updated_by:
   kind:
@@ -33,8 +29,6 @@ notification_3:
   distance: 8690
   bitkey: 1
   follower_ids: "{3}"
-  created_at: 2019-08-18 02:21:39.643227000 Z
-  updated_at: 2019-08-18 02:21:39.643227000 Z
   created_by:
   updated_by:
   kind:
@@ -47,8 +41,6 @@ notification_4:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:21:39.645936000 Z
-  updated_at: 2019-08-18 02:21:39.645936000 Z
   created_by:
   updated_by:
   kind:
@@ -61,8 +53,6 @@ notification_5:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:21:39.649192000 Z
-  updated_at: 2019-08-18 02:21:39.649192000 Z
   created_by:
   updated_by:
   kind:
@@ -75,8 +65,6 @@ notification_6:
   distance: 8690
   bitkey: 1
   follower_ids: "{11,4}"
-  created_at: 2019-08-18 02:21:39.652401000 Z
-  updated_at: 2019-08-18 02:21:39.652401000 Z
   created_by:
   updated_by:
   kind:
@@ -89,8 +77,6 @@ notification_7:
   distance: 8690
   bitkey: 1
   follower_ids: "{11}"
-  created_at: 2019-08-18 02:21:39.656086000 Z
-  updated_at: 2019-08-18 02:21:39.656086000 Z
   created_by:
   updated_by:
   kind:
@@ -103,8 +89,6 @@ notification_8:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:21:39.659282000 Z
-  updated_at: 2019-08-18 02:21:39.659282000 Z
   created_by:
   updated_by:
   kind:
@@ -117,8 +101,6 @@ notification_9:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:21:39.662004000 Z
-  updated_at: 2019-08-18 02:21:39.662004000 Z
   created_by:
   updated_by:
   kind:
@@ -131,8 +113,6 @@ notification_10:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:21:39.665225000 Z
-  updated_at: 2019-08-18 02:21:39.665225000 Z
   created_by:
   updated_by:
   kind:
@@ -145,8 +125,6 @@ notification_11:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:21:39.669213000 Z
-  updated_at: 2019-08-18 02:21:39.669213000 Z
   created_by:
   updated_by:
   kind:
@@ -159,8 +137,6 @@ notification_12:
   distance: 0
   bitkey: 1
   follower_ids: "{1}"
-  created_at: 2019-08-18 02:21:39.672655000 Z
-  updated_at: 2019-08-18 02:21:39.672655000 Z
   created_by:
   updated_by:
   kind:
@@ -173,8 +149,6 @@ notification_13:
   distance: 4345
   bitkey: 1
   follower_ids: "{11,1}"
-  created_at: 2019-08-18 02:21:39.675640000 Z
-  updated_at: 2019-08-18 02:21:39.675640000 Z
   created_by:
   updated_by:
   kind:
@@ -187,8 +161,6 @@ notification_14:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:21:39.678523000 Z
-  updated_at: 2019-08-18 02:21:39.678523000 Z
   created_by:
   updated_by:
   kind:
@@ -201,8 +173,6 @@ notification_15:
   distance: 0
   bitkey: 1
   follower_ids: "{1,11}"
-  created_at: 2019-08-18 02:21:39.681017000 Z
-  updated_at: 2019-08-18 02:21:39.681017000 Z
   created_by:
   updated_by:
   kind:
@@ -215,8 +185,6 @@ notification_16:
   distance: 4345
   bitkey: 1
   follower_ids: "{1,11}"
-  created_at: 2019-08-18 02:21:39.683807000 Z
-  updated_at: 2019-08-18 02:21:39.683807000 Z
   created_by:
   updated_by:
   kind:
@@ -229,8 +197,6 @@ notification_17:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:21:39.686460000 Z
-  updated_at: 2019-08-18 02:21:39.686460000 Z
   created_by:
   updated_by:
   kind:
@@ -243,8 +209,6 @@ notification_18:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:21:39.688866000 Z
-  updated_at: 2019-08-18 02:21:39.688866000 Z
   created_by:
   updated_by:
   kind:
@@ -257,8 +221,6 @@ notification_19:
   distance: 8690
   bitkey: 1
   follower_ids: "{1}"
-  created_at: 2019-08-18 02:21:39.691243000 Z
-  updated_at: 2019-08-18 02:21:39.691243000 Z
   created_by:
   updated_by:
   kind:
@@ -271,8 +233,6 @@ notification_20:
   distance: 4345
   bitkey: 1
   follower_ids: "{3,1}"
-  created_at: 2019-08-18 02:21:39.693695000 Z
-  updated_at: 2019-08-18 02:21:39.693695000 Z
   created_by:
   updated_by:
   kind:
@@ -285,8 +245,6 @@ notification_21:
   distance: 8690
   bitkey: 1
   follower_ids: "{4}"
-  created_at: 2019-08-18 02:21:39.696204000 Z
-  updated_at: 2019-08-18 02:21:39.696204000 Z
   created_by:
   updated_by:
   kind:
@@ -299,8 +257,6 @@ notification_22:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:00.594299000 Z
-  updated_at: 2019-08-18 02:22:00.594299000 Z
   created_by:
   updated_by:
   kind:
@@ -313,8 +269,6 @@ notification_23:
   distance: 0
   bitkey: 1
   follower_ids: "{3,1}"
-  created_at: 2019-08-18 02:22:00.597465000 Z
-  updated_at: 2019-08-18 02:22:00.597465000 Z
   created_by:
   updated_by:
   kind:
@@ -327,8 +281,6 @@ notification_24:
   distance: 8690
   bitkey: 1
   follower_ids: "{4,1}"
-  created_at: 2019-08-18 02:22:00.600768000 Z
-  updated_at: 2019-08-18 02:22:00.600768000 Z
   created_by:
   updated_by:
   kind:
@@ -341,8 +293,6 @@ notification_25:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:00.603909000 Z
-  updated_at: 2019-08-18 02:22:00.603909000 Z
   created_by:
   updated_by:
   kind:
@@ -355,8 +305,6 @@ notification_26:
   distance: 0
   bitkey: 1
   follower_ids: "{3,1}"
-  created_at: 2019-08-18 02:22:00.606936000 Z
-  updated_at: 2019-08-18 02:22:00.606936000 Z
   created_by:
   updated_by:
   kind:
@@ -369,8 +317,6 @@ notification_27:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:00.610213000 Z
-  updated_at: 2019-08-18 02:22:00.610213000 Z
   created_by:
   updated_by:
   kind:
@@ -383,8 +329,6 @@ notification_28:
   distance: 8690
   bitkey: 1
   follower_ids: "{1,11}"
-  created_at: 2019-08-18 02:22:00.613146000 Z
-  updated_at: 2019-08-18 02:22:00.613146000 Z
   created_by:
   updated_by:
   kind:
@@ -397,8 +341,6 @@ notification_29:
   distance: 4345
   bitkey: 1
   follower_ids: "{1}"
-  created_at: 2019-08-18 02:22:00.615828000 Z
-  updated_at: 2019-08-18 02:22:00.615828000 Z
   created_by:
   updated_by:
   kind:
@@ -411,8 +353,6 @@ notification_30:
   distance: 4345
   bitkey: 1
   follower_ids: "{3,11}"
-  created_at: 2019-08-18 02:22:00.619014000 Z
-  updated_at: 2019-08-18 02:22:00.619014000 Z
   created_by:
   updated_by:
   kind:
@@ -425,8 +365,6 @@ notification_31:
   distance: 0
   bitkey: 1
   follower_ids: "{11,4}"
-  created_at: 2019-08-18 02:22:00.621946000 Z
-  updated_at: 2019-08-18 02:22:00.621946000 Z
   created_by:
   updated_by:
   kind:
@@ -439,8 +377,6 @@ notification_32:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:00.624788000 Z
-  updated_at: 2019-08-18 02:22:00.624788000 Z
   created_by:
   updated_by:
   kind:
@@ -453,8 +389,6 @@ notification_33:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:00.628353000 Z
-  updated_at: 2019-08-18 02:22:00.628353000 Z
   created_by:
   updated_by:
   kind:
@@ -467,8 +401,6 @@ notification_34:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:00.631874000 Z
-  updated_at: 2019-08-18 02:22:00.631874000 Z
   created_by:
   updated_by:
   kind:
@@ -481,8 +413,6 @@ notification_35:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:00.635056000 Z
-  updated_at: 2019-08-18 02:22:00.635056000 Z
   created_by:
   updated_by:
   kind:
@@ -495,8 +425,6 @@ notification_36:
   distance: 8690
   bitkey: 1
   follower_ids: "{3,4}"
-  created_at: 2019-08-18 02:22:00.637998000 Z
-  updated_at: 2019-08-18 02:22:00.637998000 Z
   created_by:
   updated_by:
   kind:
@@ -509,8 +437,6 @@ notification_37:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:00.640948000 Z
-  updated_at: 2019-08-18 02:22:00.640948000 Z
   created_by:
   updated_by:
   kind:
@@ -523,8 +449,6 @@ notification_38:
   distance: 8690
   bitkey: 1
   follower_ids: "{3,11}"
-  created_at: 2019-08-18 02:22:00.643630000 Z
-  updated_at: 2019-08-18 02:22:00.643630000 Z
   created_by:
   updated_by:
   kind:
@@ -537,8 +461,6 @@ notification_39:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:00.646174000 Z
-  updated_at: 2019-08-18 02:22:00.646174000 Z
   created_by:
   updated_by:
   kind:
@@ -551,8 +473,6 @@ notification_40:
   distance: 4345
   bitkey: 1
   follower_ids: "{4}"
-  created_at: 2019-08-18 02:22:00.648825000 Z
-  updated_at: 2019-08-18 02:22:00.648825000 Z
   created_by:
   updated_by:
   kind:
@@ -565,8 +485,6 @@ notification_41:
   distance: 4345
   bitkey: 1
   follower_ids: "{4,11}"
-  created_at: 2019-08-18 02:22:00.651511000 Z
-  updated_at: 2019-08-18 02:22:00.651511000 Z
   created_by:
   updated_by:
   kind:
@@ -579,8 +497,6 @@ notification_42:
   distance: 8690
   bitkey: 1
   follower_ids: "{11}"
-  created_at: 2019-08-18 02:22:03.740365000 Z
-  updated_at: 2019-08-18 02:22:03.740365000 Z
   created_by:
   updated_by:
   kind:
@@ -593,8 +509,6 @@ notification_43:
   distance: 0
   bitkey: 1
   follower_ids: "{3,4}"
-  created_at: 2019-08-18 02:22:03.743891000 Z
-  updated_at: 2019-08-18 02:22:03.743891000 Z
   created_by:
   updated_by:
   kind:
@@ -607,8 +521,6 @@ notification_44:
   distance: 0
   bitkey: 1
   follower_ids: "{4,1}"
-  created_at: 2019-08-18 02:22:03.747260000 Z
-  updated_at: 2019-08-18 02:22:03.747260000 Z
   created_by:
   updated_by:
   kind:
@@ -621,8 +533,6 @@ notification_45:
   distance: 0
   bitkey: 1
   follower_ids: "{11,1}"
-  created_at: 2019-08-18 02:22:03.750294000 Z
-  updated_at: 2019-08-18 02:22:03.750294000 Z
   created_by:
   updated_by:
   kind:
@@ -635,8 +545,6 @@ notification_46:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:03.753331000 Z
-  updated_at: 2019-08-18 02:22:03.753331000 Z
   created_by:
   updated_by:
   kind:
@@ -649,8 +557,6 @@ notification_47:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:03.756028000 Z
-  updated_at: 2019-08-18 02:22:03.756028000 Z
   created_by:
   updated_by:
   kind:
@@ -663,8 +569,6 @@ notification_48:
   distance: 8690
   bitkey: 1
   follower_ids: "{11,1}"
-  created_at: 2019-08-18 02:22:03.758756000 Z
-  updated_at: 2019-08-18 02:22:03.758756000 Z
   created_by:
   updated_by:
   kind:
@@ -677,8 +581,6 @@ notification_49:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:03.761502000 Z
-  updated_at: 2019-08-18 02:22:03.761502000 Z
   created_by:
   updated_by:
   kind:
@@ -691,8 +593,6 @@ notification_50:
   distance: 8690
   bitkey: 1
   follower_ids: "{11,1}"
-  created_at: 2019-08-18 02:22:03.764169000 Z
-  updated_at: 2019-08-18 02:22:03.764169000 Z
   created_by:
   updated_by:
   kind:
@@ -705,8 +605,6 @@ notification_51:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:03.767274000 Z
-  updated_at: 2019-08-18 02:22:03.767274000 Z
   created_by:
   updated_by:
   kind:
@@ -719,8 +617,6 @@ notification_52:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:03.769888000 Z
-  updated_at: 2019-08-18 02:22:03.769888000 Z
   created_by:
   updated_by:
   kind:
@@ -733,8 +629,6 @@ notification_53:
   distance: 4345
   bitkey: 1
   follower_ids: "{3}"
-  created_at: 2019-08-18 02:22:03.772715000 Z
-  updated_at: 2019-08-18 02:22:03.772715000 Z
   created_by:
   updated_by:
   kind:
@@ -747,8 +641,6 @@ notification_54:
   distance: 8690
   bitkey: 1
   follower_ids: "{3}"
-  created_at: 2019-08-18 02:22:03.775720000 Z
-  updated_at: 2019-08-18 02:22:03.775720000 Z
   created_by:
   updated_by:
   kind:
@@ -761,8 +653,6 @@ notification_55:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:22:03.778815000 Z
-  updated_at: 2019-08-18 02:22:03.778815000 Z
   created_by:
   updated_by:
   kind:
@@ -775,8 +665,6 @@ notification_56:
   distance: 4345
   bitkey: 1
   follower_ids: "{11,3}"
-  created_at: 2019-08-18 02:22:03.781889000 Z
-  updated_at: 2019-08-18 02:22:03.781889000 Z
   created_by:
   updated_by:
   kind:
@@ -789,8 +677,6 @@ notification_57:
   distance: 8690
   bitkey: 1
   follower_ids: "{3,11}"
-  created_at: 2019-08-18 02:22:03.784907000 Z
-  updated_at: 2019-08-18 02:22:03.784907000 Z
   created_by:
   updated_by:
   kind:
@@ -803,8 +689,6 @@ notification_58:
   distance: 8690
   bitkey: 1
   follower_ids: "{3,11}"
-  created_at: 2019-08-18 02:22:03.787679000 Z
-  updated_at: 2019-08-18 02:22:03.787679000 Z
   created_by:
   updated_by:
   kind:
@@ -817,8 +701,6 @@ notification_59:
   distance: 8690
   bitkey: 1
   follower_ids: "{3}"
-  created_at: 2019-08-18 02:22:03.790433000 Z
-  updated_at: 2019-08-18 02:22:03.790433000 Z
   created_by:
   updated_by:
   kind:
@@ -831,8 +713,6 @@ notification_60:
   distance: 0
   bitkey: 1
   follower_ids: "{11}"
-  created_at: 2019-08-18 02:22:03.793040000 Z
-  updated_at: 2019-08-18 02:22:03.793040000 Z
   created_by:
   updated_by:
   kind:
@@ -845,8 +725,6 @@ notification_61:
   distance: 4345
   bitkey: 1
   follower_ids: "{3,11}"
-  created_at: 2019-08-18 02:22:03.795526000 Z
-  updated_at: 2019-08-18 02:22:03.795526000 Z
   created_by:
   updated_by:
   kind:
@@ -859,8 +737,6 @@ notification_62:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.703434000 Z
-  updated_at: 2019-08-18 02:23:49.703434000 Z
   created_by:
   updated_by:
   kind:
@@ -873,8 +749,6 @@ notification_63:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.706540000 Z
-  updated_at: 2019-08-18 02:23:49.706540000 Z
   created_by:
   updated_by:
   kind:
@@ -887,8 +761,6 @@ notification_64:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.710050000 Z
-  updated_at: 2019-08-18 02:23:49.710050000 Z
   created_by:
   updated_by:
   kind:
@@ -901,8 +773,6 @@ notification_65:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.712839000 Z
-  updated_at: 2019-08-18 02:23:49.712839000 Z
   created_by:
   updated_by:
   kind:
@@ -915,8 +785,6 @@ notification_66:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.715634000 Z
-  updated_at: 2019-08-18 02:23:49.715634000 Z
   created_by:
   updated_by:
   kind:
@@ -929,8 +797,6 @@ notification_67:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.718365000 Z
-  updated_at: 2019-08-18 02:23:49.718365000 Z
   created_by:
   updated_by:
   kind:
@@ -943,8 +809,6 @@ notification_68:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.721319000 Z
-  updated_at: 2019-08-18 02:23:49.721319000 Z
   created_by:
   updated_by:
   kind:
@@ -957,8 +821,6 @@ notification_69:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.724003000 Z
-  updated_at: 2019-08-18 02:23:49.724003000 Z
   created_by:
   updated_by:
   kind:
@@ -971,8 +833,6 @@ notification_70:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.727139000 Z
-  updated_at: 2019-08-18 02:23:49.727139000 Z
   created_by:
   updated_by:
   kind:
@@ -985,8 +845,6 @@ notification_71:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.730150000 Z
-  updated_at: 2019-08-18 02:23:49.730150000 Z
   created_by:
   updated_by:
   kind:
@@ -999,8 +857,6 @@ notification_72:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.732711000 Z
-  updated_at: 2019-08-18 02:23:49.732711000 Z
   created_by:
   updated_by:
   kind:
@@ -1013,8 +869,6 @@ notification_73:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.735305000 Z
-  updated_at: 2019-08-18 02:23:49.735305000 Z
   created_by:
   updated_by:
   kind:
@@ -1027,8 +881,6 @@ notification_74:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.737657000 Z
-  updated_at: 2019-08-18 02:23:49.737657000 Z
   created_by:
   updated_by:
   kind:
@@ -1041,8 +893,6 @@ notification_75:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.740214000 Z
-  updated_at: 2019-08-18 02:23:49.740214000 Z
   created_by:
   updated_by:
   kind:
@@ -1055,8 +905,6 @@ notification_76:
   distance: 4345
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.742797000 Z
-  updated_at: 2019-08-18 02:23:49.742797000 Z
   created_by:
   updated_by:
   kind:
@@ -1069,8 +917,6 @@ notification_77:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.745507000 Z
-  updated_at: 2019-08-18 02:23:49.745507000 Z
   created_by:
   updated_by:
   kind:
@@ -1083,8 +929,6 @@ notification_78:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.748012000 Z
-  updated_at: 2019-08-18 02:23:49.748012000 Z
   created_by:
   updated_by:
   kind:
@@ -1097,8 +941,6 @@ notification_79:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.751010000 Z
-  updated_at: 2019-08-18 02:23:49.751010000 Z
   created_by:
   updated_by:
   kind:
@@ -1111,8 +953,6 @@ notification_80:
   distance: 0
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.753972000 Z
-  updated_at: 2019-08-18 02:23:49.753972000 Z
   created_by:
   updated_by:
   kind:
@@ -1125,8 +965,6 @@ notification_81:
   distance: 8690
   bitkey: 1
   follower_ids: "{}"
-  created_at: 2019-08-18 02:23:49.756949000 Z
-  updated_at: 2019-08-18 02:23:49.756949000 Z
   created_by:
   updated_by:
   kind:

--- a/spec/fixtures/organizations.yml
+++ b/spec/fixtures/organizations.yml
@@ -3,8 +3,6 @@ hardrock:
   id: 4
   name: Hardrock
   description: A long race
-  created_at: 2016-04-16 19:25:07.662405000 Z
-  updated_at: 2019-01-30 23:40:32.921105000 Z
   created_by: 1
   updated_by: 1
   concealed: false
@@ -13,8 +11,6 @@ rattlesnake_ramble:
   id: 6
   name: Rattlesnake Ramble
   description: Bill's Race to benefit Eldorado Canyon State Park
-  created_at: 2016-05-07 23:07:36.375440000 Z
-  updated_at: 2017-03-05 04:55:57.129926000 Z
   created_by: 1
   updated_by: 1
   concealed: false
@@ -23,8 +19,6 @@ running_up_for_air:
   id: 14
   name: Running Up For Air
   description:
-  created_at: 2017-05-12 07:28:04.903865000 Z
-  updated_at: 2017-05-12 07:28:04.903865000 Z
   created_by: 1
   updated_by: 1
   concealed: false
@@ -33,8 +27,6 @@ dirty_30_running:
   id: 15
   name: Dirty 30 Running
   description:
-  created_at: 2017-05-23 06:06:29.680019000 Z
-  updated_at: 2018-06-11 07:08:24.245466000 Z
   created_by: 1
   updated_by: 1
   concealed: false

--- a/spec/fixtures/partners.yml
+++ b/spec/fixtures/partners.yml
@@ -3,8 +3,6 @@ partner_5:
   id: 5
   banner_link: www.blackdiamondequipment.com
   weight: 1
-  created_at: 2017-06-14 14:23:53.474866000 Z
-  updated_at: 2018-06-10 11:31:53.304523000 Z
   name: Black Diamond Equipment
   partnerable_type: EventGroup
   partnerable_id: 27
@@ -12,8 +10,6 @@ partner_6:
   id: 6
   banner_link: blackdiamondequipment.com
   weight: 100
-  created_at: 2018-06-11 10:24:00.962529000 Z
-  updated_at: 2018-06-11 10:24:00.962529000 Z
   name: BD
   partnerable_type: EventGroup
   partnerable_id: 32

--- a/spec/fixtures/people.yml
+++ b/spec/fixtures/people.yml
@@ -9,8 +9,6 @@ bruno_fadel:
   state_code: CA
   email:
   phone:
-  created_at: 2016-04-18 09:10:13.966803000 Z
-  updated_at: 2020-09-09 14:15:13.095995000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -30,8 +28,6 @@ robby_gerlach:
   state_code: VA
   email:
   phone:
-  created_at: 2016-04-18 09:10:13.995708000 Z
-  updated_at: 2020-09-09 14:15:13.290207000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -51,8 +47,6 @@ brinda_fisher:
   state_code: SC
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.005889000 Z
-  updated_at: 2020-09-09 14:15:13.300855000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -72,8 +66,6 @@ bad_status:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.043379000 Z
-  updated_at: 2020-09-09 14:15:13.311210000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -93,8 +85,6 @@ willis_murray:
   state_code: FL
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.083822000 Z
-  updated_at: 2020-09-09 14:15:13.320823000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -114,8 +104,6 @@ finished_with_stop:
   state_code: UT
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.125481000 Z
-  updated_at: 2020-09-09 14:15:13.330776000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -135,8 +123,6 @@ garry_kuhlman:
   state_code: MT
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.265724000 Z
-  updated_at: 2020-09-09 14:15:13.343577000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -156,8 +142,6 @@ donn_mckenzie:
   state_code: WY
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.276164000 Z
-  updated_at: 2020-09-09 14:15:13.354664000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -177,8 +161,6 @@ gilberto_mckenzie:
   state_code: WA
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.297646000 Z
-  updated_at: 2020-09-09 14:15:13.365446000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -198,8 +180,6 @@ benedict_davis:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.311539000 Z
-  updated_at: 2020-09-09 14:15:13.375913000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -219,8 +199,6 @@ paul_predovic:
   state_code: ID
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.326152000 Z
-  updated_at: 2020-09-09 14:15:13.386510000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -240,8 +218,6 @@ erich_larson:
   state_code: MT
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.436300000 Z
-  updated_at: 2020-09-09 14:15:13.399587000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -261,8 +237,6 @@ lavon_paucek:
   state_code:
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.463923000 Z
-  updated_at: 2020-09-09 14:15:13.428462000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -282,8 +256,6 @@ irvin_harber:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.569434000 Z
-  updated_at: 2020-09-09 14:15:13.439591000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -303,8 +275,6 @@ santa_green:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.582024000 Z
-  updated_at: 2020-09-09 14:15:13.450468000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -324,8 +294,6 @@ carmine_adams:
   state_code: WA
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.670130000 Z
-  updated_at: 2020-09-09 14:15:13.461902000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -345,8 +313,6 @@ vesta_borer:
   state_code: UT
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.681414000 Z
-  updated_at: 2020-09-09 14:15:13.472952000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -366,8 +332,6 @@ susanna_abshire:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.730660000 Z
-  updated_at: 2020-09-09 14:15:13.485649000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -387,8 +351,6 @@ pat_schaden:
   state_code: AZ
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.794649000 Z
-  updated_at: 2020-09-09 14:15:13.503411000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -408,8 +370,6 @@ tuan_jacobs:
   state_code:
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.804640000 Z
-  updated_at: 2020-09-09 14:15:13.516517000 Z
   created_by: 1
   updated_by: 1
   country_code: ES
@@ -429,8 +389,6 @@ rachelle_eichmann:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.813922000 Z
-  updated_at: 2020-09-09 14:15:13.528406000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -450,8 +408,6 @@ leif_carter:
   state_code:
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.833880000 Z
-  updated_at: 2020-09-09 14:15:13.541528000 Z
   created_by: 1
   updated_by: 1
   country_code: ES
@@ -471,8 +427,6 @@ leroy_leffler:
   state_code: NM
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.855811000 Z
-  updated_at: 2020-09-09 14:15:13.554347000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -492,8 +446,6 @@ cassondra_nienow:
   state_code: OH
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.974286000 Z
-  updated_at: 2020-09-09 14:15:13.565822000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -513,8 +465,6 @@ gus_walker:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.983941000 Z
-  updated_at: 2020-09-09 14:15:13.577591000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -534,8 +484,6 @@ donte_spencer:
   state_code: UT
   email:
   phone:
-  created_at: 2016-04-18 09:10:14.993252000 Z
-  updated_at: 2020-09-09 14:15:13.589165000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -555,8 +503,6 @@ ken_bradtke:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.012012000 Z
-  updated_at: 2020-09-09 14:15:13.599469000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -576,8 +522,6 @@ darius_jacobson:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.077918000 Z
-  updated_at: 2020-09-09 14:15:13.609603000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -597,8 +541,6 @@ chris_rempel:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.087654000 Z
-  updated_at: 2020-09-09 14:15:13.619876000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -618,8 +560,6 @@ samara_vandervort:
   state_code: CA
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.096853000 Z
-  updated_at: 2020-09-09 14:15:13.630395000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -639,8 +579,6 @@ douglas_vandervort:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.126029000 Z
-  updated_at: 2020-09-09 14:15:13.642094000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -660,8 +598,6 @@ leandro_cole:
   state_code: UT
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.155158000 Z
-  updated_at: 2020-09-09 14:15:13.652702000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -681,8 +617,6 @@ elden_morissette:
   state_code: WI
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.183099000 Z
-  updated_at: 2020-09-09 14:15:13.665606000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -702,8 +636,6 @@ raphael_swift:
   state_code: AR
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.192624000 Z
-  updated_at: 2020-09-09 14:15:13.677082000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -723,8 +655,6 @@ vern_buckridge:
   state_code: TX
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.271416000 Z
-  updated_at: 2020-09-09 14:15:13.689563000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -744,8 +674,6 @@ cedric_windler:
   state_code: TN
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.342313000 Z
-  updated_at: 2020-09-09 14:15:13.701489000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -765,8 +693,6 @@ clarence_goyette:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.352342000 Z
-  updated_at: 2020-09-09 14:15:13.712905000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -786,8 +712,6 @@ vince_willms:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.401845000 Z
-  updated_at: 2020-09-09 14:15:13.724118000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -807,8 +731,6 @@ eddy_goldner:
   state_code: WA
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.467534000 Z
-  updated_at: 2020-09-09 14:15:13.735437000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -828,8 +750,6 @@ demetrius_moen:
   state_code: OR
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.476481000 Z
-  updated_at: 2020-09-09 14:15:13.746369000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -849,8 +769,6 @@ robt_wintheiser:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-18 09:10:15.513925000 Z
-  updated_at: 2020-09-09 14:15:13.758285000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -870,8 +788,6 @@ mervin_smitham:
   state_code: NM
   email:
   phone:
-  created_at: 2016-04-28 08:14:29.684152000 Z
-  updated_at: 2020-09-09 14:15:13.769896000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -891,8 +807,6 @@ without_start:
   state_code: MT
   email:
   phone:
-  created_at: 2016-04-28 08:14:29.762812000 Z
-  updated_at: 2020-09-09 14:15:13.781403000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -912,8 +826,6 @@ humberto_adams:
   state_code: NM
   email:
   phone:
-  created_at: 2016-04-28 08:14:29.886921000 Z
-  updated_at: 2020-09-09 14:15:13.792028000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -933,8 +845,6 @@ omer_yundt:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-28 08:14:29.962932000 Z
-  updated_at: 2020-09-09 14:15:13.802718000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -954,8 +864,6 @@ drop_ouray:
   state_code: CA
   email:
   phone:
-  created_at: 2016-04-28 08:14:31.327182000 Z
-  updated_at: 2020-09-09 14:15:13.813213000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -975,8 +883,6 @@ charlie_mueller:
   state_code: OR
   email:
   phone:
-  created_at: 2016-04-28 08:14:31.426276000 Z
-  updated_at: 2020-09-09 14:15:13.827098000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -996,8 +902,6 @@ kendall_koch:
   state_code: CO
   email:
   phone:
-  created_at: 2016-04-28 08:14:31.615349000 Z
-  updated_at: 2020-09-09 14:15:13.841071000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1017,8 +921,6 @@ dropped_grouse:
   state_code: CO
   email:
   phone:
-  created_at: 2016-05-02 16:06:11.816280000 Z
-  updated_at: 2020-09-09 14:15:13.853126000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1038,8 +940,6 @@ hoyt_macejkovic:
   state_code: TX
   email:
   phone:
-  created_at: 2016-05-02 16:06:11.885594000 Z
-  updated_at: 2020-09-09 14:15:13.864703000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1059,8 +959,6 @@ progress_sherman_colorado_us:
   state_code: CO
   email:
   phone:
-  created_at: 2016-05-02 16:06:12.251172000 Z
-  updated_at: 2020-09-09 14:15:13.876692000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1080,8 +978,6 @@ finished_second_montana_us:
   state_code: MT
   email:
   phone:
-  created_at: 2016-05-08 07:06:11.133052000 Z
-  updated_at: 2019-02-01 07:19:52.991074000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -1101,8 +997,6 @@ start_only_2019_02_01:
   state_code:
   email:
   phone:
-  created_at: 2016-05-08 07:06:11.174801000 Z
-  updated_at: 2019-02-01 07:19:53.339210000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -1122,8 +1016,6 @@ finished_first_2019_02_01:
   state_code:
   email:
   phone:
-  created_at: 2016-05-08 07:11:03.042740000 Z
-  updated_at: 2019-02-01 07:19:53.352940000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -1143,8 +1035,6 @@ not_started_2019_02_01:
   state_code:
   email:
   phone:
-  created_at: 2016-05-08 07:11:03.177256000 Z
-  updated_at: 2019-02-01 07:19:53.365861000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -1164,8 +1054,6 @@ shad_hirthe:
   state_code: CO
   email:
   phone:
-  created_at: 2016-05-10 07:28:03.541069000 Z
-  updated_at: 2020-09-09 14:15:13.888748000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1185,8 +1073,6 @@ finished_without_stop:
   state_code: UT
   email:
   phone:
-  created_at: 2016-05-10 07:28:11.212024000 Z
-  updated_at: 2020-09-09 14:15:13.899791000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1206,8 +1092,6 @@ progress_sherman:
   state_code: ID
   email:
   phone:
-  created_at: 2016-05-11 15:44:32.114719000 Z
-  updated_at: 2020-09-09 14:15:13.911463000 Z
   created_by: 2
   updated_by: 1
   country_code: US
@@ -1227,8 +1111,6 @@ finished_first_japan:
   state_code:
   email:
   phone:
-  created_at: 2016-05-23 07:18:34.771455000 Z
-  updated_at: 2020-09-09 14:15:13.922385000 Z
   created_by: 1
   updated_by: 1
   country_code: JP
@@ -1248,8 +1130,6 @@ claudio_wunsch:
   state_code:
   email:
   phone:
-  created_at: 2016-05-23 07:18:34.845156000 Z
-  updated_at: 2020-09-09 14:15:13.932886000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1269,8 +1149,6 @@ keith_metz:
   state_code: UT
   email:
   phone:
-  created_at: 2016-05-23 07:18:34.856224000 Z
-  updated_at: 2020-09-09 14:15:13.943328000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1290,8 +1168,6 @@ major_green:
   state_code: NC
   email:
   phone:
-  created_at: 2016-05-23 07:18:34.865687000 Z
-  updated_at: 2020-09-09 14:15:13.954019000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1311,8 +1187,6 @@ irvin_corkery:
   state_code: DC
   email:
   phone:
-  created_at: 2016-05-23 07:18:34.949440000 Z
-  updated_at: 2020-09-09 14:15:13.965433000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1332,8 +1206,6 @@ multiple_stops:
   state_code: HI
   email:
   phone:
-  created_at: 2016-05-23 07:18:35.032341000 Z
-  updated_at: 2020-09-09 14:15:13.976330000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1353,8 +1225,6 @@ not_started:
   state_code: CO
   email:
   phone:
-  created_at: 2016-05-23 07:18:35.057652000 Z
-  updated_at: 2020-09-09 14:15:13.987409000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1374,8 +1244,6 @@ start_only_maine_us:
   state_code: ME
   email:
   phone:
-  created_at: 2016-05-24 04:48:52.377760000 Z
-  updated_at: 2020-09-09 14:15:13.998434000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1395,8 +1263,6 @@ junior_lesch:
   state_code: NM
   email:
   phone:
-  created_at: 2016-05-24 04:48:52.529697000 Z
-  updated_at: 2020-09-09 14:15:14.009690000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1416,8 +1282,6 @@ finished_first_utah_us:
   state_code: UT
   email:
   phone:
-  created_at: 2017-03-28 07:19:22.668710000 Z
-  updated_at: 2020-09-09 14:15:14.046848000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1437,8 +1301,6 @@ progress_lap6:
   state_code: UT
   email:
   phone:
-  created_at: 2017-03-28 07:19:22.822139000 Z
-  updated_at: 2020-09-09 14:15:14.058789000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1458,8 +1320,6 @@ multiple_stops_utah_us:
   state_code: UT
   email:
   phone:
-  created_at: 2017-03-28 07:19:29.184827000 Z
-  updated_at: 2020-09-09 14:15:14.070082000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1479,8 +1339,6 @@ finished_last:
   state_code: UT
   email:
   phone:
-  created_at: 2017-03-28 07:19:32.066094000 Z
-  updated_at: 2020-09-09 14:15:14.081760000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1500,8 +1358,6 @@ progress_lap1:
   state_code: UT
   email:
   phone:
-  created_at: 2017-03-28 07:19:35.252811000 Z
-  updated_at: 2020-09-09 14:15:14.092948000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1521,8 +1377,6 @@ kory_kulas:
   state_code: CA
   email:
   phone:
-  created_at: 2017-04-18 08:22:57.705080000 Z
-  updated_at: 2020-09-09 14:15:14.111183000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1542,8 +1396,6 @@ benito_moen:
   state_code: OH
   email:
   phone:
-  created_at: 2017-04-18 08:22:59.120573000 Z
-  updated_at: 2020-09-09 14:15:14.123212000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1563,8 +1415,6 @@ rene_mclaughlin:
   state_code: TX
   email:
   phone:
-  created_at: 2017-04-18 08:23:01.385694000 Z
-  updated_at: 2020-09-09 14:15:14.136268000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1584,8 +1434,6 @@ start_only_colorado_us_2019_02_01:
   state_code: CO
   email:
   phone:
-  created_at: 2018-01-18 05:23:53.922446000 Z
-  updated_at: 2020-09-09 14:15:14.147475000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1605,8 +1453,6 @@ drop_bandera:
   state_code: CO
   email:
   phone:
-  created_at: 2018-01-18 05:23:54.016843000 Z
-  updated_at: 2020-09-09 14:15:14.159556000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1626,8 +1472,6 @@ progress_rolling:
   state_code: CA
   email:
   phone:
-  created_at: 2018-01-18 05:23:54.175400000 Z
-  updated_at: 2020-09-09 14:15:14.173638000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1647,8 +1491,6 @@ not_started_colorado_us_2019_02_01:
   state_code: CO
   email:
   phone:
-  created_at: 2018-01-18 05:23:54.418009000 Z
-  updated_at: 2020-09-09 14:15:14.185675000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1668,8 +1510,6 @@ finished_first_colorado_us:
   state_code: CO
   email:
   phone:
-  created_at: 2018-01-18 05:23:56.334499000 Z
-  updated_at: 2020-09-09 14:15:14.197020000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1689,8 +1529,6 @@ drop_aid4:
   state_code:
   email:
   phone:
-  created_at: 2018-05-10 09:47:58.890141000 Z
-  updated_at: 2019-02-01 07:19:53.832943000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -1710,8 +1548,6 @@ progress_aid3:
   state_code:
   email:
   phone:
-  created_at: 2018-05-10 09:48:33.933618000 Z
-  updated_at: 2019-02-01 07:19:53.810374000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -1731,8 +1567,6 @@ drop_anvil:
   state_code:
   email:
   phone:
-  created_at: 2018-07-28 11:18:08.492197000 Z
-  updated_at: 2019-02-01 07:19:54.011406000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -1752,8 +1586,6 @@ progress_cascade:
   state_code: UT
   email:
   phone:
-  created_at: 2018-07-28 11:18:10.049155000 Z
-  updated_at: 2020-09-09 14:15:14.210417000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1773,8 +1605,6 @@ not_started_colorado_us:
   state_code: CO
   email:
   phone:
-  created_at: 2018-12-28 19:34:35.090390000 Z
-  updated_at: 2020-09-09 14:15:14.222140000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1794,8 +1624,6 @@ finished_second_colorado_us:
   state_code: CO
   email:
   phone:
-  created_at: 2018-12-28 19:34:43.417273000 Z
-  updated_at: 2020-09-09 14:15:14.233446000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1815,8 +1643,6 @@ start_only_colorado_us:
   state_code: CO
   email:
   phone:
-  created_at: 2018-12-28 19:34:44.799339000 Z
-  updated_at: 2020-09-09 14:15:14.244649000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1836,8 +1662,6 @@ finished_first_france:
   state_code:
   email:
   phone:
-  created_at: 2018-12-28 19:34:49.627320000 Z
-  updated_at: 2020-09-09 14:15:14.254568000 Z
   created_by: 1
   updated_by: 1
   country_code: FR
@@ -1857,8 +1681,6 @@ start_only_2019_02_01_07_19_53:
   state_code:
   email:
   phone:
-  created_at: 2018-12-28 19:35:21.894405000 Z
-  updated_at: 2019-02-01 07:19:53.845347000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -1878,8 +1700,6 @@ progress_aid4:
   state_code:
   email:
   phone:
-  created_at: 2018-12-28 19:35:28.943000000 Z
-  updated_at: 2019-02-01 07:19:53.821661000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -1899,8 +1719,6 @@ bad_finish:
   state_code:
   email:
   phone:
-  created_at: 2018-12-28 19:35:38.330897000 Z
-  updated_at: 2019-02-01 07:19:53.788073000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -1920,8 +1738,6 @@ progress_lap5_partial:
   state_code: UT
   email:
   phone:
-  created_at: 2019-01-30 19:00:44.965267000 Z
-  updated_at: 2020-09-09 14:15:14.265442000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1941,8 +1757,6 @@ finished_first:
   state_code: AZ
   email:
   phone:
-  created_at: 2019-01-30 19:00:45.095305000 Z
-  updated_at: 2020-09-09 14:15:14.277471000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1962,8 +1776,6 @@ finished_lap6:
   state_code: UT
   email:
   phone:
-  created_at: 2019-01-30 19:00:45.241578000 Z
-  updated_at: 2020-09-09 14:15:14.288991000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -1983,8 +1795,6 @@ progress_lap2:
   state_code: UT
   email:
   phone:
-  created_at: 2019-01-30 19:00:45.694985000 Z
-  updated_at: 2020-09-09 14:15:14.299405000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -2004,8 +1814,6 @@ not_started_utah_us:
   state_code: UT
   email:
   phone:
-  created_at: 2019-01-30 19:00:45.813779000 Z
-  updated_at: 2020-09-09 14:15:14.310401000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -2025,8 +1833,6 @@ start_only:
   state_code: UT
   email:
   phone:
-  created_at: 2019-01-30 19:00:45.946704000 Z
-  updated_at: 2020-09-09 14:15:14.323832000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -2046,8 +1852,6 @@ on_dst_change:
   state_code:
   email:
   phone:
-  created_at: 2019-02-21 23:23:43.929477000 Z
-  updated_at: 2019-02-21 23:23:43.929477000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -2067,8 +1871,6 @@ across_dst_change:
   state_code:
   email:
   phone:
-  created_at: 2019-02-21 23:23:44.141109000 Z
-  updated_at: 2019-02-21 23:23:44.141109000 Z
   created_by: 1
   updated_by: 1
   country_code:
@@ -2088,8 +1890,6 @@ un_started:
   state_code: CO
   email:
   phone:
-  created_at: 2019-02-21 23:23:44.276762000 Z
-  updated_at: 2020-09-09 14:15:14.337527000 Z
   created_by: 1
   updated_by: 1
   country_code: US
@@ -2109,8 +1909,6 @@ series_finisher:
   state_code: CO
   email:
   phone:
-  created_at: 2019-02-21 23:40:15.216434000 Z
-  updated_at: 2020-09-09 14:15:14.348239000 Z
   created_by: 1
   updated_by:
   country_code: US
@@ -2130,8 +1928,6 @@ slow_finisher:
   state_code: UT
   email:
   phone:
-  created_at: 2019-02-21 23:53:21.216763000 Z
-  updated_at: 2020-09-09 14:15:14.358990000 Z
   created_by: 1
   updated_by:
   country_code: US

--- a/spec/fixtures/raw_times.yml
+++ b/spec/fixtures/raw_times.yml
@@ -15,8 +15,6 @@ raw_time_49:
   reviewed_at: 2017-07-08 22:38:12.817174000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.732619000 Z
-  updated_at: 2020-02-14 08:08:54.171286000 Z
   parameterized_split_name: pole-creek
   remarks:
   sortable_bib_number: 102
@@ -40,8 +38,6 @@ raw_time_50:
   reviewed_at: 2017-07-08 22:38:12.817174000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.735995000 Z
-  updated_at: 2020-02-14 08:08:54.176666000 Z
   parameterized_split_name: pole-creek
   remarks:
   sortable_bib_number: 103
@@ -65,8 +61,6 @@ raw_time_67:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.798201000 Z
-  updated_at: 2020-02-14 08:08:54.185329000 Z
   parameterized_split_name: molas-pass-aid1
   remarks:
   sortable_bib_number: 130
@@ -90,8 +84,6 @@ raw_time_68:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.801611000 Z
-  updated_at: 2020-02-14 08:08:54.189250000 Z
   parameterized_split_name: molas-pass-aid1
   remarks:
   sortable_bib_number: 130
@@ -115,8 +107,6 @@ raw_time_69:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.805381000 Z
-  updated_at: 2020-02-14 08:08:54.193883000 Z
   parameterized_split_name: anvil-cg-aid6
   remarks:
   sortable_bib_number: 999
@@ -140,8 +130,6 @@ raw_time_70:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.809416000 Z
-  updated_at: 2020-02-14 08:08:54.202090000 Z
   parameterized_split_name: anvil-cg-aid6
   remarks:
   sortable_bib_number: 999
@@ -165,8 +153,6 @@ raw_time_73:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.819696000 Z
-  updated_at: 2020-02-14 08:08:54.206927000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 999
@@ -190,8 +176,6 @@ raw_time_74:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.825046000 Z
-  updated_at: 2020-02-14 08:08:54.263475000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 999
@@ -215,8 +199,6 @@ raw_time_75:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.828907000 Z
-  updated_at: 2020-02-14 08:08:54.266843000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 130
@@ -240,8 +222,6 @@ raw_time_76:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.832235000 Z
-  updated_at: 2020-02-14 08:08:54.270025000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 130
@@ -265,8 +245,6 @@ raw_time_77:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.835982000 Z
-  updated_at: 2020-02-14 08:08:54.273103000 Z
   parameterized_split_name: start
   remarks:
   sortable_bib_number: 999
@@ -290,8 +268,6 @@ raw_time_78:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.840667000 Z
-  updated_at: 2020-02-14 08:08:54.276343000 Z
   parameterized_split_name: molas-pass-aid1
   remarks:
   sortable_bib_number: 999
@@ -315,8 +291,6 @@ raw_time_79:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.844310000 Z
-  updated_at: 2020-02-14 08:08:54.383085000 Z
   parameterized_split_name: molas-pass-aid1
   remarks:
   sortable_bib_number: 999
@@ -340,8 +314,6 @@ raw_time_80:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.847562000 Z
-  updated_at: 2020-02-14 08:08:54.422543000 Z
   parameterized_split_name: cascade-creek-rd-aid3
   remarks:
   sortable_bib_number: 999
@@ -365,8 +337,6 @@ raw_time_81:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.851043000 Z
-  updated_at: 2020-02-14 08:08:54.428582000 Z
   parameterized_split_name: cascade-creek-rd-aid3
   remarks:
   sortable_bib_number: 999
@@ -390,8 +360,6 @@ raw_time_82:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.854819000 Z
-  updated_at: 2020-02-14 08:08:54.433537000 Z
   parameterized_split_name: engineer-mtn-th-aid4
   remarks:
   sortable_bib_number: 999
@@ -415,8 +383,6 @@ raw_time_83:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.858689000 Z
-  updated_at: 2020-02-14 08:08:54.443909000 Z
   parameterized_split_name: engineer-mtn-th-aid4
   remarks:
   sortable_bib_number: 999
@@ -440,8 +406,6 @@ raw_time_84:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.862327000 Z
-  updated_at: 2020-02-14 08:08:54.449647000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 101
@@ -465,8 +429,6 @@ raw_time_85:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.865972000 Z
-  updated_at: 2020-02-14 08:08:54.456282000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 101
@@ -490,8 +452,6 @@ raw_time_86:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
   created_by:
   updated_by:
-  created_at: 2018-06-11 10:56:14.869530000 Z
-  updated_at: 2020-02-14 08:08:54.463522000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 999
@@ -515,8 +475,6 @@ raw_time_87:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
   created_by:
   updated_by:
-  created_at: 2018-06-11 10:56:14.873617000 Z
-  updated_at: 2020-02-14 08:08:54.473485000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 999
@@ -540,8 +498,6 @@ raw_time_88:
   reviewed_at: 2018-07-27 03:39:21.949460000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.877397000 Z
-  updated_at: 2020-02-14 08:08:54.478597000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks: ''
   sortable_bib_number: 999
@@ -565,8 +521,6 @@ raw_time_89:
   reviewed_at:
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-11 10:56:14.880784000 Z
-  updated_at: 2020-02-14 08:08:54.492420000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 130
@@ -590,8 +544,6 @@ raw_time_91:
   reviewed_at: 2018-07-27 03:40:08.987644000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-06-29 04:42:41.128703000 Z
-  updated_at: 2020-02-14 08:08:54.501138000 Z
   parameterized_split_name: start
   remarks: ''
   sortable_bib_number: 777
@@ -615,8 +567,6 @@ raw_time_92:
   reviewed_at: 2018-07-27 03:24:12.907737000 Z
   created_by:
   updated_by:
-  created_at: 2018-06-29 05:01:22.505217000 Z
-  updated_at: 2020-02-14 08:08:54.506504000 Z
   parameterized_split_name: start
   remarks:
   sortable_bib_number: 777
@@ -640,8 +590,6 @@ raw_time_176:
   reviewed_at: 2018-11-14 05:48:02.521295000 Z
   created_by:
   updated_by:
-  created_at: 2018-10-25 20:05:12.500786000 Z
-  updated_at: 2020-02-14 08:08:54.513966000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 130
@@ -665,8 +613,6 @@ raw_time_177:
   reviewed_at: 2018-11-14 05:48:25.812628000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-10-25 20:06:21.058980000 Z
-  updated_at: 2020-02-14 08:08:54.521708000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks: ''
   sortable_bib_number: 130
@@ -690,8 +636,6 @@ raw_time_178:
   reviewed_at: 2018-11-14 05:48:27.582171000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-10-25 20:06:31.146819000 Z
-  updated_at: 2020-02-14 08:08:54.537936000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks: ''
   sortable_bib_number: 130
@@ -715,8 +659,6 @@ raw_time_1100:
   reviewed_at: 2018-11-14 05:48:22.553830000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-11-14 05:48:22.555587000 Z
-  updated_at: 2020-02-14 08:08:54.546191000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 130
@@ -740,8 +682,6 @@ raw_time_1106:
   reviewed_at: 2018-12-09 02:24:15.750492000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-12-09 02:24:15.750994000 Z
-  updated_at: 2020-02-14 08:08:54.552154000 Z
   parameterized_split_name: bandera-mine-aid5
   remarks:
   sortable_bib_number: 103
@@ -765,8 +705,6 @@ raw_time_1110:
   reviewed_at: 2018-12-09 02:25:03.158304000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-12-09 02:25:03.158886000 Z
-  updated_at: 2020-02-14 08:08:54.557109000 Z
   parameterized_split_name: anvil-cg-aid6
   remarks:
   sortable_bib_number: 103
@@ -790,8 +728,6 @@ raw_time_1111:
   reviewed_at: 2018-12-09 02:26:54.169992000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-12-09 02:26:54.170813000 Z
-  updated_at: 2020-02-14 08:08:54.561129000 Z
   parameterized_split_name: anvil-cg-aid6
   remarks:
   sortable_bib_number: 103
@@ -815,8 +751,6 @@ raw_time_1117:
   reviewed_at: 2018-12-15 17:29:59.171376000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2018-12-15 17:29:59.172639000 Z
-  updated_at: 2020-02-14 08:08:54.570039000 Z
   parameterized_split_name: anvil-cg-aid6
   remarks:
   sortable_bib_number: 103
@@ -840,8 +774,6 @@ raw_time_1122:
   reviewed_at: 2019-01-25 00:23:15.068615000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2019-01-25 00:23:15.069786000 Z
-  updated_at: 2020-02-14 08:08:54.574315000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 101
@@ -865,8 +797,6 @@ raw_time_1123:
   reviewed_at: 2019-01-25 00:23:15.075358000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2019-01-25 00:23:15.075882000 Z
-  updated_at: 2020-02-14 08:08:54.578410000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 101
@@ -890,8 +820,6 @@ raw_time_1124:
   reviewed_at: 2019-01-25 00:23:57.468470000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2019-01-25 00:23:57.469491000 Z
-  updated_at: 2020-02-14 08:08:54.587049000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 101
@@ -915,8 +843,6 @@ raw_time_1125:
   reviewed_at: 2019-01-25 00:23:57.472413000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2019-01-25 00:23:57.472951000 Z
-  updated_at: 2020-02-14 08:08:54.592574000 Z
   parameterized_split_name: rolling-pass-aid2
   remarks:
   sortable_bib_number: 101
@@ -940,8 +866,6 @@ raw_time_1126:
   reviewed_at: 2019-01-25 00:25:12.563910000 Z
   created_by: 1
   updated_by: 1
-  created_at: 2019-01-25 00:25:12.564450000 Z
-  updated_at: 2020-02-14 08:08:54.597859000 Z
   parameterized_split_name: start
   remarks:
   sortable_bib_number: 114

--- a/spec/fixtures/results_categories.yml
+++ b/spec/fixtures/results_categories.yml
@@ -10,8 +10,6 @@ overall:
   temp_key: combined_overall
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.216125000 Z
-  updated_at: 2019-02-14 05:23:14.216125000 Z
 overall_men:
   id: 2
   organization_id:
@@ -23,8 +21,6 @@ overall_men:
   temp_key: men_overall
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.240465000 Z
-  updated_at: 2019-02-14 05:23:14.240465000 Z
 overall_women:
   id: 3
   organization_id:
@@ -36,8 +32,6 @@ overall_women:
   temp_key: women_overall
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.246694000 Z
-  updated_at: 2019-02-14 05:23:14.246694000 Z
 masters_men_40:
   id: 4
   organization_id:
@@ -49,8 +43,6 @@ masters_men_40:
   temp_key: men_masters
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.252543000 Z
-  updated_at: 2019-02-14 05:23:14.252543000 Z
 masters_women_40:
   id: 5
   organization_id:
@@ -62,8 +54,6 @@ masters_women_40:
   temp_key: women_masters
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.258249000 Z
-  updated_at: 2019-02-14 05:23:14.258249000 Z
 masters_men_40_49:
   id: 6
   organization_id:
@@ -75,8 +65,6 @@ masters_men_40_49:
   temp_key: men_40s_masters
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.263779000 Z
-  updated_at: 2019-02-14 05:23:14.263779000 Z
 masters_women_40_49:
   id: 7
   organization_id:
@@ -88,8 +76,6 @@ masters_women_40_49:
   temp_key: women_40s_masters
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.269301000 Z
-  updated_at: 2019-02-14 05:23:14.269301000 Z
 grandmasters_men_50:
   id: 8
   organization_id:
@@ -101,8 +87,6 @@ grandmasters_men_50:
   temp_key: men_grandmasters
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.276758000 Z
-  updated_at: 2019-02-14 05:23:14.276758000 Z
 grandmasters_women_50:
   id: 9
   organization_id:
@@ -114,8 +98,6 @@ grandmasters_women_50:
   temp_key: women_grandmasters
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.282907000 Z
-  updated_at: 2019-02-14 05:23:14.282907000 Z
 senior_grandmasters_men_60:
   id: 10
   organization_id:
@@ -127,8 +109,6 @@ senior_grandmasters_men_60:
   temp_key: men_seniors
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.288430000 Z
-  updated_at: 2019-02-14 05:23:14.288430000 Z
 senior_grandmasters_women_60:
   id: 11
   organization_id:
@@ -140,8 +120,6 @@ senior_grandmasters_women_60:
   temp_key: women_seniors
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.295124000 Z
-  updated_at: 2019-02-14 05:23:14.295124000 Z
 boys_12_and_under:
   id: 12
   organization_id:
@@ -153,8 +131,6 @@ boys_12_and_under:
   temp_key: boys_12_and_under
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.303036000 Z
-  updated_at: 2019-02-14 05:23:14.303036000 Z
 girls_12_and_under:
   id: 13
   organization_id:
@@ -166,8 +142,6 @@ girls_12_and_under:
   temp_key: girls_12_and_under
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.310181000 Z
-  updated_at: 2019-02-14 05:23:14.310181000 Z
 boys_13_to_16:
   id: 14
   organization_id:
@@ -179,8 +153,6 @@ boys_13_to_16:
   temp_key: boys_13_to_16
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.322522000 Z
-  updated_at: 2019-02-14 05:23:14.322522000 Z
 girls_13_to_16:
   id: 15
   organization_id:
@@ -192,8 +164,6 @@ girls_13_to_16:
   temp_key: girls_13_to_16
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.330382000 Z
-  updated_at: 2019-02-14 05:23:14.330382000 Z
 boys_16_and_under:
   id: 16
   organization_id:
@@ -205,8 +175,6 @@ boys_16_and_under:
   temp_key: boys_16_and_under
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.338496000 Z
-  updated_at: 2019-02-14 05:23:14.338496000 Z
 girls_16_and_under:
   id: 17
   organization_id:
@@ -218,8 +186,6 @@ girls_16_and_under:
   temp_key: girls_16_and_under
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.348408000 Z
-  updated_at: 2019-02-14 05:23:14.348408000 Z
 under_20_men:
   id: 18
   organization_id:
@@ -231,8 +197,6 @@ under_20_men:
   temp_key: men_under_20
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.357627000 Z
-  updated_at: 2019-02-14 05:23:14.357627000 Z
 under_20_women:
   id: 19
   organization_id:
@@ -244,8 +208,6 @@ under_20_women:
   temp_key: women_under_20
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.371632000 Z
-  updated_at: 2019-02-14 05:23:14.371632000 Z
 13_to_39_men:
   id: 20
   organization_id:
@@ -257,8 +219,6 @@ under_20_women:
   temp_key: men_13_to_39
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.380530000 Z
-  updated_at: 2019-02-14 05:23:14.380530000 Z
 13_to_39_women:
   id: 21
   organization_id:
@@ -270,8 +230,6 @@ under_20_women:
   temp_key: women_13_to_39
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.388081000 Z
-  updated_at: 2019-02-14 05:23:14.388081000 Z
 17_to_39_men:
   id: 22
   organization_id:
@@ -283,8 +241,6 @@ under_20_women:
   temp_key: men_17_to_39
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.396785000 Z
-  updated_at: 2019-02-14 05:23:14.396785000 Z
 17_to_39_women:
   id: 23
   organization_id:
@@ -296,8 +252,6 @@ under_20_women:
   temp_key: women_17_to_39
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.405085000 Z
-  updated_at: 2019-02-14 05:23:14.405085000 Z
 20_to_29_men:
   id: 24
   organization_id:
@@ -309,8 +263,6 @@ under_20_women:
   temp_key: men_20s
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.418062000 Z
-  updated_at: 2019-02-14 05:23:14.418062000 Z
 20_to_29_women:
   id: 25
   organization_id:
@@ -322,8 +274,6 @@ under_20_women:
   temp_key: women_20s
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.426851000 Z
-  updated_at: 2019-02-14 05:23:14.426851000 Z
 30_to_39_men:
   id: 26
   organization_id:
@@ -335,8 +285,6 @@ under_20_women:
   temp_key: men_30s
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.435691000 Z
-  updated_at: 2019-02-14 05:23:14.435691000 Z
 30_to_39_women:
   id: 27
   organization_id:
@@ -348,8 +296,6 @@ under_20_women:
   temp_key: women_30s
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.445779000 Z
-  updated_at: 2019-02-14 05:23:14.445779000 Z
 40_to_49_men:
   id: 28
   organization_id:
@@ -361,8 +307,6 @@ under_20_women:
   temp_key: men_40s
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.453568000 Z
-  updated_at: 2019-02-14 05:23:14.453568000 Z
 40_to_49_women:
   id: 29
   organization_id:
@@ -374,8 +318,6 @@ under_20_women:
   temp_key: women_40s
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.461776000 Z
-  updated_at: 2019-02-14 05:23:14.461776000 Z
 50_to_59_men:
   id: 30
   organization_id:
@@ -387,8 +329,6 @@ under_20_women:
   temp_key: men_50s
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.469249000 Z
-  updated_at: 2019-02-14 05:23:14.469249000 Z
 50_to_59_women:
   id: 31
   organization_id:
@@ -400,8 +340,6 @@ under_20_women:
   temp_key: women_50s
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.476449000 Z
-  updated_at: 2019-02-14 05:23:14.476449000 Z
 60_to_69_men:
   id: 32
   organization_id:
@@ -413,8 +351,6 @@ under_20_women:
   temp_key: men_60s
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.483272000 Z
-  updated_at: 2019-02-14 05:23:14.483272000 Z
 60_to_69_women:
   id: 33
   organization_id:
@@ -426,8 +362,6 @@ under_20_women:
   temp_key: women_60s
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.489825000 Z
-  updated_at: 2019-02-14 05:23:14.489825000 Z
 under_30_men:
   id: 34
   organization_id:
@@ -439,8 +373,6 @@ under_30_men:
   temp_key: men_under_30
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.498658000 Z
-  updated_at: 2019-02-14 05:23:14.498658000 Z
 under_30_women:
   id: 35
   organization_id:
@@ -452,8 +384,6 @@ under_30_women:
   temp_key: women_under_30
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.506807000 Z
-  updated_at: 2019-02-14 05:23:14.506807000 Z
 under_40_men:
   id: 36
   organization_id:
@@ -465,8 +395,6 @@ under_40_men:
   temp_key: men_under_40
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.519912000 Z
-  updated_at: 2019-02-14 05:23:14.519912000 Z
 under_40_women:
   id: 37
   organization_id:
@@ -478,5 +406,3 @@ under_40_women:
   temp_key: women_under_40
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.529403000 Z
-  updated_at: 2019-02-14 05:23:14.529403000 Z

--- a/spec/fixtures/results_template_categories.yml
+++ b/spec/fixtures/results_template_categories.yml
@@ -3,351 +3,263 @@ results_template_category_1:
   id: 1
   results_template_id: 1
   results_category_id: 2
-  created_at: 2019-02-14 05:23:14.608640000 Z
-  updated_at: 2019-02-14 05:23:14.608640000 Z
   position: 1
   fixed_position: true
 results_template_category_2:
   id: 2
   results_template_id: 1
   results_category_id: 3
-  created_at: 2019-02-14 05:23:14.612271000 Z
-  updated_at: 2019-02-14 05:23:14.612271000 Z
   position: 2
   fixed_position: true
 results_template_category_3:
   id: 3
   results_template_id: 1
   results_category_id: 4
-  created_at: 2019-02-14 05:23:14.640713000 Z
-  updated_at: 2019-02-14 05:23:14.640713000 Z
   position: 3
   fixed_position: true
 results_template_category_4:
   id: 4
   results_template_id: 1
   results_category_id: 5
-  created_at: 2019-02-14 05:23:14.643194000 Z
-  updated_at: 2019-02-14 05:23:14.643194000 Z
   position: 4
   fixed_position: true
 results_template_category_5:
   id: 5
   results_template_id: 1
   results_category_id: 18
-  created_at: 2019-02-14 05:23:14.645254000 Z
-  updated_at: 2019-02-14 05:23:14.645254000 Z
   position: 5
   fixed_position:
 results_template_category_6:
   id: 6
   results_template_id: 1
   results_category_id: 19
-  created_at: 2019-02-14 05:23:14.647280000 Z
-  updated_at: 2019-02-14 05:23:14.647280000 Z
   position: 6
   fixed_position:
 results_template_category_7:
   id: 7
   results_template_id: 1
   results_category_id: 24
-  created_at: 2019-02-14 05:23:14.649226000 Z
-  updated_at: 2019-02-14 05:23:14.649226000 Z
   position: 7
   fixed_position:
 results_template_category_8:
   id: 8
   results_template_id: 1
   results_category_id: 25
-  created_at: 2019-02-14 05:23:14.651033000 Z
-  updated_at: 2019-02-14 05:23:14.651033000 Z
   position: 8
   fixed_position:
 results_template_category_9:
   id: 9
   results_template_id: 1
   results_category_id: 26
-  created_at: 2019-02-14 05:23:14.652781000 Z
-  updated_at: 2019-02-14 05:23:14.652781000 Z
   position: 9
   fixed_position:
 results_template_category_10:
   id: 10
   results_template_id: 1
   results_category_id: 27
-  created_at: 2019-02-14 05:23:14.654557000 Z
-  updated_at: 2019-02-14 05:23:14.654557000 Z
   position: 10
   fixed_position:
 results_template_category_11:
   id: 11
   results_template_id: 1
   results_category_id: 28
-  created_at: 2019-02-14 05:23:14.656262000 Z
-  updated_at: 2019-02-14 05:23:14.656262000 Z
   position: 11
   fixed_position:
 results_template_category_12:
   id: 12
   results_template_id: 1
   results_category_id: 29
-  created_at: 2019-02-14 05:23:14.657967000 Z
-  updated_at: 2019-02-14 05:23:14.657967000 Z
   position: 12
   fixed_position:
 results_template_category_13:
   id: 13
   results_template_id: 1
   results_category_id: 30
-  created_at: 2019-02-14 05:23:14.659630000 Z
-  updated_at: 2019-02-14 05:23:14.659630000 Z
   position: 13
   fixed_position:
 results_template_category_14:
   id: 14
   results_template_id: 1
   results_category_id: 31
-  created_at: 2019-02-14 05:23:14.661252000 Z
-  updated_at: 2019-02-14 05:23:14.661252000 Z
   position: 14
   fixed_position:
 results_template_category_15:
   id: 15
   results_template_id: 1
   results_category_id: 32
-  created_at: 2019-02-14 05:23:14.662843000 Z
-  updated_at: 2019-02-14 05:23:14.662843000 Z
   position: 15
   fixed_position:
 results_template_category_16:
   id: 16
   results_template_id: 1
   results_category_id: 33
-  created_at: 2019-02-14 05:23:14.664436000 Z
-  updated_at: 2019-02-14 05:23:14.664436000 Z
   position: 16
   fixed_position:
 results_template_category_17:
   id: 17
   results_template_id: 2
   results_category_id: 2
-  created_at: 2019-02-14 05:23:14.672381000 Z
-  updated_at: 2019-02-14 05:23:14.672381000 Z
   position: 1
   fixed_position:
 results_template_category_18:
   id: 18
   results_template_id: 2
   results_category_id: 3
-  created_at: 2019-02-14 05:23:14.674256000 Z
-  updated_at: 2019-02-14 05:23:14.674256000 Z
   position: 2
   fixed_position:
 results_template_category_19:
   id: 19
   results_template_id: 2
   results_category_id: 34
-  created_at: 2019-02-14 05:23:14.675766000 Z
-  updated_at: 2019-02-14 05:23:14.675766000 Z
   position: 3
   fixed_position:
 results_template_category_20:
   id: 20
   results_template_id: 2
   results_category_id: 35
-  created_at: 2019-02-14 05:23:14.677232000 Z
-  updated_at: 2019-02-14 05:23:14.677232000 Z
   position: 4
   fixed_position:
 results_template_category_21:
   id: 21
   results_template_id: 2
   results_category_id: 26
-  created_at: 2019-02-14 05:23:14.678700000 Z
-  updated_at: 2019-02-14 05:23:14.678700000 Z
   position: 5
   fixed_position:
 results_template_category_22:
   id: 22
   results_template_id: 2
   results_category_id: 27
-  created_at: 2019-02-14 05:23:14.680174000 Z
-  updated_at: 2019-02-14 05:23:14.680174000 Z
   position: 6
   fixed_position:
 results_template_category_23:
   id: 23
   results_template_id: 2
   results_category_id: 28
-  created_at: 2019-02-14 05:23:14.681600000 Z
-  updated_at: 2019-02-14 05:23:14.681600000 Z
   position: 7
   fixed_position:
 results_template_category_24:
   id: 24
   results_template_id: 2
   results_category_id: 29
-  created_at: 2019-02-14 05:23:14.683025000 Z
-  updated_at: 2019-02-14 05:23:14.683025000 Z
   position: 8
   fixed_position:
 results_template_category_25:
   id: 25
   results_template_id: 2
   results_category_id: 30
-  created_at: 2019-02-14 05:23:14.684548000 Z
-  updated_at: 2019-02-14 05:23:14.684548000 Z
   position: 9
   fixed_position:
 results_template_category_26:
   id: 26
   results_template_id: 2
   results_category_id: 31
-  created_at: 2019-02-14 05:23:14.685979000 Z
-  updated_at: 2019-02-14 05:23:14.685979000 Z
   position: 10
   fixed_position:
 results_template_category_27:
   id: 27
   results_template_id: 2
   results_category_id: 10
-  created_at: 2019-02-14 05:23:14.687401000 Z
-  updated_at: 2019-02-14 05:23:14.687401000 Z
   position: 11
   fixed_position:
 results_template_category_28:
   id: 28
   results_template_id: 2
   results_category_id: 11
-  created_at: 2019-02-14 05:23:14.688828000 Z
-  updated_at: 2019-02-14 05:23:14.688828000 Z
   position: 12
   fixed_position:
 results_template_category_29:
   id: 29
   results_template_id: 3
   results_category_id: 2
-  created_at: 2019-02-14 05:23:14.695887000 Z
-  updated_at: 2019-02-14 05:23:14.695887000 Z
   position: 1
   fixed_position:
 results_template_category_30:
   id: 30
   results_template_id: 3
   results_category_id: 3
-  created_at: 2019-02-14 05:23:14.697353000 Z
-  updated_at: 2019-02-14 05:23:14.697353000 Z
   position: 2
   fixed_position:
 results_template_category_31:
   id: 31
   results_template_id: 3
   results_category_id: 36
-  created_at: 2019-02-14 05:23:14.698787000 Z
-  updated_at: 2019-02-14 05:23:14.698787000 Z
   position: 3
   fixed_position:
 results_template_category_32:
   id: 32
   results_template_id: 3
   results_category_id: 37
-  created_at: 2019-02-14 05:23:14.701303000 Z
-  updated_at: 2019-02-14 05:23:14.701303000 Z
   position: 4
   fixed_position:
 results_template_category_33:
   id: 33
   results_template_id: 3
   results_category_id: 6
-  created_at: 2019-02-14 05:23:14.703485000 Z
-  updated_at: 2019-02-14 05:23:14.703485000 Z
   position: 5
   fixed_position:
 results_template_category_34:
   id: 34
   results_template_id: 3
   results_category_id: 7
-  created_at: 2019-02-14 05:23:14.705275000 Z
-  updated_at: 2019-02-14 05:23:14.705275000 Z
   position: 6
   fixed_position:
 results_template_category_35:
   id: 35
   results_template_id: 3
   results_category_id: 8
-  created_at: 2019-02-14 05:23:14.706930000 Z
-  updated_at: 2019-02-14 05:23:14.706930000 Z
   position: 7
   fixed_position:
 results_template_category_36:
   id: 36
   results_template_id: 3
   results_category_id: 9
-  created_at: 2019-02-14 05:23:14.708544000 Z
-  updated_at: 2019-02-14 05:23:14.708544000 Z
   position: 8
   fixed_position:
 results_template_category_37:
   id: 37
   results_template_id: 4
   results_category_id: 2
-  created_at: 2019-02-14 05:23:14.715758000 Z
-  updated_at: 2019-02-14 05:23:14.715758000 Z
   position: 1
   fixed_position:
 results_template_category_38:
   id: 38
   results_template_id: 4
   results_category_id: 3
-  created_at: 2019-02-14 05:23:14.717225000 Z
-  updated_at: 2019-02-14 05:23:14.717225000 Z
   position: 2
   fixed_position:
 results_template_category_39:
   id: 39
   results_template_id: 4
   results_category_id: 6
-  created_at: 2019-02-14 05:23:14.718644000 Z
-  updated_at: 2019-02-14 05:23:14.718644000 Z
   position: 3
   fixed_position:
 results_template_category_40:
   id: 40
   results_template_id: 4
   results_category_id: 7
-  created_at: 2019-02-14 05:23:14.720056000 Z
-  updated_at: 2019-02-14 05:23:14.720056000 Z
   position: 4
   fixed_position:
 results_template_category_41:
   id: 41
   results_template_id: 4
   results_category_id: 8
-  created_at: 2019-02-14 05:23:14.721467000 Z
-  updated_at: 2019-02-14 05:23:14.721467000 Z
   position: 5
   fixed_position:
 results_template_category_42:
   id: 42
   results_template_id: 4
   results_category_id: 9
-  created_at: 2019-02-14 05:23:14.722884000 Z
-  updated_at: 2019-02-14 05:23:14.722884000 Z
   position: 6
   fixed_position:
 results_template_category_61:
   id: 61
   results_template_id: 7
   results_category_id: 2
-  created_at: 2019-02-14 05:23:14.795980000 Z
-  updated_at: 2019-02-14 05:23:14.795980000 Z
   position: 1
   fixed_position:
 results_template_category_62:
   id: 62
   results_template_id: 7
   results_category_id: 3
-  created_at: 2019-02-14 05:23:14.797984000 Z
-  updated_at: 2019-02-14 05:23:14.797984000 Z
   position: 2
   fixed_position:

--- a/spec/fixtures/results_templates.yml
+++ b/spec/fixtures/results_templates.yml
@@ -10,8 +10,6 @@ masters_and_decades:
   slug: masters-and-decades
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.562811000 Z
-  updated_at: 2019-02-14 16:45:20.264760000 Z
 overall_30s_40s_50s_seniors:
   id: 2
   organization_id:
@@ -23,8 +21,6 @@ overall_30s_40s_50s_seniors:
   slug: overall-30s-40s-50s-seniors
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.667926000 Z
-  updated_at: 2019-02-14 05:23:14.667926000 Z
 sub_masters_masters_and_grandmasters:
   id: 3
   organization_id:
@@ -36,8 +32,6 @@ sub_masters_masters_and_grandmasters:
   slug: sub-masters-masters-and-grandmasters
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.691868000 Z
-  updated_at: 2019-02-14 16:45:03.667365000 Z
 masters_and_grandmasters:
   id: 4
   organization_id:
@@ -49,8 +43,6 @@ masters_and_grandmasters:
   slug: masters-and-grandmasters
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.711695000 Z
-  updated_at: 2019-02-14 05:23:14.711695000 Z
 simple:
   id: 7
   organization_id:
@@ -62,5 +54,3 @@ simple:
   slug: simple
   created_by: 1
   updated_by:
-  created_at: 2019-02-14 05:23:14.789381000 Z
-  updated_at: 2019-02-14 05:23:14.789381000 Z

--- a/spec/fixtures/split_times.yml
+++ b/spec/fixtures/split_times.yml
@@ -4,8 +4,6 @@ hardrock_2015_tuan_jacobs_cunningham_in_1:
   effort_id: 7
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:39.952829000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -20,8 +18,6 @@ hardrock_2015_tuan_jacobs_cunningham_out_1:
   effort_id: 7
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:49.224030000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -36,8 +32,6 @@ hardrock_2015_tuan_jacobs_sherman_in_1:
   effort_id: 7
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:41.318854000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -52,8 +46,6 @@ hardrock_2015_tuan_jacobs_sherman_out_1:
   effort_id: 7
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:41.338848000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -68,8 +60,6 @@ hardrock_2015_tuan_jacobs_grouse_in_1:
   effort_id: 7
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:41.345412000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -84,8 +74,6 @@ hardrock_2015_tuan_jacobs_grouse_out_1:
   effort_id: 7
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:41.378686000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -100,8 +88,6 @@ hardrock_2015_tuan_jacobs_ouray_in_1:
   effort_id: 7
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:49.598174000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -116,8 +102,6 @@ hardrock_2015_tuan_jacobs_ouray_out_1:
   effort_id: 7
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:49.227033000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -132,8 +116,6 @@ hardrock_2015_tuan_jacobs_telluride_in_1:
   effort_id: 7
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:50.127464000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -148,8 +130,6 @@ hardrock_2015_tuan_jacobs_telluride_out_1:
   effort_id: 7
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:38.341610000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -164,8 +144,6 @@ hardrock_2015_tuan_jacobs_putnam_in_1:
   effort_id: 7
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:38.360111000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -180,8 +158,6 @@ hardrock_2015_tuan_jacobs_putnam_out_1:
   effort_id: 7
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:49.054977000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -196,8 +172,6 @@ hardrock_2015_tuan_jacobs_finish_1:
   effort_id: 7
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:02.647798000 Z
-  updated_at: 2018-01-10 08:48:49.058049000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -212,8 +186,6 @@ hardrock_2015_erich_larson_start_1:
   effort_id: 8
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2017-12-08 07:10:17.706855000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -228,8 +200,6 @@ hardrock_2015_erich_larson_cunningham_in_1:
   effort_id: 8
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:36.686597000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -244,8 +214,6 @@ hardrock_2015_erich_larson_cunningham_out_1:
   effort_id: 8
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:37.228156000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -260,8 +228,6 @@ hardrock_2015_erich_larson_sherman_in_1:
   effort_id: 8
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:36.684502000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -276,8 +242,6 @@ hardrock_2015_erich_larson_sherman_out_1:
   effort_id: 8
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:37.238322000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -292,8 +256,6 @@ hardrock_2015_erich_larson_grouse_in_1:
   effort_id: 8
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:36.695837000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -308,8 +270,6 @@ hardrock_2015_erich_larson_grouse_out_1:
   effort_id: 8
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:37.244230000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -324,8 +284,6 @@ hardrock_2015_erich_larson_ouray_in_1:
   effort_id: 8
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:36.704609000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -340,8 +298,6 @@ hardrock_2015_erich_larson_ouray_out_1:
   effort_id: 8
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:37.251553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -356,8 +312,6 @@ hardrock_2015_erich_larson_telluride_in_1:
   effort_id: 8
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:36.711157000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -372,8 +326,6 @@ hardrock_2015_erich_larson_telluride_out_1:
   effort_id: 8
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:37.260960000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -388,8 +340,6 @@ hardrock_2015_erich_larson_putnam_in_1:
   effort_id: 8
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:36.716473000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -404,8 +354,6 @@ hardrock_2015_erich_larson_putnam_out_1:
   effort_id: 8
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:38.242550000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -420,8 +368,6 @@ hardrock_2015_erich_larson_finish_1:
   effort_id: 8
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:02.678283000 Z
-  updated_at: 2018-01-10 08:48:36.718641000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -436,8 +382,6 @@ hardrock_2015_leif_carter_start_1:
   effort_id: 15
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2017-12-08 07:10:18.120352000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -452,8 +396,6 @@ hardrock_2015_leif_carter_cunningham_in_1:
   effort_id: 15
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.910184000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -468,8 +410,6 @@ hardrock_2015_leif_carter_cunningham_out_1:
   effort_id: 15
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.912513000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -484,8 +424,6 @@ hardrock_2015_leif_carter_sherman_in_1:
   effort_id: 15
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.929342000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -500,8 +438,6 @@ hardrock_2015_leif_carter_sherman_out_1:
   effort_id: 15
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.932331000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -516,8 +452,6 @@ hardrock_2015_leif_carter_grouse_in_1:
   effort_id: 15
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.934755000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -532,8 +466,6 @@ hardrock_2015_leif_carter_grouse_out_1:
   effort_id: 15
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:36.677993000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -548,8 +480,6 @@ hardrock_2015_leif_carter_ouray_in_1:
   effort_id: 15
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.939586000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -564,8 +494,6 @@ hardrock_2015_leif_carter_ouray_out_1:
   effort_id: 15
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.941986000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -580,8 +508,6 @@ hardrock_2015_leif_carter_telluride_in_1:
   effort_id: 15
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.956173000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -596,8 +522,6 @@ hardrock_2015_leif_carter_telluride_out_1:
   effort_id: 15
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.958870000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -612,8 +536,6 @@ hardrock_2015_leif_carter_putnam_in_1:
   effort_id: 15
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.970026000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -628,8 +550,6 @@ hardrock_2015_leif_carter_putnam_out_1:
   effort_id: 15
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.983795000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -644,8 +564,6 @@ hardrock_2015_leif_carter_finish_1:
   effort_id: 15
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:02.922699000 Z
-  updated_at: 2018-01-10 08:48:37.986154000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -660,8 +578,6 @@ hardrock_2015_carmine_adams_start_1:
   effort_id: 20
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2017-12-08 07:10:18.500821000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -676,8 +592,6 @@ hardrock_2015_carmine_adams_cunningham_in_1:
   effort_id: 20
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:38.533229000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -692,8 +606,6 @@ hardrock_2015_carmine_adams_cunningham_out_1:
   effort_id: 20
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:38.536435000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -708,8 +620,6 @@ hardrock_2015_carmine_adams_sherman_in_1:
   effort_id: 20
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:38.545253000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -724,8 +634,6 @@ hardrock_2015_carmine_adams_sherman_out_1:
   effort_id: 20
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:38.548960000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -740,8 +648,6 @@ hardrock_2015_carmine_adams_grouse_in_1:
   effort_id: 20
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:37.195831000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -756,8 +662,6 @@ hardrock_2015_carmine_adams_grouse_out_1:
   effort_id: 20
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:38.557232000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -772,8 +676,6 @@ hardrock_2015_carmine_adams_ouray_in_1:
   effort_id: 20
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:38.564369000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -788,8 +690,6 @@ hardrock_2015_carmine_adams_ouray_out_1:
   effort_id: 20
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:38.566830000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -804,8 +704,6 @@ hardrock_2015_carmine_adams_telluride_in_1:
   effort_id: 20
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:44.652134000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -820,8 +718,6 @@ hardrock_2015_carmine_adams_telluride_out_1:
   effort_id: 20
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:44.654261000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -836,8 +732,6 @@ hardrock_2015_carmine_adams_putnam_in_1:
   effort_id: 20
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:44.669119000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -852,8 +746,6 @@ hardrock_2015_carmine_adams_putnam_out_1:
   effort_id: 20
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:44.671577000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -868,8 +760,6 @@ hardrock_2015_carmine_adams_finish_1:
   effort_id: 20
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.003461000 Z
-  updated_at: 2018-01-10 08:48:44.674157000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -884,8 +774,6 @@ hardrock_2015_garry_kuhlman_start_1:
   effort_id: 24
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2017-12-08 07:10:18.805478000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -900,8 +788,6 @@ hardrock_2015_garry_kuhlman_cunningham_in_1:
   effort_id: 24
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:38.645741000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -916,8 +802,6 @@ hardrock_2015_garry_kuhlman_cunningham_out_1:
   effort_id: 24
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:38.649129000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -932,8 +816,6 @@ hardrock_2015_garry_kuhlman_sherman_in_1:
   effort_id: 24
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:38.672133000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -948,8 +830,6 @@ hardrock_2015_garry_kuhlman_sherman_out_1:
   effort_id: 24
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:38.674715000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -964,8 +844,6 @@ hardrock_2015_garry_kuhlman_grouse_in_1:
   effort_id: 24
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:38.682918000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -980,8 +858,6 @@ hardrock_2015_garry_kuhlman_grouse_out_1:
   effort_id: 24
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:38.686395000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -996,8 +872,6 @@ hardrock_2015_garry_kuhlman_ouray_in_1:
   effort_id: 24
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:38.694800000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1012,8 +886,6 @@ hardrock_2015_garry_kuhlman_ouray_out_1:
   effort_id: 24
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:38.697315000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1028,8 +900,6 @@ hardrock_2015_garry_kuhlman_telluride_in_1:
   effort_id: 24
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:49.512627000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1044,8 +914,6 @@ hardrock_2015_garry_kuhlman_telluride_out_1:
   effort_id: 24
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:49.516620000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1060,8 +928,6 @@ hardrock_2015_garry_kuhlman_putnam_in_1:
   effort_id: 24
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:49.531262000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1076,8 +942,6 @@ hardrock_2015_garry_kuhlman_putnam_out_1:
   effort_id: 24
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:38.200705000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1092,8 +956,6 @@ hardrock_2015_garry_kuhlman_finish_1:
   effort_id: 24
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.086130000 Z
-  updated_at: 2018-01-10 08:48:36.943834000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1108,8 +970,6 @@ hardrock_2015_darius_jacobson_start_1:
   effort_id: 25
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2017-12-08 07:10:26.108188000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1124,8 +984,6 @@ hardrock_2015_darius_jacobson_cunningham_in_1:
   effort_id: 25
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2018-01-10 08:48:36.950625000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1140,8 +998,6 @@ hardrock_2015_darius_jacobson_cunningham_out_1:
   effort_id: 25
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2018-01-10 08:48:36.980259000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1156,8 +1012,6 @@ hardrock_2015_darius_jacobson_sherman_in_1:
   effort_id: 25
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2018-01-10 08:48:38.717730000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1172,8 +1026,6 @@ hardrock_2015_darius_jacobson_sherman_out_1:
   effort_id: 25
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2018-01-10 08:48:41.102619000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1188,8 +1040,6 @@ hardrock_2015_darius_jacobson_grouse_in_1:
   effort_id: 25
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2018-01-10 08:48:41.107360000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1204,8 +1054,6 @@ hardrock_2015_darius_jacobson_grouse_out_1:
   effort_id: 25
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2018-01-10 08:48:41.110127000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1220,8 +1068,6 @@ hardrock_2015_darius_jacobson_telluride_in_1:
   effort_id: 25
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2018-01-10 08:48:38.726153000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1236,8 +1082,6 @@ hardrock_2015_darius_jacobson_telluride_out_1:
   effort_id: 25
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2018-01-10 08:48:38.728277000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1252,8 +1096,6 @@ hardrock_2015_darius_jacobson_putnam_in_1:
   effort_id: 25
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2018-01-10 08:48:38.742104000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1268,8 +1110,6 @@ hardrock_2015_darius_jacobson_putnam_out_1:
   effort_id: 25
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2018-01-10 08:48:38.744433000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1284,8 +1124,6 @@ hardrock_2015_darius_jacobson_finish_1:
   effort_id: 25
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.102496000 Z
-  updated_at: 2018-01-10 08:48:38.746869000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1300,8 +1138,6 @@ hardrock_2015_santa_green_start_1:
   effort_id: 29
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2017-12-08 07:10:19.081578000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1316,8 +1152,6 @@ hardrock_2015_santa_green_cunningham_in_1:
   effort_id: 29
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:41.305058000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1332,8 +1166,6 @@ hardrock_2015_santa_green_cunningham_out_1:
   effort_id: 29
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:41.307739000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1348,8 +1180,6 @@ hardrock_2015_santa_green_sherman_in_1:
   effort_id: 29
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:49.562229000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1364,8 +1194,6 @@ hardrock_2015_santa_green_sherman_out_1:
   effort_id: 29
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:37.318383000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1380,8 +1208,6 @@ hardrock_2015_santa_green_grouse_in_1:
   effort_id: 29
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:49.567312000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1396,8 +1222,6 @@ hardrock_2015_santa_green_grouse_out_1:
   effort_id: 29
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:38.904157000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1412,8 +1236,6 @@ hardrock_2015_santa_green_ouray_in_1:
   effort_id: 29
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:38.915534000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1428,8 +1250,6 @@ hardrock_2015_santa_green_ouray_out_1:
   effort_id: 29
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:38.918075000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1444,8 +1264,6 @@ hardrock_2015_santa_green_telluride_in_1:
   effort_id: 29
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:37.000350000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1460,8 +1278,6 @@ hardrock_2015_santa_green_telluride_out_1:
   effort_id: 29
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:37.008010000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1476,8 +1292,6 @@ hardrock_2015_santa_green_putnam_in_1:
   effort_id: 29
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:38.926664000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1492,8 +1306,6 @@ hardrock_2015_santa_green_putnam_out_1:
   effort_id: 29
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:38.929221000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1508,8 +1320,6 @@ hardrock_2015_santa_green_finish_1:
   effort_id: 29
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.182180000 Z
-  updated_at: 2018-01-10 08:48:38.932298000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1524,8 +1334,6 @@ hardrock_2015_gilberto_mckenzie_start_1:
   effort_id: 31
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2017-12-08 07:10:19.118972000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1540,8 +1348,6 @@ hardrock_2015_gilberto_mckenzie_cunningham_in_1:
   effort_id: 31
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.012055000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1556,8 +1362,6 @@ hardrock_2015_gilberto_mckenzie_cunningham_out_1:
   effort_id: 31
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:37.033481000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1572,8 +1376,6 @@ hardrock_2015_gilberto_mckenzie_sherman_in_1:
   effort_id: 31
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.025884000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1588,8 +1390,6 @@ hardrock_2015_gilberto_mckenzie_sherman_out_1:
   effort_id: 31
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.027981000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1604,8 +1404,6 @@ hardrock_2015_gilberto_mckenzie_grouse_in_1:
   effort_id: 31
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.036247000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1620,8 +1418,6 @@ hardrock_2015_gilberto_mckenzie_grouse_out_1:
   effort_id: 31
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.038637000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1636,8 +1432,6 @@ hardrock_2015_gilberto_mckenzie_ouray_in_1:
   effort_id: 31
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.045422000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1652,8 +1446,6 @@ hardrock_2015_gilberto_mckenzie_ouray_out_1:
   effort_id: 31
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.049027000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1668,8 +1460,6 @@ hardrock_2015_gilberto_mckenzie_telluride_in_1:
   effort_id: 31
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.061125000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1684,8 +1474,6 @@ hardrock_2015_gilberto_mckenzie_telluride_out_1:
   effort_id: 31
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.064276000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1700,8 +1488,6 @@ hardrock_2015_gilberto_mckenzie_putnam_in_1:
   effort_id: 31
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.074358000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1716,8 +1502,6 @@ hardrock_2015_gilberto_mckenzie_putnam_out_1:
   effort_id: 31
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.076574000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1732,8 +1516,6 @@ hardrock_2015_gilberto_mckenzie_finish_1:
   effort_id: 31
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.220908000 Z
-  updated_at: 2018-01-10 08:48:39.079047000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1748,8 +1530,6 @@ hardrock_2015_vince_willms_start_1:
   effort_id: 47
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2017-12-08 07:10:20.147478000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1764,8 +1544,6 @@ hardrock_2015_vince_willms_cunningham_in_1:
   effort_id: 47
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:39.876306000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1780,8 +1558,6 @@ hardrock_2015_vince_willms_cunningham_out_1:
   effort_id: 47
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:39.878659000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1796,8 +1572,6 @@ hardrock_2015_vince_willms_sherman_in_1:
   effort_id: 47
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:39.893764000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1812,8 +1586,6 @@ hardrock_2015_vince_willms_sherman_out_1:
   effort_id: 47
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:37.114864000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1828,8 +1600,6 @@ hardrock_2015_vince_willms_grouse_in_1:
   effort_id: 47
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:37.124190000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1844,8 +1614,6 @@ hardrock_2015_vince_willms_grouse_out_1:
   effort_id: 47
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:42.926940000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1860,8 +1628,6 @@ hardrock_2015_vince_willms_ouray_in_1:
   effort_id: 47
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:41.441607000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1876,8 +1642,6 @@ hardrock_2015_vince_willms_ouray_out_1:
   effort_id: 47
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:41.443856000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1892,8 +1656,6 @@ hardrock_2015_vince_willms_telluride_in_1:
   effort_id: 47
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:39.905068000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1908,8 +1670,6 @@ hardrock_2015_vince_willms_telluride_out_1:
   effort_id: 47
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:39.908346000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1924,8 +1684,6 @@ hardrock_2015_vince_willms_putnam_in_1:
   effort_id: 47
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:39.915844000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1940,8 +1698,6 @@ hardrock_2015_vince_willms_putnam_out_1:
   effort_id: 47
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:46.037844000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -1956,8 +1712,6 @@ hardrock_2015_vince_willms_finish_1:
   effort_id: 47
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.567663000 Z
-  updated_at: 2018-01-10 08:48:39.927016000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1972,8 +1726,6 @@ hardrock_2015_cedric_windler_cunningham_in_1:
   effort_id: 50
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.046129000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -1988,8 +1740,6 @@ hardrock_2015_cedric_windler_cunningham_out_1:
   effort_id: 50
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.049017000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2004,8 +1754,6 @@ hardrock_2015_cedric_windler_sherman_in_1:
   effort_id: 50
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.375699000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2020,8 +1768,6 @@ hardrock_2015_cedric_windler_sherman_out_1:
   effort_id: 50
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.378099000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2036,8 +1782,6 @@ hardrock_2015_cedric_windler_grouse_in_1:
   effort_id: 50
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.406708000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2052,8 +1796,6 @@ hardrock_2015_cedric_windler_grouse_out_1:
   effort_id: 50
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.409186000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2068,8 +1810,6 @@ hardrock_2015_cedric_windler_ouray_in_1:
   effort_id: 50
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.417994000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2084,8 +1824,6 @@ hardrock_2015_cedric_windler_ouray_out_1:
   effort_id: 50
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:37.135301000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2100,8 +1838,6 @@ hardrock_2015_cedric_windler_telluride_in_1:
   effort_id: 50
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.425060000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2116,8 +1852,6 @@ hardrock_2015_cedric_windler_telluride_out_1:
   effort_id: 50
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.428599000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2132,8 +1866,6 @@ hardrock_2015_cedric_windler_putnam_in_1:
   effort_id: 50
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.436369000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2148,8 +1880,6 @@ hardrock_2015_cedric_windler_putnam_out_1:
   effort_id: 50
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.438974000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2164,8 +1894,6 @@ hardrock_2015_cedric_windler_finish_1:
   effort_id: 50
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.614108000 Z
-  updated_at: 2018-01-10 08:48:40.442845000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2180,8 +1908,6 @@ hardrock_2015_chris_rempel_start_1:
   effort_id: 56
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2017-12-08 07:10:20.620393000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2196,8 +1922,6 @@ hardrock_2015_chris_rempel_cunningham_in_1:
   effort_id: 56
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:40.876407000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2212,8 +1936,6 @@ hardrock_2015_chris_rempel_cunningham_out_1:
   effort_id: 56
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:40.878815000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2228,8 +1950,6 @@ hardrock_2015_chris_rempel_sherman_in_1:
   effort_id: 56
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:40.886038000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2244,8 +1964,6 @@ hardrock_2015_chris_rempel_sherman_out_1:
   effort_id: 56
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:40.888232000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2260,8 +1978,6 @@ hardrock_2015_chris_rempel_grouse_in_1:
   effort_id: 56
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:40.896424000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2276,8 +1992,6 @@ hardrock_2015_chris_rempel_grouse_out_1:
   effort_id: 56
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:40.899087000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2292,8 +2006,6 @@ hardrock_2015_chris_rempel_ouray_in_1:
   effort_id: 56
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:40.905976000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2308,8 +2020,6 @@ hardrock_2015_chris_rempel_ouray_out_1:
   effort_id: 56
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:40.909699000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2324,8 +2034,6 @@ hardrock_2015_chris_rempel_telluride_in_1:
   effort_id: 56
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:40.993900000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2340,8 +2048,6 @@ hardrock_2015_chris_rempel_telluride_out_1:
   effort_id: 56
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:40.997764000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2356,8 +2062,6 @@ hardrock_2015_chris_rempel_putnam_in_1:
   effort_id: 56
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:41.011801000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2372,8 +2076,6 @@ hardrock_2015_chris_rempel_putnam_out_1:
   effort_id: 56
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:41.014290000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2388,8 +2090,6 @@ hardrock_2015_chris_rempel_finish_1:
   effort_id: 56
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.713351000 Z
-  updated_at: 2018-01-10 08:48:41.018103000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2404,8 +2104,6 @@ hardrock_2015_robby_gerlach_start_1:
   effort_id: 57
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2017-12-08 07:10:20.719530000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2420,8 +2118,6 @@ hardrock_2015_robby_gerlach_cunningham_in_1:
   effort_id: 57
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:41.020769000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2436,8 +2132,6 @@ hardrock_2015_robby_gerlach_cunningham_out_1:
   effort_id: 57
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:41.023221000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2452,8 +2146,6 @@ hardrock_2015_robby_gerlach_sherman_in_1:
   effort_id: 57
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:41.036311000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2468,8 +2160,6 @@ hardrock_2015_robby_gerlach_sherman_out_1:
   effort_id: 57
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:41.038448000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2484,8 +2174,6 @@ hardrock_2015_robby_gerlach_grouse_in_1:
   effort_id: 57
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:50.012678000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2500,8 +2188,6 @@ hardrock_2015_robby_gerlach_grouse_out_1:
   effort_id: 57
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:41.045678000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2516,8 +2202,6 @@ hardrock_2015_robby_gerlach_ouray_in_1:
   effort_id: 57
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:41.054219000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2532,8 +2216,6 @@ hardrock_2015_robby_gerlach_ouray_out_1:
   effort_id: 57
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:37.039154000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2548,8 +2230,6 @@ hardrock_2015_robby_gerlach_telluride_in_1:
   effort_id: 57
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:41.067586000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2564,8 +2244,6 @@ hardrock_2015_robby_gerlach_telluride_out_1:
   effort_id: 57
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:41.069979000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2580,8 +2258,6 @@ hardrock_2015_robby_gerlach_putnam_in_1:
   effort_id: 57
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:41.083101000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2596,8 +2272,6 @@ hardrock_2015_robby_gerlach_putnam_out_1:
   effort_id: 57
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:41.085533000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2612,8 +2286,6 @@ hardrock_2015_robby_gerlach_finish_1:
   effort_id: 57
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.730687000 Z
-  updated_at: 2018-01-10 08:48:41.087695000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2628,8 +2300,6 @@ hardrock_2015_rachelle_eichmann_start_1:
   effort_id: 59
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2017-12-08 07:10:26.157523000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2644,8 +2314,6 @@ hardrock_2015_rachelle_eichmann_cunningham_in_1:
   effort_id: 59
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:41.368303000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2660,8 +2328,6 @@ hardrock_2015_rachelle_eichmann_cunningham_out_1:
   effort_id: 59
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:41.370501000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2676,8 +2342,6 @@ hardrock_2015_rachelle_eichmann_sherman_in_1:
   effort_id: 59
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:41.398668000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2692,8 +2356,6 @@ hardrock_2015_rachelle_eichmann_sherman_out_1:
   effort_id: 59
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:41.401392000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2708,8 +2370,6 @@ hardrock_2015_rachelle_eichmann_grouse_in_1:
   effort_id: 59
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:41.410132000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2724,8 +2384,6 @@ hardrock_2015_rachelle_eichmann_grouse_out_1:
   effort_id: 59
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:41.412220000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2740,8 +2398,6 @@ hardrock_2015_rachelle_eichmann_ouray_in_1:
   effort_id: 59
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:41.461114000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2756,8 +2412,6 @@ hardrock_2015_rachelle_eichmann_ouray_out_1:
   effort_id: 59
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:37.358607000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2772,8 +2426,6 @@ hardrock_2015_rachelle_eichmann_telluride_in_1:
   effort_id: 59
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:46.864890000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2788,8 +2440,6 @@ hardrock_2015_rachelle_eichmann_telluride_out_1:
   effort_id: 59
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:46.868142000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2804,8 +2454,6 @@ hardrock_2015_rachelle_eichmann_putnam_in_1:
   effort_id: 59
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:46.879892000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2820,8 +2468,6 @@ hardrock_2015_rachelle_eichmann_putnam_out_1:
   effort_id: 59
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:50.017845000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2836,8 +2482,6 @@ hardrock_2015_rachelle_eichmann_finish_1:
   effort_id: 59
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.764376000 Z
-  updated_at: 2018-01-10 08:48:46.882096000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2852,8 +2496,6 @@ hardrock_2015_elden_morissette_start_1:
   effort_id: 61
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2017-12-08 07:10:20.854713000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2868,8 +2510,6 @@ hardrock_2015_elden_morissette_cunningham_in_1:
   effort_id: 61
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:41.487504000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2884,8 +2524,6 @@ hardrock_2015_elden_morissette_cunningham_out_1:
   effort_id: 61
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:41.489834000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2900,8 +2538,6 @@ hardrock_2015_elden_morissette_sherman_in_1:
   effort_id: 61
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:41.500124000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2916,8 +2552,6 @@ hardrock_2015_elden_morissette_sherman_out_1:
   effort_id: 61
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:41.502433000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2932,8 +2566,6 @@ hardrock_2015_elden_morissette_grouse_in_1:
   effort_id: 61
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:41.510425000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2948,8 +2580,6 @@ hardrock_2015_elden_morissette_grouse_out_1:
   effort_id: 61
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:41.513051000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2964,8 +2594,6 @@ hardrock_2015_elden_morissette_ouray_in_1:
   effort_id: 61
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:41.587770000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -2980,8 +2608,6 @@ hardrock_2015_elden_morissette_ouray_out_1:
   effort_id: 61
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:41.590901000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -2996,8 +2622,6 @@ hardrock_2015_elden_morissette_telluride_in_1:
   effort_id: 61
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:41.604632000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3012,8 +2636,6 @@ hardrock_2015_elden_morissette_telluride_out_1:
   effort_id: 61
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:41.609041000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3028,8 +2650,6 @@ hardrock_2015_elden_morissette_putnam_in_1:
   effort_id: 61
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:37.216215000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3044,8 +2664,6 @@ hardrock_2015_elden_morissette_putnam_out_1:
   effort_id: 61
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:37.221086000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3060,8 +2678,6 @@ hardrock_2015_elden_morissette_finish_1:
   effort_id: 61
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.796744000 Z
-  updated_at: 2018-01-10 08:48:37.224344000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3076,8 +2692,6 @@ hardrock_2015_leroy_leffler_start_1:
   effort_id: 63
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2017-12-08 07:10:21.064455000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3092,8 +2706,6 @@ hardrock_2015_leroy_leffler_cunningham_in_1:
   effort_id: 63
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:41.712580000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3108,8 +2720,6 @@ hardrock_2015_leroy_leffler_cunningham_out_1:
   effort_id: 63
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:41.714927000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3124,8 +2734,6 @@ hardrock_2015_leroy_leffler_sherman_in_1:
   effort_id: 63
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:41.728567000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3140,8 +2748,6 @@ hardrock_2015_leroy_leffler_sherman_out_1:
   effort_id: 63
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:41.730723000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3156,8 +2762,6 @@ hardrock_2015_leroy_leffler_grouse_in_1:
   effort_id: 63
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:41.738795000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3172,8 +2776,6 @@ hardrock_2015_leroy_leffler_grouse_out_1:
   effort_id: 63
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:41.741550000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3188,8 +2790,6 @@ hardrock_2015_leroy_leffler_ouray_in_1:
   effort_id: 63
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:41.749162000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3204,8 +2804,6 @@ hardrock_2015_leroy_leffler_ouray_out_1:
   effort_id: 63
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:41.752177000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3220,8 +2818,6 @@ hardrock_2015_leroy_leffler_telluride_in_1:
   effort_id: 63
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:41.759158000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3236,8 +2832,6 @@ hardrock_2015_leroy_leffler_telluride_out_1:
   effort_id: 63
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:41.761240000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3252,8 +2846,6 @@ hardrock_2015_leroy_leffler_putnam_in_1:
   effort_id: 63
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:37.279691000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3268,8 +2860,6 @@ hardrock_2015_leroy_leffler_putnam_out_1:
   effort_id: 63
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:37.282727000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3284,8 +2874,6 @@ hardrock_2015_leroy_leffler_finish_1:
   effort_id: 63
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.830651000 Z
-  updated_at: 2018-01-10 08:48:37.285015000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3300,8 +2888,6 @@ hardrock_2015_samara_vandervort_start_1:
   effort_id: 73
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2017-12-08 07:10:21.529917000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3316,8 +2902,6 @@ hardrock_2015_samara_vandervort_cunningham_in_1:
   effort_id: 73
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:42.438644000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3332,8 +2916,6 @@ hardrock_2015_samara_vandervort_cunningham_out_1:
   effort_id: 73
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:42.441537000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3348,8 +2930,6 @@ hardrock_2015_samara_vandervort_sherman_in_1:
   effort_id: 73
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:50.033289000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3364,8 +2944,6 @@ hardrock_2015_samara_vandervort_sherman_out_1:
   effort_id: 73
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:42.455678000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3380,8 +2958,6 @@ hardrock_2015_samara_vandervort_grouse_in_1:
   effort_id: 73
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:42.465006000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3396,8 +2972,6 @@ hardrock_2015_samara_vandervort_grouse_out_1:
   effort_id: 73
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:42.468062000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3412,8 +2986,6 @@ hardrock_2015_samara_vandervort_ouray_in_1:
   effort_id: 73
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:42.476402000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3428,8 +3000,6 @@ hardrock_2015_samara_vandervort_ouray_out_1:
   effort_id: 73
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:42.479500000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3444,8 +3014,6 @@ hardrock_2015_samara_vandervort_telluride_in_1:
   effort_id: 73
   split_id: 26
   data_status: 0
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:47.158164000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3460,8 +3028,6 @@ hardrock_2015_samara_vandervort_telluride_out_1:
   effort_id: 73
   split_id: 26
   data_status: 0
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:48.763966000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3476,8 +3042,6 @@ hardrock_2015_samara_vandervort_putnam_in_1:
   effort_id: 73
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:42.498041000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3492,8 +3056,6 @@ hardrock_2015_samara_vandervort_putnam_out_1:
   effort_id: 73
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:42.500587000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3508,8 +3070,6 @@ hardrock_2015_samara_vandervort_finish_1:
   effort_id: 73
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:03.995786000 Z
-  updated_at: 2018-01-10 08:48:42.502929000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3524,8 +3084,6 @@ hardrock_2015_robt_wintheiser_start_1:
   effort_id: 94
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2017-12-08 07:10:22.828396000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3540,8 +3098,6 @@ hardrock_2015_robt_wintheiser_cunningham_in_1:
   effort_id: 94
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.298837000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3556,8 +3112,6 @@ hardrock_2015_robt_wintheiser_cunningham_out_1:
   effort_id: 94
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.301637000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3572,8 +3126,6 @@ hardrock_2015_robt_wintheiser_sherman_in_1:
   effort_id: 94
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.316577000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3588,8 +3140,6 @@ hardrock_2015_robt_wintheiser_sherman_out_1:
   effort_id: 94
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.319729000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3604,8 +3154,6 @@ hardrock_2015_robt_wintheiser_grouse_in_1:
   effort_id: 94
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.326078000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3620,8 +3168,6 @@ hardrock_2015_robt_wintheiser_grouse_out_1:
   effort_id: 94
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:37.536547000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3636,8 +3182,6 @@ hardrock_2015_robt_wintheiser_ouray_in_1:
   effort_id: 94
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.335824000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3652,8 +3196,6 @@ hardrock_2015_robt_wintheiser_ouray_out_1:
   effort_id: 94
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.338954000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3668,8 +3210,6 @@ hardrock_2015_robt_wintheiser_telluride_in_1:
   effort_id: 94
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.350554000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3684,8 +3224,6 @@ hardrock_2015_robt_wintheiser_telluride_out_1:
   effort_id: 94
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.354488000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3700,8 +3238,6 @@ hardrock_2015_robt_wintheiser_putnam_in_1:
   effort_id: 94
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.369258000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3716,8 +3252,6 @@ hardrock_2015_robt_wintheiser_putnam_out_1:
   effort_id: 94
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.372181000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3732,8 +3266,6 @@ hardrock_2015_robt_wintheiser_finish_1:
   effort_id: 94
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:04.345460000 Z
-  updated_at: 2018-01-10 08:48:44.375898000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3748,8 +3280,6 @@ hardrock_2015_demetrius_moen_start_1:
   effort_id: 96
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2017-12-08 07:10:22.881859000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3764,8 +3294,6 @@ hardrock_2015_demetrius_moen_cunningham_in_1:
   effort_id: 96
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.479914000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3780,8 +3308,6 @@ hardrock_2015_demetrius_moen_cunningham_out_1:
   effort_id: 96
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:50.070352000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3796,8 +3322,6 @@ hardrock_2015_demetrius_moen_sherman_in_1:
   effort_id: 96
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.492958000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3812,8 +3336,6 @@ hardrock_2015_demetrius_moen_sherman_out_1:
   effort_id: 96
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.495958000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3828,8 +3350,6 @@ hardrock_2015_demetrius_moen_grouse_in_1:
   effort_id: 96
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.504617000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3844,8 +3364,6 @@ hardrock_2015_demetrius_moen_grouse_out_1:
   effort_id: 96
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.507586000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3860,8 +3378,6 @@ hardrock_2015_demetrius_moen_ouray_in_1:
   effort_id: 96
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.516659000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3876,8 +3392,6 @@ hardrock_2015_demetrius_moen_ouray_out_1:
   effort_id: 96
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.519042000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3892,8 +3406,6 @@ hardrock_2015_demetrius_moen_telluride_in_1:
   effort_id: 96
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.533339000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3908,8 +3420,6 @@ hardrock_2015_demetrius_moen_telluride_out_1:
   effort_id: 96
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.535963000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3924,8 +3434,6 @@ hardrock_2015_demetrius_moen_putnam_in_1:
   effort_id: 96
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.550984000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3940,8 +3448,6 @@ hardrock_2015_demetrius_moen_putnam_out_1:
   effort_id: 96
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.553367000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -3956,8 +3462,6 @@ hardrock_2015_demetrius_moen_finish_1:
   effort_id: 96
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:04.375791000 Z
-  updated_at: 2018-01-10 08:48:44.557882000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3972,8 +3476,6 @@ hardrock_2015_vern_buckridge_start_1:
   effort_id: 105
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2017-12-08 07:10:26.337241000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -3988,8 +3490,6 @@ hardrock_2015_vern_buckridge_cunningham_in_1:
   effort_id: 105
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.265611000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4004,8 +3504,6 @@ hardrock_2015_vern_buckridge_cunningham_out_1:
   effort_id: 105
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.268416000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4020,8 +3518,6 @@ hardrock_2015_vern_buckridge_sherman_in_1:
   effort_id: 105
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.282522000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4036,8 +3532,6 @@ hardrock_2015_vern_buckridge_sherman_out_1:
   effort_id: 105
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.285194000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4052,8 +3546,6 @@ hardrock_2015_vern_buckridge_grouse_in_1:
   effort_id: 105
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.293679000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4068,8 +3560,6 @@ hardrock_2015_vern_buckridge_grouse_out_1:
   effort_id: 105
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.296194000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4084,8 +3574,6 @@ hardrock_2015_vern_buckridge_ouray_in_1:
   effort_id: 105
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.303982000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4100,8 +3588,6 @@ hardrock_2015_vern_buckridge_ouray_out_1:
   effort_id: 105
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.307530000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4116,8 +3602,6 @@ hardrock_2015_vern_buckridge_telluride_in_1:
   effort_id: 105
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.320646000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4132,8 +3616,6 @@ hardrock_2015_vern_buckridge_telluride_out_1:
   effort_id: 105
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.324510000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4148,8 +3630,6 @@ hardrock_2015_vern_buckridge_putnam_in_1:
   effort_id: 105
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.338068000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4164,8 +3644,6 @@ hardrock_2015_vern_buckridge_putnam_out_1:
   effort_id: 105
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.342824000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4180,8 +3658,6 @@ hardrock_2015_vern_buckridge_finish_1:
   effort_id: 105
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:04.522932000 Z
-  updated_at: 2018-01-10 08:48:45.346253000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4196,8 +3672,6 @@ hardrock_2015_donte_spencer_start_1:
   effort_id: 112
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2017-12-08 07:10:23.916231000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4212,8 +3686,6 @@ hardrock_2015_donte_spencer_cunningham_in_1:
   effort_id: 112
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.889602000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4228,8 +3700,6 @@ hardrock_2015_donte_spencer_cunningham_out_1:
   effort_id: 112
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.892317000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4244,8 +3714,6 @@ hardrock_2015_donte_spencer_sherman_in_1:
   effort_id: 112
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.907859000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4260,8 +3728,6 @@ hardrock_2015_donte_spencer_sherman_out_1:
   effort_id: 112
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.911325000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4276,8 +3742,6 @@ hardrock_2015_donte_spencer_grouse_in_1:
   effort_id: 112
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.920356000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4292,8 +3756,6 @@ hardrock_2015_donte_spencer_grouse_out_1:
   effort_id: 112
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.922590000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4308,8 +3770,6 @@ hardrock_2015_donte_spencer_ouray_in_1:
   effort_id: 112
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.931272000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4324,8 +3784,6 @@ hardrock_2015_donte_spencer_ouray_out_1:
   effort_id: 112
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.933983000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4340,8 +3798,6 @@ hardrock_2015_donte_spencer_telluride_in_1:
   effort_id: 112
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.949161000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4356,8 +3812,6 @@ hardrock_2015_donte_spencer_telluride_out_1:
   effort_id: 112
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.952526000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4372,8 +3826,6 @@ hardrock_2015_donte_spencer_putnam_in_1:
   effort_id: 112
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.966109000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4388,8 +3840,6 @@ hardrock_2015_donte_spencer_putnam_out_1:
   effort_id: 112
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.968893000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4404,8 +3854,6 @@ hardrock_2015_donte_spencer_finish_1:
   effort_id: 112
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:04.646069000 Z
-  updated_at: 2018-01-10 08:48:45.971252000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4420,8 +3868,6 @@ hardrock_2015_bruno_fadel_start_1:
   effort_id: 116
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2017-12-08 07:10:26.552217000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4436,8 +3882,6 @@ hardrock_2015_bruno_fadel_cunningham_in_1:
   effort_id: 116
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:46.188316000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4452,8 +3896,6 @@ hardrock_2015_bruno_fadel_cunningham_out_1:
   effort_id: 116
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:46.190953000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4468,8 +3910,6 @@ hardrock_2015_bruno_fadel_sherman_in_1:
   effort_id: 116
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:46.199420000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4484,8 +3924,6 @@ hardrock_2015_bruno_fadel_sherman_out_1:
   effort_id: 116
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:46.269089000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4500,8 +3938,6 @@ hardrock_2015_bruno_fadel_grouse_in_1:
   effort_id: 116
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:50.157520000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4516,8 +3952,6 @@ hardrock_2015_bruno_fadel_grouse_out_1:
   effort_id: 116
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:46.279590000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4532,8 +3966,6 @@ hardrock_2015_bruno_fadel_ouray_in_1:
   effort_id: 116
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:46.290561000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4548,8 +3980,6 @@ hardrock_2015_bruno_fadel_ouray_out_1:
   effort_id: 116
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:46.293302000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4564,8 +3994,6 @@ hardrock_2015_bruno_fadel_telluride_in_1:
   effort_id: 116
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:46.308139000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4580,8 +4008,6 @@ hardrock_2015_bruno_fadel_telluride_out_1:
   effort_id: 116
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:46.312188000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4596,8 +4022,6 @@ hardrock_2015_bruno_fadel_putnam_in_1:
   effort_id: 116
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:46.323827000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4612,8 +4036,6 @@ hardrock_2015_bruno_fadel_putnam_out_1:
   effort_id: 116
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:46.327159000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4628,8 +4050,6 @@ hardrock_2015_bruno_fadel_finish_1:
   effort_id: 116
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:04.707992000 Z
-  updated_at: 2018-01-10 08:48:43.988539000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4644,8 +4064,6 @@ hardrock_2015_gus_walker_start_1:
   effort_id: 117
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2017-12-08 07:10:24.270151000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4660,8 +4078,6 @@ hardrock_2015_gus_walker_cunningham_in_1:
   effort_id: 117
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:43.992242000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4676,8 +4092,6 @@ hardrock_2015_gus_walker_cunningham_out_1:
   effort_id: 117
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:43.994549000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4692,8 +4106,6 @@ hardrock_2015_gus_walker_sherman_in_1:
   effort_id: 117
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:44.008593000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4708,8 +4120,6 @@ hardrock_2015_gus_walker_sherman_out_1:
   effort_id: 117
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:44.087114000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4724,8 +4134,6 @@ hardrock_2015_gus_walker_grouse_in_1:
   effort_id: 117
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:44.089257000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4740,8 +4148,6 @@ hardrock_2015_gus_walker_grouse_out_1:
   effort_id: 117
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:44.093423000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4756,8 +4162,6 @@ hardrock_2015_gus_walker_ouray_in_1:
   effort_id: 117
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:44.095999000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4772,8 +4176,6 @@ hardrock_2015_gus_walker_ouray_out_1:
   effort_id: 117
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:44.098447000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4788,8 +4190,6 @@ hardrock_2015_gus_walker_telluride_in_1:
   effort_id: 117
   split_id: 26
   data_status: 1
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:48.622568000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4804,8 +4204,6 @@ hardrock_2015_gus_walker_telluride_out_1:
   effort_id: 117
   split_id: 26
   data_status: 1
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:48.625006000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4820,8 +4218,6 @@ hardrock_2015_gus_walker_putnam_in_1:
   effort_id: 117
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:46.345645000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4836,8 +4232,6 @@ hardrock_2015_gus_walker_putnam_out_1:
   effort_id: 117
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:46.348682000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4852,8 +4246,6 @@ hardrock_2015_gus_walker_finish_1:
   effort_id: 117
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:04.723660000 Z
-  updated_at: 2018-01-10 08:48:46.351475000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4868,8 +4260,6 @@ hardrock_2015_susanna_abshire_start_1:
   effort_id: 121
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2017-12-08 07:10:24.547535000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4884,8 +4274,6 @@ hardrock_2015_susanna_abshire_cunningham_in_1:
   effort_id: 121
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2018-01-10 08:48:46.590813000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4900,8 +4288,6 @@ hardrock_2015_susanna_abshire_cunningham_out_1:
   effort_id: 121
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2018-01-10 08:48:46.593992000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4916,8 +4302,6 @@ hardrock_2015_susanna_abshire_sherman_in_1:
   effort_id: 121
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2018-01-10 08:48:46.609966000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4932,8 +4316,6 @@ hardrock_2015_susanna_abshire_sherman_out_1:
   effort_id: 121
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2018-01-10 08:48:46.612595000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4948,8 +4330,6 @@ hardrock_2015_susanna_abshire_grouse_in_1:
   effort_id: 121
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2018-01-10 08:48:46.620903000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4964,8 +4344,6 @@ hardrock_2015_susanna_abshire_grouse_out_1:
   effort_id: 121
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2018-01-10 08:48:46.625367000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -4980,8 +4358,6 @@ hardrock_2015_susanna_abshire_telluride_in_1:
   effort_id: 121
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2018-01-10 08:48:46.632500000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -4996,8 +4372,6 @@ hardrock_2015_susanna_abshire_telluride_out_1:
   effort_id: 121
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2018-01-10 08:48:46.635597000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5012,8 +4386,6 @@ hardrock_2015_susanna_abshire_putnam_in_1:
   effort_id: 121
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2018-01-10 08:48:46.651183000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5028,8 +4400,6 @@ hardrock_2015_susanna_abshire_putnam_out_1:
   effort_id: 121
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2018-01-10 08:48:46.654988000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5044,8 +4414,6 @@ hardrock_2015_susanna_abshire_finish_1:
   effort_id: 121
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:04.788647000 Z
-  updated_at: 2018-01-10 08:48:46.657969000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5060,8 +4428,6 @@ hardrock_2015_leandro_cole_start_1:
   effort_id: 125
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2017-12-08 07:10:24.604573000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5076,8 +4442,6 @@ hardrock_2015_leandro_cole_cunningham_in_1:
   effort_id: 125
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:46.846977000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5092,8 +4456,6 @@ hardrock_2015_leandro_cole_cunningham_out_1:
   effort_id: 125
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:46.849589000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5108,8 +4470,6 @@ hardrock_2015_leandro_cole_sherman_in_1:
   effort_id: 125
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:46.886004000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5124,8 +4484,6 @@ hardrock_2015_leandro_cole_sherman_out_1:
   effort_id: 125
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:46.888594000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5140,8 +4498,6 @@ hardrock_2015_leandro_cole_grouse_in_1:
   effort_id: 125
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:46.976456000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5156,8 +4512,6 @@ hardrock_2015_leandro_cole_grouse_out_1:
   effort_id: 125
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:46.994079000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5172,8 +4526,6 @@ hardrock_2015_leandro_cole_ouray_in_1:
   effort_id: 125
   split_id: 20
   data_status: 1
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:48.663720000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5188,8 +4540,6 @@ hardrock_2015_leandro_cole_ouray_out_1:
   effort_id: 125
   split_id: 20
   data_status: 1
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:48.665985000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5204,8 +4554,6 @@ hardrock_2015_leandro_cole_telluride_in_1:
   effort_id: 125
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:47.045870000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5220,8 +4568,6 @@ hardrock_2015_leandro_cole_telluride_out_1:
   effort_id: 125
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:47.048122000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5236,8 +4582,6 @@ hardrock_2015_leandro_cole_putnam_in_1:
   effort_id: 125
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:47.122340000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5252,8 +4596,6 @@ hardrock_2015_leandro_cole_putnam_out_1:
   effort_id: 125
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:47.124745000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5268,8 +4610,6 @@ hardrock_2015_leandro_cole_finish_1:
   effort_id: 125
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:04.850711000 Z
-  updated_at: 2018-01-10 08:48:47.127326000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5284,8 +4624,6 @@ hardrock_2015_benedict_davis_start_1:
   effort_id: 129
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2017-12-08 07:10:24.921957000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5300,8 +4638,6 @@ hardrock_2015_benedict_davis_cunningham_in_1:
   effort_id: 129
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:47.280007000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5316,8 +4652,6 @@ hardrock_2015_benedict_davis_cunningham_out_1:
   effort_id: 129
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:47.282437000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5332,8 +4666,6 @@ hardrock_2015_benedict_davis_sherman_in_1:
   effort_id: 129
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:47.294870000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5348,8 +4680,6 @@ hardrock_2015_benedict_davis_sherman_out_1:
   effort_id: 129
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:47.297096000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5364,8 +4694,6 @@ hardrock_2015_benedict_davis_grouse_in_1:
   effort_id: 129
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:39.616227000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5380,8 +4708,6 @@ hardrock_2015_benedict_davis_grouse_out_1:
   effort_id: 129
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:39.618715000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5396,8 +4722,6 @@ hardrock_2015_benedict_davis_ouray_in_1:
   effort_id: 129
   split_id: 20
   data_status: 1
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:39.642009000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5412,8 +4736,6 @@ hardrock_2015_benedict_davis_ouray_out_1:
   effort_id: 129
   split_id: 20
   data_status: 1
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:39.644262000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5428,8 +4750,6 @@ hardrock_2015_benedict_davis_telluride_in_1:
   effort_id: 129
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:49.733680000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5444,8 +4764,6 @@ hardrock_2015_benedict_davis_telluride_out_1:
   effort_id: 129
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:49.737289000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5460,8 +4778,6 @@ hardrock_2015_benedict_davis_putnam_in_1:
   effort_id: 129
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:49.728141000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5476,8 +4792,6 @@ hardrock_2015_benedict_davis_putnam_out_1:
   effort_id: 129
   split_id: 32
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:49.730573000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5492,8 +4806,6 @@ hardrock_2015_benedict_davis_finish_1:
   effort_id: 129
   split_id: 34
   data_status: 2
-  created_at: 2016-04-18 09:10:04.913842000 Z
-  updated_at: 2018-01-10 08:48:49.747169000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5508,8 +4820,6 @@ hardrock_2015_raphael_swift_start_1:
   effort_id: 136
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:05.024930000 Z
-  updated_at: 2017-12-08 07:10:34.367256000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5524,8 +4834,6 @@ hardrock_2015_raphael_swift_cunningham_in_1:
   effort_id: 136
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:05.024930000 Z
-  updated_at: 2018-01-10 08:48:47.668430000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5540,8 +4848,6 @@ hardrock_2015_raphael_swift_cunningham_out_1:
   effort_id: 136
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:05.024930000 Z
-  updated_at: 2018-01-10 08:48:47.671457000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5556,8 +4862,6 @@ hardrock_2015_raphael_swift_sherman_in_1:
   effort_id: 136
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:05.024930000 Z
-  updated_at: 2018-01-10 08:48:47.686039000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5572,8 +4876,6 @@ hardrock_2015_raphael_swift_sherman_out_1:
   effort_id: 136
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:05.024930000 Z
-  updated_at: 2018-01-10 08:48:47.688297000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5588,8 +4890,6 @@ hardrock_2015_raphael_swift_grouse_in_1:
   effort_id: 136
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:05.024930000 Z
-  updated_at: 2018-01-10 08:48:47.690805000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5604,8 +4904,6 @@ hardrock_2015_raphael_swift_grouse_out_1:
   effort_id: 136
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:05.024930000 Z
-  updated_at: 2018-01-10 08:48:47.695301000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5620,8 +4918,6 @@ hardrock_2015_raphael_swift_ouray_in_1:
   effort_id: 136
   split_id: 20
   data_status: 1
-  created_at: 2016-04-18 09:10:05.024930000 Z
-  updated_at: 2018-01-10 08:48:48.695948000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5636,8 +4932,6 @@ hardrock_2015_raphael_swift_ouray_out_1:
   effort_id: 136
   split_id: 20
   data_status: 1
-  created_at: 2016-04-18 09:10:05.024930000 Z
-  updated_at: 2018-01-10 08:48:48.698530000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5652,8 +4946,6 @@ hardrock_2015_raphael_swift_telluride_in_1:
   effort_id: 136
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:05.024930000 Z
-  updated_at: 2018-01-10 08:48:47.711651000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5668,8 +4960,6 @@ hardrock_2015_raphael_swift_telluride_out_1:
   effort_id: 136
   split_id: 26
   data_status: 2
-  created_at: 2016-04-18 09:10:05.024930000 Z
-  updated_at: 2018-01-10 08:48:47.713833000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5684,8 +4974,6 @@ hardrock_2015_bad_status_start_1:
   effort_id: 138
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:05.056722000 Z
-  updated_at: 2017-12-08 07:10:26.500609000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5700,8 +4988,6 @@ hardrock_2015_bad_status_cunningham_in_1:
   effort_id: 138
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:05.056722000 Z
-  updated_at: 2018-01-10 08:48:47.761646000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5716,8 +5002,6 @@ hardrock_2015_bad_status_cunningham_out_1:
   effort_id: 138
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:05.056722000 Z
-  updated_at: 2018-01-10 08:48:47.764159000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5732,8 +5016,6 @@ hardrock_2015_bad_status_sherman_in_1:
   effort_id: 138
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:05.056722000 Z
-  updated_at: 2018-01-10 08:48:47.789258000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5748,8 +5030,6 @@ hardrock_2015_bad_status_sherman_out_1:
   effort_id: 138
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:05.056722000 Z
-  updated_at: 2018-01-10 08:48:47.791707000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5764,8 +5044,6 @@ hardrock_2015_bad_status_grouse_in_1:
   effort_id: 138
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:05.056722000 Z
-  updated_at: 2018-01-10 08:48:47.800076000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5780,8 +5058,6 @@ hardrock_2015_bad_status_grouse_out_1:
   effort_id: 138
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:05.056722000 Z
-  updated_at: 2018-01-10 08:48:47.803891000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5796,8 +5072,6 @@ hardrock_2015_bad_status_ouray_in_1:
   effort_id: 138
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:05.056722000 Z
-  updated_at: 2018-01-10 08:48:47.806497000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5812,8 +5086,6 @@ hardrock_2015_bad_status_ouray_out_1:
   effort_id: 138
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:05.056722000 Z
-  updated_at: 2018-01-10 08:48:47.808976000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5828,8 +5100,6 @@ hardrock_2015_irvin_harber_start_1:
   effort_id: 141
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:05.111461000 Z
-  updated_at: 2017-12-08 07:10:25.550103000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5844,8 +5114,6 @@ hardrock_2015_irvin_harber_cunningham_in_1:
   effort_id: 141
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:05.111461000 Z
-  updated_at: 2018-01-10 08:48:47.895759000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5860,8 +5128,6 @@ hardrock_2015_irvin_harber_cunningham_out_1:
   effort_id: 141
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:05.111461000 Z
-  updated_at: 2018-01-10 08:48:50.080845000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5876,8 +5142,6 @@ hardrock_2015_irvin_harber_sherman_in_1:
   effort_id: 141
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:05.111461000 Z
-  updated_at: 2018-01-10 08:48:50.094731000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5892,8 +5156,6 @@ hardrock_2015_irvin_harber_sherman_out_1:
   effort_id: 141
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:05.111461000 Z
-  updated_at: 2018-01-10 08:48:47.898668000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5908,8 +5170,6 @@ hardrock_2015_irvin_harber_grouse_in_1:
   effort_id: 141
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:05.111461000 Z
-  updated_at: 2018-01-10 08:48:47.907170000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5924,8 +5184,6 @@ hardrock_2015_irvin_harber_grouse_out_1:
   effort_id: 141
   split_id: 16
   data_status: 2
-  created_at: 2016-04-18 09:10:05.111461000 Z
-  updated_at: 2018-01-10 08:48:47.909602000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5940,8 +5198,6 @@ hardrock_2015_irvin_harber_ouray_in_1:
   effort_id: 141
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:05.111461000 Z
-  updated_at: 2018-01-10 08:48:47.918356000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5956,8 +5212,6 @@ hardrock_2015_irvin_harber_ouray_out_1:
   effort_id: 141
   split_id: 20
   data_status: 2
-  created_at: 2016-04-18 09:10:05.111461000 Z
-  updated_at: 2018-01-10 08:48:47.920985000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -5972,8 +5226,6 @@ hardrock_2015_cassondra_nienow_start_1:
   effort_id: 155
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:05.306513000 Z
-  updated_at: 2017-12-08 07:10:25.972458000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -5988,8 +5240,6 @@ hardrock_2015_cassondra_nienow_cunningham_in_1:
   effort_id: 155
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:05.306513000 Z
-  updated_at: 2018-01-10 08:48:48.443950000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6004,8 +5254,6 @@ hardrock_2015_cassondra_nienow_cunningham_out_1:
   effort_id: 155
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:05.306513000 Z
-  updated_at: 2018-01-10 08:48:48.446467000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6020,8 +5268,6 @@ hardrock_2015_cassondra_nienow_sherman_in_1:
   effort_id: 155
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:05.306513000 Z
-  updated_at: 2018-01-10 08:48:48.457976000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6036,8 +5282,6 @@ hardrock_2015_cassondra_nienow_sherman_out_1:
   effort_id: 155
   split_id: 12
   data_status: 2
-  created_at: 2016-04-18 09:10:05.306513000 Z
-  updated_at: 2018-01-10 08:48:48.460455000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6052,8 +5296,6 @@ hardrock_2015_donn_mckenzie_start_1:
   effort_id: 158
   split_id: 5
   data_status: 2
-  created_at: 2016-04-18 09:10:05.347008000 Z
-  updated_at: 2017-12-08 07:10:25.913152000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6068,8 +5310,6 @@ hardrock_2015_donn_mckenzie_cunningham_in_1:
   effort_id: 158
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:05.347008000 Z
-  updated_at: 2018-01-10 08:48:48.489781000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6084,8 +5324,6 @@ hardrock_2015_donn_mckenzie_cunningham_out_1:
   effort_id: 158
   split_id: 6
   data_status: 2
-  created_at: 2016-04-18 09:10:05.347008000 Z
-  updated_at: 2018-01-10 08:48:48.492682000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6100,8 +5338,6 @@ ramble_finished_first_start_1:
   effort_id: 1040
   split_id: 46
   data_status: 2
-  created_at: 2016-05-09 01:56:15.133391000 Z
-  updated_at: 2017-01-11 07:34:36.550209000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6116,8 +5352,6 @@ ramble_finished_first_finish_1:
   effort_id: 1040
   split_id: 47
   data_status: 2
-  created_at: 2016-05-09 01:56:15.133391000 Z
-  updated_at: 2017-02-19 02:02:34.861400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6132,8 +5366,6 @@ ramble_finished_second_start_1:
   effort_id: 1048
   split_id: 46
   data_status: 2
-  created_at: 2016-05-09 01:56:15.238637000 Z
-  updated_at: 2017-01-11 07:34:36.554528000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6148,8 +5380,6 @@ ramble_finished_second_finish_1:
   effort_id: 1048
   split_id: 47
   data_status: 2
-  created_at: 2016-05-09 01:56:15.238637000 Z
-  updated_at: 2017-02-19 02:02:34.925881000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6164,8 +5394,6 @@ ramble_start_only_start_1:
   effort_id: 1051
   split_id: 46
   data_status: 2
-  created_at: 2016-05-09 01:56:15.280011000 Z
-  updated_at: 2017-01-11 07:34:36.557882000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6180,8 +5408,6 @@ hardrock_2014_finished_first_start_1:
   effort_id: 4172
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2016-05-24 03:02:37.497296000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6196,8 +5422,6 @@ hardrock_2014_finished_first_telluride_in_1:
   effort_id: 4172
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2016-05-24 03:02:35.771419000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6212,8 +5436,6 @@ hardrock_2014_finished_first_telluride_out_1:
   effort_id: 4172
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2016-05-24 03:02:35.771419000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6228,8 +5450,6 @@ hardrock_2014_finished_first_ouray_in_1:
   effort_id: 4172
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2016-05-24 03:02:35.771419000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6244,8 +5464,6 @@ hardrock_2014_finished_first_ouray_out_1:
   effort_id: 4172
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2016-05-24 03:02:35.771419000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6260,8 +5478,6 @@ hardrock_2014_finished_first_grouse_in_1:
   effort_id: 4172
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2016-05-24 03:02:35.771419000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6276,8 +5492,6 @@ hardrock_2014_finished_first_grouse_out_1:
   effort_id: 4172
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2016-05-24 03:02:35.771419000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6292,8 +5506,6 @@ hardrock_2014_finished_first_sherman_in_1:
   effort_id: 4172
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2016-05-24 03:02:35.771419000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6308,8 +5520,6 @@ hardrock_2014_finished_first_sherman_out_1:
   effort_id: 4172
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2016-05-24 03:02:35.771419000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6324,8 +5534,6 @@ hardrock_2014_finished_first_cunningham_in_1:
   effort_id: 4172
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2016-05-24 03:02:35.771419000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6340,8 +5548,6 @@ hardrock_2014_finished_first_cunningham_out_1:
   effort_id: 4172
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2016-05-24 03:02:35.771419000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6356,8 +5562,6 @@ hardrock_2014_finished_first_finish_1:
   effort_id: 4172
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:35.771419000 Z
-  updated_at: 2017-02-19 02:02:38.586109000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6372,8 +5576,6 @@ hardrock_2014_finished_with_stop_start_1:
   effort_id: 4173
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2016-05-24 03:02:37.497667000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6388,8 +5590,6 @@ hardrock_2014_finished_with_stop_telluride_in_1:
   effort_id: 4173
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2016-05-24 03:02:35.783392000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6404,8 +5604,6 @@ hardrock_2014_finished_with_stop_telluride_out_1:
   effort_id: 4173
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2016-05-24 03:02:35.783392000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6420,8 +5618,6 @@ hardrock_2014_finished_with_stop_ouray_in_1:
   effort_id: 4173
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2016-05-24 03:02:35.783392000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6436,8 +5632,6 @@ hardrock_2014_finished_with_stop_ouray_out_1:
   effort_id: 4173
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2016-05-24 03:02:35.783392000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6452,8 +5646,6 @@ hardrock_2014_finished_with_stop_grouse_in_1:
   effort_id: 4173
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2016-05-24 03:02:35.783392000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6468,8 +5660,6 @@ hardrock_2014_finished_with_stop_grouse_out_1:
   effort_id: 4173
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2016-05-24 03:02:35.783392000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6484,8 +5674,6 @@ hardrock_2014_finished_with_stop_sherman_in_1:
   effort_id: 4173
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2016-05-24 03:02:35.783392000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6500,8 +5688,6 @@ hardrock_2014_finished_with_stop_sherman_out_1:
   effort_id: 4173
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2016-05-24 03:02:35.783392000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6516,8 +5702,6 @@ hardrock_2014_finished_with_stop_cunningham_in_1:
   effort_id: 4173
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2016-05-24 03:02:35.783392000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6532,8 +5716,6 @@ hardrock_2014_finished_with_stop_cunningham_out_1:
   effort_id: 4173
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2016-05-24 03:02:35.783392000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6548,8 +5730,6 @@ hardrock_2014_finished_with_stop_finish_1:
   effort_id: 4173
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:35.783392000 Z
-  updated_at: 2017-02-19 02:02:38.590300000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6564,8 +5744,6 @@ hardrock_2014_finished_without_stop_start_1:
   effort_id: 4174
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2016-05-24 03:02:37.497964000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6580,8 +5758,6 @@ hardrock_2014_finished_without_stop_telluride_in_1:
   effort_id: 4174
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2016-05-24 03:02:35.794729000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6596,8 +5772,6 @@ hardrock_2014_finished_without_stop_telluride_out_1:
   effort_id: 4174
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2016-05-24 03:02:35.794729000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6612,8 +5786,6 @@ hardrock_2014_finished_without_stop_ouray_in_1:
   effort_id: 4174
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2016-05-24 03:02:35.794729000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6628,8 +5800,6 @@ hardrock_2014_finished_without_stop_ouray_out_1:
   effort_id: 4174
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2016-05-24 03:02:35.794729000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6644,8 +5814,6 @@ hardrock_2014_finished_without_stop_grouse_in_1:
   effort_id: 4174
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2016-05-24 03:02:35.794729000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6660,8 +5828,6 @@ hardrock_2014_finished_without_stop_grouse_out_1:
   effort_id: 4174
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2016-05-24 03:02:35.794729000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6676,8 +5842,6 @@ hardrock_2014_finished_without_stop_sherman_in_1:
   effort_id: 4174
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2016-05-24 03:02:35.794729000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6692,8 +5856,6 @@ hardrock_2014_finished_without_stop_sherman_out_1:
   effort_id: 4174
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2016-05-24 03:02:35.794729000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6708,8 +5870,6 @@ hardrock_2014_finished_without_stop_cunningham_in_1:
   effort_id: 4174
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2016-05-24 03:02:35.794729000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6724,8 +5884,6 @@ hardrock_2014_finished_without_stop_cunningham_out_1:
   effort_id: 4174
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2016-05-24 03:02:35.794729000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6740,8 +5898,6 @@ hardrock_2014_finished_without_stop_finish_1:
   effort_id: 4174
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:35.794729000 Z
-  updated_at: 2019-01-28 10:36:51.882516000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6756,8 +5912,6 @@ hardrock_2014_claudio_wunsch_start_1:
   effort_id: 4192
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2016-05-24 03:02:37.503390000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6772,8 +5926,6 @@ hardrock_2014_claudio_wunsch_telluride_in_1:
   effort_id: 4192
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2016-05-24 03:02:36.050912000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6788,8 +5940,6 @@ hardrock_2014_claudio_wunsch_telluride_out_1:
   effort_id: 4192
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2016-05-24 03:02:36.050912000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6804,8 +5954,6 @@ hardrock_2014_claudio_wunsch_ouray_in_1:
   effort_id: 4192
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2016-05-24 03:02:36.050912000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6820,8 +5968,6 @@ hardrock_2014_claudio_wunsch_ouray_out_1:
   effort_id: 4192
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2016-05-24 03:02:36.050912000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6836,8 +5982,6 @@ hardrock_2014_claudio_wunsch_grouse_in_1:
   effort_id: 4192
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2016-05-24 03:02:36.050912000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6852,8 +5996,6 @@ hardrock_2014_claudio_wunsch_grouse_out_1:
   effort_id: 4192
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2016-05-24 03:02:36.050912000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6868,8 +6010,6 @@ hardrock_2014_claudio_wunsch_sherman_in_1:
   effort_id: 4192
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2016-05-24 03:02:36.050912000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6884,8 +6024,6 @@ hardrock_2014_claudio_wunsch_sherman_out_1:
   effort_id: 4192
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2016-05-24 03:02:36.050912000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6900,8 +6038,6 @@ hardrock_2014_claudio_wunsch_cunningham_in_1:
   effort_id: 4192
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2016-05-24 03:02:36.050912000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6916,8 +6052,6 @@ hardrock_2014_claudio_wunsch_cunningham_out_1:
   effort_id: 4192
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2016-05-24 03:02:36.050912000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6932,8 +6066,6 @@ hardrock_2014_claudio_wunsch_finish_1:
   effort_id: 4192
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:36.050912000 Z
-  updated_at: 2017-02-19 02:02:38.671414000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6948,8 +6080,6 @@ hardrock_2014_paul_predovic_start_1:
   effort_id: 4199
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2016-05-24 03:02:37.505241000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6964,8 +6094,6 @@ hardrock_2014_paul_predovic_telluride_in_1:
   effort_id: 4199
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2016-05-24 03:02:36.133592000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -6980,8 +6108,6 @@ hardrock_2014_paul_predovic_telluride_out_1:
   effort_id: 4199
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2016-05-24 03:02:36.133592000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -6996,8 +6122,6 @@ hardrock_2014_paul_predovic_ouray_in_1:
   effort_id: 4199
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2016-05-24 03:02:36.133592000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7012,8 +6136,6 @@ hardrock_2014_paul_predovic_ouray_out_1:
   effort_id: 4199
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2016-05-24 03:02:36.133592000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7028,8 +6150,6 @@ hardrock_2014_paul_predovic_grouse_in_1:
   effort_id: 4199
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2016-05-24 03:02:36.133592000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7044,8 +6164,6 @@ hardrock_2014_paul_predovic_grouse_out_1:
   effort_id: 4199
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2016-05-24 03:02:36.133592000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7060,8 +6178,6 @@ hardrock_2014_paul_predovic_sherman_in_1:
   effort_id: 4199
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2016-05-24 03:02:36.133592000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7076,8 +6192,6 @@ hardrock_2014_paul_predovic_sherman_out_1:
   effort_id: 4199
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2016-05-24 03:02:36.133592000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7092,8 +6206,6 @@ hardrock_2014_paul_predovic_cunningham_in_1:
   effort_id: 4199
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2016-05-24 03:02:36.133592000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7108,8 +6220,6 @@ hardrock_2014_paul_predovic_cunningham_out_1:
   effort_id: 4199
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2016-05-24 03:02:36.133592000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7124,8 +6234,6 @@ hardrock_2014_paul_predovic_finish_1:
   effort_id: 4199
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:36.133592000 Z
-  updated_at: 2017-02-19 02:02:38.699958000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7140,8 +6248,6 @@ hardrock_2014_keith_metz_start_1:
   effort_id: 4206
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2016-05-24 03:02:37.507090000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7156,8 +6262,6 @@ hardrock_2014_keith_metz_telluride_in_1:
   effort_id: 4206
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2016-05-24 03:02:36.235218000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7172,8 +6276,6 @@ hardrock_2014_keith_metz_telluride_out_1:
   effort_id: 4206
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2016-05-24 03:02:36.235218000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7188,8 +6290,6 @@ hardrock_2014_keith_metz_ouray_in_1:
   effort_id: 4206
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2016-05-24 03:02:36.235218000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7204,8 +6304,6 @@ hardrock_2014_keith_metz_ouray_out_1:
   effort_id: 4206
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2016-05-24 03:02:36.235218000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7220,8 +6318,6 @@ hardrock_2014_keith_metz_grouse_in_1:
   effort_id: 4206
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2016-05-24 03:02:36.235218000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7236,8 +6332,6 @@ hardrock_2014_keith_metz_grouse_out_1:
   effort_id: 4206
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2016-05-24 03:02:36.235218000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7252,8 +6346,6 @@ hardrock_2014_keith_metz_sherman_in_1:
   effort_id: 4206
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2016-05-24 03:02:36.235218000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7268,8 +6360,6 @@ hardrock_2014_keith_metz_sherman_out_1:
   effort_id: 4206
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2016-05-24 03:02:36.235218000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7284,8 +6374,6 @@ hardrock_2014_keith_metz_cunningham_in_1:
   effort_id: 4206
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2016-05-24 03:02:36.235218000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7300,8 +6388,6 @@ hardrock_2014_keith_metz_cunningham_out_1:
   effort_id: 4206
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2016-05-24 03:02:36.235218000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7316,8 +6402,6 @@ hardrock_2014_keith_metz_finish_1:
   effort_id: 4206
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:36.235218000 Z
-  updated_at: 2017-02-19 02:02:38.728255000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7332,8 +6416,6 @@ hardrock_2014_major_green_start_1:
   effort_id: 4207
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2016-05-24 03:02:37.507380000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7348,8 +6430,6 @@ hardrock_2014_major_green_telluride_in_1:
   effort_id: 4207
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2016-05-24 03:02:36.254088000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7364,8 +6444,6 @@ hardrock_2014_major_green_telluride_out_1:
   effort_id: 4207
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2016-05-24 03:02:36.254088000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7380,8 +6458,6 @@ hardrock_2014_major_green_ouray_in_1:
   effort_id: 4207
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2016-05-24 03:02:36.254088000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7396,8 +6472,6 @@ hardrock_2014_major_green_ouray_out_1:
   effort_id: 4207
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2016-05-24 03:02:36.254088000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7412,8 +6486,6 @@ hardrock_2014_major_green_grouse_in_1:
   effort_id: 4207
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2016-05-24 03:02:36.254088000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7428,8 +6500,6 @@ hardrock_2014_major_green_grouse_out_1:
   effort_id: 4207
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2016-05-24 03:02:36.254088000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7444,8 +6514,6 @@ hardrock_2014_major_green_sherman_in_1:
   effort_id: 4207
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2016-05-24 03:02:36.254088000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7460,8 +6528,6 @@ hardrock_2014_major_green_sherman_out_1:
   effort_id: 4207
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2016-05-24 03:02:36.254088000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7476,8 +6542,6 @@ hardrock_2014_major_green_cunningham_in_1:
   effort_id: 4207
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2016-05-24 03:02:36.254088000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7492,8 +6556,6 @@ hardrock_2014_major_green_cunningham_out_1:
   effort_id: 4207
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2016-05-24 03:02:36.254088000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7508,8 +6570,6 @@ hardrock_2014_major_green_finish_1:
   effort_id: 4207
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:36.254088000 Z
-  updated_at: 2017-02-19 02:02:38.732411000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7524,8 +6584,6 @@ hardrock_2014_humberto_adams_start_1:
   effort_id: 4221
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2016-05-24 03:02:37.511278000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7540,8 +6598,6 @@ hardrock_2014_humberto_adams_telluride_in_1:
   effort_id: 4221
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2016-05-24 03:02:36.478166000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7556,8 +6612,6 @@ hardrock_2014_humberto_adams_telluride_out_1:
   effort_id: 4221
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2016-05-24 03:02:36.478166000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7572,8 +6626,6 @@ hardrock_2014_humberto_adams_ouray_in_1:
   effort_id: 4221
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2016-05-24 03:02:36.478166000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7588,8 +6640,6 @@ hardrock_2014_humberto_adams_ouray_out_1:
   effort_id: 4221
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2016-05-24 03:02:36.478166000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7604,8 +6654,6 @@ hardrock_2014_humberto_adams_grouse_in_1:
   effort_id: 4221
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2016-05-24 03:02:36.478166000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7620,8 +6668,6 @@ hardrock_2014_humberto_adams_grouse_out_1:
   effort_id: 4221
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2016-05-24 03:02:36.478166000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7636,8 +6682,6 @@ hardrock_2014_humberto_adams_sherman_in_1:
   effort_id: 4221
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2016-05-24 03:02:36.478166000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7652,8 +6696,6 @@ hardrock_2014_humberto_adams_sherman_out_1:
   effort_id: 4221
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2016-05-24 03:02:36.478166000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7668,8 +6710,6 @@ hardrock_2014_humberto_adams_cunningham_in_1:
   effort_id: 4221
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2016-05-24 03:02:36.478166000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7684,8 +6724,6 @@ hardrock_2014_humberto_adams_cunningham_out_1:
   effort_id: 4221
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2016-05-24 03:02:36.478166000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7700,8 +6738,6 @@ hardrock_2014_humberto_adams_finish_1:
   effort_id: 4221
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:36.478166000 Z
-  updated_at: 2017-02-19 02:02:38.789492000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7716,8 +6752,6 @@ hardrock_2014_omer_yundt_start_1:
   effort_id: 4246
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2016-05-24 03:02:37.519210000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7732,8 +6766,6 @@ hardrock_2014_omer_yundt_telluride_in_1:
   effort_id: 4246
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2016-05-24 03:02:36.786803000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7748,8 +6780,6 @@ hardrock_2014_omer_yundt_telluride_out_1:
   effort_id: 4246
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2016-05-24 03:02:36.786803000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7764,8 +6794,6 @@ hardrock_2014_omer_yundt_ouray_in_1:
   effort_id: 4246
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2016-05-24 03:02:36.786803000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7780,8 +6808,6 @@ hardrock_2014_omer_yundt_ouray_out_1:
   effort_id: 4246
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2016-05-24 03:02:36.786803000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7796,8 +6822,6 @@ hardrock_2014_omer_yundt_grouse_in_1:
   effort_id: 4246
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2016-05-24 03:02:36.786803000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7812,8 +6836,6 @@ hardrock_2014_omer_yundt_grouse_out_1:
   effort_id: 4246
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2016-05-24 03:02:36.786803000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7828,8 +6850,6 @@ hardrock_2014_omer_yundt_sherman_in_1:
   effort_id: 4246
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2016-05-24 03:02:36.786803000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7844,8 +6864,6 @@ hardrock_2014_omer_yundt_sherman_out_1:
   effort_id: 4246
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2016-05-24 03:02:36.786803000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7860,8 +6878,6 @@ hardrock_2014_omer_yundt_cunningham_in_1:
   effort_id: 4246
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2016-05-24 03:02:36.786803000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7876,8 +6892,6 @@ hardrock_2014_omer_yundt_cunningham_out_1:
   effort_id: 4246
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2016-05-24 03:02:36.786803000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7892,8 +6906,6 @@ hardrock_2014_omer_yundt_finish_1:
   effort_id: 4246
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:36.786803000 Z
-  updated_at: 2017-02-19 02:02:38.893104000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7908,8 +6920,6 @@ hardrock_2014_pat_schaden_start_1:
   effort_id: 4247
   split_id: 81
   data_status: 2
-  created_at: 2016-05-24 03:02:36.801099000 Z
-  updated_at: 2016-05-24 03:02:37.519504000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7924,8 +6934,6 @@ hardrock_2014_pat_schaden_telluride_in_1:
   effort_id: 4247
   split_id: 87
   data_status: 2
-  created_at: 2016-05-24 03:02:36.801099000 Z
-  updated_at: 2016-05-24 03:02:36.801099000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7940,8 +6948,6 @@ hardrock_2014_pat_schaden_telluride_out_1:
   effort_id: 4247
   split_id: 87
   data_status: 2
-  created_at: 2016-05-24 03:02:36.801099000 Z
-  updated_at: 2016-05-24 03:02:36.801099000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7956,8 +6962,6 @@ hardrock_2014_pat_schaden_ouray_in_1:
   effort_id: 4247
   split_id: 93
   data_status: 2
-  created_at: 2016-05-24 03:02:36.801099000 Z
-  updated_at: 2016-05-24 03:02:36.801099000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -7972,8 +6976,6 @@ hardrock_2014_pat_schaden_ouray_out_1:
   effort_id: 4247
   split_id: 93
   data_status: 2
-  created_at: 2016-05-24 03:02:36.801099000 Z
-  updated_at: 2016-05-24 03:02:36.801099000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -7988,8 +6990,6 @@ hardrock_2014_pat_schaden_grouse_in_1:
   effort_id: 4247
   split_id: 97
   data_status: 2
-  created_at: 2016-05-24 03:02:36.801099000 Z
-  updated_at: 2016-05-24 03:02:36.801099000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8004,8 +7004,6 @@ hardrock_2014_pat_schaden_grouse_out_1:
   effort_id: 4247
   split_id: 97
   data_status: 2
-  created_at: 2016-05-24 03:02:36.801099000 Z
-  updated_at: 2016-05-24 03:02:36.801099000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8020,8 +7018,6 @@ hardrock_2014_pat_schaden_sherman_in_1:
   effort_id: 4247
   split_id: 101
   data_status: 2
-  created_at: 2016-05-24 03:02:36.801099000 Z
-  updated_at: 2016-05-24 03:02:36.801099000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8036,8 +7032,6 @@ hardrock_2014_pat_schaden_sherman_out_1:
   effort_id: 4247
   split_id: 101
   data_status: 2
-  created_at: 2016-05-24 03:02:36.801099000 Z
-  updated_at: 2016-05-24 03:02:36.801099000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8052,8 +7046,6 @@ hardrock_2014_pat_schaden_cunningham_in_1:
   effort_id: 4247
   split_id: 107
   data_status: 2
-  created_at: 2016-05-24 03:02:36.801099000 Z
-  updated_at: 2016-05-24 03:02:36.801099000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8068,8 +7060,6 @@ hardrock_2014_clarence_goyette_start_1:
   effort_id: 4249
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2016-05-24 03:02:37.520085000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8084,8 +7074,6 @@ hardrock_2014_clarence_goyette_telluride_in_1:
   effort_id: 4249
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2016-05-24 03:02:36.826062000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8100,8 +7088,6 @@ hardrock_2014_clarence_goyette_telluride_out_1:
   effort_id: 4249
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2016-05-24 03:02:36.826062000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8116,8 +7102,6 @@ hardrock_2014_clarence_goyette_ouray_in_1:
   effort_id: 4249
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2016-05-24 03:02:36.826062000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8132,8 +7116,6 @@ hardrock_2014_clarence_goyette_ouray_out_1:
   effort_id: 4249
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2016-05-24 03:02:36.826062000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8148,8 +7130,6 @@ hardrock_2014_clarence_goyette_grouse_in_1:
   effort_id: 4249
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2016-05-24 03:02:36.826062000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8164,8 +7144,6 @@ hardrock_2014_clarence_goyette_grouse_out_1:
   effort_id: 4249
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2016-05-24 03:02:36.826062000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8180,8 +7158,6 @@ hardrock_2014_clarence_goyette_sherman_in_1:
   effort_id: 4249
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2016-05-24 03:02:36.826062000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8196,8 +7172,6 @@ hardrock_2014_clarence_goyette_sherman_out_1:
   effort_id: 4249
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2016-05-24 03:02:36.826062000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8212,8 +7186,6 @@ hardrock_2014_clarence_goyette_cunningham_in_1:
   effort_id: 4249
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2016-05-24 03:02:36.826062000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8228,8 +7200,6 @@ hardrock_2014_clarence_goyette_cunningham_out_1:
   effort_id: 4249
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2016-05-24 03:02:36.826062000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8244,8 +7214,6 @@ hardrock_2014_clarence_goyette_finish_1:
   effort_id: 4249
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:36.826062000 Z
-  updated_at: 2017-02-19 02:02:38.905730000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8260,8 +7228,6 @@ hardrock_2014_irvin_corkery_start_1:
   effort_id: 4251
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2016-05-24 03:02:37.520696000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8276,8 +7242,6 @@ hardrock_2014_irvin_corkery_telluride_in_1:
   effort_id: 4251
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2016-05-24 03:02:36.849322000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8292,8 +7256,6 @@ hardrock_2014_irvin_corkery_telluride_out_1:
   effort_id: 4251
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2016-05-24 03:02:36.849322000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8308,8 +7270,6 @@ hardrock_2014_irvin_corkery_ouray_in_1:
   effort_id: 4251
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2016-05-24 03:02:36.849322000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8324,8 +7284,6 @@ hardrock_2014_irvin_corkery_ouray_out_1:
   effort_id: 4251
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2016-05-24 03:02:36.849322000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8340,8 +7298,6 @@ hardrock_2014_irvin_corkery_grouse_in_1:
   effort_id: 4251
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2016-05-24 03:02:36.849322000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8356,8 +7312,6 @@ hardrock_2014_irvin_corkery_grouse_out_1:
   effort_id: 4251
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2016-05-24 03:02:36.849322000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8372,8 +7326,6 @@ hardrock_2014_irvin_corkery_sherman_in_1:
   effort_id: 4251
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2016-05-24 03:02:36.849322000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8388,8 +7340,6 @@ hardrock_2014_irvin_corkery_sherman_out_1:
   effort_id: 4251
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2016-05-24 03:02:36.849322000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8404,8 +7354,6 @@ hardrock_2014_irvin_corkery_cunningham_in_1:
   effort_id: 4251
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2016-05-24 03:02:36.849322000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8420,8 +7368,6 @@ hardrock_2014_irvin_corkery_cunningham_out_1:
   effort_id: 4251
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2016-05-24 03:02:36.849322000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8436,8 +7382,6 @@ hardrock_2014_irvin_corkery_finish_1:
   effort_id: 4251
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:36.849322000 Z
-  updated_at: 2017-02-19 02:02:38.914139000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8452,8 +7396,6 @@ hardrock_2014_willis_murray_start_1:
   effort_id: 4253
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2016-05-24 03:02:37.521265000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8468,8 +7410,6 @@ hardrock_2014_willis_murray_telluride_in_1:
   effort_id: 4253
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2016-05-24 03:02:36.876748000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8484,8 +7424,6 @@ hardrock_2014_willis_murray_telluride_out_1:
   effort_id: 4253
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2016-05-24 03:02:36.876748000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8500,8 +7438,6 @@ hardrock_2014_willis_murray_ouray_in_1:
   effort_id: 4253
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2016-05-24 03:02:36.876748000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8516,8 +7452,6 @@ hardrock_2014_willis_murray_ouray_out_1:
   effort_id: 4253
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2016-05-24 03:02:36.876748000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8532,8 +7466,6 @@ hardrock_2014_willis_murray_grouse_in_1:
   effort_id: 4253
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2016-05-24 03:02:36.876748000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8548,8 +7480,6 @@ hardrock_2014_willis_murray_grouse_out_1:
   effort_id: 4253
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2016-05-24 03:02:36.876748000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8564,8 +7494,6 @@ hardrock_2014_willis_murray_sherman_in_1:
   effort_id: 4253
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2016-05-24 03:02:36.876748000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8580,8 +7508,6 @@ hardrock_2014_willis_murray_sherman_out_1:
   effort_id: 4253
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2016-05-24 03:02:36.876748000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8596,8 +7522,6 @@ hardrock_2014_willis_murray_cunningham_in_1:
   effort_id: 4253
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2016-05-24 03:02:36.876748000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8612,8 +7536,6 @@ hardrock_2014_willis_murray_cunningham_out_1:
   effort_id: 4253
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2016-05-24 03:02:36.876748000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8628,8 +7550,6 @@ hardrock_2014_willis_murray_finish_1:
   effort_id: 4253
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:36.876748000 Z
-  updated_at: 2017-02-19 02:02:38.922548000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8644,8 +7564,6 @@ hardrock_2014_ken_bradtke_start_1:
   effort_id: 4256
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2016-05-24 03:02:37.522140000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8660,8 +7578,6 @@ hardrock_2014_ken_bradtke_telluride_in_1:
   effort_id: 4256
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2016-05-24 03:02:36.912057000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8676,8 +7592,6 @@ hardrock_2014_ken_bradtke_telluride_out_1:
   effort_id: 4256
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2016-05-24 03:02:36.912057000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8692,8 +7606,6 @@ hardrock_2014_ken_bradtke_ouray_in_1:
   effort_id: 4256
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2016-05-24 03:02:36.912057000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8708,8 +7620,6 @@ hardrock_2014_ken_bradtke_ouray_out_1:
   effort_id: 4256
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2016-05-24 03:02:36.912057000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8724,8 +7634,6 @@ hardrock_2014_ken_bradtke_grouse_in_1:
   effort_id: 4256
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2016-05-24 03:02:36.912057000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8740,8 +7648,6 @@ hardrock_2014_ken_bradtke_grouse_out_1:
   effort_id: 4256
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2016-05-24 03:02:36.912057000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8756,8 +7662,6 @@ hardrock_2014_ken_bradtke_sherman_in_1:
   effort_id: 4256
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2016-05-24 03:02:36.912057000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8772,8 +7676,6 @@ hardrock_2014_ken_bradtke_sherman_out_1:
   effort_id: 4256
   split_id: 101
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2016-05-24 03:02:36.912057000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8788,8 +7690,6 @@ hardrock_2014_ken_bradtke_cunningham_in_1:
   effort_id: 4256
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2016-05-24 03:02:36.912057000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8804,8 +7704,6 @@ hardrock_2014_ken_bradtke_cunningham_out_1:
   effort_id: 4256
   split_id: 107
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2016-05-24 03:02:36.912057000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8820,8 +7718,6 @@ hardrock_2014_ken_bradtke_finish_1:
   effort_id: 4256
   split_id: 82
   data_status:
-  created_at: 2016-05-24 03:02:36.912057000 Z
-  updated_at: 2017-02-19 02:02:38.934771000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8836,8 +7732,6 @@ hardrock_2014_progress_sherman_start_1:
   effort_id: 4277
   split_id: 81
   data_status: 2
-  created_at: 2016-05-24 03:02:37.149167000 Z
-  updated_at: 2016-05-24 03:02:37.528214000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8852,8 +7746,6 @@ hardrock_2014_progress_sherman_telluride_in_1:
   effort_id: 4277
   split_id: 87
   data_status: 2
-  created_at: 2016-05-24 03:02:37.149167000 Z
-  updated_at: 2016-05-24 03:02:37.149167000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8868,8 +7760,6 @@ hardrock_2014_progress_sherman_telluride_out_1:
   effort_id: 4277
   split_id: 87
   data_status: 2
-  created_at: 2016-05-24 03:02:37.149167000 Z
-  updated_at: 2016-05-24 03:02:37.149167000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8884,8 +7774,6 @@ hardrock_2014_progress_sherman_ouray_in_1:
   effort_id: 4277
   split_id: 93
   data_status: 2
-  created_at: 2016-05-24 03:02:37.149167000 Z
-  updated_at: 2016-05-24 03:02:37.149167000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8900,8 +7788,6 @@ hardrock_2014_progress_sherman_ouray_out_1:
   effort_id: 4277
   split_id: 93
   data_status: 2
-  created_at: 2016-05-24 03:02:37.149167000 Z
-  updated_at: 2016-05-24 03:02:37.149167000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8916,8 +7802,6 @@ hardrock_2014_progress_sherman_grouse_in_1:
   effort_id: 4277
   split_id: 97
   data_status: 2
-  created_at: 2016-05-24 03:02:37.149167000 Z
-  updated_at: 2016-05-24 03:02:37.149167000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8932,8 +7816,6 @@ hardrock_2014_progress_sherman_grouse_out_1:
   effort_id: 4277
   split_id: 97
   data_status: 2
-  created_at: 2016-05-24 03:02:37.149167000 Z
-  updated_at: 2016-05-24 03:02:37.149167000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8948,8 +7830,6 @@ hardrock_2014_progress_sherman_sherman_in_1:
   effort_id: 4277
   split_id: 101
   data_status: 2
-  created_at: 2016-05-24 03:02:37.149167000 Z
-  updated_at: 2016-05-24 03:02:37.149167000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8964,8 +7844,6 @@ hardrock_2014_progress_sherman_sherman_out_1:
   effort_id: 4277
   split_id: 101
   data_status: 2
-  created_at: 2016-05-24 03:02:37.149167000 Z
-  updated_at: 2017-02-19 02:02:39.023455000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -8980,8 +7858,6 @@ hardrock_2014_multiple_stops_start_1:
   effort_id: 4293
   split_id: 81
   data_status:
-  created_at: 2016-05-24 03:02:37.324739000 Z
-  updated_at: 2016-05-24 03:02:37.532869000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -8996,8 +7872,6 @@ hardrock_2014_multiple_stops_telluride_in_1:
   effort_id: 4293
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:37.324739000 Z
-  updated_at: 2016-05-24 03:02:37.324739000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9012,8 +7886,6 @@ hardrock_2014_multiple_stops_telluride_out_1:
   effort_id: 4293
   split_id: 87
   data_status:
-  created_at: 2016-05-24 03:02:37.324739000 Z
-  updated_at: 2016-05-24 03:02:37.324739000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -9028,8 +7900,6 @@ hardrock_2014_multiple_stops_ouray_in_1:
   effort_id: 4293
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:37.324739000 Z
-  updated_at: 2016-05-24 03:02:37.324739000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9044,8 +7914,6 @@ hardrock_2014_multiple_stops_ouray_out_1:
   effort_id: 4293
   split_id: 93
   data_status:
-  created_at: 2016-05-24 03:02:37.324739000 Z
-  updated_at: 2019-01-28 10:51:38.630596000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -9060,8 +7928,6 @@ hardrock_2014_multiple_stops_grouse_in_1:
   effort_id: 4293
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:37.324739000 Z
-  updated_at: 2016-05-24 03:02:37.324739000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9076,8 +7942,6 @@ hardrock_2014_multiple_stops_grouse_out_1:
   effort_id: 4293
   split_id: 97
   data_status:
-  created_at: 2016-05-24 03:02:37.324739000 Z
-  updated_at: 2017-02-19 02:02:39.096574000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -9092,8 +7956,6 @@ hardrock_2014_without_start_telluride_in_1:
   effort_id: 4294
   split_id: 87
   data_status: 2
-  created_at: 2016-05-24 03:02:37.334335000 Z
-  updated_at: 2016-05-24 03:02:37.334335000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9108,8 +7970,6 @@ hardrock_2014_without_start_telluride_out_1:
   effort_id: 4294
   split_id: 87
   data_status: 2
-  created_at: 2016-05-24 03:02:37.334335000 Z
-  updated_at: 2016-05-24 03:02:37.334335000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -9124,8 +7984,6 @@ hardrock_2014_without_start_ouray_in_1:
   effort_id: 4294
   split_id: 93
   data_status: 2
-  created_at: 2016-05-24 03:02:37.334335000 Z
-  updated_at: 2016-05-24 03:02:37.334335000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9140,8 +7998,6 @@ hardrock_2014_without_start_ouray_out_1:
   effort_id: 4294
   split_id: 93
   data_status: 2
-  created_at: 2016-05-24 03:02:37.334335000 Z
-  updated_at: 2016-05-24 03:02:37.334335000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -9156,8 +8012,6 @@ hardrock_2014_without_start_grouse_in_1:
   effort_id: 4294
   split_id: 97
   data_status: 2
-  created_at: 2016-05-24 03:02:37.334335000 Z
-  updated_at: 2016-05-24 03:02:37.334335000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9172,8 +8026,6 @@ hardrock_2014_without_start_grouse_out_1:
   effort_id: 4294
   split_id: 97
   data_status: 2
-  created_at: 2016-05-24 03:02:37.334335000 Z
-  updated_at: 2017-02-19 02:02:39.100925000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -9188,8 +8040,6 @@ hardrock_2014_drop_ouray_start_1:
   effort_id: 4295
   split_id: 81
   data_status: 2
-  created_at: 2016-05-24 03:02:37.343903000 Z
-  updated_at: 2016-05-24 03:02:37.533540000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9204,8 +8054,6 @@ hardrock_2014_drop_ouray_telluride_in_1:
   effort_id: 4295
   split_id: 87
   data_status: 2
-  created_at: 2016-05-24 03:02:37.343903000 Z
-  updated_at: 2016-05-24 03:02:37.343903000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9220,8 +8068,6 @@ hardrock_2014_drop_ouray_telluride_out_1:
   effort_id: 4295
   split_id: 87
   data_status: 2
-  created_at: 2016-05-24 03:02:37.343903000 Z
-  updated_at: 2016-05-24 03:02:37.343903000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -9236,8 +8082,6 @@ hardrock_2014_drop_ouray_ouray_in_1:
   effort_id: 4295
   split_id: 93
   data_status: 2
-  created_at: 2016-05-24 03:02:37.343903000 Z
-  updated_at: 2016-05-24 03:02:37.343903000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9252,8 +8096,6 @@ hardrock_2014_drop_ouray_ouray_out_1:
   effort_id: 4295
   split_id: 93
   data_status: 2
-  created_at: 2016-05-24 03:02:37.343903000 Z
-  updated_at: 2022-03-08 08:40:50.642196000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -9268,8 +8110,6 @@ hardrock_2015_bad_status_telluride_in_1:
   effort_id: 138
   split_id: 26
   data_status: 1
-  created_at: 2016-06-14 15:37:38.846614000 Z
-  updated_at: 2018-01-10 08:48:48.722101000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9284,8 +8124,6 @@ hardrock_2015_bad_status_telluride_out_1:
   effort_id: 138
   split_id: 26
   data_status: 1
-  created_at: 2016-06-14 15:37:38.851625000 Z
-  updated_at: 2018-01-10 08:48:48.724447000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -9300,8 +8138,6 @@ hardrock_2015_irvin_harber_telluride_in_1:
   effort_id: 141
   split_id: 26
   data_status: 2
-  created_at: 2016-06-14 15:37:38.884490000 Z
-  updated_at: 2018-01-10 08:48:48.508286000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9316,8 +8152,6 @@ hardrock_2015_irvin_harber_telluride_out_1:
   effort_id: 141
   split_id: 26
   data_status: 2
-  created_at: 2016-06-14 15:37:38.888574000 Z
-  updated_at: 2018-01-10 08:48:48.510587000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -9332,8 +8166,6 @@ hardrock_2015_bad_status_putnam_in_1:
   effort_id: 138
   split_id: 32
   data_status: 0
-  created_at: 2016-06-25 04:31:24.300724000 Z
-  updated_at: 2018-01-10 08:48:49.003233000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9348,8 +8180,6 @@ hardrock_2015_bad_status_putnam_out_1:
   effort_id: 138
   split_id: 32
   data_status: 0
-  created_at: 2016-06-25 04:31:24.306442000 Z
-  updated_at: 2018-01-10 08:48:49.006107000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -9364,8 +8194,6 @@ rufa_2016_finished_first_start_1:
   effort_id: 6518
   split_id: 135
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9380,8 +8208,6 @@ rufa_2016_finished_first_grandeur_peak_1:
   effort_id: 6518
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9396,8 +8222,6 @@ rufa_2016_finished_first_grandeur_peak_2:
   effort_id: 6518
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9412,8 +8236,6 @@ rufa_2016_finished_first_finish_2:
   effort_id: 6518
   split_id: 136
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9428,8 +8250,6 @@ rufa_2016_finished_first_grandeur_peak_3:
   effort_id: 6518
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9444,8 +8264,6 @@ rufa_2016_finished_first_grandeur_peak_4:
   effort_id: 6518
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9460,8 +8278,6 @@ rufa_2016_finished_first_finish_4:
   effort_id: 6518
   split_id: 136
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9476,8 +8292,6 @@ rufa_2016_finished_first_start_5:
   effort_id: 6518
   split_id: 135
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9492,8 +8306,6 @@ rufa_2016_finished_first_grandeur_peak_5:
   effort_id: 6518
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9508,8 +8320,6 @@ rufa_2016_finished_first_finish_5:
   effort_id: 6518
   split_id: 136
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9524,8 +8334,6 @@ rufa_2016_finished_first_start_6:
   effort_id: 6518
   split_id: 135
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9540,8 +8348,6 @@ rufa_2016_finished_first_grandeur_peak_6:
   effort_id: 6518
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9556,8 +8362,6 @@ rufa_2016_finished_first_finish_6:
   effort_id: 6518
   split_id: 136
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9572,8 +8376,6 @@ rufa_2016_finished_first_start_7:
   effort_id: 6518
   split_id: 135
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9588,8 +8390,6 @@ rufa_2016_finished_first_grandeur_peak_7:
   effort_id: 6518
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-18 07:04:04.097334000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9604,8 +8404,6 @@ rufa_2016_finished_first_finish_7:
   effort_id: 6518
   split_id: 136
   data_status: 2
-  created_at: 2017-02-18 07:04:04.097334000 Z
-  updated_at: 2017-02-19 02:02:44.012268000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9620,8 +8418,6 @@ rufa_2016_finished_second_start_1:
   effort_id: 6520
   split_id: 135
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9636,8 +8432,6 @@ rufa_2016_finished_second_grandeur_peak_1:
   effort_id: 6520
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9652,8 +8446,6 @@ rufa_2016_finished_second_finish_1:
   effort_id: 6520
   split_id: 136
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9668,8 +8460,6 @@ rufa_2016_finished_second_start_2:
   effort_id: 6520
   split_id: 135
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9684,8 +8474,6 @@ rufa_2016_finished_second_grandeur_peak_2:
   effort_id: 6520
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9700,8 +8488,6 @@ rufa_2016_finished_second_finish_2:
   effort_id: 6520
   split_id: 136
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9716,8 +8502,6 @@ rufa_2016_finished_second_grandeur_peak_3:
   effort_id: 6520
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9732,8 +8516,6 @@ rufa_2016_finished_second_finish_3:
   effort_id: 6520
   split_id: 136
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9748,8 +8530,6 @@ rufa_2016_finished_second_start_4:
   effort_id: 6520
   split_id: 135
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9764,8 +8544,6 @@ rufa_2016_finished_second_grandeur_peak_4:
   effort_id: 6520
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9780,8 +8558,6 @@ rufa_2016_finished_second_finish_4:
   effort_id: 6520
   split_id: 136
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9796,8 +8572,6 @@ rufa_2016_finished_second_grandeur_peak_5:
   effort_id: 6520
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9812,8 +8586,6 @@ rufa_2016_finished_second_finish_5:
   effort_id: 6520
   split_id: 136
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9828,8 +8600,6 @@ rufa_2016_finished_second_start_6:
   effort_id: 6520
   split_id: 135
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9844,8 +8614,6 @@ rufa_2016_finished_second_grandeur_peak_6:
   effort_id: 6520
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-18 07:04:05.602591000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9860,8 +8628,6 @@ rufa_2016_finished_second_finish_6:
   effort_id: 6520
   split_id: 136
   data_status: 2
-  created_at: 2017-02-18 07:04:05.602591000 Z
-  updated_at: 2017-02-19 02:02:44.020816000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9876,8 +8642,6 @@ rufa_2016_progress_lap1_start_1:
   effort_id: 6560
   split_id: 135
   data_status: 2
-  created_at: 2017-02-18 07:04:23.776349000 Z
-  updated_at: 2017-02-18 07:04:23.776349000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9892,8 +8656,6 @@ rufa_2016_progress_lap1_grandeur_peak_1:
   effort_id: 6560
   split_id: 137
   data_status: 2
-  created_at: 2017-02-18 07:04:23.776349000 Z
-  updated_at: 2017-02-18 07:04:23.776349000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9908,8 +8670,6 @@ rufa_2017_24h_finished_first_start_1:
   effort_id: 6693
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:12.667312000 Z
-  updated_at: 2017-03-28 07:24:12.667312000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9924,8 +8684,6 @@ rufa_2017_24h_finished_first_grandeur_peak_1:
   effort_id: 6693
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:12.673789000 Z
-  updated_at: 2017-03-28 07:24:12.673789000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9940,8 +8698,6 @@ rufa_2017_24h_finished_first_finish_1:
   effort_id: 6693
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:12.679640000 Z
-  updated_at: 2017-03-28 07:24:12.679640000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9956,8 +8712,6 @@ rufa_2017_24h_finished_first_start_2:
   effort_id: 6693
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:12.685235000 Z
-  updated_at: 2017-03-28 07:24:12.685235000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9972,8 +8726,6 @@ rufa_2017_24h_finished_first_grandeur_peak_2:
   effort_id: 6693
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:12.691834000 Z
-  updated_at: 2017-03-28 07:24:12.691834000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -9988,8 +8740,6 @@ rufa_2017_24h_finished_first_finish_2:
   effort_id: 6693
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:12.697497000 Z
-  updated_at: 2017-03-28 07:24:12.697497000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10004,8 +8754,6 @@ rufa_2017_24h_finished_first_start_3:
   effort_id: 6693
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:12.703446000 Z
-  updated_at: 2017-03-28 07:24:12.703446000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10020,8 +8768,6 @@ rufa_2017_24h_finished_first_grandeur_peak_3:
   effort_id: 6693
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:12.709023000 Z
-  updated_at: 2017-03-28 07:24:12.709023000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10036,8 +8782,6 @@ rufa_2017_24h_finished_first_finish_3:
   effort_id: 6693
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:12.743441000 Z
-  updated_at: 2017-03-28 07:24:12.743441000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10052,8 +8796,6 @@ rufa_2017_24h_finished_first_start_4:
   effort_id: 6693
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:12.752521000 Z
-  updated_at: 2017-03-28 07:24:12.752521000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10068,8 +8810,6 @@ rufa_2017_24h_finished_first_grandeur_peak_4:
   effort_id: 6693
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:12.763359000 Z
-  updated_at: 2017-03-28 07:24:12.763359000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10084,8 +8824,6 @@ rufa_2017_24h_finished_first_finish_4:
   effort_id: 6693
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:12.775359000 Z
-  updated_at: 2017-03-28 07:24:12.775359000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10100,8 +8838,6 @@ rufa_2017_24h_finished_first_start_5:
   effort_id: 6693
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:12.781905000 Z
-  updated_at: 2017-03-28 07:24:12.781905000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10116,8 +8852,6 @@ rufa_2017_24h_finished_first_grandeur_peak_5:
   effort_id: 6693
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:12.789316000 Z
-  updated_at: 2017-03-28 07:24:12.789316000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10132,8 +8866,6 @@ rufa_2017_24h_finished_first_finish_5:
   effort_id: 6693
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:12.796904000 Z
-  updated_at: 2017-03-28 07:24:12.796904000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10148,8 +8880,6 @@ rufa_2017_24h_finished_first_start_6:
   effort_id: 6693
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:12.802432000 Z
-  updated_at: 2017-03-28 07:24:12.802432000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10164,8 +8894,6 @@ rufa_2017_24h_finished_first_grandeur_peak_6:
   effort_id: 6693
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:12.810621000 Z
-  updated_at: 2017-03-28 07:24:12.810621000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10180,8 +8908,6 @@ rufa_2017_24h_finished_first_finish_6:
   effort_id: 6693
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:12.816844000 Z
-  updated_at: 2017-03-28 07:24:12.816844000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10196,8 +8922,6 @@ rufa_2017_24h_finished_first_start_7:
   effort_id: 6693
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:12.824537000 Z
-  updated_at: 2017-03-28 07:24:12.824537000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10212,8 +8936,6 @@ rufa_2017_24h_finished_first_grandeur_peak_7:
   effort_id: 6693
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:12.831884000 Z
-  updated_at: 2017-03-28 07:24:12.831884000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10228,8 +8950,6 @@ rufa_2017_24h_finished_first_finish_7:
   effort_id: 6693
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:12.839485000 Z
-  updated_at: 2017-03-28 07:24:12.839485000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10244,8 +8964,6 @@ rufa_2017_24h_progress_lap6_start_1:
   effort_id: 6695
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:13.362877000 Z
-  updated_at: 2017-03-28 07:24:13.362877000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10260,8 +8978,6 @@ rufa_2017_24h_progress_lap6_grandeur_peak_1:
   effort_id: 6695
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:13.371196000 Z
-  updated_at: 2017-03-28 07:24:13.371196000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10276,8 +8992,6 @@ rufa_2017_24h_progress_lap6_finish_1:
   effort_id: 6695
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:13.379462000 Z
-  updated_at: 2017-03-28 07:24:13.379462000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10292,8 +9006,6 @@ rufa_2017_24h_progress_lap6_start_2:
   effort_id: 6695
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:13.393398000 Z
-  updated_at: 2017-03-28 07:24:13.393398000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10308,8 +9020,6 @@ rufa_2017_24h_progress_lap6_grandeur_peak_2:
   effort_id: 6695
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:13.401433000 Z
-  updated_at: 2017-03-28 07:24:13.401433000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10324,8 +9034,6 @@ rufa_2017_24h_progress_lap6_finish_2:
   effort_id: 6695
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:13.414347000 Z
-  updated_at: 2017-03-28 07:24:13.414347000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10340,8 +9048,6 @@ rufa_2017_24h_progress_lap6_start_3:
   effort_id: 6695
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:13.419652000 Z
-  updated_at: 2017-03-28 07:24:13.419652000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10356,8 +9062,6 @@ rufa_2017_24h_progress_lap6_grandeur_peak_3:
   effort_id: 6695
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:13.425302000 Z
-  updated_at: 2017-03-28 07:24:13.425302000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10372,8 +9076,6 @@ rufa_2017_24h_progress_lap6_finish_3:
   effort_id: 6695
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:13.430614000 Z
-  updated_at: 2017-03-28 07:24:13.430614000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10388,8 +9090,6 @@ rufa_2017_24h_progress_lap6_start_4:
   effort_id: 6695
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:13.436712000 Z
-  updated_at: 2017-03-28 07:24:13.436712000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10404,8 +9104,6 @@ rufa_2017_24h_progress_lap6_grandeur_peak_4:
   effort_id: 6695
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:13.444308000 Z
-  updated_at: 2017-03-28 07:24:13.444308000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10420,8 +9118,6 @@ rufa_2017_24h_progress_lap6_finish_4:
   effort_id: 6695
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:13.450753000 Z
-  updated_at: 2017-03-28 07:24:13.450753000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10436,8 +9132,6 @@ rufa_2017_24h_progress_lap6_start_5:
   effort_id: 6695
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:13.457372000 Z
-  updated_at: 2017-03-28 07:24:13.457372000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10452,8 +9146,6 @@ rufa_2017_24h_progress_lap6_grandeur_peak_5:
   effort_id: 6695
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:13.462594000 Z
-  updated_at: 2017-03-28 07:24:13.462594000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10468,8 +9160,6 @@ rufa_2017_24h_progress_lap6_finish_5:
   effort_id: 6695
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:13.468088000 Z
-  updated_at: 2017-03-28 07:24:13.468088000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10484,8 +9174,6 @@ rufa_2017_24h_progress_lap6_start_6:
   effort_id: 6695
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:13.474476000 Z
-  updated_at: 2017-03-28 07:24:13.474476000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10500,8 +9188,6 @@ rufa_2017_24h_progress_lap6_grandeur_peak_6:
   effort_id: 6695
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:13.480574000 Z
-  updated_at: 2017-03-28 07:24:13.480574000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10516,8 +9202,6 @@ rufa_2017_24h_progress_lap6_finish_6:
   effort_id: 6695
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:13.485958000 Z
-  updated_at: 2017-03-28 07:24:13.485958000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10532,8 +9216,6 @@ rufa_2017_24h_multiple_stops_start_1:
   effort_id: 6756
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:26.050267000 Z
-  updated_at: 2017-03-28 07:24:26.050267000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10548,8 +9230,6 @@ rufa_2017_24h_multiple_stops_grandeur_peak_1:
   effort_id: 6756
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:26.056359000 Z
-  updated_at: 2017-03-28 07:24:26.056359000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10564,8 +9244,6 @@ rufa_2017_24h_multiple_stops_finish_1:
   effort_id: 6756
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:26.061585000 Z
-  updated_at: 2017-03-28 07:24:26.061585000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10580,8 +9258,6 @@ rufa_2017_24h_multiple_stops_start_2:
   effort_id: 6756
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:26.066800000 Z
-  updated_at: 2017-03-28 07:24:26.066800000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10596,8 +9272,6 @@ rufa_2017_24h_multiple_stops_grandeur_peak_2:
   effort_id: 6756
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:26.072107000 Z
-  updated_at: 2017-03-28 07:24:26.072107000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10612,8 +9286,6 @@ rufa_2017_24h_multiple_stops_finish_2:
   effort_id: 6756
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:26.077311000 Z
-  updated_at: 2019-01-28 11:07:00.106756000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10628,8 +9300,6 @@ rufa_2017_24h_multiple_stops_grandeur_peak_3:
   effort_id: 6756
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:26.083537000 Z
-  updated_at: 2017-03-28 07:24:26.083537000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10644,8 +9314,6 @@ rufa_2017_24h_multiple_stops_finish_3:
   effort_id: 6756
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:26.088714000 Z
-  updated_at: 2017-03-28 07:24:26.088714000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10660,8 +9328,6 @@ rufa_2017_24h_finished_last_start_1:
   effort_id: 6780
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:29.220630000 Z
-  updated_at: 2017-03-28 07:24:29.220630000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10676,8 +9342,6 @@ rufa_2017_24h_finished_last_grandeur_peak_1:
   effort_id: 6780
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:29.226509000 Z
-  updated_at: 2017-03-28 07:24:29.226509000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10692,8 +9356,6 @@ rufa_2017_24h_finished_last_finish_1:
   effort_id: 6780
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:29.232888000 Z
-  updated_at: 2017-03-28 07:24:29.232888000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10708,8 +9370,6 @@ rufa_2017_24h_finished_last_start_2:
   effort_id: 6780
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:29.237883000 Z
-  updated_at: 2017-03-28 07:24:29.237883000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10724,8 +9384,6 @@ rufa_2017_24h_finished_last_grandeur_peak_2:
   effort_id: 6780
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:29.244497000 Z
-  updated_at: 2017-03-28 07:24:29.244497000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10740,8 +9398,6 @@ rufa_2017_24h_finished_last_finish_2:
   effort_id: 6780
   split_id: 136
   data_status: 2
-  created_at: 2017-03-28 07:24:29.249554000 Z
-  updated_at: 2017-03-28 07:24:29.249554000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10756,8 +9412,6 @@ rufa_2017_24h_progress_lap1_start_1:
   effort_id: 6805
   split_id: 135
   data_status: 2
-  created_at: 2017-03-28 07:24:31.380981000 Z
-  updated_at: 2017-03-28 07:24:31.380981000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10772,8 +9426,6 @@ rufa_2017_24h_progress_lap1_grandeur_peak_1:
   effort_id: 6805
   split_id: 137
   data_status: 2
-  created_at: 2017-03-28 07:24:31.387254000 Z
-  updated_at: 2017-03-28 07:24:31.387254000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10788,8 +9440,6 @@ rufa_2017_24h_progress_lap1_finish_1:
   effort_id: 6805
   split_id: 136
   data_status: 1
-  created_at: 2017-03-28 07:24:31.393349000 Z
-  updated_at: 2017-03-28 07:24:31.393349000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10804,8 +9454,6 @@ hardrock_2016_lavon_paucek_start_1:
   effort_id: 7270
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:13.971505000 Z
-  updated_at: 2017-04-18 09:43:13.971505000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -10820,8 +9468,6 @@ hardrock_2016_lavon_paucek_telluride_in_1:
   effort_id: 7270
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:13.993821000 Z
-  updated_at: 2018-01-10 09:48:24.363647000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10836,8 +9482,6 @@ hardrock_2016_lavon_paucek_telluride_out_1:
   effort_id: 7270
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:13.997990000 Z
-  updated_at: 2018-01-10 09:48:24.365784000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -10852,8 +9496,6 @@ hardrock_2016_lavon_paucek_ouray_in_1:
   effort_id: 7270
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:14.027135000 Z
-  updated_at: 2018-01-10 09:48:24.376129000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10868,8 +9510,6 @@ hardrock_2016_lavon_paucek_ouray_out_1:
   effort_id: 7270
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:14.031381000 Z
-  updated_at: 2018-01-10 09:48:24.378701000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -10884,8 +9524,6 @@ hardrock_2016_lavon_paucek_grouse_in_1:
   effort_id: 7270
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:14.047739000 Z
-  updated_at: 2018-01-10 09:48:24.385828000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10900,8 +9538,6 @@ hardrock_2016_lavon_paucek_grouse_out_1:
   effort_id: 7270
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:14.051986000 Z
-  updated_at: 2018-01-10 09:48:24.388180000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -10916,8 +9552,6 @@ hardrock_2016_lavon_paucek_sherman_in_1:
   effort_id: 7270
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:14.067788000 Z
-  updated_at: 2018-01-10 09:48:24.393333000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10932,8 +9566,6 @@ hardrock_2016_lavon_paucek_sherman_out_1:
   effort_id: 7270
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:14.073605000 Z
-  updated_at: 2018-01-10 09:48:24.396009000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -10948,8 +9580,6 @@ hardrock_2016_lavon_paucek_cunningham_in_1:
   effort_id: 7270
   split_id: 107
   data_status: 2
-  created_at: 2017-04-18 09:43:14.100738000 Z
-  updated_at: 2018-01-10 09:48:24.411171000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10964,8 +9594,6 @@ hardrock_2016_lavon_paucek_cunningham_out_1:
   effort_id: 7270
   split_id: 107
   data_status: 2
-  created_at: 2017-04-18 09:43:14.105866000 Z
-  updated_at: 2018-01-10 09:48:24.431276000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -10980,8 +9608,6 @@ hardrock_2016_lavon_paucek_finish_1:
   effort_id: 7270
   split_id: 82
   data_status: 2
-  created_at: 2017-04-18 09:43:14.111943000 Z
-  updated_at: 2018-01-10 09:48:34.544964000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -10996,8 +9622,6 @@ hardrock_2016_vesta_borer_start_1:
   effort_id: 7284
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:17.441403000 Z
-  updated_at: 2017-04-18 09:43:17.441403000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -11012,8 +9636,6 @@ hardrock_2016_vesta_borer_telluride_in_1:
   effort_id: 7284
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:17.465443000 Z
-  updated_at: 2018-01-10 09:48:25.662957000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11028,8 +9650,6 @@ hardrock_2016_vesta_borer_telluride_out_1:
   effort_id: 7284
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:17.470250000 Z
-  updated_at: 2018-01-10 09:48:25.665579000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11044,8 +9664,6 @@ hardrock_2016_vesta_borer_ouray_in_1:
   effort_id: 7284
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:17.498596000 Z
-  updated_at: 2018-01-10 09:48:25.676404000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11060,8 +9678,6 @@ hardrock_2016_vesta_borer_ouray_out_1:
   effort_id: 7284
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:17.503752000 Z
-  updated_at: 2018-01-10 09:48:25.679854000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11076,8 +9692,6 @@ hardrock_2016_vesta_borer_grouse_in_1:
   effort_id: 7284
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:17.520433000 Z
-  updated_at: 2018-01-10 09:48:34.914474000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11092,8 +9706,6 @@ hardrock_2016_vesta_borer_grouse_out_1:
   effort_id: 7284
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:17.525181000 Z
-  updated_at: 2018-01-10 09:48:25.687032000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11108,8 +9720,6 @@ hardrock_2016_vesta_borer_sherman_in_1:
   effort_id: 7284
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:17.539766000 Z
-  updated_at: 2018-01-10 09:48:25.696953000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11124,8 +9734,6 @@ hardrock_2016_vesta_borer_sherman_out_1:
   effort_id: 7284
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:17.544884000 Z
-  updated_at: 2018-01-10 09:48:25.699063000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11140,8 +9748,6 @@ hardrock_2016_vesta_borer_cunningham_in_1:
   effort_id: 7284
   split_id: 107
   data_status: 2
-  created_at: 2017-04-18 09:43:17.570417000 Z
-  updated_at: 2018-01-10 09:48:25.710690000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11156,8 +9762,6 @@ hardrock_2016_vesta_borer_cunningham_out_1:
   effort_id: 7284
   split_id: 107
   data_status: 2
-  created_at: 2017-04-18 09:43:17.575438000 Z
-  updated_at: 2018-01-10 09:48:25.714054000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11172,8 +9776,6 @@ hardrock_2016_kory_kulas_start_1:
   effort_id: 7289
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:18.643850000 Z
-  updated_at: 2017-04-18 09:43:18.643850000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -11188,8 +9790,6 @@ hardrock_2016_kory_kulas_telluride_in_1:
   effort_id: 7289
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:18.668928000 Z
-  updated_at: 2018-01-10 09:48:34.952509000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11204,8 +9804,6 @@ hardrock_2016_kory_kulas_telluride_out_1:
   effort_id: 7289
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:18.673408000 Z
-  updated_at: 2018-01-10 09:48:26.035151000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11220,8 +9818,6 @@ hardrock_2016_kory_kulas_ouray_in_1:
   effort_id: 7289
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:18.697293000 Z
-  updated_at: 2018-01-10 09:48:26.048851000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11236,8 +9832,6 @@ hardrock_2016_kory_kulas_ouray_out_1:
   effort_id: 7289
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:18.703866000 Z
-  updated_at: 2018-01-10 09:48:26.051970000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11252,8 +9846,6 @@ hardrock_2016_kory_kulas_grouse_in_1:
   effort_id: 7289
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:18.717897000 Z
-  updated_at: 2018-01-10 09:48:26.057886000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11268,8 +9860,6 @@ hardrock_2016_kory_kulas_grouse_out_1:
   effort_id: 7289
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:18.722964000 Z
-  updated_at: 2018-01-10 09:48:26.060295000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11284,8 +9874,6 @@ hardrock_2016_kory_kulas_sherman_in_1:
   effort_id: 7289
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:18.737305000 Z
-  updated_at: 2018-01-10 09:48:26.068865000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11300,8 +9888,6 @@ hardrock_2016_kory_kulas_sherman_out_1:
   effort_id: 7289
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:18.741289000 Z
-  updated_at: 2018-01-10 09:48:27.521467000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11316,8 +9902,6 @@ hardrock_2016_kory_kulas_cunningham_in_1:
   effort_id: 7289
   split_id: 107
   data_status: 2
-  created_at: 2017-04-18 09:43:18.764302000 Z
-  updated_at: 2018-01-10 09:48:34.957072000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11332,8 +9916,6 @@ hardrock_2016_kory_kulas_cunningham_out_1:
   effort_id: 7289
   split_id: 107
   data_status: 2
-  created_at: 2017-04-18 09:43:18.769491000 Z
-  updated_at: 2018-01-10 09:48:26.087329000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11348,8 +9930,6 @@ hardrock_2016_shad_hirthe_start_1:
   effort_id: 7297
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:20.599754000 Z
-  updated_at: 2017-04-18 09:43:20.599754000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -11364,8 +9944,6 @@ hardrock_2016_shad_hirthe_telluride_in_1:
   effort_id: 7297
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:20.625036000 Z
-  updated_at: 2018-01-10 09:48:26.619708000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11380,8 +9958,6 @@ hardrock_2016_shad_hirthe_telluride_out_1:
   effort_id: 7297
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:20.629926000 Z
-  updated_at: 2018-01-10 09:48:26.621896000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11396,8 +9972,6 @@ hardrock_2016_shad_hirthe_ouray_in_1:
   effort_id: 7297
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:20.654688000 Z
-  updated_at: 2018-01-10 09:48:35.021178000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11412,8 +9986,6 @@ hardrock_2016_shad_hirthe_ouray_out_1:
   effort_id: 7297
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:20.660378000 Z
-  updated_at: 2018-01-10 09:48:26.635178000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11428,8 +10000,6 @@ hardrock_2016_shad_hirthe_grouse_in_1:
   effort_id: 7297
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:20.674981000 Z
-  updated_at: 2018-01-10 09:48:26.643135000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11444,8 +10014,6 @@ hardrock_2016_shad_hirthe_grouse_out_1:
   effort_id: 7297
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:20.679605000 Z
-  updated_at: 2018-01-10 09:48:26.645831000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11460,8 +10028,6 @@ hardrock_2016_shad_hirthe_sherman_in_1:
   effort_id: 7297
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:20.693276000 Z
-  updated_at: 2018-01-10 09:48:26.652421000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11476,8 +10042,6 @@ hardrock_2016_shad_hirthe_sherman_out_1:
   effort_id: 7297
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:20.697518000 Z
-  updated_at: 2018-01-10 09:48:35.023315000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11492,8 +10056,6 @@ hardrock_2016_douglas_vandervort_start_1:
   effort_id: 7302
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:21.789313000 Z
-  updated_at: 2017-04-18 09:43:21.789313000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -11508,8 +10070,6 @@ hardrock_2016_douglas_vandervort_telluride_in_1:
   effort_id: 7302
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:21.815686000 Z
-  updated_at: 2018-01-10 09:48:26.917923000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11524,8 +10084,6 @@ hardrock_2016_douglas_vandervort_telluride_out_1:
   effort_id: 7302
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:21.820437000 Z
-  updated_at: 2018-01-10 09:48:26.919952000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11540,8 +10098,6 @@ hardrock_2016_douglas_vandervort_ouray_in_1:
   effort_id: 7302
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:21.845265000 Z
-  updated_at: 2018-01-10 09:48:26.935125000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11556,8 +10112,6 @@ hardrock_2016_douglas_vandervort_ouray_out_1:
   effort_id: 7302
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:21.851302000 Z
-  updated_at: 2018-01-10 09:48:26.937375000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11572,8 +10126,6 @@ hardrock_2016_douglas_vandervort_grouse_in_1:
   effort_id: 7302
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:21.866141000 Z
-  updated_at: 2018-01-10 09:48:26.943806000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11588,8 +10140,6 @@ hardrock_2016_douglas_vandervort_grouse_out_1:
   effort_id: 7302
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:21.870239000 Z
-  updated_at: 2018-01-10 09:48:26.946005000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11604,8 +10154,6 @@ hardrock_2016_douglas_vandervort_sherman_in_1:
   effort_id: 7302
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:21.885124000 Z
-  updated_at: 2018-01-10 09:48:26.952791000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11620,8 +10168,6 @@ hardrock_2016_douglas_vandervort_sherman_out_1:
   effort_id: 7302
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:21.889467000 Z
-  updated_at: 2018-01-10 09:48:26.955965000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11636,8 +10182,6 @@ hardrock_2016_missing_telluride_out_start_1:
   effort_id: 7308
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:23.443210000 Z
-  updated_at: 2017-04-18 09:43:23.443210000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -11652,8 +10196,6 @@ hardrock_2016_missing_telluride_out_telluride_in_1:
   effort_id: 7308
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:23.503502000 Z
-  updated_at: 2018-01-10 09:48:27.353298000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11668,8 +10210,6 @@ hardrock_2016_missing_telluride_out_ouray_in_1:
   effort_id: 7308
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:23.533271000 Z
-  updated_at: 2018-01-10 09:48:27.366660000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11684,8 +10224,6 @@ hardrock_2016_missing_telluride_out_ouray_out_1:
   effort_id: 7308
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:23.537605000 Z
-  updated_at: 2018-01-10 09:48:27.369905000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11700,8 +10238,6 @@ hardrock_2016_missing_telluride_out_grouse_in_1:
   effort_id: 7308
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:23.552517000 Z
-  updated_at: 2018-01-10 09:48:27.377069000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11716,8 +10252,6 @@ hardrock_2016_missing_telluride_out_grouse_out_1:
   effort_id: 7308
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:23.557337000 Z
-  updated_at: 2018-01-10 09:48:27.535840000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11732,8 +10266,6 @@ hardrock_2016_missing_telluride_out_sherman_in_1:
   effort_id: 7308
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:23.572424000 Z
-  updated_at: 2018-01-10 09:48:27.387710000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11748,8 +10280,6 @@ hardrock_2016_missing_telluride_out_sherman_out_1:
   effort_id: 7308
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:23.578463000 Z
-  updated_at: 2018-01-10 09:48:27.389785000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11764,8 +10294,6 @@ hardrock_2016_junior_lesch_start_1:
   effort_id: 7311
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:24.209567000 Z
-  updated_at: 2017-04-18 09:43:24.209567000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -11780,8 +10308,6 @@ hardrock_2016_junior_lesch_telluride_in_1:
   effort_id: 7311
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:24.244050000 Z
-  updated_at: 2018-01-10 09:48:35.140054000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11796,8 +10322,6 @@ hardrock_2016_junior_lesch_telluride_out_1:
   effort_id: 7311
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:24.250787000 Z
-  updated_at: 2018-01-10 09:48:27.826323000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11812,8 +10336,6 @@ hardrock_2016_junior_lesch_ouray_in_1:
   effort_id: 7311
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:24.276597000 Z
-  updated_at: 2018-01-10 09:48:27.841292000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11828,8 +10350,6 @@ hardrock_2016_junior_lesch_ouray_out_1:
   effort_id: 7311
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:24.282208000 Z
-  updated_at: 2018-01-10 09:48:27.844826000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11844,8 +10364,6 @@ hardrock_2016_junior_lesch_grouse_in_1:
   effort_id: 7311
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:24.295672000 Z
-  updated_at: 2018-01-10 09:48:27.849575000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11860,8 +10378,6 @@ hardrock_2016_junior_lesch_grouse_out_1:
   effort_id: 7311
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:24.300518000 Z
-  updated_at: 2018-01-10 09:48:27.853163000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11876,8 +10392,6 @@ hardrock_2016_junior_lesch_sherman_in_1:
   effort_id: 7311
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:24.313322000 Z
-  updated_at: 2018-01-10 09:48:27.862122000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11892,8 +10406,6 @@ hardrock_2016_junior_lesch_sherman_out_1:
   effort_id: 7311
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:24.318803000 Z
-  updated_at: 2018-01-10 09:48:27.540110000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11908,8 +10420,6 @@ hardrock_2016_eddy_goldner_start_1:
   effort_id: 7315
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:25.160676000 Z
-  updated_at: 2017-04-18 09:43:25.160676000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -11924,8 +10434,6 @@ hardrock_2016_eddy_goldner_telluride_in_1:
   effort_id: 7315
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:25.186348000 Z
-  updated_at: 2018-01-10 09:48:28.116400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11940,8 +10448,6 @@ hardrock_2016_eddy_goldner_telluride_out_1:
   effort_id: 7315
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:25.191761000 Z
-  updated_at: 2018-01-10 09:48:28.118870000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11956,8 +10462,6 @@ hardrock_2016_eddy_goldner_ouray_in_1:
   effort_id: 7315
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:25.216551000 Z
-  updated_at: 2018-01-10 09:48:28.131160000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -11972,8 +10476,6 @@ hardrock_2016_eddy_goldner_ouray_out_1:
   effort_id: 7315
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:25.220808000 Z
-  updated_at: 2018-01-10 09:48:28.134630000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -11988,8 +10490,6 @@ hardrock_2016_eddy_goldner_grouse_in_1:
   effort_id: 7315
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:25.236388000 Z
-  updated_at: 2018-01-10 09:48:28.142360000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12004,8 +10504,6 @@ hardrock_2016_eddy_goldner_grouse_out_1:
   effort_id: 7315
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:25.241361000 Z
-  updated_at: 2018-01-10 09:48:28.147248000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12020,8 +10518,6 @@ hardrock_2016_eddy_goldner_sherman_in_1:
   effort_id: 7315
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:25.255517000 Z
-  updated_at: 2018-01-10 09:48:28.152356000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12036,8 +10532,6 @@ hardrock_2016_eddy_goldner_sherman_out_1:
   effort_id: 7315
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:25.260521000 Z
-  updated_at: 2018-01-10 09:48:28.155345000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12052,8 +10546,6 @@ hardrock_2016_progress_sherman_start_1:
   effort_id: 7328
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:28.242505000 Z
-  updated_at: 2017-04-18 09:43:28.242505000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -12068,8 +10560,6 @@ hardrock_2016_progress_sherman_telluride_in_1:
   effort_id: 7328
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:28.267091000 Z
-  updated_at: 2018-01-10 09:48:29.177278000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12084,8 +10574,6 @@ hardrock_2016_progress_sherman_telluride_out_1:
   effort_id: 7328
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:28.272233000 Z
-  updated_at: 2018-01-10 09:48:29.179898000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12100,8 +10588,6 @@ hardrock_2016_progress_sherman_ouray_in_1:
   effort_id: 7328
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:28.303482000 Z
-  updated_at: 2018-01-10 09:48:29.190664000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12116,8 +10602,6 @@ hardrock_2016_progress_sherman_ouray_out_1:
   effort_id: 7328
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:28.309475000 Z
-  updated_at: 2018-01-10 09:48:29.193194000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12132,8 +10616,6 @@ hardrock_2016_progress_sherman_grouse_in_1:
   effort_id: 7328
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:28.326107000 Z
-  updated_at: 2018-01-10 09:48:35.280906000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12148,8 +10630,6 @@ hardrock_2016_progress_sherman_grouse_out_1:
   effort_id: 7328
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:28.330551000 Z
-  updated_at: 2018-01-10 09:48:29.201853000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12164,8 +10644,6 @@ hardrock_2016_progress_sherman_sherman_in_1:
   effort_id: 7328
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:28.344075000 Z
-  updated_at: 2018-01-10 09:48:29.210505000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12180,8 +10658,6 @@ hardrock_2016_progress_sherman_sherman_out_1:
   effort_id: 7328
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:28.348250000 Z
-  updated_at: 2018-01-10 09:48:29.214124000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12196,8 +10672,6 @@ hardrock_2016_benito_moen_start_1:
   effort_id: 7337
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:30.393277000 Z
-  updated_at: 2017-04-18 09:43:30.393277000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -12212,8 +10686,6 @@ hardrock_2016_benito_moen_telluride_in_1:
   effort_id: 7337
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:30.418034000 Z
-  updated_at: 2018-01-10 09:48:29.842117000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12228,8 +10700,6 @@ hardrock_2016_benito_moen_telluride_out_1:
   effort_id: 7337
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:30.422688000 Z
-  updated_at: 2018-01-10 09:48:29.844996000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12244,8 +10714,6 @@ hardrock_2016_benito_moen_ouray_in_1:
   effort_id: 7337
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:30.462694000 Z
-  updated_at: 2018-01-10 09:48:29.855962000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12260,8 +10728,6 @@ hardrock_2016_benito_moen_ouray_out_1:
   effort_id: 7337
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:30.467965000 Z
-  updated_at: 2018-01-10 09:48:29.858215000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12276,8 +10742,6 @@ hardrock_2016_benito_moen_grouse_in_1:
   effort_id: 7337
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:30.483281000 Z
-  updated_at: 2018-01-10 09:48:29.867412000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12292,8 +10756,6 @@ hardrock_2016_benito_moen_grouse_out_1:
   effort_id: 7337
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:30.488287000 Z
-  updated_at: 2018-01-10 09:48:29.869843000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12308,8 +10770,6 @@ hardrock_2016_benito_moen_sherman_in_1:
   effort_id: 7337
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:30.503087000 Z
-  updated_at: 2018-01-10 09:48:29.874510000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12324,8 +10784,6 @@ hardrock_2016_benito_moen_sherman_out_1:
   effort_id: 7337
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:30.508633000 Z
-  updated_at: 2018-01-10 09:48:29.877386000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12340,8 +10798,6 @@ hardrock_2016_kendall_koch_start_1:
   effort_id: 7340
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:31.156789000 Z
-  updated_at: 2017-04-18 09:43:31.156789000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -12356,8 +10812,6 @@ hardrock_2016_kendall_koch_telluride_in_1:
   effort_id: 7340
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:31.177471000 Z
-  updated_at: 2018-01-10 09:48:35.432147000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12372,8 +10826,6 @@ hardrock_2016_kendall_koch_telluride_out_1:
   effort_id: 7340
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:31.181952000 Z
-  updated_at: 2018-01-10 09:48:30.042561000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12388,8 +10840,6 @@ hardrock_2016_kendall_koch_ouray_in_1:
   effort_id: 7340
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:31.202731000 Z
-  updated_at: 2018-01-10 09:48:30.057593000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12404,8 +10854,6 @@ hardrock_2016_kendall_koch_ouray_out_1:
   effort_id: 7340
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:31.207065000 Z
-  updated_at: 2018-01-10 09:48:30.061423000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12420,8 +10868,6 @@ hardrock_2016_kendall_koch_grouse_in_1:
   effort_id: 7340
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:31.221923000 Z
-  updated_at: 2018-01-10 09:48:30.309368000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12436,8 +10882,6 @@ hardrock_2016_kendall_koch_grouse_out_1:
   effort_id: 7340
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:31.226377000 Z
-  updated_at: 2018-01-10 09:48:30.312953000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12452,8 +10896,6 @@ hardrock_2016_kendall_koch_sherman_in_1:
   effort_id: 7340
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:31.240493000 Z
-  updated_at: 2018-01-10 09:48:30.322782000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12468,8 +10910,6 @@ hardrock_2016_kendall_koch_sherman_out_1:
   effort_id: 7340
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:31.245626000 Z
-  updated_at: 2018-01-10 09:48:30.325445000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12484,8 +10924,6 @@ hardrock_2016_charlie_mueller_start_1:
   effort_id: 7343
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:31.832915000 Z
-  updated_at: 2017-04-18 09:43:31.832915000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -12500,8 +10938,6 @@ hardrock_2016_charlie_mueller_telluride_in_1:
   effort_id: 7343
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:31.856171000 Z
-  updated_at: 2018-01-10 09:48:30.497641000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12516,8 +10952,6 @@ hardrock_2016_charlie_mueller_telluride_out_1:
   effort_id: 7343
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:31.860528000 Z
-  updated_at: 2018-01-10 09:48:30.500738000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12532,8 +10966,6 @@ hardrock_2016_charlie_mueller_ouray_in_1:
   effort_id: 7343
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:31.883694000 Z
-  updated_at: 2018-01-10 09:48:30.512718000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12548,8 +10980,6 @@ hardrock_2016_charlie_mueller_ouray_out_1:
   effort_id: 7343
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:31.888027000 Z
-  updated_at: 2018-01-10 09:48:30.515192000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12564,8 +10994,6 @@ hardrock_2016_charlie_mueller_grouse_in_1:
   effort_id: 7343
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:31.903325000 Z
-  updated_at: 2018-01-10 09:48:30.523536000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12580,8 +11008,6 @@ hardrock_2016_charlie_mueller_grouse_out_1:
   effort_id: 7343
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:31.907650000 Z
-  updated_at: 2018-01-10 09:48:30.526035000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12596,8 +11022,6 @@ hardrock_2016_charlie_mueller_sherman_in_1:
   effort_id: 7343
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:31.920997000 Z
-  updated_at: 2018-01-10 09:48:30.532007000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12612,8 +11036,6 @@ hardrock_2016_charlie_mueller_sherman_out_1:
   effort_id: 7343
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:31.925256000 Z
-  updated_at: 2018-01-10 09:48:30.534481000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12628,8 +11050,6 @@ hardrock_2016_brinda_fisher_start_1:
   effort_id: 7376
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:39.496177000 Z
-  updated_at: 2017-04-18 09:43:39.496177000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -12644,8 +11064,6 @@ hardrock_2016_brinda_fisher_telluride_in_1:
   effort_id: 7376
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:39.520548000 Z
-  updated_at: 2018-01-10 09:48:32.899023000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12660,8 +11078,6 @@ hardrock_2016_brinda_fisher_telluride_out_1:
   effort_id: 7376
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:39.524696000 Z
-  updated_at: 2018-01-10 09:48:32.901200000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12676,8 +11092,6 @@ hardrock_2016_brinda_fisher_ouray_in_1:
   effort_id: 7376
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:39.548776000 Z
-  updated_at: 2018-01-10 09:48:32.912236000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12692,8 +11106,6 @@ hardrock_2016_brinda_fisher_ouray_out_1:
   effort_id: 7376
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:39.552849000 Z
-  updated_at: 2018-01-10 09:48:32.914811000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12708,8 +11120,6 @@ hardrock_2016_brinda_fisher_grouse_in_1:
   effort_id: 7376
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:39.567551000 Z
-  updated_at: 2018-01-10 09:48:32.922811000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12724,8 +11134,6 @@ hardrock_2016_brinda_fisher_grouse_out_1:
   effort_id: 7376
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:39.572026000 Z
-  updated_at: 2018-01-10 09:48:35.722091000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12740,8 +11148,6 @@ hardrock_2016_rene_mclaughlin_start_1:
   effort_id: 7380
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:40.365189000 Z
-  updated_at: 2017-04-18 09:43:40.365189000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -12756,8 +11162,6 @@ hardrock_2016_rene_mclaughlin_telluride_in_1:
   effort_id: 7380
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:40.389399000 Z
-  updated_at: 2018-01-10 09:48:33.127202000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12772,8 +11176,6 @@ hardrock_2016_rene_mclaughlin_telluride_out_1:
   effort_id: 7380
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:40.394012000 Z
-  updated_at: 2018-01-10 09:48:33.130064000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12788,8 +11190,6 @@ hardrock_2016_rene_mclaughlin_ouray_in_1:
   effort_id: 7380
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:40.417481000 Z
-  updated_at: 2018-01-10 09:48:33.139214000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12804,8 +11204,6 @@ hardrock_2016_rene_mclaughlin_ouray_out_1:
   effort_id: 7380
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:40.426205000 Z
-  updated_at: 2018-01-10 09:48:33.200560000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12820,8 +11218,6 @@ hardrock_2016_rene_mclaughlin_grouse_in_1:
   effort_id: 7380
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:40.441263000 Z
-  updated_at: 2018-01-10 09:48:35.753665000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12836,8 +11232,6 @@ hardrock_2016_rene_mclaughlin_grouse_out_1:
   effort_id: 7380
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:40.445481000 Z
-  updated_at: 2018-01-10 09:48:33.209318000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12852,8 +11246,6 @@ hardrock_2016_rene_mclaughlin_sherman_in_1:
   effort_id: 7380
   split_id: 101
   data_status: 2
-  created_at: 2017-04-18 09:43:40.458988000 Z
-  updated_at: 2018-01-10 09:48:33.217489000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12868,8 +11260,6 @@ hardrock_2016_dropped_grouse_start_1:
   effort_id: 7396
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:43.315817000 Z
-  updated_at: 2017-04-18 09:43:43.315817000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -12884,8 +11274,6 @@ hardrock_2016_dropped_grouse_telluride_in_1:
   effort_id: 7396
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:43.344606000 Z
-  updated_at: 2018-01-10 09:48:33.963174000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12900,8 +11288,6 @@ hardrock_2016_dropped_grouse_telluride_out_1:
   effort_id: 7396
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:43.348787000 Z
-  updated_at: 2018-01-10 09:48:33.965653000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12916,8 +11302,6 @@ hardrock_2016_dropped_grouse_ouray_in_1:
   effort_id: 7396
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:43.371014000 Z
-  updated_at: 2018-01-10 09:48:35.845017000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12932,8 +11316,6 @@ hardrock_2016_dropped_grouse_ouray_out_1:
   effort_id: 7396
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:43.374928000 Z
-  updated_at: 2018-01-10 09:48:33.978146000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12948,8 +11330,6 @@ hardrock_2016_dropped_grouse_grouse_in_1:
   effort_id: 7396
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:43.387888000 Z
-  updated_at: 2018-01-10 09:48:33.985597000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -12964,8 +11344,6 @@ hardrock_2016_dropped_grouse_grouse_out_1:
   effort_id: 7396
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:43.392219000 Z
-  updated_at: 2018-01-10 09:48:33.987981000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -12980,8 +11358,6 @@ hardrock_2016_mervin_smitham_start_1:
   effort_id: 7400
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:44.005515000 Z
-  updated_at: 2017-04-18 09:43:44.005515000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -12996,8 +11372,6 @@ hardrock_2016_mervin_smitham_telluride_in_1:
   effort_id: 7400
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:44.029012000 Z
-  updated_at: 2018-01-10 09:48:34.108624000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13012,8 +11386,6 @@ hardrock_2016_mervin_smitham_telluride_out_1:
   effort_id: 7400
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:44.036988000 Z
-  updated_at: 2018-01-10 09:48:35.865953000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -13028,8 +11400,6 @@ hardrock_2016_mervin_smitham_ouray_in_1:
   effort_id: 7400
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:44.059200000 Z
-  updated_at: 2018-01-10 09:48:34.122798000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13044,8 +11414,6 @@ hardrock_2016_mervin_smitham_ouray_out_1:
   effort_id: 7400
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:44.063401000 Z
-  updated_at: 2018-01-10 09:48:34.125458000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -13060,8 +11428,6 @@ hardrock_2016_mervin_smitham_grouse_in_1:
   effort_id: 7400
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:44.078024000 Z
-  updated_at: 2018-01-10 09:48:34.133565000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13076,8 +11442,6 @@ hardrock_2016_mervin_smitham_grouse_out_1:
   effort_id: 7400
   split_id: 97
   data_status: 2
-  created_at: 2017-04-18 09:43:44.082612000 Z
-  updated_at: 2018-01-10 09:48:34.136907000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -13092,8 +11456,6 @@ hardrock_2016_rhett_auer_start_1:
   effort_id: 7404
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:44.761290000 Z
-  updated_at: 2017-04-18 09:43:44.761290000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -13108,8 +11470,6 @@ hardrock_2016_rhett_auer_telluride_in_1:
   effort_id: 7404
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:44.784086000 Z
-  updated_at: 2018-01-10 09:48:34.260796000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13124,8 +11484,6 @@ hardrock_2016_rhett_auer_telluride_out_1:
   effort_id: 7404
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:44.788290000 Z
-  updated_at: 2018-01-10 09:48:35.885801000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -13140,8 +11498,6 @@ hardrock_2016_rhett_auer_ouray_in_1:
   effort_id: 7404
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:44.810888000 Z
-  updated_at: 2018-01-10 09:48:34.334483000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13156,8 +11512,6 @@ hardrock_2016_rhett_auer_ouray_out_1:
   effort_id: 7404
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:44.815037000 Z
-  updated_at: 2018-01-10 09:48:34.639136000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -13172,8 +11526,6 @@ hardrock_2016_hoyt_macejkovic_start_1:
   effort_id: 7407
   split_id: 81
   data_status: 2
-  created_at: 2017-04-18 09:43:45.266072000 Z
-  updated_at: 2017-04-18 09:43:45.266072000 Z
   created_by:
   updated_by:
   sub_split_bitkey: 1
@@ -13188,8 +11540,6 @@ hardrock_2016_hoyt_macejkovic_telluride_in_1:
   effort_id: 7407
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:45.288319000 Z
-  updated_at: 2018-01-10 09:48:34.398488000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13204,8 +11554,6 @@ hardrock_2016_hoyt_macejkovic_telluride_out_1:
   effort_id: 7407
   split_id: 87
   data_status: 2
-  created_at: 2017-04-18 09:43:45.292453000 Z
-  updated_at: 2018-01-10 09:48:34.401504000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -13220,8 +11568,6 @@ hardrock_2016_hoyt_macejkovic_ouray_in_1:
   effort_id: 7407
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:45.315424000 Z
-  updated_at: 2018-01-10 09:48:34.414269000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13236,8 +11582,6 @@ hardrock_2016_hoyt_macejkovic_ouray_out_1:
   effort_id: 7407
   split_id: 93
   data_status: 2
-  created_at: 2017-04-18 09:43:45.320863000 Z
-  updated_at: 2018-01-10 09:48:35.899015000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -13252,8 +11596,6 @@ ggd30_50k_finished_first_start_1:
   effort_id: 15626
   split_id: 164
   data_status:
-  created_at: 2017-06-09 08:26:06.153717000 Z
-  updated_at: 2017-06-09 08:26:06.153717000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13268,8 +11610,6 @@ ggd30_50k_finished_first_aid_1_1:
   effort_id: 15626
   split_id: 167
   data_status:
-  created_at: 2017-06-09 08:26:06.157519000 Z
-  updated_at: 2017-06-09 08:26:06.157519000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13284,8 +11624,6 @@ ggd30_50k_finished_first_aid_2_1:
   effort_id: 15626
   split_id: 171
   data_status:
-  created_at: 2017-06-09 08:26:06.161310000 Z
-  updated_at: 2017-06-09 08:26:06.161310000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13300,8 +11638,6 @@ ggd30_50k_finished_first_aid_3_1:
   effort_id: 15626
   split_id: 170
   data_status:
-  created_at: 2017-06-09 08:26:06.164914000 Z
-  updated_at: 2017-06-09 08:26:06.164914000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13316,8 +11652,6 @@ ggd30_50k_bad_finish_start_1:
   effort_id: 15664
   split_id: 164
   data_status: 2
-  created_at: 2017-06-09 08:26:07.432114000 Z
-  updated_at: 2017-06-09 08:26:07.432114000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13332,8 +11666,6 @@ ggd30_50k_bad_finish_aid_1_1:
   effort_id: 15664
   split_id: 167
   data_status: 2
-  created_at: 2017-06-09 08:26:07.435878000 Z
-  updated_at: 2017-06-09 08:26:07.435878000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13348,8 +11680,6 @@ ggd30_50k_bad_finish_aid_2_1:
   effort_id: 15664
   split_id: 171
   data_status: 2
-  created_at: 2017-06-09 08:26:07.439482000 Z
-  updated_at: 2017-06-09 08:26:07.439482000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13364,8 +11694,6 @@ ggd30_50k_bad_finish_aid_3_1:
   effort_id: 15664
   split_id: 170
   data_status: 2
-  created_at: 2017-06-09 08:26:07.443531000 Z
-  updated_at: 2017-06-09 08:26:07.443531000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13380,8 +11708,6 @@ ggd30_50k_progress_aid4_start_1:
   effort_id: 15891
   split_id: 164
   data_status:
-  created_at: 2017-06-09 08:26:15.213795000 Z
-  updated_at: 2017-06-09 08:26:15.213795000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13396,8 +11722,6 @@ ggd30_50k_progress_aid4_aid_1_1:
   effort_id: 15891
   split_id: 167
   data_status:
-  created_at: 2017-06-09 08:26:15.217512000 Z
-  updated_at: 2017-06-09 08:26:15.217512000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13412,8 +11736,6 @@ ggd30_50k_progress_aid4_aid_2_1:
   effort_id: 15891
   split_id: 171
   data_status:
-  created_at: 2017-06-09 08:26:15.221103000 Z
-  updated_at: 2017-06-09 08:26:15.221103000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13428,8 +11750,6 @@ ggd30_50k_progress_aid3_start_1:
   effort_id: 15901
   split_id: 164
   data_status: 2
-  created_at: 2017-06-09 08:26:15.546829000 Z
-  updated_at: 2017-06-09 08:26:15.546829000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13444,8 +11764,6 @@ ggd30_50k_progress_aid3_aid_1_1:
   effort_id: 15901
   split_id: 167
   data_status: 2
-  created_at: 2017-06-09 08:26:15.550261000 Z
-  updated_at: 2019-02-01 06:18:12.452490000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13460,8 +11778,6 @@ ggd30_50k_progress_aid3_aid_2_1:
   effort_id: 15901
   split_id: 171
   data_status: 2
-  created_at: 2017-06-09 08:26:15.553720000 Z
-  updated_at: 2019-02-01 06:18:12.449128000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13476,8 +11792,6 @@ ggd30_50k_drop_aid4_start_1:
   effort_id: 15931
   split_id: 164
   data_status: 2
-  created_at: 2017-06-09 08:26:16.461771000 Z
-  updated_at: 2017-06-09 08:26:16.461771000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13492,8 +11806,6 @@ ggd30_50k_drop_aid4_aid_1_1:
   effort_id: 15931
   split_id: 167
   data_status: 2
-  created_at: 2017-06-09 08:26:16.465563000 Z
-  updated_at: 2017-06-09 08:26:16.465563000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13508,8 +11820,6 @@ ggd30_50k_drop_aid4_aid_2_1:
   effort_id: 15931
   split_id: 171
   data_status: 2
-  created_at: 2017-06-09 08:26:16.469336000 Z
-  updated_at: 2017-06-09 08:26:16.469336000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13524,8 +11834,6 @@ ggd30_50k_finished_first_aid_4_1:
   effort_id: 15626
   split_id: 168
   data_status:
-  created_at: 2017-06-09 09:43:14.583597000 Z
-  updated_at: 2017-06-09 09:43:14.583597000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13540,8 +11848,6 @@ ggd30_50k_finished_first_aid_5_1:
   effort_id: 15626
   split_id: 166
   data_status:
-  created_at: 2017-06-09 09:43:14.587667000 Z
-  updated_at: 2017-06-09 09:43:14.587667000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13556,8 +11862,6 @@ ggd30_50k_finished_first_finish_1:
   effort_id: 15626
   split_id: 165
   data_status:
-  created_at: 2017-06-09 09:43:14.591449000 Z
-  updated_at: 2017-06-09 09:43:14.591449000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13572,8 +11876,6 @@ ggd30_50k_bad_finish_aid_4_1:
   effort_id: 15664
   split_id: 168
   data_status: 2
-  created_at: 2017-06-09 09:43:15.284941000 Z
-  updated_at: 2017-06-09 09:43:15.284941000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13588,8 +11890,6 @@ ggd30_50k_bad_finish_aid_5_1:
   effort_id: 15664
   split_id: 166
   data_status: 2
-  created_at: 2017-06-09 09:43:15.288414000 Z
-  updated_at: 2017-06-09 09:43:15.288414000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13604,8 +11904,6 @@ ggd30_50k_bad_finish_finish_1:
   effort_id: 15664
   split_id: 165
   data_status: 0
-  created_at: 2017-06-09 09:43:15.291926000 Z
-  updated_at: 2017-06-09 09:43:15.291926000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13620,8 +11918,6 @@ ggd30_50k_progress_aid4_aid_3_1:
   effort_id: 15891
   split_id: 170
   data_status:
-  created_at: 2017-06-09 09:43:20.049182000 Z
-  updated_at: 2017-06-09 09:43:20.049182000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13636,8 +11932,6 @@ ggd30_50k_progress_aid4_aid_4_1:
   effort_id: 15891
   split_id: 168
   data_status:
-  created_at: 2017-06-09 09:43:20.054147000 Z
-  updated_at: 2017-06-09 09:43:20.054147000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13652,8 +11946,6 @@ ggd30_50k_progress_aid3_aid_3_1:
   effort_id: 15901
   split_id: 170
   data_status: 2
-  created_at: 2017-06-09 09:43:20.279004000 Z
-  updated_at: 2019-02-01 06:18:12.451010000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13668,8 +11960,6 @@ ggd30_50k_drop_aid4_aid_3_1:
   effort_id: 15931
   split_id: 170
   data_status: 2
-  created_at: 2017-06-09 09:43:20.870863000 Z
-  updated_at: 2017-06-09 09:43:20.870863000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13684,8 +11974,6 @@ ggd30_50k_drop_aid4_aid_4_1:
   effort_id: 15931
   split_id: 168
   data_status: 2
-  created_at: 2017-06-09 09:43:20.874474000 Z
-  updated_at: 2017-06-09 09:43:20.874474000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13700,8 +11988,6 @@ ggd30_12m_finished_first_start_1:
   effort_id: 16173
   split_id: 172
   data_status:
-  created_at: 2017-06-09 09:53:53.747481000 Z
-  updated_at: 2017-06-09 09:53:53.747481000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13716,8 +12002,6 @@ ggd30_12m_finished_first_finish_1:
   effort_id: 16173
   split_id: 173
   data_status:
-  created_at: 2017-06-09 09:53:53.751585000 Z
-  updated_at: 2017-06-09 09:53:53.751585000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13732,8 +12016,6 @@ ggd30_12m_finished_second_start_1:
   effort_id: 16107
   split_id: 172
   data_status:
-  created_at: 2017-06-09 09:53:54.674562000 Z
-  updated_at: 2017-06-09 09:53:54.674562000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13748,8 +12030,6 @@ ggd30_12m_finished_second_finish_1:
   effort_id: 16107
   split_id: 173
   data_status:
-  created_at: 2017-06-09 09:53:54.678397000 Z
-  updated_at: 2017-06-09 09:53:54.678397000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13764,8 +12044,6 @@ hardrock_2015_cedric_windler_start_1:
   effort_id: 50
   split_id: 5
   data_status: 2
-  created_at: 2017-12-16 14:32:29.562923000 Z
-  updated_at: 2017-12-16 14:32:29.562923000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13780,8 +12058,6 @@ hardrock_2015_tuan_jacobs_start_1:
   effort_id: 7
   split_id: 5
   data_status: 2
-  created_at: 2018-01-10 08:51:17.125681000 Z
-  updated_at: 2018-06-20 07:53:07.463674000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13796,8 +12072,6 @@ sum_55k_finished_first_start_1:
   effort_id: 16227
   split_id: 212
   data_status: 2
-  created_at: 2018-01-18 05:23:46.231652000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13812,8 +12086,6 @@ sum_55k_finished_first_molas_pass_aid1_in_1:
   effort_id: 16227
   split_id: 218
   data_status: 2
-  created_at: 2018-01-18 05:23:46.232902000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13828,8 +12100,6 @@ sum_55k_finished_first_molas_pass_aid1_out_1:
   effort_id: 16227
   split_id: 218
   data_status: 2
-  created_at: 2018-01-18 05:23:46.233975000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -13844,8 +12114,6 @@ sum_55k_finished_first_rolling_pass_aid2_in_1:
   effort_id: 16227
   split_id: 219
   data_status: 2
-  created_at: 2018-01-18 05:23:46.235037000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13860,8 +12128,6 @@ sum_55k_finished_first_rolling_pass_aid2_out_1:
   effort_id: 16227
   split_id: 219
   data_status: 2
-  created_at: 2018-01-18 05:23:46.236148000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -13876,8 +12142,6 @@ sum_55k_finished_first_bandera_mine_aid5_in_1:
   effort_id: 16227
   split_id: 220
   data_status: 2
-  created_at: 2018-01-18 05:23:46.237220000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13892,8 +12156,6 @@ sum_55k_finished_first_bandera_mine_aid5_out_1:
   effort_id: 16227
   split_id: 220
   data_status: 2
-  created_at: 2018-01-18 05:23:46.238288000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -13908,8 +12170,6 @@ sum_55k_finished_first_anvil_cg_aid6_in_1:
   effort_id: 16227
   split_id: 221
   data_status: 2
-  created_at: 2018-01-18 05:23:46.239695000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13924,8 +12184,6 @@ sum_55k_finished_first_anvil_cg_aid6_out_1:
   effort_id: 16227
   split_id: 221
   data_status: 2
-  created_at: 2018-01-18 05:23:46.241121000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -13940,8 +12198,6 @@ sum_55k_finished_first_finish_1:
   effort_id: 16227
   split_id: 213
   data_status: 2
-  created_at: 2018-01-18 05:23:46.242220000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13956,8 +12212,6 @@ sum_55k_finished_second_start_1:
   effort_id: 16229
   split_id: 212
   data_status: 2
-  created_at: 2018-01-18 05:23:46.318006000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13972,8 +12226,6 @@ sum_55k_finished_second_molas_pass_aid1_in_1:
   effort_id: 16229
   split_id: 218
   data_status: 2
-  created_at: 2018-01-18 05:23:46.320057000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -13988,8 +12240,6 @@ sum_55k_finished_second_molas_pass_aid1_out_1:
   effort_id: 16229
   split_id: 218
   data_status: 2
-  created_at: 2018-01-18 05:23:46.321198000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14004,8 +12254,6 @@ sum_55k_finished_second_rolling_pass_aid2_in_1:
   effort_id: 16229
   split_id: 219
   data_status: 2
-  created_at: 2018-01-18 05:23:46.322421000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14020,8 +12268,6 @@ sum_55k_finished_second_rolling_pass_aid2_out_1:
   effort_id: 16229
   split_id: 219
   data_status: 2
-  created_at: 2018-01-18 05:23:46.323545000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14036,8 +12282,6 @@ sum_55k_finished_second_bandera_mine_aid5_in_1:
   effort_id: 16229
   split_id: 220
   data_status: 2
-  created_at: 2018-01-18 05:23:46.324635000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14052,8 +12296,6 @@ sum_55k_finished_second_bandera_mine_aid5_out_1:
   effort_id: 16229
   split_id: 220
   data_status: 2
-  created_at: 2018-01-18 05:23:46.325747000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14068,8 +12310,6 @@ sum_55k_finished_second_anvil_cg_aid6_in_1:
   effort_id: 16229
   split_id: 221
   data_status: 2
-  created_at: 2018-01-18 05:23:46.326920000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14084,8 +12324,6 @@ sum_55k_finished_second_anvil_cg_aid6_out_1:
   effort_id: 16229
   split_id: 221
   data_status: 2
-  created_at: 2018-01-18 05:23:46.327995000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14100,8 +12338,6 @@ sum_55k_finished_second_finish_1:
   effort_id: 16229
   split_id: 213
   data_status: 2
-  created_at: 2018-01-18 05:23:46.329083000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14116,8 +12352,6 @@ sum_55k_progress_rolling_start_1:
   effort_id: 16244
   split_id: 212
   data_status: 2
-  created_at: 2018-01-18 05:23:52.748632000 Z
-  updated_at: 2019-01-30 21:20:34.662308000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14132,8 +12366,6 @@ sum_55k_progress_rolling_molas_pass_aid1_in_1:
   effort_id: 16244
   split_id: 218
   data_status: 2
-  created_at: 2018-01-18 05:23:52.749859000 Z
-  updated_at: 2019-01-30 21:20:34.660905000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14148,8 +12380,6 @@ sum_55k_progress_rolling_molas_pass_aid1_out_1:
   effort_id: 16244
   split_id: 218
   data_status: 2
-  created_at: 2018-01-18 05:23:52.751218000 Z
-  updated_at: 2019-01-30 21:20:34.663498000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14164,8 +12394,6 @@ sum_55k_progress_rolling_rolling_pass_aid2_in_1:
   effort_id: 16244
   split_id: 219
   data_status: 2
-  created_at: 2018-01-18 05:23:52.753314000 Z
-  updated_at: 2019-01-31 17:30:13.217130000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14180,8 +12408,6 @@ sum_55k_progress_rolling_rolling_pass_aid2_out_1:
   effort_id: 16244
   split_id: 219
   data_status: 2
-  created_at: 2018-01-18 05:23:52.754695000 Z
-  updated_at: 2019-01-31 17:30:13.215642000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14196,8 +12422,6 @@ sum_55k_drop_bandera_start_1:
   effort_id: 16245
   split_id: 212
   data_status: 2
-  created_at: 2018-01-18 05:23:52.795703000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14212,8 +12436,6 @@ sum_55k_drop_bandera_molas_pass_aid1_in_1:
   effort_id: 16245
   split_id: 218
   data_status: 2
-  created_at: 2018-01-18 05:23:52.798300000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14228,8 +12450,6 @@ sum_55k_drop_bandera_molas_pass_aid1_out_1:
   effort_id: 16245
   split_id: 218
   data_status: 2
-  created_at: 2018-01-18 05:23:52.799591000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14244,8 +12464,6 @@ sum_55k_drop_bandera_rolling_pass_aid2_in_1:
   effort_id: 16245
   split_id: 219
   data_status: 2
-  created_at: 2018-01-18 05:23:52.800718000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14260,8 +12478,6 @@ sum_55k_drop_bandera_rolling_pass_aid2_out_1:
   effort_id: 16245
   split_id: 219
   data_status:
-  created_at: 2018-01-18 05:23:52.801827000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14276,8 +12492,6 @@ sum_55k_drop_bandera_bandera_mine_aid5_in_1:
   effort_id: 16245
   split_id: 220
   data_status: 2
-  created_at: 2018-01-18 05:23:52.802901000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14292,8 +12506,6 @@ sum_100k_drop_anvil_anvil_cg_aid6_in_1:
   effort_id: 16247
   split_id: 211
   data_status:
-  created_at: 2018-02-04 04:44:27.343547000 Z
-  updated_at: 2019-01-25 06:32:10.521553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14308,8 +12520,6 @@ sum_100k_drop_anvil_anvil_cg_aid6_out_1:
   effort_id: 16247
   split_id: 211
   data_status:
-  created_at: 2018-02-04 04:44:27.347661000 Z
-  updated_at: 2019-01-25 06:32:10.521553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14324,8 +12534,6 @@ sum_100k_drop_anvil_rolling_pass_aid2_in_1:
   effort_id: 16247
   split_id: 207
   data_status:
-  created_at: 2018-02-04 15:17:04.619963000 Z
-  updated_at: 2019-01-25 06:32:10.521553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14340,8 +12548,6 @@ sum_100k_drop_anvil_rolling_pass_aid2_out_1:
   effort_id: 16247
   split_id: 207
   data_status:
-  created_at: 2018-02-04 15:17:04.622203000 Z
-  updated_at: 2019-01-25 06:32:10.521553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14356,8 +12562,6 @@ sum_100k_drop_anvil_start_1:
   effort_id: 16247
   split_id: 204
   data_status:
-  created_at: 2018-02-06 06:02:38.832101000 Z
-  updated_at: 2019-01-25 06:32:10.521553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14372,8 +12576,6 @@ sum_100k_drop_anvil_molas_pass_aid1_in_1:
   effort_id: 16247
   split_id: 206
   data_status:
-  created_at: 2018-02-06 06:04:06.858299000 Z
-  updated_at: 2019-01-25 06:32:10.521553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14388,8 +12590,6 @@ sum_100k_drop_anvil_molas_pass_aid1_out_1:
   effort_id: 16247
   split_id: 206
   data_status:
-  created_at: 2018-02-06 06:04:06.860477000 Z
-  updated_at: 2019-01-25 06:32:10.521553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14404,8 +12604,6 @@ sum_100k_drop_anvil_cascade_creek_rd_aid3_in_1:
   effort_id: 16247
   split_id: 208
   data_status:
-  created_at: 2018-02-06 06:04:06.945167000 Z
-  updated_at: 2019-01-25 06:32:10.521553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14420,8 +12618,6 @@ sum_100k_drop_anvil_cascade_creek_rd_aid3_out_1:
   effort_id: 16247
   split_id: 208
   data_status:
-  created_at: 2018-02-06 06:04:06.946979000 Z
-  updated_at: 2019-01-25 06:32:10.521553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14436,8 +12632,6 @@ sum_100k_drop_anvil_engineer_mtn_th_aid4_in_1:
   effort_id: 16247
   split_id: 209
   data_status:
-  created_at: 2018-02-06 07:14:23.512709000 Z
-  updated_at: 2019-01-25 06:32:10.521553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14452,8 +12646,6 @@ sum_100k_drop_anvil_engineer_mtn_th_aid4_out_1:
   effort_id: 16247
   split_id: 209
   data_status:
-  created_at: 2018-02-06 07:14:23.515121000 Z
-  updated_at: 2019-01-25 06:32:10.521553000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -14468,8 +12660,6 @@ ggd30_12m_start_only_start_1:
   effort_id: 16094
   split_id: 172
   data_status:
-  created_at: 2018-05-10 11:25:15.043645000 Z
-  updated_at: 2018-05-10 11:25:15.043645000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14484,8 +12674,6 @@ ggd30_50k_start_only_start_1:
   effort_id: 16023
   split_id: 164
   data_status:
-  created_at: 2018-05-10 11:25:15.468236000 Z
-  updated_at: 2018-05-10 11:25:15.468236000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14500,8 +12688,6 @@ sum_55k_start_only_start_1:
   effort_id: 16246
   split_id: 212
   data_status:
-  created_at: 2018-11-05 04:50:56.800354000 Z
-  updated_at: 2019-01-25 22:35:49.077400000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14516,8 +12702,6 @@ rufa_2017_12h_finished_first_start_1:
   effort_id: 16643
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.406672000 Z
-  updated_at: 2019-01-30 18:51:23.406672000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14532,8 +12716,6 @@ rufa_2017_12h_finished_first_finish_1:
   effort_id: 16643
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.408387000 Z
-  updated_at: 2019-01-30 18:51:23.408387000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14548,8 +12730,6 @@ rufa_2017_12h_finished_first_start_2:
   effort_id: 16643
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.409890000 Z
-  updated_at: 2019-01-30 18:51:23.409890000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14564,8 +12744,6 @@ rufa_2017_12h_finished_first_grandeur_peak_2:
   effort_id: 16643
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.411519000 Z
-  updated_at: 2019-01-30 18:51:23.411519000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14580,8 +12758,6 @@ rufa_2017_12h_finished_first_finish_2:
   effort_id: 16643
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.412915000 Z
-  updated_at: 2019-01-30 18:51:23.412915000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14596,8 +12772,6 @@ rufa_2017_12h_finished_first_start_3:
   effort_id: 16643
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.414220000 Z
-  updated_at: 2019-01-30 18:51:23.414220000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14612,8 +12786,6 @@ rufa_2017_12h_finished_first_grandeur_peak_3:
   effort_id: 16643
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.415853000 Z
-  updated_at: 2019-01-30 18:51:23.415853000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14628,8 +12800,6 @@ rufa_2017_12h_finished_first_finish_3:
   effort_id: 16643
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.417333000 Z
-  updated_at: 2019-01-30 18:51:23.417333000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14644,8 +12814,6 @@ rufa_2017_12h_finished_first_start_4:
   effort_id: 16643
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.418785000 Z
-  updated_at: 2019-01-30 18:51:23.418785000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14660,8 +12828,6 @@ rufa_2017_12h_finished_first_grandeur_peak_4:
   effort_id: 16643
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.420170000 Z
-  updated_at: 2019-01-30 18:51:23.420170000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14676,8 +12842,6 @@ rufa_2017_12h_finished_first_finish_4:
   effort_id: 16643
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.421439000 Z
-  updated_at: 2019-01-30 18:51:23.421439000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14692,8 +12856,6 @@ rufa_2017_12h_finished_first_start_5:
   effort_id: 16643
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.423196000 Z
-  updated_at: 2019-01-30 18:51:23.423196000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14708,8 +12870,6 @@ rufa_2017_12h_finished_first_grandeur_peak_5:
   effort_id: 16643
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.424858000 Z
-  updated_at: 2019-01-30 18:51:23.424858000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14724,8 +12884,6 @@ rufa_2017_12h_finished_first_finish_5:
   effort_id: 16643
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.426168000 Z
-  updated_at: 2019-01-30 18:51:23.426168000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14740,8 +12898,6 @@ rufa_2017_12h_finished_first_start_6:
   effort_id: 16643
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.427474000 Z
-  updated_at: 2019-01-30 18:51:23.427474000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14756,8 +12912,6 @@ rufa_2017_12h_finished_first_grandeur_peak_6:
   effort_id: 16643
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.428827000 Z
-  updated_at: 2019-01-30 18:51:23.428827000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14772,8 +12926,6 @@ rufa_2017_12h_finished_first_finish_6:
   effort_id: 16643
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.430252000 Z
-  updated_at: 2019-01-30 18:51:23.430252000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14788,8 +12940,6 @@ rufa_2017_12h_finished_first_start_7:
   effort_id: 16643
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.431507000 Z
-  updated_at: 2019-01-30 18:51:23.431507000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14804,8 +12954,6 @@ rufa_2017_12h_finished_first_grandeur_peak_7:
   effort_id: 16643
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.432978000 Z
-  updated_at: 2019-01-30 18:51:23.432978000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14820,8 +12968,6 @@ rufa_2017_12h_finished_first_finish_7:
   effort_id: 16643
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.434432000 Z
-  updated_at: 2019-01-30 18:51:23.434432000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14836,8 +12982,6 @@ rufa_2017_12h_finished_lap6_start_1:
   effort_id: 16648
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.830578000 Z
-  updated_at: 2019-01-30 18:51:23.830578000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14852,8 +12996,6 @@ rufa_2017_12h_finished_lap6_grandeur_peak_1:
   effort_id: 16648
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.832646000 Z
-  updated_at: 2019-01-30 18:51:23.832646000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14868,8 +13010,6 @@ rufa_2017_12h_finished_lap6_finish_1:
   effort_id: 16648
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.833989000 Z
-  updated_at: 2019-01-30 18:51:23.833989000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14884,8 +13024,6 @@ rufa_2017_12h_finished_lap6_start_2:
   effort_id: 16648
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.834987000 Z
-  updated_at: 2019-01-30 18:51:23.834987000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14900,8 +13038,6 @@ rufa_2017_12h_finished_lap6_grandeur_peak_2:
   effort_id: 16648
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.835862000 Z
-  updated_at: 2019-01-30 18:51:23.835862000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14916,8 +13052,6 @@ rufa_2017_12h_finished_lap6_finish_2:
   effort_id: 16648
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.836723000 Z
-  updated_at: 2019-01-30 18:51:23.836723000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14932,8 +13066,6 @@ rufa_2017_12h_finished_lap6_start_3:
   effort_id: 16648
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.837612000 Z
-  updated_at: 2019-01-30 18:51:23.837612000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14948,8 +13080,6 @@ rufa_2017_12h_finished_lap6_grandeur_peak_3:
   effort_id: 16648
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.838989000 Z
-  updated_at: 2019-01-30 18:51:23.838989000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14964,8 +13094,6 @@ rufa_2017_12h_finished_lap6_finish_3:
   effort_id: 16648
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.840690000 Z
-  updated_at: 2019-01-30 18:51:23.840690000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14980,8 +13108,6 @@ rufa_2017_12h_finished_lap6_start_4:
   effort_id: 16648
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.842287000 Z
-  updated_at: 2019-01-30 18:51:23.842287000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -14996,8 +13122,6 @@ rufa_2017_12h_finished_lap6_grandeur_peak_4:
   effort_id: 16648
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.843525000 Z
-  updated_at: 2019-01-30 18:51:23.843525000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15012,8 +13136,6 @@ rufa_2017_12h_finished_lap6_finish_4:
   effort_id: 16648
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.844543000 Z
-  updated_at: 2019-01-30 18:51:23.844543000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15028,8 +13150,6 @@ rufa_2017_12h_finished_lap6_start_5:
   effort_id: 16648
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.845604000 Z
-  updated_at: 2019-01-30 18:51:23.845604000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15044,8 +13164,6 @@ rufa_2017_12h_finished_lap6_grandeur_peak_5:
   effort_id: 16648
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.847187000 Z
-  updated_at: 2019-01-30 18:51:23.847187000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15060,8 +13178,6 @@ rufa_2017_12h_finished_lap6_finish_5:
   effort_id: 16648
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.848333000 Z
-  updated_at: 2019-01-30 18:51:23.848333000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15076,8 +13192,6 @@ rufa_2017_12h_finished_lap6_start_6:
   effort_id: 16648
   split_id: 135
   data_status:
-  created_at: 2019-01-30 18:51:23.850036000 Z
-  updated_at: 2019-01-30 18:51:23.850036000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15092,8 +13206,6 @@ rufa_2017_12h_finished_lap6_grandeur_peak_6:
   effort_id: 16648
   split_id: 137
   data_status:
-  created_at: 2019-01-30 18:51:23.851613000 Z
-  updated_at: 2019-01-30 18:51:23.851613000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15108,8 +13220,6 @@ rufa_2017_12h_finished_lap6_finish_6:
   effort_id: 16648
   split_id: 136
   data_status:
-  created_at: 2019-01-30 18:51:23.853500000 Z
-  updated_at: 2019-01-30 18:51:23.853500000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15124,8 +13234,6 @@ rufa_2017_12h_progress_lap5_partial_start_1:
   effort_id: 16657
   split_id: 135
   data_status: 2
-  created_at: 2019-01-30 18:51:24.463174000 Z
-  updated_at: 2019-01-30 18:51:24.463174000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15140,8 +13248,6 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_1:
   effort_id: 16657
   split_id: 137
   data_status: 2
-  created_at: 2019-01-30 18:51:24.464714000 Z
-  updated_at: 2019-01-30 18:51:24.464714000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15156,8 +13262,6 @@ rufa_2017_12h_progress_lap5_partial_finish_1:
   effort_id: 16657
   split_id: 136
   data_status: 2
-  created_at: 2019-01-30 18:51:24.465929000 Z
-  updated_at: 2019-01-30 18:51:24.465929000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15172,8 +13276,6 @@ rufa_2017_12h_progress_lap5_partial_start_2:
   effort_id: 16657
   split_id: 135
   data_status: 2
-  created_at: 2019-01-30 18:51:24.467157000 Z
-  updated_at: 2019-01-30 18:51:24.467157000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15188,8 +13290,6 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_2:
   effort_id: 16657
   split_id: 137
   data_status: 2
-  created_at: 2019-01-30 18:51:24.468296000 Z
-  updated_at: 2019-01-30 18:51:24.468296000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15204,8 +13304,6 @@ rufa_2017_12h_progress_lap5_partial_finish_2:
   effort_id: 16657
   split_id: 136
   data_status: 2
-  created_at: 2019-01-30 18:51:24.469240000 Z
-  updated_at: 2019-01-30 18:51:24.469240000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15220,8 +13318,6 @@ rufa_2017_12h_progress_lap5_partial_start_3:
   effort_id: 16657
   split_id: 135
   data_status: 2
-  created_at: 2019-01-30 18:51:24.470135000 Z
-  updated_at: 2019-01-30 18:51:24.470135000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15236,8 +13332,6 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_3:
   effort_id: 16657
   split_id: 137
   data_status: 2
-  created_at: 2019-01-30 18:51:24.471037000 Z
-  updated_at: 2019-01-30 18:51:24.471037000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15252,8 +13346,6 @@ rufa_2017_12h_progress_lap5_partial_finish_3:
   effort_id: 16657
   split_id: 136
   data_status: 2
-  created_at: 2019-01-30 18:51:24.472008000 Z
-  updated_at: 2019-01-30 18:51:24.472008000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15268,8 +13360,6 @@ rufa_2017_12h_progress_lap5_partial_start_4:
   effort_id: 16657
   split_id: 135
   data_status: 2
-  created_at: 2019-01-30 18:51:24.473759000 Z
-  updated_at: 2019-01-30 18:51:24.473759000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15284,8 +13374,6 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_4:
   effort_id: 16657
   split_id: 137
   data_status: 2
-  created_at: 2019-01-30 18:51:24.474998000 Z
-  updated_at: 2019-01-30 18:51:24.474998000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15300,8 +13388,6 @@ rufa_2017_12h_progress_lap5_partial_finish_4:
   effort_id: 16657
   split_id: 136
   data_status: 2
-  created_at: 2019-01-30 18:51:24.476242000 Z
-  updated_at: 2019-01-30 18:51:24.476242000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15316,8 +13402,6 @@ rufa_2017_12h_progress_lap5_partial_start_5:
   effort_id: 16657
   split_id: 135
   data_status: 2
-  created_at: 2019-01-30 18:51:24.477606000 Z
-  updated_at: 2019-01-30 18:51:24.477606000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15332,8 +13416,6 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_5:
   effort_id: 16657
   split_id: 137
   data_status: 2
-  created_at: 2019-01-30 18:51:24.478924000 Z
-  updated_at: 2019-01-30 18:51:24.478924000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15348,8 +13430,6 @@ rufa_2017_12h_progress_lap2_start_1:
   effort_id: 16663
   split_id: 135
   data_status: 2
-  created_at: 2019-01-30 18:51:24.784633000 Z
-  updated_at: 2019-01-30 18:51:24.784633000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15364,8 +13444,6 @@ rufa_2017_12h_progress_lap2_grandeur_peak_1:
   effort_id: 16663
   split_id: 137
   data_status: 2
-  created_at: 2019-01-30 18:51:24.785628000 Z
-  updated_at: 2019-01-30 18:51:24.785628000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15380,8 +13458,6 @@ rufa_2017_12h_progress_lap2_finish_1:
   effort_id: 16663
   split_id: 136
   data_status: 2
-  created_at: 2019-01-30 18:51:24.786721000 Z
-  updated_at: 2019-01-30 18:51:24.786721000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15396,8 +13472,6 @@ rufa_2017_12h_progress_lap2_start_2:
   effort_id: 16663
   split_id: 135
   data_status: 2
-  created_at: 2019-01-30 18:51:24.788774000 Z
-  updated_at: 2019-01-30 18:51:24.788774000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15412,8 +13486,6 @@ rufa_2017_12h_progress_lap2_grandeur_peak_2:
   effort_id: 16663
   split_id: 137
   data_status: 2
-  created_at: 2019-01-30 18:51:24.790042000 Z
-  updated_at: 2019-01-30 18:51:24.790042000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15428,8 +13500,6 @@ rufa_2017_12h_progress_lap2_finish_2:
   effort_id: 16663
   split_id: 136
   data_status: 2
-  created_at: 2019-01-30 18:51:24.791138000 Z
-  updated_at: 2019-01-30 18:51:24.791138000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15444,8 +13514,6 @@ rufa_2017_12h_start_only_start_1:
   effort_id: 16667
   split_id: 135
   data_status: 2
-  created_at: 2019-01-30 18:51:24.985018000 Z
-  updated_at: 2019-01-30 18:51:24.985018000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15460,8 +13528,6 @@ sum_100k_progress_cascade_start_1:
   effort_id: 16248
   split_id: 204
   data_status: 2
-  created_at: 2019-01-30 19:36:01.696734000 Z
-  updated_at: 2019-01-30 19:36:01.696734000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15476,8 +13542,6 @@ sum_100k_progress_cascade_molas_pass_aid1_in_1:
   effort_id: 16248
   split_id: 206
   data_status:
-  created_at: 2019-01-30 19:36:30.696950000 Z
-  updated_at: 2019-01-30 19:36:30.696950000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15492,8 +13556,6 @@ sum_100k_progress_cascade_molas_pass_aid1_out_1:
   effort_id: 16248
   split_id: 206
   data_status:
-  created_at: 2019-01-30 19:36:30.698485000 Z
-  updated_at: 2019-01-30 19:36:30.698485000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -15508,8 +13570,6 @@ sum_100k_progress_cascade_rolling_pass_aid2_in_1:
   effort_id: 16248
   split_id: 207
   data_status:
-  created_at: 2019-01-30 19:38:09.400954000 Z
-  updated_at: 2019-01-30 19:38:09.400954000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15524,8 +13584,6 @@ sum_100k_progress_cascade_rolling_pass_aid2_out_1:
   effort_id: 16248
   split_id: 207
   data_status:
-  created_at: 2019-01-30 19:38:09.402519000 Z
-  updated_at: 2019-01-30 19:38:09.402519000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -15540,8 +13598,6 @@ sum_100k_progress_cascade_cascade_creek_rd_aid3_in_1:
   effort_id: 16248
   split_id: 208
   data_status:
-  created_at: 2019-02-01 05:48:31.485426000 Z
-  updated_at: 2019-02-01 05:48:31.485426000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15556,8 +13612,6 @@ sum_100k_progress_cascade_cascade_creek_rd_aid3_out_1:
   effort_id: 16248
   split_id: 208
   data_status:
-  created_at: 2019-02-01 05:48:31.488018000 Z
-  updated_at: 2019-02-01 05:48:31.488018000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -15572,8 +13626,6 @@ hardrock_2016_start_only_start_1:
   effort_id: 7411
   split_id: 81
   data_status:
-  created_at: 2019-02-01 07:23:53.571303000 Z
-  updated_at: 2019-02-01 07:23:53.571303000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15588,8 +13640,6 @@ sum_100k_on_dst_change_start_1:
   effort_id: 16684
   split_id: 204
   data_status: 2
-  created_at: 2019-02-01 17:53:29.266612000 Z
-  updated_at: 2019-02-01 18:59:26.754107000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15604,8 +13654,6 @@ sum_100k_across_dst_change_start_1:
   effort_id: 16685
   split_id: 204
   data_status: 2
-  created_at: 2019-02-01 17:53:34.833534000 Z
-  updated_at: 2019-02-02 00:45:43.687580000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15620,8 +13668,6 @@ sum_100k_across_dst_change_molas_pass_aid1_in_1:
   effort_id: 16685
   split_id: 206
   data_status: 2
-  created_at: 2019-02-01 18:31:39.404315000 Z
-  updated_at: 2019-02-02 00:48:21.804341000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15636,8 +13682,6 @@ sum_100k_on_dst_change_molas_pass_aid1_in_1:
   effort_id: 16684
   split_id: 206
   data_status: 2
-  created_at: 2019-02-01 18:58:04.983201000 Z
-  updated_at: 2019-02-01 18:59:26.755360000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15652,8 +13696,6 @@ ggd30_50k_finished_second_start_1:
   effort_id: 16686
   split_id: 164
   data_status: 2
-  created_at: 2019-02-21 23:20:16.855576000 Z
-  updated_at: 2019-02-21 23:20:16.855576000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15668,8 +13710,6 @@ ggd30_50k_finished_second_aid_1_1:
   effort_id: 16686
   split_id: 167
   data_status: 2
-  created_at: 2019-02-21 23:20:16.863498000 Z
-  updated_at: 2019-02-21 23:20:16.863498000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15684,8 +13724,6 @@ ggd30_50k_finished_second_aid_2_1:
   effort_id: 16686
   split_id: 171
   data_status: 2
-  created_at: 2019-02-21 23:20:16.865552000 Z
-  updated_at: 2019-02-21 23:20:16.865552000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15700,8 +13738,6 @@ ggd30_50k_finished_second_aid_3_1:
   effort_id: 16686
   split_id: 170
   data_status: 2
-  created_at: 2019-02-21 23:20:16.867187000 Z
-  updated_at: 2019-02-21 23:20:16.867187000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15716,8 +13752,6 @@ ggd30_50k_finished_second_aid_4_1:
   effort_id: 16686
   split_id: 168
   data_status: 2
-  created_at: 2019-02-21 23:20:16.868799000 Z
-  updated_at: 2019-02-21 23:20:16.868799000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15732,8 +13766,6 @@ ggd30_50k_finished_second_aid_5_1:
   effort_id: 16686
   split_id: 166
   data_status:
-  created_at: 2019-02-21 23:20:16.870347000 Z
-  updated_at: 2019-02-21 23:20:16.870347000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15748,8 +13780,6 @@ ggd30_50k_finished_second_finish_1:
   effort_id: 16686
   split_id: 165
   data_status:
-  created_at: 2019-02-21 23:20:16.872886000 Z
-  updated_at: 2019-02-21 23:20:16.872886000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15764,8 +13794,6 @@ ggd30_12m_series_finisher_start_1:
   effort_id: 16687
   split_id: 172
   data_status: 2
-  created_at: 2019-02-21 23:45:05.368856000 Z
-  updated_at: 2019-02-21 23:45:05.368856000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15780,8 +13808,6 @@ ggd30_12m_series_finisher_finish_1:
   effort_id: 16687
   split_id: 173
   data_status:
-  created_at: 2019-02-21 23:45:17.026567000 Z
-  updated_at: 2019-02-21 23:45:17.026567000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15796,8 +13822,6 @@ sum_55k_series_finisher_start_1:
   effort_id: 16688
   split_id: 212
   data_status: 2
-  created_at: 2019-02-21 23:49:30.325090000 Z
-  updated_at: 2019-02-21 23:49:30.325090000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15812,8 +13836,6 @@ sum_55k_series_finisher_molas_pass_aid1_in_1:
   effort_id: 16688
   split_id: 218
   data_status: 2
-  created_at: 2019-02-21 23:49:30.327270000 Z
-  updated_at: 2019-02-21 23:50:57.045082000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15828,8 +13850,6 @@ sum_55k_series_finisher_molas_pass_aid1_out_1:
   effort_id: 16688
   split_id: 218
   data_status: 2
-  created_at: 2019-02-21 23:49:30.328630000 Z
-  updated_at: 2019-02-21 23:50:57.046330000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -15844,8 +13864,6 @@ sum_55k_series_finisher_rolling_pass_aid2_in_1:
   effort_id: 16688
   split_id: 219
   data_status: 2
-  created_at: 2019-02-21 23:49:30.330647000 Z
-  updated_at: 2019-02-21 23:50:41.578082000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15860,8 +13878,6 @@ sum_55k_series_finisher_rolling_pass_aid2_out_1:
   effort_id: 16688
   split_id: 219
   data_status: 2
-  created_at: 2019-02-21 23:49:30.332352000 Z
-  updated_at: 2019-02-21 23:50:41.579319000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -15876,8 +13892,6 @@ sum_55k_series_finisher_bandera_mine_aid5_in_1:
   effort_id: 16688
   split_id: 220
   data_status: 2
-  created_at: 2019-02-21 23:49:30.334035000 Z
-  updated_at: 2019-02-21 23:50:41.580250000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15892,8 +13906,6 @@ sum_55k_series_finisher_bandera_mine_aid5_out_1:
   effort_id: 16688
   split_id: 220
   data_status:
-  created_at: 2019-02-21 23:49:30.335174000 Z
-  updated_at: 2019-02-21 23:50:41.581134000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -15908,8 +13920,6 @@ sum_55k_series_finisher_anvil_cg_aid6_in_1:
   effort_id: 16688
   split_id: 221
   data_status:
-  created_at: 2019-02-21 23:49:30.336543000 Z
-  updated_at: 2019-02-21 23:50:41.582010000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15924,8 +13934,6 @@ sum_55k_series_finisher_anvil_cg_aid6_out_1:
   effort_id: 16688
   split_id: 221
   data_status:
-  created_at: 2019-02-21 23:49:30.337786000 Z
-  updated_at: 2019-02-21 23:50:41.583102000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -15940,8 +13948,6 @@ sum_55k_series_finisher_finish_1:
   effort_id: 16688
   split_id: 213
   data_status:
-  created_at: 2019-02-21 23:49:30.338625000 Z
-  updated_at: 2019-02-21 23:50:41.583991000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15956,8 +13962,6 @@ sum_55k_slow_finisher_start_1:
   effort_id: 16689
   split_id: 212
   data_status: 2
-  created_at: 2019-02-21 23:55:55.751321000 Z
-  updated_at: 2019-02-21 23:55:55.751321000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15972,8 +13976,6 @@ sum_55k_slow_finisher_molas_pass_aid1_in_1:
   effort_id: 16689
   split_id: 218
   data_status: 2
-  created_at: 2019-02-21 23:55:55.752843000 Z
-  updated_at: 2019-02-21 23:55:55.752843000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -15988,8 +13990,6 @@ sum_55k_slow_finisher_molas_pass_aid1_out_1:
   effort_id: 16689
   split_id: 218
   data_status: 2
-  created_at: 2019-02-21 23:55:55.754057000 Z
-  updated_at: 2019-02-21 23:55:55.754057000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -16004,8 +14004,6 @@ sum_55k_slow_finisher_rolling_pass_aid2_in_1:
   effort_id: 16689
   split_id: 219
   data_status: 2
-  created_at: 2019-02-21 23:55:55.755142000 Z
-  updated_at: 2019-02-21 23:55:55.755142000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -16020,8 +14018,6 @@ sum_55k_slow_finisher_rolling_pass_aid2_out_1:
   effort_id: 16689
   split_id: 219
   data_status: 2
-  created_at: 2019-02-21 23:55:55.756772000 Z
-  updated_at: 2019-02-21 23:55:55.756772000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -16036,8 +14032,6 @@ sum_55k_slow_finisher_bandera_mine_aid5_in_1:
   effort_id: 16689
   split_id: 220
   data_status: 2
-  created_at: 2019-02-21 23:55:55.757851000 Z
-  updated_at: 2019-02-21 23:55:55.757851000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -16052,8 +14046,6 @@ sum_55k_slow_finisher_bandera_mine_aid5_out_1:
   effort_id: 16689
   split_id: 220
   data_status: 2
-  created_at: 2019-02-21 23:55:55.758820000 Z
-  updated_at: 2019-02-21 23:55:55.758820000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -16068,8 +14060,6 @@ sum_55k_slow_finisher_anvil_cg_aid6_in_1:
   effort_id: 16689
   split_id: 221
   data_status: 2
-  created_at: 2019-02-21 23:55:55.759635000 Z
-  updated_at: 2019-02-21 23:55:55.759635000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -16084,8 +14074,6 @@ sum_55k_slow_finisher_anvil_cg_aid6_out_1:
   effort_id: 16689
   split_id: 221
   data_status: 2
-  created_at: 2019-02-21 23:55:55.760483000 Z
-  updated_at: 2019-02-21 23:55:55.760483000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 64
@@ -16100,8 +14088,6 @@ sum_55k_slow_finisher_finish_1:
   effort_id: 16689
   split_id: 213
   data_status: 2
-  created_at: 2019-02-21 23:55:55.761286000 Z
-  updated_at: 2019-02-21 23:55:55.761286000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -16116,8 +14102,6 @@ ggd30_12m_slow_finisher_start_1:
   effort_id: 16690
   split_id: 172
   data_status: 2
-  created_at: 2019-02-21 23:58:07.794197000 Z
-  updated_at: 2019-02-21 23:58:07.794197000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1
@@ -16132,8 +14116,6 @@ ggd30_12m_slow_finisher_finish_1:
   effort_id: 16690
   split_id: 173
   data_status:
-  created_at: 2019-02-21 23:58:26.939984000 Z
-  updated_at: 2019-02-21 23:58:26.939984000 Z
   created_by: 1
   updated_by: 1
   sub_split_bitkey: 1

--- a/spec/fixtures/splits.yml
+++ b/spec/fixtures/splits.yml
@@ -7,8 +7,6 @@ hardrock_ccw_start:
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
   kind: 0
-  created_at: 2016-04-18 09:09:56.005933000 Z
-  updated_at: 2018-03-16 14:58:28.105359000 Z
   created_by: 3
   updated_by: 1
   description: Silverton High School
@@ -27,8 +25,6 @@ hardrock_ccw_cunningham:
   vert_gain_from_start: 1170.432
   vert_loss_from_start: 844.296
   kind: 2
-  created_at: 2016-04-18 09:09:56.017581000 Z
-  updated_at: 2019-01-31 08:35:14.073410000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -47,8 +43,6 @@ hardrock_ccw_sherman:
   vert_gain_from_start: 3084.576
   vert_loss_from_start: 2749.296
   kind: 2
-  created_at: 2016-04-18 09:09:56.048422000 Z
-  updated_at: 2019-01-31 08:35:32.868078000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -67,8 +61,6 @@ hardrock_ccw_grouse:
   vert_gain_from_start: 4452.5184
   vert_loss_from_start: 4025.7984
   kind: 2
-  created_at: 2016-04-18 09:09:56.067613000 Z
-  updated_at: 2019-01-31 08:36:52.637995000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -87,8 +79,6 @@ hardrock_ccw_ouray:
   vert_gain_from_start: 5295.2904
   vert_loss_from_start: 5792.1144
   kind: 2
-  created_at: 2016-04-18 09:09:56.086046000 Z
-  updated_at: 2018-03-16 14:58:28.264170000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -107,8 +97,6 @@ hardrock_ccw_telluride:
   vert_gain_from_start: 6961.9368
   vert_loss_from_start: 7144.8168
   kind: 2
-  created_at: 2016-04-18 09:09:56.114590000 Z
-  updated_at: 2018-03-16 14:58:28.321610000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -127,8 +115,6 @@ hardrock_ccw_putnam:
   vert_gain_from_start: 9974.8848
   vert_loss_from_start: 9276.8928
   kind: 2
-  created_at: 2016-04-18 09:09:56.148374000 Z
-  updated_at: 2018-03-16 14:58:28.379562000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -147,8 +133,6 @@ hardrock_ccw_finish:
   vert_gain_from_start: 10073.64
   vert_loss_from_start: 10073.64
   kind: 1
-  created_at: 2016-04-18 09:09:56.159252000 Z
-  updated_at: 2019-01-30 21:33:24.052358000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -167,8 +151,6 @@ ramble_even_course_start:
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
   kind: 0
-  created_at: 2016-05-08 07:10:07.193995000 Z
-  updated_at: 2019-01-30 21:33:43.974804000 Z
   created_by: 1
   updated_by: 1
   description: Starting point for the Ramble Even-Year Course course.
@@ -187,8 +169,6 @@ ramble_even_course_finish:
   vert_gain_from_start: 249.935992002048
   vert_loss_from_start: 249.935992002048
   kind: 1
-  created_at: 2016-05-08 07:10:07.195406000 Z
-  updated_at: 2019-01-30 21:34:01.576579000 Z
   created_by: 1
   updated_by: 1
   description: Finish point for the Ramble Even-Year Course course.
@@ -207,8 +187,6 @@ hardrock_cw_start:
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
   kind: 0
-  created_at: 2016-05-23 01:04:57.226299000 Z
-  updated_at: 2019-01-31 08:29:08.562736000 Z
   created_by: 1
   updated_by: 1
   description: Starting point for the Hardrock CW course.
@@ -227,8 +205,6 @@ hardrock_cw_finish:
   vert_gain_from_start: 10073.64
   vert_loss_from_start: 10073.64
   kind: 1
-  created_at: 2016-05-23 01:04:57.227554000 Z
-  updated_at: 2019-01-31 08:33:29.136331000 Z
   created_by: 1
   updated_by: 1
   description: Finish point for the Hardrock CW course.
@@ -247,8 +223,6 @@ hardrock_cw_telluride:
   vert_gain_from_start: 2928.82310627766
   vert_loss_from_start: 3099.51110081564
   kind: 2
-  created_at: 2016-05-23 01:09:02.026784000 Z
-  updated_at: 2019-01-31 08:28:21.230857000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -267,8 +241,6 @@ hardrock_cw_ouray:
   vert_gain_from_start: 4281.52546299119
   vert_loss_from_start: 4778.34944709282
   kind: 2
-  created_at: 2016-05-23 01:09:02.078134000 Z
-  updated_at: 2019-01-31 08:29:48.792823000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -287,8 +259,6 @@ hardrock_cw_grouse:
   vert_gain_from_start: 6047.84140646908
   vert_loss_from_start: 5621.12142012411
   kind: 2
-  created_at: 2016-05-23 01:09:02.100361000 Z
-  updated_at: 2019-01-31 08:30:38.830627000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -307,8 +277,6 @@ hardrock_cw_sherman:
   vert_gain_from_start: 7324.343765621
   vert_loss_from_start: 7223.75976883969
   kind: 2
-  created_at: 2016-05-23 01:09:02.122487000 Z
-  updated_at: 2019-01-31 08:31:27.036218000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -327,8 +295,6 @@ hardrock_cw_cunningham:
   vert_gain_from_start: 9229.343704661
   vert_loss_from_start: 8903.20771509735
   kind: 2
-  created_at: 2016-05-23 01:09:02.155415000 Z
-  updated_at: 2019-01-31 08:32:27.561806000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -347,8 +313,6 @@ rufa_course_start:
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
   kind: 0
-  created_at: 2017-01-28 13:21:38.627377000 Z
-  updated_at: 2018-03-16 14:58:29.096437000 Z
   created_by: 1
   updated_by: 1
   description: Starting point for the RUFA Course course.
@@ -367,8 +331,6 @@ rufa_course_finish:
   vert_gain_from_start: 780.288
   vert_loss_from_start: 780.288
   kind: 1
-  created_at: 2017-01-28 13:21:38.656813000 Z
-  updated_at: 2018-03-16 14:58:29.106766000 Z
   created_by: 1
   updated_by: 1
   description: Finish point for the RUFA Course course.
@@ -387,8 +349,6 @@ rufa_course_grandeur_peak:
   vert_gain_from_start: 780.288
   vert_loss_from_start: 0.0
   kind: 2
-  created_at: 2017-01-28 13:23:10.270043000 Z
-  updated_at: 2018-11-21 00:01:19.151959000 Z
   created_by: 1
   updated_by: 1
   description: Top of Grander Peak
@@ -407,8 +367,6 @@ d30_50k_course_start:
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
   kind: 0
-  created_at: 2017-05-23 06:06:29.670579000 Z
-  updated_at: 2019-01-30 21:33:24.072287000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -427,8 +385,6 @@ d30_50k_course_finish:
   vert_gain_from_start: 2286.0
   vert_loss_from_start: 2286.0
   kind: 1
-  created_at: 2017-05-23 06:06:29.673112000 Z
-  updated_at: 2019-01-30 21:33:24.089928000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -447,8 +403,6 @@ d30_50k_course_aid_5:
   vert_gain_from_start: 2164.08
   vert_loss_from_start: 2072.64
   kind: 2
-  created_at: 2017-05-23 06:17:22.480349000 Z
-  updated_at: 2019-01-30 21:33:24.144024000 Z
   created_by: 1
   updated_by: 1
   description: On the Burro Trail on the slopes of Windy Peak
@@ -467,8 +421,6 @@ d30_50k_course_aid_1:
   vert_gain_from_start: 487.68
   vert_loss_from_start: 243.84
   kind: 2
-  created_at: 2017-05-23 06:19:26.049070000 Z
-  updated_at: 2019-01-30 21:33:24.182548000 Z
   created_by: 1
   updated_by: 1
   description: In Forgotten Valley
@@ -487,8 +439,6 @@ d30_50k_course_aid_4:
   vert_gain_from_start: 1798.32
   vert_loss_from_start: 1615.44
   kind: 2
-  created_at: 2017-05-23 06:20:05.636886000 Z
-  updated_at: 2019-01-30 21:33:24.201557000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -507,8 +457,6 @@ d30_50k_course_aid_3:
   vert_gain_from_start: 1310.64
   vert_loss_from_start: 1158.24
   kind: 2
-  created_at: 2017-05-23 06:23:13.751342000 Z
-  updated_at: 2019-01-30 21:33:24.220248000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -527,8 +475,6 @@ d30_50k_course_aid_2:
   vert_gain_from_start: 1036.32
   vert_loss_from_start: 701.04
   kind: 2
-  created_at: 2017-05-31 15:06:56.010141000 Z
-  updated_at: 2019-01-30 21:33:24.238842000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -547,8 +493,6 @@ d30_12m_course_start:
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
   kind: 0
-  created_at: 2017-06-09 09:51:15.477285000 Z
-  updated_at: 2019-01-30 21:33:24.255640000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -567,8 +511,6 @@ d30_12m_course_finish:
   vert_gain_from_start: 1066.7999658624
   vert_loss_from_start: 1066.7999658624
   kind: 1
-  created_at: 2017-06-09 09:51:15.480173000 Z
-  updated_at: 2019-01-30 21:33:24.274251000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -587,8 +529,6 @@ sum_100k_course_start:
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
   kind: 0
-  created_at: 2018-01-18 05:09:16.742408000 Z
-  updated_at: 2019-01-30 21:33:24.327917000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -607,8 +547,6 @@ sum_100k_course_finish:
   vert_gain_from_start: 2676.144
   vert_loss_from_start: 2529.84
   kind: 1
-  created_at: 2018-01-18 05:09:16.744523000 Z
-  updated_at: 2019-01-30 21:33:24.343889000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -627,8 +565,6 @@ sum_100k_course_molas_pass_aid1:
   vert_gain_from_start: 609.6
   vert_loss_from_start: 60.96
   kind: 2
-  created_at: 2018-01-18 05:09:24.887373000 Z
-  updated_at: 2019-01-30 21:33:24.308328000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -647,8 +583,6 @@ sum_100k_course_rolling_pass_aid2:
   vert_gain_from_start: 1005.84
   vert_loss_from_start: 152.4
   kind: 2
-  created_at: 2018-01-18 05:09:24.901188000 Z
-  updated_at: 2019-01-30 21:33:24.401037000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -667,8 +601,6 @@ sum_100k_course_cascade_creek_rd_aid3:
   vert_gain_from_start: 1112.52
   vert_loss_from_start: 365.76
   kind: 2
-  created_at: 2018-01-18 05:09:24.912892000 Z
-  updated_at: 2019-01-30 21:33:24.418100000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -687,8 +619,6 @@ sum_100k_course_engineer_mtn_th_aid4:
   vert_gain_from_start: 1271.016
   vert_loss_from_start: 1203.96
   kind: 2
-  created_at: 2018-01-18 05:09:24.923832000 Z
-  updated_at: 2019-01-30 21:33:24.434565000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -707,8 +637,6 @@ sum_100k_course_bandera_mine_aid5:
   vert_gain_from_start: 2496.312
   vert_loss_from_start: 1938.528
   kind: 2
-  created_at: 2018-01-18 05:09:24.936790000 Z
-  updated_at: 2019-01-30 21:33:24.449463000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -727,8 +655,6 @@ sum_100k_course_anvil_cg_aid6:
   vert_gain_from_start: 2542.032
   vert_loss_from_start: 2328.672
   kind: 2
-  created_at: 2018-01-18 05:09:24.961170000 Z
-  updated_at: 2019-01-30 21:33:24.585470000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -747,8 +673,6 @@ sum_55k_course_start:
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
   kind: 0
-  created_at: 2018-01-18 05:15:20.743652000 Z
-  updated_at: 2019-01-30 21:45:11.794264000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -767,8 +691,6 @@ sum_55k_course_finish:
   vert_gain_from_start: 1097.28
   vert_loss_from_start: 1097.28
   kind: 1
-  created_at: 2018-01-18 05:15:20.745798000 Z
-  updated_at: 2019-01-30 21:45:11.812282000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -787,8 +709,6 @@ sum_55k_course_molas_pass_aid1:
   vert_gain_from_start: 609.6
   vert_loss_from_start: 60.96
   kind: 2
-  created_at: 2018-01-18 05:20:09.848746000 Z
-  updated_at: 2019-01-30 21:45:11.828308000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -807,8 +727,6 @@ sum_55k_course_rolling_pass_aid2:
   vert_gain_from_start: 1005.84
   vert_loss_from_start: 152.4
   kind: 2
-  created_at: 2018-01-18 05:20:09.859521000 Z
-  updated_at: 2019-01-30 21:45:11.844000000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -827,8 +745,6 @@ sum_55k_course_bandera_mine_aid5:
   vert_gain_from_start: 1005.84
   vert_loss_from_start: 670.56
   kind: 2
-  created_at: 2018-01-18 05:20:09.869372000 Z
-  updated_at: 2019-01-30 21:45:11.858884000 Z
   created_by: 1
   updated_by: 1
   description:
@@ -847,8 +763,6 @@ sum_55k_course_anvil_cg_aid6:
   vert_gain_from_start: 1051.56
   vert_loss_from_start: 1021.08
   kind: 2
-  created_at: 2018-01-18 05:20:09.879917000 Z
-  updated_at: 2019-01-30 21:45:11.873936000 Z
   created_by: 1
   updated_by: 1
   description:

--- a/spec/fixtures/subscriptions.yml
+++ b/spec/fixtures/subscriptions.yml
@@ -2,8 +2,6 @@
 subscription_2:
   id: 2
   user_id: 1
-  created_at: 2019-08-18 16:39:16.680645000 Z
-  updated_at: 2019-08-18 16:39:16.680645000 Z
   protocol: 1
   resource_key: arn:aws:sns:us-west-2:998989370925:d-follow_rufa-2017-12h-not-started:c7853bd1-f4c2-44e8-bb25-e814aafdf134
   subscribable_type: Effort
@@ -11,8 +9,6 @@ subscription_2:
 subscription_3:
   id: 3
   user_id: 1
-  created_at: 2019-08-18 16:39:29.690231000 Z
-  updated_at: 2019-08-18 16:39:29.690231000 Z
   protocol: 1
   resource_key: arn:aws:sns:us-west-2:998989370925:d-follow_cartest-gletest:fae4dfcc-5d19-4fc5-81d2-6d88660df480
   subscribable_type: Person
@@ -20,8 +16,6 @@ subscription_3:
 subscription_4:
   id: 4
   user_id: 1
-  created_at: 2019-08-18 16:39:16.680645000 Z
-  updated_at: 2019-08-18 16:39:16.680645000 Z
   protocol: 0
   resource_key: arn:aws:sns:us-west-2:998989370925:d-follow_rufa-2017-12h-not-started:c7853bd1-f4c2-44e8-bb25-e814aafdf134
   subscribable_type: Effort

--- a/spec/fixtures/syncable_relations.yml
+++ b/spec/fixtures/syncable_relations.yml
@@ -7,8 +7,6 @@ syncable_relation_1:
   destination_name: internal
   destination_type: EventGroup
   destination_id: '59'
-  created_at: 2023-02-03 03:02:40.494099000 Z
-  updated_at: 2023-02-03 03:02:40.494099000 Z
 syncable_relation_2:
   id: 2
   source_name: runsignup
@@ -17,8 +15,6 @@ syncable_relation_2:
   destination_name: internal
   destination_type: Event
   destination_id: '36'
-  created_at: 2023-02-03 03:03:41.940759000 Z
-  updated_at: 2023-02-03 03:03:41.940759000 Z
 syncable_relation_3:
   id: 3
   source_name: runsignup
@@ -27,5 +23,3 @@ syncable_relation_3:
   destination_name: internal
   destination_type: Event
   destination_id: '70'
-  created_at: 2023-02-03 03:04:17.734829000 Z
-  updated_at: 2023-02-03 03:04:17.734829000 Z

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -8,20 +8,13 @@ admin_user:
   uid:
   email: user@example.com
   encrypted_password: "$2a$10$jhYkzuAbTVmMbK60m85zZ.K/bEMxQ.Qfqy7nDxmWsOvno7wvWrkTq"
-  reset_password_token: c8b8b7024cb8e95502ac89fe88ecb15e54a316d78c25c08654246111169c4fef
-  reset_password_sent_at: 2018-08-28 22:14:57.732468000 Z
-  remember_created_at:
   sign_in_count: 222
   current_sign_in_at: 2022-03-08 08:40:31.063076000 Z
   last_sign_in_at: 2019-02-23 04:32:53.993206000 Z
   current_sign_in_ip: 127.0.0.1
   last_sign_in_ip: 127.0.0.1
-  confirmation_token:
   confirmed_at: 2016-04-16 19:25:07.374438000 Z
-  confirmation_sent_at:
   unconfirmed_email:
-  created_at: 2016-04-16 19:25:07.455868000 Z
-  updated_at: 2022-03-08 08:40:31.063373000 Z
   pref_distance_unit: 0
   pref_elevation_unit: 0
   slug: admin-user
@@ -41,20 +34,13 @@ third_user:
   uid:
   email: thirduser@example.com
   encrypted_password: "$2a$10$/i14/9oGIR.0UWJaQYofNOeS85UAUgU0LOpd9C1mn.x4ZJxIZTSCy"
-  reset_password_token: ac4a7d72233563868fd69757e71597087a8010da3eb09c13a63bb85bd13f0b3e
-  reset_password_sent_at: 2018-08-28 21:02:15.748779000 Z
-  remember_created_at:
   sign_in_count: 22
   current_sign_in_at: 2019-01-25 22:45:17.386817000 Z
   last_sign_in_at: 2019-01-25 22:41:52.540192000 Z
   current_sign_in_ip: 127.0.0.1
   last_sign_in_ip: 127.0.0.1
-  confirmation_token:
   confirmed_at: 2016-04-16 19:25:07.514373000 Z
-  confirmation_sent_at:
   unconfirmed_email:
-  created_at: 2016-04-16 19:25:07.566303000 Z
-  updated_at: 2019-01-25 22:45:17.388127000 Z
   pref_distance_unit: 0
   pref_elevation_unit: 0
   slug: third-user
@@ -74,20 +60,13 @@ fourth_user:
   uid:
   email: fourthuser@example.com
   encrypted_password: "$2a$10$KpMwP1bN1IZfIMYi0mTj.uWOguBBs4tW.Ew/g4E3dfimQ61mo/Eom"
-  reset_password_token:
-  reset_password_sent_at:
-  remember_created_at:
   sign_in_count: 0
   current_sign_in_at:
   last_sign_in_at:
   current_sign_in_ip:
   last_sign_in_ip:
-  confirmation_token:
   confirmed_at: 2016-04-16 19:25:07.568372000 Z
-  confirmation_sent_at:
   unconfirmed_email:
-  created_at: 2016-04-16 19:25:07.620128000 Z
-  updated_at: 2017-03-05 04:55:53.390190000 Z
   pref_distance_unit: 0
   pref_elevation_unit: 0
   slug: fourth-user
@@ -107,20 +86,13 @@ fifth_user:
   uid:
   email: fifthuser@example.com
   encrypted_password: "$2a$10$OEXtV8bNIUspArW48HCjGO86WR3aUnPqSJLClYo.kINpUvdSFBQxu"
-  reset_password_token:
-  reset_password_sent_at:
-  remember_created_at:
   sign_in_count: 1
   current_sign_in_at: 2018-01-10 06:35:01.065288000 Z
   last_sign_in_at: 2018-01-10 06:35:01.065288000 Z
   current_sign_in_ip: 127.0.0.1
   last_sign_in_ip: 127.0.0.1
-  confirmation_token: sKp8deFPAb_fFQXDzjMZ
   confirmed_at: 2018-01-10 06:34:50.173537000 Z
-  confirmation_sent_at: 2018-01-10 06:34:30.911109000 Z
   unconfirmed_email:
-  created_at: 2018-01-10 06:34:30.910617000 Z
-  updated_at: 2018-01-10 06:35:01.067858000 Z
   pref_distance_unit: 0
   pref_elevation_unit: 0
   slug: fifth-user

--- a/spec/models/event_group_spec.rb
+++ b/spec/models/event_group_spec.rb
@@ -56,21 +56,12 @@ RSpec.describe EventGroup, type: :model do
 
   describe "after_save" do
     let(:event_group) { event_groups(:dirty_30) }
-    let(:events) { event_group.events }
+    let(:event_1) { event_group.events.first }
+    let(:event_2) { event_group.events.last }
 
     it "touches all events" do
-      events.each do |event|
-        event.reload
-        expect(event.updated_at > 1.minute.ago).not_to eq(true)
-      end
-
       expect(event_group).to be_available_live
-      event_group.update(available_live: false)
-
-      events.each do |event|
-        event.reload
-        expect(event.updated_at > 1.minute.ago).to eq(true)
-      end
+      expect { event_group.update(available_live: false) }.to change { event_1.reload.updated_at }.and change { event_2.reload.updated_at }
     end
 
     describe "conforms the concealed status of related records" do


### PR DESCRIPTION
Currently, the rake tasks `db:from_fixtures` and `db:to_fixtures` contain a list of tables to ignore, meaning that whenever a new table is created, these tasks fail until the list is updated.

This PR changes these rake tasks so that tables are opt-in rather than opt-out. It also removes several unused attributes that clutter the fixture files, notably `created_at` and `updated_at` (except in the case of lottery draws, which rely on `created_at` for ordering).