### PR TITLE
Rename highlight-created-value to highlight-timestamp-value

### DIFF
--- a/app/javascript/controllers/highlight_controller.js
+++ b/app/javascript/controllers/highlight_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
 
   static values = {
-    created: Number,
+    timestamp: Number,
     fast: Boolean,
   }
 
@@ -11,7 +11,7 @@ export default class extends Controller {
     const five_seconds_ago = Math.round(Date.now() / 1000) - 5
     const subjectElement = this.element
 
-    if (this.createdValue > five_seconds_ago) {
+    if (this.timestampValue > five_seconds_ago) {
       const cssFadeClass = this.fastValue ? "bg-highlight-faded-fast" : "bg-highlight-faded"
       const delay = this.fastValue ? 200 : 2000
       subjectElement.classList.add("bg-highlight")

--- a/app/views/efforts/_entrant_for_roster.html.erb
+++ b/app/views/efforts/_entrant_for_roster.html.erb
@@ -1,6 +1,10 @@
 <%# locals: (effort:, multiple_events, :started_efforts_present:) -%>
 
-<tr id="<%= dom_id effort, :roster_row %>" data-controller="highlight" data-highlight-fast-value="true" data-highlight-created-value="<%= effort.updated_at.to_i %>">
+<tr id="<%= dom_id effort, :roster_row %>"
+    data-controller="highlight"
+    data-highlight-fast-value="true"
+    data-highlight-timestamp-value="<%= effort.updated_at.to_i %>"
+>
   <td class="text-center">
     <%= effort.unreconciled? ? fa_icon("check-circle", type: :regular, class: "text-danger") : fa_icon("check-circle", type: :solid, class: "text-success") %>
   </td>

--- a/app/views/efforts/_entrant_for_setup.html.erb
+++ b/app/views/efforts/_entrant_for_setup.html.erb
@@ -1,6 +1,10 @@
 <%# locals: (effort:, presenter:) -%>
 
-<tr id="<%= dom_id effort, :event_group_setup %>" data-controller="highlight" data-highlight-fast-value="true" data-highlight-created-value="<%= effort.updated_at.to_i %>">
+<tr id="<%= dom_id effort, :event_group_setup %>"
+    data-controller="highlight"
+    data-highlight-fast-value="true"
+    data-highlight-timestamp-value="<%= effort.updated_at.to_i %>"
+>
   <td class="text-center">
     <%= effort.unreconciled? ? fa_icon("check-circle", type: :regular, class: "text-danger") : fa_icon("check-circle", type: :solid, class: "text-success") %>
   </td>

--- a/app/views/events/_course_setup_split.html.erb
+++ b/app/views/events/_course_setup_split.html.erb
@@ -4,7 +4,7 @@
     class="align-middle <%= ' bg-light fst-italic fw-light' if aid_station.blank? %>"
     data-controller="highlight"
     data-highlight-fast-value="true"
-    data-highlight-created-value="<%= split.updated_at.to_i %>"
+    data-highlight-timestamp-value="<%= split.updated_at.to_i %>"
     data-course-setup--splits-table-target="splitRow"
     data-split-id="<%= split.id %>"
 >

--- a/app/views/lottery_draws/_lottery_draw.html.erb
+++ b/app/views/lottery_draws/_lottery_draw.html.erb
@@ -1,6 +1,10 @@
 <%# locals: (lottery_draw:) -%>
 
-<div id="<%= dom_id lottery_draw %>" class="card mt-3" data-controller="highlight" data-highlight-created-value="<%= lottery_draw.created_at.to_i %>">
+<div id="<%= dom_id lottery_draw %>"
+     class="card mt-3"
+     data-controller="highlight"
+     data-highlight-timestamp-value="<%= lottery_draw.updated_at.to_i %>"
+>
   <div class="card-header fw-bold bg-primary text-white">
     <div class="row">
       <div class="col col-8">

--- a/app/views/lottery_draws/_lottery_draw_admin.html.erb
+++ b/app/views/lottery_draws/_lottery_draw_admin.html.erb
@@ -1,4 +1,10 @@
-<div id="<%= dom_id lottery_draw %>" class="card mt-3 min-width-3" data-controller="highlight" data-highlight-created-value="<%= lottery_draw.created_at.to_i %>">
+<%# locals: (lottery_draw:) %>
+
+<div id="<%= dom_id lottery_draw %>"
+     class="card mt-3 min-width-3"
+     data-controller="highlight"
+     data-highlight-timestamp-value="<%= lottery_draw.updated_at.to_i %>"
+>
   <div class="card-header fw-bold bg-primary text-white">
     <div class="row">
       <div class="col col-8">

--- a/app/views/raw_times/_raw_time.html.erb
+++ b/app/views/raw_times/_raw_time.html.erb
@@ -1,6 +1,9 @@
 <%# locals: (raw_time:, multiple_events:, multiple_sub_splits:, monitor_pacers:, home_time_zone:) -%>
 
-<tr id="<%= dom_id(raw_time) %>" data-controller="highlight" data-highlight-created-value="<%= raw_time.created_at.to_i %>">
+<tr id="<%= dom_id(raw_time) %>"
+    data-controller="highlight"
+    data-highlight-timestamp-value="<%= raw_time.updated_at.to_i %>"
+>
   <td><%= raw_time.bib_number %></td>
   <% if multiple_events %>
     <td><%= raw_time.event&.guaranteed_short_name || "--" %></td>


### PR DESCRIPTION
The name `timestamp` describes this value better than `created`, particularly because it typically uses the `updated_at` instead of `created_at` value for a record.