### PR TITLE
Trigger conditional reload on submit success instead of modal close

### DIFF
--- a/app/javascript/controllers/form_modal_controller.js
+++ b/app/javascript/controllers/form_modal_controller.js
@@ -32,9 +32,9 @@ export default class extends Controller {
     }
   }
 
-  conditionalReload() {
-    const reloadIndicator = this.element.querySelector("[data-reload-on-close]")
-    if (reloadIndicator) {
+  conditionalReload(event) {
+    const reloadIndicator = this.element.querySelector("[data-reload-on-submit]")
+    if (event.detail.success && reloadIndicator) {
       reloadWithTurbo()
     }
   }

--- a/app/views/devise/sessions/_form.html.erb
+++ b/app/views/devise/sessions/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="modal-header" data-reload-on-close="true">
+<div class="modal-header" data-reload-on-submit="true">
   <h3 class="modal-title"><strong><%= t("devise.sessions.new.sign_in").titleize %></strong></h3>
   <button type="button" class="btn-close" data-bs-dismiss="modal" tabindex="-1"></button>
 </div>

--- a/app/views/layouts/_form_modal.html.erb
+++ b/app/views/layouts/_form_modal.html.erb
@@ -5,8 +5,8 @@
      data-controller="form-modal"
      data-action="turbo:frame-load->form-modal#open
                   turbo:submit-end->form-modal#close
-                  shown.bs.modal->form-modal#autofocus
-                  hide.bs.modal->form-modal#conditionalReload"
+                  turbo:submit-end->form-modal#conditionalReload
+                  shown.bs.modal->form-modal#autofocus"
 >
   <div class="modal-dialog <%= bs_modal_modifier %>">
     <div class="modal-content">


### PR DESCRIPTION
Submit success is a better measure for closing a modal.