### PR TITLE
Eliminate form_modal_large in favor of a single resizable form_modal

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -247,7 +247,7 @@ module DropdownHelper
       { role: :separator },
       { name: "Edit Entrant",
         link: edit_effort_path(view_object.effort),
-        data: { turbo_frame: "form_modal_large" } },
+        data: { turbo_frame: "form_modal" } },
       { name: "Rebuild Times",
         link: rebuild_effort_path(view_object.effort),
         method: :patch,

--- a/app/helpers/efforts_helper.rb
+++ b/app/helpers/efforts_helper.rb
@@ -58,7 +58,7 @@ module EffortsHelper
   def link_to_effort_edit(effort)
     url = edit_effort_path(effort)
     tooltip = "Edit effort"
-    options = { data: { turbo_frame: "form_modal_large",
+    options = { data: { turbo_frame: "form_modal",
                         controller: "tooltip",
                         bs_placement: :bottom,
                         bs_original_title: tooltip },

--- a/app/helpers/splits_helper.rb
+++ b/app/helpers/splits_helper.rb
@@ -12,7 +12,7 @@ module SplitsHelper
   def link_to_event_split_edit(event, split)
     url = edit_event_group_event_split_path(event.event_group, event, split)
     tooltip = "Edit this split"
-    options = { data: { turbo_frame: "form_modal_large",
+    options = { data: { turbo_frame: "form_modal",
                         controller: "tooltip",
                         bs_placement: :bottom,
                         bs_original_title: tooltip },

--- a/app/javascript/controllers/form_modal_controller.js
+++ b/app/javascript/controllers/form_modal_controller.js
@@ -29,7 +29,7 @@ export default class extends Controller {
   }
 
   resizeIndicatorTargetConnected(element) {
-    this.resizedElementTarget.classList.add(element.dataset.resizeClass)
+    this.resizedElementTarget.classList.add("modal-lg")
   }
 
   autofocus() {

--- a/app/javascript/controllers/form_modal_controller.js
+++ b/app/javascript/controllers/form_modal_controller.js
@@ -2,7 +2,10 @@ import { Controller } from "@hotwired/stimulus"
 import * as bootstrap from "bootstrap"
 
 export default class extends Controller {
-  static targets = [ "cancelButton" ]
+  static targets = [
+    "resizedElement",
+    "resizeIndicator",
+  ]
 
   connect() {
     this.modal = new bootstrap.Modal(this.element)
@@ -23,6 +26,10 @@ export default class extends Controller {
   hide(event) {
     event.preventDefault()
     this.modal.hide()
+  }
+
+  resizeIndicatorTargetConnected(element) {
+    this.resizedElementTarget.classList.add(element.dataset.resizeClass)
   }
 
   autofocus() {

--- a/app/views/efforts/_actions_kebab.html.erb
+++ b/app/views/efforts/_actions_kebab.html.erb
@@ -4,6 +4,6 @@
                class: "dropdown-toggle no-caret btn btn-sm btn-light",
                data: { bs_toggle: "dropdown" } %>
 <div class="dropdown-menu dropdown-menu-end" style="min-width:inherit">
-  <%= link_to "Edit", edit_effort_path(effort), class: "dropdown-item", data: { turbo_frame: "form_modal_large" } %>
+  <%= link_to "Edit", edit_effort_path(effort), class: "dropdown-item", data: { turbo_frame: "form_modal" } %>
   <%= link_to "Delete", effort_path(effort), class: "dropdown-item", data: { method: :delete, confirm: "This cannot be undone. Proceed?" } %>
 </div>

--- a/app/views/efforts/_projections_modal.html.erb
+++ b/app/views/efforts/_projections_modal.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (presenter:) -%>
 
-<%= turbo_frame_tag "form_modal_large" do %>
-  <div class="modal-header">
+<%= turbo_frame_tag "form_modal" do %>
+  <div class="modal-header" data-form-modal-target="resizeIndicator" data-resize-class="modal-lg">
     <div class="modal-title h4 fw-bold"><%= "##{presenter.bib_number} #{presenter.full_name}" %></div>
   </div>
   <div class="modal-body">

--- a/app/views/efforts/_projections_modal.html.erb
+++ b/app/views/efforts/_projections_modal.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (presenter:) -%>
 
 <%= turbo_frame_tag "form_modal" do %>
-  <div class="modal-header" data-form-modal-target="resizeIndicator" data-resize-class="modal-lg">
+  <div class="modal-header" data-form-modal-target="resizeIndicator">
     <div class="modal-title h4 fw-bold"><%= "##{presenter.bib_number} #{presenter.full_name}" %></div>
   </div>
   <div class="modal-body">

--- a/app/views/efforts/edit.html.erb
+++ b/app/views/efforts/edit.html.erb
@@ -27,8 +27,8 @@
 </header>
 
 <article class="ost-article container">
-  <%= turbo_frame_tag "form_modal_large" do %>
-    <div class="modal-header">
+  <%= turbo_frame_tag "form_modal" do %>
+    <div class="modal-header" data-form-modal-target="resizeIndicator" data-resize-class="modal-lg">
       <div class="modal-title h4 fw-bold">Edit Entrant - <%= @effort.full_name %></div>
     </div>
     <div class="modal-body">

--- a/app/views/efforts/edit.html.erb
+++ b/app/views/efforts/edit.html.erb
@@ -28,7 +28,7 @@
 
 <article class="ost-article container">
   <%= turbo_frame_tag "form_modal" do %>
-    <div class="modal-header" data-form-modal-target="resizeIndicator" data-resize-class="modal-lg">
+    <div class="modal-header" data-form-modal-target="resizeIndicator">
       <div class="modal-title h4 fw-bold">Edit Entrant - <%= @effort.full_name %></div>
     </div>
     <div class="modal-body">

--- a/app/views/efforts/new.html.erb
+++ b/app/views/efforts/new.html.erb
@@ -26,8 +26,8 @@
 </header>
 
 <article class="ost-article container">
-  <%= turbo_frame_tag "form_modal_large" do %>
-    <div class="modal-header">
+  <%= turbo_frame_tag "form_modal" do %>
+    <div class="modal-header" data-modal-css-modifier="modal-lg">
       <div class="modal-title h4 fw-bold">Add an Entrant</div>
     </div>
     <div class="modal-body">

--- a/app/views/event_groups/_entrants_list.html.erb
+++ b/app/views/event_groups/_entrants_list.html.erb
@@ -6,7 +6,7 @@
           <div>
             <%= link_to fa_icon("plus", text: "Add"),
                         new_effort_path(event_id: presenter.first_event.id),
-                        data: { turbo_frame: "form_modal_large" },
+                        data: { turbo_frame: "form_modal" },
                         id: "add-entrant",
                         class: "btn btn-success" %>
             <% if @presenter.event_group_efforts_count.positive? %>

--- a/app/views/event_groups/_finish_line_effort.html.erb
+++ b/app/views/event_groups/_finish_line_effort.html.erb
@@ -16,7 +16,7 @@
           <strong><%= bib_effort_name_and_event_name(effort, effort.event_group.multiple_events?) %></strong>
           <%= link_to "Details", projections_effort_path(effort, modal: true),
                       class: "btn btn-success float-end",
-                      data: { turbo_frame: "form_modal_large" } %>
+                      data: { turbo_frame: "form_modal" } %>
         </h3>
         <div class="card-body">
           <h4 class="card-text"><%= effort.bio %></h4>

--- a/app/views/events/_course_gpx_form.html.erb
+++ b/app/views/events/_course_gpx_form.html.erb
@@ -8,7 +8,7 @@
     <div class="modal-body">
       <%= form_with model: [event.course],
                     url: attach_course_gpx_event_group_event_path(event.event_group, event),
-                    data: { turbo_frame: "_top" } do |f| %>
+                    data: { controller: "form-apply", turbo_frame: "_top" } do |f| %>
         <% if current_user.errors.any? %>
           <div id="error_explanation">
             <ul>

--- a/app/views/events/setup_course.html.erb
+++ b/app/views/events/setup_course.html.erb
@@ -51,7 +51,7 @@
                   new_event_group_event_split_path(@presenter.event_group, @presenter.event),
                   id: "add-split",
                   class: "btn btn-success",
-                  data: { turbo_frame: "form_modal_large" }
+                  data: { turbo_frame: "form_modal" }
       %>
       <%= event_setup_course_import_dropdown(@presenter) %>
       <%= link_to "Export",

--- a/app/views/layouts/_form_modal.html.erb
+++ b/app/views/layouts/_form_modal.html.erb
@@ -1,5 +1,3 @@
-<%# locals: (turbo_frame_id:, bs_modal_modifier:) -%>
-
 <div class="modal fade"
      tabindex="-1"
      data-controller="form-modal"
@@ -8,9 +6,9 @@
                   turbo:submit-end->form-modal#conditionalReload
                   shown.bs.modal->form-modal#autofocus"
 >
-  <div class="modal-dialog <%= bs_modal_modifier %>">
+  <div class="modal-dialog" data-form-modal-target="resizedElement">
     <div class="modal-content">
-      <%= turbo_frame_tag turbo_frame_id %>
+      <%= turbo_frame_tag "form_modal" %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,8 +23,7 @@
 
 <%= yield %>
 
-<%= render "layouts/form_modal", bs_modal_modifier: nil, turbo_frame_id: "form_modal" %>
-<%= render "layouts/form_modal", bs_modal_modifier: "modal-lg", turbo_frame_id: "form_modal_large" %>
+<%= render "layouts/form_modal", turbo_frame_id: "form_modal" %>
 
 <%= render "layouts/footer" unless @skip_footer %>
 </body>

--- a/app/views/split_times/_projections_list.html.erb
+++ b/app/views/split_times/_projections_list.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (presenter:) -%>
 
-<%= turbo_frame_tag "form_modal_large" do %>
+<%= turbo_frame_tag "form_modal" do %>
   <table class="table table-striped">
     <thead>
     <tr>

--- a/app/views/splits/edit.html.erb
+++ b/app/views/splits/edit.html.erb
@@ -3,8 +3,8 @@
 <% end %>
 
 <main class="container">
-  <%= turbo_frame_tag "form_modal_large" do %>
-    <div class="modal-body">
+  <%= turbo_frame_tag "form_modal" do %>
+    <div class="modal-body" data-form-modal-target="resizeIndicator" data-resize-class="modal-lg">
       <%= render "splits/form", event: @event, split: @split %>
     </div>
   <% end %>

--- a/app/views/splits/edit.html.erb
+++ b/app/views/splits/edit.html.erb
@@ -4,7 +4,7 @@
 
 <main class="container">
   <%= turbo_frame_tag "form_modal" do %>
-    <div class="modal-body" data-form-modal-target="resizeIndicator" data-resize-class="modal-lg">
+    <div class="modal-body" data-form-modal-target="resizeIndicator">
       <%= render "splits/form", event: @event, split: @split %>
     </div>
   <% end %>

--- a/app/views/splits/new.html.erb
+++ b/app/views/splits/new.html.erb
@@ -3,8 +3,8 @@
 <% end %>
 
 <main class="container">
-  <%= turbo_frame_tag "form_modal_large" do %>
-    <div class="modal-body">
+  <%= turbo_frame_tag "form_modal" do %>
+    <div class="modal-body" data-form-modal-target="resizeIndicator" data-resize-class="modal-lg">
       <%= render "splits/form", event: @event, split: @split %>
     </div>
   <% end %>

--- a/app/views/splits/new.html.erb
+++ b/app/views/splits/new.html.erb
@@ -4,7 +4,7 @@
 
 <main class="container">
   <%= turbo_frame_tag "form_modal" do %>
-    <div class="modal-body" data-form-modal-target="resizeIndicator" data-resize-class="modal-lg">
+    <div class="modal-body" data-form-modal-target="resizeIndicator">
       <%= render "splits/form", event: @event, split: @split %>
     </div>
   <% end %>


### PR DESCRIPTION
Avoids the confusion of having two modal partials with different turbo frame tags.