### PR TITLE
Convert popover controller to turbo stream

### DIFF
--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -270,11 +270,11 @@ class EffortsController < ApplicationController
   end
 
   def mini_table
-    if params[:effort_ids].present?
-      @mini_table = EffortsMiniTable.new(params[:effort_ids])
-      render partial: "efforts_mini_table"
-    else
-      render html: "No effort ids provided", status: :unprocessable_entity
+    respond_to do |format|
+      format.turbo_stream do
+        mini_table = EffortsMiniTable.new(params[:effort_ids])
+        render turbo_stream: turbo_stream.update(params[:target], partial: "efforts/efforts_mini_table", locals: { effort_rows: mini_table.effort_rows })
+      end
     end
   end
 

--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -269,15 +269,18 @@ class EffortsController < ApplicationController
     redirect_to effort_path(@effort)
   end
 
+  # This action uses POST because a GET may exceed the maximum length of a URL.
+  # POST /efforts/mini_table
   def mini_table
-    respond_to do |format|
-      format.turbo_stream do
-        mini_table = EffortsMiniTable.new(params[:effort_ids])
-        render turbo_stream: turbo_stream.update(params[:target], partial: "efforts/efforts_mini_table", locals: { effort_rows: mini_table.effort_rows })
-      end
+    if params[:effort_ids].present? && params[:target].present?
+      mini_table = EffortsMiniTable.new(params[:effort_ids])
+      render turbo_stream: turbo_stream.update(params[:target], partial: "efforts/efforts_mini_table", locals: { effort_rows: mini_table.effort_rows })
+    else
+      head :unprocessable_entity
     end
   end
 
+  # GET /efforts/1/show_photo
   def show_photo
     render partial: "show_photo"
   end

--- a/app/helpers/popovers_helper.rb
+++ b/app/helpers/popovers_helper.rb
@@ -4,15 +4,17 @@ module PopoversHelper
   def link_to_effort_ids_popover(effort_ids, title)
     return "--" if effort_ids.empty?
 
+    target_value = "popover_#{SecureRandom.hex(4)}"
     content_tag :a, effort_ids.size,
                 tabindex: 0,
                 class: "btn btn-sm btn-outline-primary fw-bold",
                 data: {
                   controller: "popover",
                   popover_effort_ids_value: effort_ids,
+                  popover_target_value: target_value,
                   bs_toggle: "popover",
                   bs_title: title,
-                  bs_content: "Loading...",
+                  bs_content: "<div id='#{target_value}'></div>",
                   bs_trigger: "focus",
                 }
   end

--- a/app/javascript/controllers/popover_controller.js
+++ b/app/javascript/controllers/popover_controller.js
@@ -1,16 +1,18 @@
 import { Controller } from "@hotwired/stimulus"
-import { FetchRequest } from "@rails/request.js"
+import { post } from "@rails/request.js"
 import { Popover } from "bootstrap"
 
 export default class extends Controller {
   static values = {
     effortIds: Array,
+    target: String,
     theme: String,
   }
 
   connect() {
     const theme = this.themeValue
     const effortIds = this.effortIdsValue
+    const target = this.targetValue
 
     this.element.style.cursor = "pointer"
 
@@ -26,33 +28,14 @@ export default class extends Controller {
       if (effortIds.length > 0) {
         popover.tip.classList.add("efforts-popover");
 
-        const request = new FetchRequest("post", "/efforts/mini_table/", {
-          body: {effortIds: effortIds},
+        post("/efforts/mini_table/", {
+          body: {
+            effortIds: effortIds,
+            target: target,
+          },
           contentType: "application/json",
-          responseKind: "html"
+          responseKind: "turbo-stream"
         })
-
-        if (!popover._config.fetched) {
-          popover._config.fetched = true
-
-          request.perform().then(function (response) {
-            if (response.ok) {
-              response.html.then(function (html) {
-                popover.setContent({
-                  ".popover-body": html
-                })
-              })
-            } else {
-              popover.setContent({
-                ".popover-body": "Error loading efforts."
-              })
-            }
-          }, function (error) {
-            popover.setContent({
-              ".popover-body": error
-            })
-          })
-        }
 
       } else {
         popover.tip.classList.add("static-popover");

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -118,3 +118,4 @@ myDefaultAllowList.td = [];
 myDefaultAllowList.th = [];
 myDefaultAllowList.tbody = [];
 myDefaultAllowList.thead = [];
+myDefaultAllowList.div = [];

--- a/app/view_models/place_detail_row.rb
+++ b/app/view_models/place_detail_row.rb
@@ -5,7 +5,7 @@ class PlaceDetailRow
 
   attr_reader :split_times
 
-  delegate :distance_from_start, to: :lap_split
+  delegate :distance_from_start, :lap, :split, to: :lap_split
 
   # split_times should be an array having size == lap_split.time_points.size,
   # with nil values where no corresponding split_time exists

--- a/app/views/efforts/_efforts_mini_table.html.erb
+++ b/app/views/efforts/_efforts_mini_table.html.erb
@@ -1,4 +1,6 @@
-<table class="table table-sm table-striped">
+<%# locals: (effort_rows:) -%>
+
+<table class="table table-sm">
   <thead>
   <tr>
     <th class="text-center">Bib</th>
@@ -7,12 +9,18 @@
   </tr>
   </thead>
   <tbody>
-  <% @mini_table.effort_rows.each do |row| %>
+  <% if effort_rows.present? %>
+    <% effort_rows.each do |row| %>
       <tr>
         <td class="text-center"><%= row.bib_number %></td>
         <td class="text-nowrap"><%= link_to row.full_name, effort_path(row) %></td>
         <td class="text-nowrap"><%= row.bio_historic %></td>
       </tr>
+    <% end %>
+  <% else %>
+    <tr>
+      <td colspan="3">Efforts could not be loaded.</td>
+    </tr>
   <% end %>
   </tbody>
 </table>

--- a/app/views/efforts/_place_detail_rows.html.erb
+++ b/app/views/efforts/_place_detail_rows.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (view_object:) -%>
 
-<table class="table table-striped">
+<table class="table">
   <thead>
   <tr>
     <th>Split</th>
@@ -29,7 +29,7 @@
 
   <tbody>
   <% view_object.place_detail_rows.each do |place_detail_row| %>
-    <tr>
+    <tr id='<%= "lap_#{place_detail_row.lap}_split_#{place_detail_row.split.id}" %>' class="align-middle">
       <td><%= place_detail_row.name %></td>
       <td class="text-end"><%= d(place_detail_row.distance_from_start) %></td>
       <td class="text-center"><%= place_detail_row.absolute_times_local.map(&method(:day_time_format)).join(' / ') %></td>

--- a/spec/system/visit_effort_place_spec.rb
+++ b/spec/system/visit_effort_place_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "visit an effort place page" do
   let(:completed_effort) { efforts(:hardrock_2014_finished_first) }
   let(:in_progress_effort) { efforts(:hardrock_2014_progress_sherman) }
   let(:unstarted_effort) { efforts(:hardrock_2014_not_started) }
+  let(:popover_effort) { efforts(:hardrock_2014_keith_metz) }
 
   context "When the effort is finished" do
     let(:effort) { completed_effort }
@@ -37,6 +38,27 @@ RSpec.describe "visit an effort place page" do
       visit place_effort_path(effort)
       verify_page_header
       expect(page).to have_text("The effort has not started")
+    end
+  end
+
+  context "when an effort has peers" do
+    let(:effort) { popover_effort }
+
+    scenario "Click a popover button", js: true do
+      split = splits(:hardrock_cw_telluride)
+
+      visit place_effort_path(effort)
+      within "#lap_1_split_#{split.id}" do
+        first("[data-controller='popover']").click
+      end
+      expect(page).to have_css(".popover-body")
+      within ".popover-body" do
+        expect(page).to have_css(".table")
+        within ".table" do
+          expect(page).to have_content("Paul Predovic")
+          expect(page).to have_content("Irvin Corkery")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This PR converts the popover stimulus controller to turbo, allowing the turbo_stream response to find its own way to the popover body.

Benefits: This is a more Rails 7 way of doing things, and it's a bit less code
Drawbacks: If a popover trigger button is repeatedly clicked, content will be reloaded each time (not cached)

This would be even cleaner with a lazy-loaded turbo frame, but that would require us to convert the `mini_table` endpoint to a GET, and the URL is theoretically too long for that.