### PR TITLE
Add "stopped here" information to cutoff analysis

### DIFF
--- a/app/presenters/course_cutoff_analysis_presenter.rb
+++ b/app/presenters/course_cutoff_analysis_presenter.rb
@@ -33,7 +33,11 @@ class CourseCutoffAnalysisPresenter < BasePresenter
           data: interval_split_cutoff_analyses.map { |isca| [range_string(isca), isca.finished_count] }
         },
         {
-          name: "Unfinished",
+          name: "Stopped Here",
+          data: interval_split_cutoff_analyses.map { |isca| [range_string(isca), isca.stopped_here_count] }
+        },
+        {
+          name: "Continued and DNF",
           data: interval_split_cutoff_analyses.map { |isca| [range_string(isca), isca.total_count - isca.finished_count] }
         },
       ]
@@ -55,7 +59,7 @@ class CourseCutoffAnalysisPresenter < BasePresenter
   end
 
   def range_string(isca)
-    if display_style == :elapsed
+    if display_style == "elapsed_time"
       "#{time_format_hhmm(isca.start_seconds)} to #{time_format_hhmm(isca.end_seconds)}"
     else
       "#{localized_time(start_time + isca.start_seconds)} to #{localized_time(start_time + isca.end_seconds)}"

--- a/app/presenters/course_cutoff_analysis_presenter.rb
+++ b/app/presenters/course_cutoff_analysis_presenter.rb
@@ -6,7 +6,8 @@ class CourseCutoffAnalysisPresenter < BasePresenter
   include TimeFormats
 
   DEFAULT_BAND_WIDTH = 30.minutes
-  DEFAULT_DISPLAY_STYLE = :absolute
+  DEFAULT_DISPLAY_STYLE = "absolute_time"
+  VALID_DISPLAY_STYLES = %w(elapsed_time absolute_time).freeze
 
   attr_reader :course
   delegate :events, :name, :organization, :simple?, to: :course
@@ -39,14 +40,14 @@ class CourseCutoffAnalysisPresenter < BasePresenter
   end
 
   def display_style
-    @display_style ||= params[:display_style].presence&.to_sym || DEFAULT_DISPLAY_STYLE
+    params[:display_style].in?(VALID_DISPLAY_STYLES) ? params[:display_style] : DEFAULT_DISPLAY_STYLE
   end
 
   def display_style_hash
     {
-      elapsed: "Elapsed",
-      absolute: "Absolute",
-    }
+      elapsed_time: "Elapsed",
+      absolute_time: "Absolute",
+    }.with_indifferent_access.freeze
   end
 
   def distance

--- a/app/views/courses/cutoff_analysis.html.erb
+++ b/app/views/courses/cutoff_analysis.html.erb
@@ -37,16 +37,20 @@
 
   <% if @presenter.visible_events_exist? && @presenter.interval_split_cutoff_analyses.present? %>
     <div>
-      <%= column_chart @presenter.chart_data, stacked: true %>
+      <%= column_chart @presenter.chart_data,
+                       stacked: true,
+                       colors: ["#198754", "#f0ad4e", "#dc3545"] %>
     </div>
     <hr/>
 
-    <table class="table table-striped" style="width:80%">
+    <table class="table">
       <thead>
       <tr>
         <th><%= @presenter.display_style.titleize %></th>
-        <th class="text-center">Total Efforts</th>
-        <th class="text-center">Finished Efforts</th>
+        <th class="text-center">Total</th>
+        <th class="text-center">Finished</th>
+        <th class="text-center">Stopped Here</th>
+        <th class="text-center">Continued</br>and DNF</th>
       </tr>
       </thead>
       <tbody>
@@ -55,6 +59,8 @@
           <td><%= @presenter.range_string(isca) %></td>
           <td class="text-center"><%= isca.total_count %></td>
           <td class="text-center"><%= isca.finished_count %></td>
+          <td class="text-center"><%= isca.stopped_here_count %></td>
+          <td class="text-center"><%= isca.continued_dnf_count %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/courses/cutoff_analysis.html.erb
+++ b/app/views/courses/cutoff_analysis.html.erb
@@ -44,7 +44,7 @@
     <table class="table table-striped" style="width:80%">
       <thead>
       <tr>
-        <th>Elapsed Time</th>
+        <th><%= @presenter.display_style.titleize %></th>
         <th class="text-center">Total Efforts</th>
         <th class="text-center">Finished Efforts</th>
       </tr>


### PR DESCRIPTION
Resolves #1031

### Before:

<img width="1202" alt="Screenshot 2023-05-19 at 6 15 03 PM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/f1e3e9ed-d11b-4b73-bb1e-7bda687fa6f5">

### After:

<img width="1202" alt="Screenshot 2023-05-19 at 6 14 33 PM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/9825f53b-1840-421c-becc-2e177dc0fdc4">
