### PR TITLE
Add nonbinary to the Person model

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -17,7 +17,7 @@ class PeopleController < ApplicationController
   end
 
   def show
-    @presenter = PersonPresenter.new(@person, prepared_params, current_user)
+    @presenter = PersonPresenter.new(@person, view_context)
   end
 
   def edit
@@ -43,13 +43,8 @@ class PeopleController < ApplicationController
 
   def avatar_claim
     authorize @person
-    @person.update(claimant: current_user)
-    redirect_to @person
-  end
 
-  def avatar_disclaim
-    authorize @person
-    @person.update(claimant: nil)
+    @person.update(claimant: current_user)
     redirect_to @person
   end
 

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -294,16 +294,27 @@ module DropdownHelper
 
   def person_actions_dropdown_menu(view_object)
     dropdown_items = [
-      { name: "Edit",
-        link: edit_person_path(view_object.person) },
-      { name: "Merge with",
-        link: merge_person_path(view_object.person) },
-      { role: :separator },
-      { name: "Delete person",
+      {
+        name: "Edit",
+        link: edit_person_path(view_object.person),
+      },
+      {
+        name: "Merge with",
+        link: merge_person_path(view_object.person),
+        visible: view_object.current_user.admin?,
+      },
+      {
+        role: :separator,
+        visible: view_object.current_user.admin?,
+      },
+      {
+        name: "Delete person",
         link: person_path(view_object.person),
+        visible: view_object.current_user.admin?,
         method: :delete,
         data: { confirm: "This action cannot be undone. Proceed?" },
-        class: "text-danger" }
+        class: "text-danger",
+      }
     ]
     build_dropdown_menu("Actions", dropdown_items, button: true)
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -18,7 +18,7 @@ class Person < ApplicationRecord
   friendly_id :slug_candidates, use: [:slugged, :history]
   has_paper_trail
 
-  enum gender: [:male, :female]
+  enum gender: [:male, :female, :nonbinary]
   has_many :efforts, dependent: :nullify
   belongs_to :claimant, class_name: "User", foreign_key: "user_id", optional: true
   has_one_attached :photo do |photo|

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -20,16 +20,20 @@ class PersonPolicy < ApplicationPolicy
     user.admin?
   end
 
+  def edit?
+    user.admin? || user.avatar == person
+  end
+
+  def update?
+    edit?
+  end
+
   def destroy?
     user.admin?
   end
 
   def avatar_claim?
     user.authorized_to_claim?(person)
-  end
-
-  def avatar_disclaim?
-    user.admin?
   end
 
   def merge?

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 class PersonPresenter < BasePresenter
-  attr_reader :person
+  attr_reader :person, :current_user
 
   delegate :to_param, to: :person
 
-  def initialize(person, params, current_user)
+  def initialize(person, view_context)
     @person = person
-    @params = params
-    @current_user = current_user
+    @current_user = view_context.current_user
   end
 
   def efforts
@@ -27,8 +26,4 @@ class PersonPresenter < BasePresenter
   def method_missing(method)
     person.send(method)
   end
-
-  private
-
-  attr_reader :params, :current_user
 end

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -50,11 +50,15 @@
       <div class="col d-inline-flex justify-content-between">
         <div>
           <% if @presenter.unclaimed? && current_user&.authorized_to_claim?(@presenter.person) %>
-            <%= link_to "This is me", avatar_claim_person_path(@presenter.person),
-                        data: { confirm: "Is this really you? (Please cancel if you were just kidding.)" },
-                        class: "btn btn-success" %>
+            <%= button_to "This is me", avatar_claim_person_path(@presenter.person),
+                          class: "btn btn-success",
+                          method: :patch,
+                          data: {
+                            turbo_confirm: "Is this really you? (Please cancel if you were just kidding.)",
+                          }
+            %>
           <% end %>
-          <% if current_user&.admin? %>
+          <% if current_user.present? && (current_user.admin? || current_user.avatar == @presenter.person) %>
             <%= person_actions_dropdown_menu(@presenter) %>
           <% end %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,8 +226,7 @@ Rails.application.routes.draw do
   resources :people, only: [:index, :show, :edit, :update, :destroy] do
     resources :subscriptions, only: [:create, :destroy], module: "people"
     collection { get :subregion_options }
-    member { get :avatar_claim }
-    member { delete :avatar_disclaim }
+    member { patch :avatar_claim }
     member { get :merge }
     member { put :combine }
   end


### PR DESCRIPTION
This PR adds `nonbinary` as a gender in the Person model. It also allows a user who has claimed a Person to edit that person, which would allow someone who changes gender identification to update gender without admin assistance.