### PR TITLE
Simplify the Carmen controller

### DIFF
--- a/app/helpers/carmen_helper.rb
+++ b/app/helpers/carmen_helper.rb
@@ -12,8 +12,11 @@ module CarmenHelper
            SORTED_COUNTRIES_FOR_SELECT,
            options,
            { class: "form-control",
-             data: { "carmen-target" => "countrySelect",
-                     action: "change->carmen#getSubregions" } })
+             data: {
+               controller: "carmen",
+               carmen_model_value: model,
+               action: "change->carmen#getSubregions"
+             } })
   end
 
   def carmen_subregion_select(model, field, country, args = {})

--- a/app/javascript/controllers/carmen_controller.js
+++ b/app/javascript/controllers/carmen_controller.js
@@ -3,11 +3,10 @@ import { get } from "@rails/request.js"
 
 export default class extends Controller {
 
-  static targets = ["countrySelect"]
   static values = { model: String }
 
   getSubregions() {
-    const countryCode = this.countrySelectTarget.value
+    const countryCode = this.element.value
     const model = this.modelValue
     const url = "/carmen/subregion_options?model=" + model + "&parent_region=" + countryCode
     const options = { responseKind: "turbo-stream" }

--- a/app/views/efforts/_form.html.erb
+++ b/app/views/efforts/_form.html.erb
@@ -43,7 +43,7 @@
           </div>
         </div>
 
-        <div class="row" data-controller="carmen" data-carmen-model-value="effort">
+        <div class="row">
           <div class="col-md-4 mb-3">
             <%= f.label :country_code, "Country", class: "mb-1" %>
             <%= carmen_country_select :effort, :country_code %>

--- a/app/views/lottery_entrants/_form.html.erb
+++ b/app/views/lottery_entrants/_form.html.erb
@@ -26,7 +26,7 @@
         </div>
       </div>
 
-      <div class="row" data-controller="carmen" data-carmen-model-value="lottery_entrant">
+      <div class="row">
         <div class="mb-3 col-md-3">
           <%= f.label :city, class: "mb-1" %>
           <%= f.text_field :city, class: "form-control", placeholder: "City" %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -27,7 +27,7 @@
       </div>
     </div>
 
-    <div class="row" data-controller="carmen" data-carmen-model-value="person">
+    <div class="row">
       <div class="col-md-4 mb-3">
         <%= f.label :country_code, "Country", class: "mb-1" %>
         <%= carmen_country_select :person, :country_code %>


### PR DESCRIPTION
For historical reasons, the Carmen stimulus controller currently lives at the level of the row containing both country and subregion dropdowns. But with the new Turbo-based logic, the controller no longer needs to interact with the subregion dropdown.

This PR reduces the scope of the Carmen stimulus controller to the country dropdown and eliminates the need to designate any targets.