### PR TITLE
Remove created_by from results models

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,7 +22,7 @@
       "formation": {
         "test": {
           "quantity": 1,
-          "size": "performance-m"
+          "size": "standard-2x"
         }
       },
       "scripts": {

--- a/app/madmin/resources/results_category_resource.rb
+++ b/app/madmin/resources/results_category_resource.rb
@@ -8,7 +8,6 @@ class ResultsCategoryResource < Madmin::Resource
   attribute :nonbinary
   attribute :low_age
   attribute :high_age
-  attribute :created_by
   attribute :created_at, form: false
   attribute :updated_at, form: false
   attribute :invalid_efforts, index: false

--- a/app/madmin/resources/results_template_resource.rb
+++ b/app/madmin/resources/results_template_resource.rb
@@ -6,7 +6,6 @@ class ResultsTemplateResource < Madmin::Resource
   attribute :aggregation_method
   attribute :podium_size
   attribute :point_system
-  attribute :created_by
   attribute :created_at, form: false
   attribute :updated_at, form: false
 

--- a/app/models/results_category.rb
+++ b/app/models/results_category.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class ResultsCategory < ApplicationRecord
-  include Auditable
   extend FriendlyId
+
+  self.ignored_columns = %w[created_by]
 
   INF = 1.0 / 0
 

--- a/app/models/results_template.rb
+++ b/app/models/results_template.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class ResultsTemplate < ApplicationRecord
-  include Auditable
   extend FriendlyId
+
+  self.ignored_columns = %w[created_by]
 
   enum aggregation_method: [:inclusive, :strict]
   friendly_id :name, use: [:slugged, :history]

--- a/app/models/results_template_category.rb
+++ b/app/models/results_template_category.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ResultsTemplateCategory < ApplicationRecord
   belongs_to :results_template, optional: false
   belongs_to :results_category, optional: false

--- a/spec/models/results_category_spec.rb
+++ b/spec/models/results_category_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe ResultsCategory do
-  it_behaves_like "auditable"
-
   subject(:results_category) { build(:results_category) }
 
   describe "#initialize" do

--- a/spec/models/results_template_category_spec.rb
+++ b/spec/models/results_template_category_spec.rb
@@ -1,5 +1,27 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
-RSpec.describe ResultsTemplateCategory, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe ResultsTemplateCategory do
+  subject(:results_template_category) { results_template_categories(:results_template_category_1) }
+
+  describe "#initialize" do
+    it "is valid when it has both a results category and a results template" do
+      expect(results_template_category).to be_valid
+    end
+  end
+
+  describe "methods" do
+    describe "#category_description" do
+      it "returns the description of the associated results_category" do
+        expect(results_template_category.category_description).to eq(results_template_category.results_category.description)
+      end
+    end
+
+    describe "#category_name" do
+      it "returns the name of the associated results_category" do
+        expect(results_template_category.category_name).to eq(results_template_category.results_category.name)
+      end
+    end
+  end
 end

--- a/spec/models/results_template_spec.rb
+++ b/spec/models/results_template_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe ResultsTemplate, type: :model do
-  it_behaves_like "auditable"
-
   subject(:results_template) { build(:results_template) }
 
   describe "#initialize" do


### PR DESCRIPTION
In an attempt to move toward portable fixtures for Results Categories and Results Templates, this PR removes `created_by` from those models.