### PR TITLE
Portable fixtures

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -33,6 +33,19 @@ module FixtureHelper
     :users,
   ].freeze
 
+  # Portable fixture tables are assigned an :id by Rails and are referenced by title
+  # rather than id in other fixture tables.
+  PORTABLE_FIXTURE_TABLES = [
+    :results_categories,
+    :results_templates,
+    :results_template_categories,
+  ].freeze
+
+  PRIMARY_KEY_MAP = {
+    effort_segments: "begin_split_id, begin_bitkey, end_split_id, end_bitkey, effort_id, lap",
+  }.freeze
+
+
   ATTRIBUTES_TO_IGNORE = [
     :created_at,
     :confirmation_sent_at,
@@ -43,7 +56,7 @@ module FixtureHelper
     :updated_at,
   ].freeze
 
-  ATTRIBUTES_TO_PRESERVE = {
+  ATTRIBUTES_TO_PRESERVE_BY_TABLE = {
     lottery_draws: [:created_at],
   }.freeze
 end

--- a/lib/tasks/db/fixtures.rake
+++ b/lib/tasks/db/fixtures.rake
@@ -7,19 +7,24 @@ require_relative "fixture_helper"
 namespace :db do
   desc "Convert development database to Rails test fixtures"
   task to_fixtures: :environment do
-    PRIMARY_KEY_MAP = {
-      "effort_segments" => "begin_split_id, begin_bitkey, end_split_id, end_bitkey, effort_id, lap"
-    }.freeze
-
     begin
       ActiveRecord::Base.establish_connection
       ActiveRecord::Base.connection.tables.each do |table_name|
         next unless table_name.to_sym.in?(FixtureHelper::FIXTURE_TABLES)
 
+        puts "Computing fixtures for #{table_name}"
+
+        model = table_name.classify.constantize
+        model_slugged = model.columns.map(&:name).include?("slug")
+        table_portable = table_name.in? FixtureHelper::PORTABLE_FIXTURE_TABLES
+        belongs_to_associations = model.reflect_on_all_associations(:belongs_to)
+
         counter = 0
         file_path = "#{Rails.root}/spec/fixtures/#{table_name}.yml"
         File.open(file_path, "w") do |file|
-          primary_key = PRIMARY_KEY_MAP[table_name] || "id"
+          default_primary_key = table_portable ? "slug" : "id"
+          primary_key = FixtureHelper::PRIMARY_KEY_MAP[table_name.to_sym] || default_primary_key
+
           rows = ActiveRecord::Base.connection.select_all("SELECT * FROM #{table_name} ORDER BY #{primary_key}")
           data = rows.each_with_object({}) do |record, hash|
             suffix = if record["id"].blank?
@@ -28,7 +33,7 @@ namespace :db do
                      else
                        record["id"]
                      end
-            title = if record["slug"].present?
+            title = if model_slugged
                       record["slug"].tr("-", "_")
                     elsif table_name == "split_times"
                       effort = Effort.find(record["effort_id"])
@@ -37,11 +42,35 @@ namespace :db do
                     else
                       "#{table_name.singularize}_#{suffix}"
                     end
-            FixtureHelper::ATTRIBUTES_TO_IGNORE.each do |attr|
-              next if attr.in? FixtureHelper::ATTRIBUTES_TO_PRESERVE.fetch(table_name.to_sym, [])
-              record.delete(attr.to_s)
+            attributes_to_preserve = FixtureHelper::ATTRIBUTES_TO_PRESERVE_BY_TABLE.fetch(table_name.to_sym, [])
+            attributes_to_ignore = FixtureHelper::ATTRIBUTES_TO_IGNORE - attributes_to_preserve
+            attributes_to_ignore << :id if table_name.in? FixtureHelper::PORTABLE_FIXTURE_TABLES
+            record.except!(*attributes_to_ignore.map(&:to_s))
+
+            association_hash = {}
+            belongs_to_associations.each do |association|
+              if association.polymorphic?
+                foreign_type = association.foreign_type
+                record_parent_type = record[foreign_type]
+                record_parent_table = record_parent_type.constantize.table_name
+                next unless record_parent_table.to_sym.in? FixtureHelper::PORTABLE_FIXTURE_TABLES
+
+                parent_class = record.delete(foreign_type).constantize
+                parent_id = record.delete(association.foreign_key)
+                parent = parent_class.find(parent_id)
+                parent_title = parent.slug.tr("-", "_")
+                association_hash[association.name.to_s] = "#{parent_title} (#{parent_class.name})"
+              else
+                next unless association.table_name.to_sym.in? FixtureHelper::PORTABLE_FIXTURE_TABLES
+
+                parent_class = association.class_name.constantize
+                parent_id = record.delete(association.foreign_key)
+                parent = parent_class.find(parent_id)
+                association_hash[association.name.to_s] = parent.slug.tr("-", "_")
+              end
             end
-            hash[title] = record
+
+            hash[title] = association_hash.merge(record)
           end
           puts "Writing table '#{table_name}' to '#{file_path}'"
           file.write(data.to_yaml)

--- a/lib/tasks/db/fixtures.rake
+++ b/lib/tasks/db/fixtures.rake
@@ -44,7 +44,7 @@ namespace :db do
                     end
             attributes_to_preserve = FixtureHelper::ATTRIBUTES_TO_PRESERVE_BY_TABLE.fetch(table_name.to_sym, [])
             attributes_to_ignore = FixtureHelper::ATTRIBUTES_TO_IGNORE - attributes_to_preserve
-            attributes_to_ignore << :id if table_name.in? FixtureHelper::PORTABLE_FIXTURE_TABLES
+            attributes_to_ignore << :id if table_name.to_sym.in? FixtureHelper::PORTABLE_FIXTURE_TABLES
             record.except!(*attributes_to_ignore.map(&:to_s))
 
             association_hash = {}

--- a/spec/fixtures/event_series.yml
+++ b/spec/fixtures/event_series.yml
@@ -1,15 +1,15 @@
 ---
 d30_50k_series:
+  results_template: simple
   id: 1
   organization_id: 15
-  results_template_id: 7
   name: D30 50K Series
   slug: d30-50k-series
   scoring_method: 0
 d30_short_series:
+  results_template: simple
   id: 2
   organization_id: 15
-  results_template_id: 7
   name: D30 Short Series
   slug: d30-short-series
   scoring_method: 0

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -1,5 +1,6 @@
 ---
 hardrock_2015:
+  results_template: simple
   id: 4
   course_id: 4
   historical_name: Hardrock 2015
@@ -10,11 +11,11 @@ hardrock_2015:
   slug: hardrock-2015
   event_group_id: 17
   short_name:
-  results_template_id: 7
   efforts_count: 30
   notice_text:
   lottery_id:
 ramble:
+  results_template: simple
   id: 14
   course_id: 9
   historical_name: Ramble
@@ -25,11 +26,11 @@ ramble:
   slug: ramble
   event_group_id: 4
   short_name:
-  results_template_id: 7
   efforts_count: 4
   notice_text:
   lottery_id:
 hardrock_2014:
+  results_template: simple
   id: 17
   course_id: 12
   historical_name: Hardrock 2014
@@ -40,11 +41,11 @@ hardrock_2014:
   slug: hardrock-2014
   event_group_id: 7
   short_name:
-  results_template_id: 7
   efforts_count: 19
   notice_text:
   lottery_id:
 rufa_2016:
+  results_template: simple
   id: 34
   course_id: 20
   historical_name: RUFA 2016
@@ -55,11 +56,11 @@ rufa_2016:
   slug: rufa-2016
   event_group_id: 25
   short_name:
-  results_template_id: 7
   efforts_count: 4
   notice_text:
   lottery_id:
 rufa_2017_24h:
+  results_template: simple
   id: 36
   course_id: 20
   historical_name: RUFA 2017 24H
@@ -70,11 +71,11 @@ rufa_2017_24h:
   slug: rufa-2017-24h
   event_group_id: 59
   short_name: 24H
-  results_template_id: 7
   efforts_count: 6
   notice_text:
   lottery_id:
 hardrock_2016:
+  results_template: simple
   id: 37
   course_id: 12
   historical_name: Hardrock 2016
@@ -85,11 +86,11 @@ hardrock_2016:
   slug: hardrock-2016
   event_group_id: 28
   short_name:
-  results_template_id: 7
   efforts_count: 19
   notice_text:
   lottery_id:
 ggd30_50k:
+  results_template: simple
   id: 48
   course_id: 26
   historical_name: GGD30 50K
@@ -100,11 +101,11 @@ ggd30_50k:
   slug: ggd30-50k
   event_group_id: 27
   short_name: 50K
-  results_template_id: 7
   efforts_count: 8
   notice_text:
   lottery_id:
 ggd30_12m:
+  results_template: simple
   id: 49
   course_id: 27
   historical_name: GGD30 12M
@@ -115,11 +116,11 @@ ggd30_12m:
   slug: ggd30-12m
   event_group_id: 27
   short_name: 12-miler
-  results_template_id: 7
   efforts_count: 6
   notice_text:
   lottery_id:
 sum_100k:
+  results_template: simple
   id: 56
   course_id: 31
   historical_name: SUM 100K
@@ -130,11 +131,11 @@ sum_100k:
   slug: sum-100k
   event_group_id: 32
   short_name: 100K
-  results_template_id: 7
   efforts_count: 5
   notice_text:
   lottery_id:
 sum_55k:
+  results_template: sub_masters_masters_and_grandmasters
   id: 57
   course_id: 32
   historical_name: SUM 55K
@@ -145,11 +146,11 @@ sum_55k:
   slug: sum-55k
   event_group_id: 32
   short_name: 55K
-  results_template_id: 3
   efforts_count: 8
   notice_text:
   lottery_id:
 rufa_2017_12h:
+  results_template: simple
   id: 70
   course_id: 20
   historical_name: RUFA 2017 12H
@@ -160,7 +161,6 @@ rufa_2017_12h:
   slug: rufa-2017-12h
   event_group_id: 59
   short_name: 12H
-  results_template_id: 7
   efforts_count: 6
   notice_text:
   lottery_id:

--- a/spec/fixtures/results_categories.yml
+++ b/spec/fixtures/results_categories.yml
@@ -1,6 +1,5 @@
 ---
 combined_overall:
-  id: 1
   organization_id:
   name: Overall
   male: true
@@ -10,7 +9,6 @@ combined_overall:
   nonbinary: true
   slug: combined-overall
 male_overall:
-  id: 2
   organization_id:
   name: Overall Men
   male: true
@@ -20,7 +18,6 @@ male_overall:
   nonbinary: false
   slug: male-overall
 female_overall:
-  id: 3
   organization_id:
   name: Overall Women
   male: false
@@ -30,7 +27,6 @@ female_overall:
   nonbinary: false
   slug: female-overall
 male_40_and_up:
-  id: 4
   organization_id:
   name: Masters Men (40+)
   male: true
@@ -40,7 +36,6 @@ male_40_and_up:
   nonbinary: false
   slug: male-40-and-up
 female_40_and_up:
-  id: 5
   organization_id:
   name: Masters Women (40+)
   male: false
@@ -50,7 +45,6 @@ female_40_and_up:
   nonbinary: false
   slug: female-40-and-up
 male_40_to_49:
-  id: 6
   organization_id:
   name: Masters Men (40-49)
   male: true
@@ -60,7 +54,6 @@ male_40_to_49:
   nonbinary: false
   slug: male-40-to-49
 female_40_to_49:
-  id: 7
   organization_id:
   name: Masters Women (40-49)
   male: false
@@ -70,7 +63,6 @@ female_40_to_49:
   nonbinary: false
   slug: female-40-to-49
 male_50_and_up:
-  id: 8
   organization_id:
   name: Grandmasters Men (50+)
   male: true
@@ -80,7 +72,6 @@ male_50_and_up:
   nonbinary: false
   slug: male-50-and-up
 female_50_and_up:
-  id: 9
   organization_id:
   name: Grandmasters Women (50+)
   male: false
@@ -90,7 +81,6 @@ female_50_and_up:
   nonbinary: false
   slug: female-50-and-up
 male_60_and_up:
-  id: 10
   organization_id:
   name: Senior Grandmasters Men (60+)
   male: true
@@ -100,7 +90,6 @@ male_60_and_up:
   nonbinary: false
   slug: male-60-and-up
 female_60_and_up:
-  id: 11
   organization_id:
   name: Senior Grandmasters Women (60+)
   male: false
@@ -110,7 +99,6 @@ female_60_and_up:
   nonbinary: false
   slug: female-60-and-up
 male_up_to_12:
-  id: 12
   organization_id:
   name: Boys 12 and Under
   male: true
@@ -120,7 +108,6 @@ male_up_to_12:
   nonbinary: false
   slug: male-up-to-12
 female_up_to_12:
-  id: 13
   organization_id:
   name: Girls 12 and Under
   male: false
@@ -130,7 +117,6 @@ female_up_to_12:
   nonbinary: false
   slug: female-up-to-12
 male_13_to_16:
-  id: 14
   organization_id:
   name: Boys 13 to 16
   male: true
@@ -140,7 +126,6 @@ male_13_to_16:
   nonbinary: false
   slug: male-13-to-16
 female_13_to_16:
-  id: 15
   organization_id:
   name: Girls 13 to 16
   male: false
@@ -150,7 +135,6 @@ female_13_to_16:
   nonbinary: false
   slug: female-13-to-16
 male_up_to_16:
-  id: 16
   organization_id:
   name: Boys 16 and Under
   male: true
@@ -160,7 +144,6 @@ male_up_to_16:
   nonbinary: false
   slug: male-up-to-16
 female_up_to_16:
-  id: 17
   organization_id:
   name: Girls 16 and Under
   male: false
@@ -170,7 +153,6 @@ female_up_to_16:
   nonbinary: false
   slug: female-up-to-16
 male_up_to_19:
-  id: 18
   organization_id:
   name: Under 20 Men
   male: true
@@ -180,7 +162,6 @@ male_up_to_19:
   nonbinary: false
   slug: male-up-to-19
 female_up_to_19:
-  id: 19
   organization_id:
   name: Under 20 Women
   male: false
@@ -190,7 +171,6 @@ female_up_to_19:
   nonbinary: false
   slug: female-up-to-19
 male_13_to_39:
-  id: 20
   organization_id:
   name: 13 to 39 Men
   male: true
@@ -200,7 +180,6 @@ male_13_to_39:
   nonbinary: false
   slug: male-13-to-39
 female_13_to_39:
-  id: 21
   organization_id:
   name: 13 to 39 Women
   male: false
@@ -210,7 +189,6 @@ female_13_to_39:
   nonbinary: false
   slug: female-13-to-39
 male_17_to_39:
-  id: 22
   organization_id:
   name: 17 to 39 Men
   male: true
@@ -220,7 +198,6 @@ male_17_to_39:
   nonbinary: false
   slug: male-17-to-39
 female_17_to_39:
-  id: 23
   organization_id:
   name: 17 to 39 Women
   male: false
@@ -230,7 +207,6 @@ female_17_to_39:
   nonbinary: false
   slug: female-17-to-39
 male_20_to_29:
-  id: 24
   organization_id:
   name: 20 to 29 Men
   male: true
@@ -240,7 +216,6 @@ male_20_to_29:
   nonbinary: false
   slug: male-20-to-29
 female_20_to_29:
-  id: 25
   organization_id:
   name: 20 to 29 Women
   male: false
@@ -250,7 +225,6 @@ female_20_to_29:
   nonbinary: false
   slug: female-20-to-29
 male_30_to_39:
-  id: 26
   organization_id:
   name: 30 to 39 Men
   male: true
@@ -260,7 +234,6 @@ male_30_to_39:
   nonbinary: false
   slug: male-30-to-39
 female_30_to_39:
-  id: 27
   organization_id:
   name: 30 to 39 Women
   male: false
@@ -270,7 +243,6 @@ female_30_to_39:
   nonbinary: false
   slug: female-30-to-39
 male_40_to_49_2:
-  id: 28
   organization_id:
   name: 40 to 49 Men
   male: true
@@ -280,7 +252,6 @@ male_40_to_49_2:
   nonbinary: false
   slug: male-40-to-49-2
 female_40_to_49_2:
-  id: 29
   organization_id:
   name: 40 to 49 Women
   male: false
@@ -290,7 +261,6 @@ female_40_to_49_2:
   nonbinary: false
   slug: female-40-to-49-2
 male_50_to_59:
-  id: 30
   organization_id:
   name: 50 to 59 Men
   male: true
@@ -300,7 +270,6 @@ male_50_to_59:
   nonbinary: false
   slug: male-50-to-59
 female_50_to_59:
-  id: 31
   organization_id:
   name: 50 to 59 Women
   male: false
@@ -310,7 +279,6 @@ female_50_to_59:
   nonbinary: false
   slug: female-50-to-59
 male_60_to_69:
-  id: 32
   organization_id:
   name: 60 to 69 Men
   male: true
@@ -320,7 +288,6 @@ male_60_to_69:
   nonbinary: false
   slug: male-60-to-69
 female_60_to_69:
-  id: 33
   organization_id:
   name: 60 to 69 Women
   male: false
@@ -330,7 +297,6 @@ female_60_to_69:
   nonbinary: false
   slug: female-60-to-69
 male_up_to_29:
-  id: 34
   organization_id:
   name: Under 30 Men
   male: true
@@ -340,7 +306,6 @@ male_up_to_29:
   nonbinary: false
   slug: male-up-to-29
 female_up_to_29:
-  id: 35
   organization_id:
   name: Under 30 Women
   male: false
@@ -350,7 +315,6 @@ female_up_to_29:
   nonbinary: false
   slug: female-up-to-29
 male_up_to_39:
-  id: 36
   organization_id:
   name: Under 40 Men
   male: true
@@ -360,7 +324,6 @@ male_up_to_39:
   nonbinary: false
   slug: male-up-to-39
 female_up_to_39:
-  id: 37
   organization_id:
   name: Under 40 Women
   male: false
@@ -370,7 +333,6 @@ female_up_to_39:
   nonbinary: false
   slug: female-up-to-39
 nonbinary_overall:
-  id: 38
   organization_id:
   name: Overall Nonbinary
   male: false

--- a/spec/fixtures/results_template_categories.yml
+++ b/spec/fixtures/results_template_categories.yml
@@ -2,324 +2,270 @@
 results_template_category_1:
   results_template: masters_and_decades
   results_category: male_overall
-  id: 1
   position: 1
   fixed_position: true
 results_template_category_2:
   results_template: masters_and_decades
   results_category: female_overall
-  id: 2
   position: 2
   fixed_position: true
 results_template_category_3:
   results_template: masters_and_decades
   results_category: male_40_and_up
-  id: 3
   position: 3
   fixed_position: true
 results_template_category_4:
   results_template: masters_and_decades
   results_category: female_40_and_up
-  id: 4
   position: 4
   fixed_position: true
 results_template_category_5:
   results_template: masters_and_decades
   results_category: male_up_to_19
-  id: 5
   position: 5
   fixed_position:
 results_template_category_6:
   results_template: masters_and_decades
   results_category: female_up_to_19
-  id: 6
   position: 6
   fixed_position:
 results_template_category_7:
   results_template: masters_and_decades
   results_category: male_20_to_29
-  id: 7
   position: 7
   fixed_position:
 results_template_category_8:
   results_template: masters_and_decades
   results_category: female_20_to_29
-  id: 8
   position: 8
   fixed_position:
 results_template_category_9:
   results_template: masters_and_decades
   results_category: male_30_to_39
-  id: 9
   position: 9
   fixed_position:
 results_template_category_10:
   results_template: masters_and_decades
   results_category: female_30_to_39
-  id: 10
   position: 10
   fixed_position:
 results_template_category_11:
   results_template: masters_and_decades
   results_category: male_40_to_49_2
-  id: 11
   position: 11
   fixed_position:
 results_template_category_12:
   results_template: masters_and_decades
   results_category: female_40_to_49_2
-  id: 12
   position: 12
   fixed_position:
 results_template_category_13:
   results_template: masters_and_decades
   results_category: male_50_to_59
-  id: 13
   position: 13
   fixed_position:
 results_template_category_14:
   results_template: masters_and_decades
   results_category: female_50_to_59
-  id: 14
   position: 14
   fixed_position:
 results_template_category_15:
   results_template: masters_and_decades
   results_category: male_60_to_69
-  id: 15
   position: 15
   fixed_position:
 results_template_category_16:
   results_template: masters_and_decades
   results_category: female_60_to_69
-  id: 16
   position: 16
   fixed_position:
 results_template_category_17:
   results_template: overall_30s_40s_50s_seniors
   results_category: male_overall
-  id: 17
   position: 1
   fixed_position:
 results_template_category_18:
   results_template: overall_30s_40s_50s_seniors
   results_category: female_overall
-  id: 18
   position: 2
   fixed_position:
 results_template_category_19:
   results_template: overall_30s_40s_50s_seniors
   results_category: male_up_to_29
-  id: 19
   position: 3
   fixed_position:
 results_template_category_20:
   results_template: overall_30s_40s_50s_seniors
   results_category: female_up_to_29
-  id: 20
   position: 4
   fixed_position:
 results_template_category_21:
   results_template: overall_30s_40s_50s_seniors
   results_category: male_30_to_39
-  id: 21
   position: 5
   fixed_position:
 results_template_category_22:
   results_template: overall_30s_40s_50s_seniors
   results_category: female_30_to_39
-  id: 22
   position: 6
   fixed_position:
 results_template_category_23:
   results_template: overall_30s_40s_50s_seniors
   results_category: male_40_to_49_2
-  id: 23
   position: 7
   fixed_position:
 results_template_category_24:
   results_template: overall_30s_40s_50s_seniors
   results_category: female_40_to_49_2
-  id: 24
   position: 8
   fixed_position:
 results_template_category_25:
   results_template: overall_30s_40s_50s_seniors
   results_category: male_50_to_59
-  id: 25
   position: 9
   fixed_position:
 results_template_category_26:
   results_template: overall_30s_40s_50s_seniors
   results_category: female_50_to_59
-  id: 26
   position: 10
   fixed_position:
 results_template_category_27:
   results_template: overall_30s_40s_50s_seniors
   results_category: male_60_and_up
-  id: 27
   position: 11
   fixed_position:
 results_template_category_28:
   results_template: overall_30s_40s_50s_seniors
   results_category: female_60_and_up
-  id: 28
   position: 12
   fixed_position:
 results_template_category_29:
   results_template: sub_masters_masters_and_grandmasters
   results_category: male_overall
-  id: 29
   position: 1
   fixed_position:
 results_template_category_30:
   results_template: sub_masters_masters_and_grandmasters
   results_category: female_overall
-  id: 30
   position: 2
   fixed_position:
 results_template_category_31:
   results_template: sub_masters_masters_and_grandmasters
   results_category: male_up_to_39
-  id: 31
   position: 3
   fixed_position:
 results_template_category_32:
   results_template: sub_masters_masters_and_grandmasters
   results_category: female_up_to_39
-  id: 32
   position: 4
   fixed_position:
 results_template_category_33:
   results_template: sub_masters_masters_and_grandmasters
   results_category: male_40_to_49
-  id: 33
   position: 5
   fixed_position:
 results_template_category_34:
   results_template: sub_masters_masters_and_grandmasters
   results_category: female_40_to_49
-  id: 34
   position: 6
   fixed_position:
 results_template_category_35:
   results_template: sub_masters_masters_and_grandmasters
   results_category: male_50_and_up
-  id: 35
   position: 7
   fixed_position:
 results_template_category_36:
   results_template: sub_masters_masters_and_grandmasters
   results_category: female_50_and_up
-  id: 36
   position: 8
   fixed_position:
 results_template_category_37:
   results_template: masters_and_grandmasters
   results_category: male_overall
-  id: 37
   position: 1
   fixed_position:
 results_template_category_38:
   results_template: masters_and_grandmasters
   results_category: female_overall
-  id: 38
   position: 2
   fixed_position:
 results_template_category_39:
   results_template: masters_and_grandmasters
   results_category: male_40_to_49
-  id: 39
   position: 3
   fixed_position:
 results_template_category_40:
   results_template: masters_and_grandmasters
   results_category: female_40_to_49
-  id: 40
   position: 4
   fixed_position:
 results_template_category_41:
   results_template: masters_and_grandmasters
   results_category: male_50_and_up
-  id: 41
   position: 5
   fixed_position:
 results_template_category_42:
   results_template: masters_and_grandmasters
   results_category: female_50_and_up
-  id: 42
   position: 6
   fixed_position:
 results_template_category_61:
   results_template: simple
   results_category: male_overall
-  id: 61
   position: 1
   fixed_position:
 results_template_category_62:
   results_template: simple
   results_category: female_overall
-  id: 62
   position: 2
   fixed_position:
 results_template_category_63:
   results_template: simple_with_nonbinary
   results_category: male_overall
-  id: 63
   position: 1
   fixed_position:
 results_template_category_64:
   results_template: simple_with_nonbinary
   results_category: female_overall
-  id: 64
   position: 2
   fixed_position:
 results_template_category_65:
   results_template: simple_with_nonbinary
   results_category: nonbinary_overall
-  id: 65
   position: 3
   fixed_position:
 results_template_category_66:
   results_template: masters_and_grandmasters_with_nonbinary
   results_category: male_overall
-  id: 66
   position: 1
   fixed_position:
 results_template_category_67:
   results_template: masters_and_grandmasters_with_nonbinary
   results_category: female_overall
-  id: 67
   position: 2
   fixed_position:
 results_template_category_68:
   results_template: masters_and_grandmasters_with_nonbinary
   results_category: male_40_to_49
-  id: 68
   position: 4
   fixed_position:
 results_template_category_69:
   results_template: masters_and_grandmasters_with_nonbinary
   results_category: female_40_to_49
-  id: 69
   position: 5
   fixed_position:
 results_template_category_70:
   results_template: masters_and_grandmasters_with_nonbinary
   results_category: male_50_and_up
-  id: 70
   position: 6
   fixed_position:
 results_template_category_71:
   results_template: masters_and_grandmasters_with_nonbinary
   results_category: female_50_and_up
-  id: 71
   position: 7
   fixed_position:
 results_template_category_72:
   results_template: masters_and_grandmasters_with_nonbinary
   results_category: nonbinary_overall
-  id: 72
   position: 3
   fixed_position:

--- a/spec/fixtures/results_template_categories.yml
+++ b/spec/fixtures/results_template_categories.yml
@@ -1,325 +1,325 @@
 ---
 results_template_category_1:
+  results_template: masters_and_decades
+  results_category: male_overall
   id: 1
-  results_template_id: 1
-  results_category_id: 2
   position: 1
   fixed_position: true
 results_template_category_2:
+  results_template: masters_and_decades
+  results_category: female_overall
   id: 2
-  results_template_id: 1
-  results_category_id: 3
   position: 2
   fixed_position: true
 results_template_category_3:
+  results_template: masters_and_decades
+  results_category: male_40_and_up
   id: 3
-  results_template_id: 1
-  results_category_id: 4
   position: 3
   fixed_position: true
 results_template_category_4:
+  results_template: masters_and_decades
+  results_category: female_40_and_up
   id: 4
-  results_template_id: 1
-  results_category_id: 5
   position: 4
   fixed_position: true
 results_template_category_5:
+  results_template: masters_and_decades
+  results_category: male_up_to_19
   id: 5
-  results_template_id: 1
-  results_category_id: 18
   position: 5
   fixed_position:
 results_template_category_6:
+  results_template: masters_and_decades
+  results_category: female_up_to_19
   id: 6
-  results_template_id: 1
-  results_category_id: 19
   position: 6
   fixed_position:
 results_template_category_7:
+  results_template: masters_and_decades
+  results_category: male_20_to_29
   id: 7
-  results_template_id: 1
-  results_category_id: 24
   position: 7
   fixed_position:
 results_template_category_8:
+  results_template: masters_and_decades
+  results_category: female_20_to_29
   id: 8
-  results_template_id: 1
-  results_category_id: 25
   position: 8
   fixed_position:
 results_template_category_9:
+  results_template: masters_and_decades
+  results_category: male_30_to_39
   id: 9
-  results_template_id: 1
-  results_category_id: 26
   position: 9
   fixed_position:
 results_template_category_10:
+  results_template: masters_and_decades
+  results_category: female_30_to_39
   id: 10
-  results_template_id: 1
-  results_category_id: 27
   position: 10
   fixed_position:
 results_template_category_11:
+  results_template: masters_and_decades
+  results_category: male_40_to_49_2
   id: 11
-  results_template_id: 1
-  results_category_id: 28
   position: 11
   fixed_position:
 results_template_category_12:
+  results_template: masters_and_decades
+  results_category: female_40_to_49_2
   id: 12
-  results_template_id: 1
-  results_category_id: 29
   position: 12
   fixed_position:
 results_template_category_13:
+  results_template: masters_and_decades
+  results_category: male_50_to_59
   id: 13
-  results_template_id: 1
-  results_category_id: 30
   position: 13
   fixed_position:
 results_template_category_14:
+  results_template: masters_and_decades
+  results_category: female_50_to_59
   id: 14
-  results_template_id: 1
-  results_category_id: 31
   position: 14
   fixed_position:
 results_template_category_15:
+  results_template: masters_and_decades
+  results_category: male_60_to_69
   id: 15
-  results_template_id: 1
-  results_category_id: 32
   position: 15
   fixed_position:
 results_template_category_16:
+  results_template: masters_and_decades
+  results_category: female_60_to_69
   id: 16
-  results_template_id: 1
-  results_category_id: 33
   position: 16
   fixed_position:
 results_template_category_17:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: male_overall
   id: 17
-  results_template_id: 2
-  results_category_id: 2
   position: 1
   fixed_position:
 results_template_category_18:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: female_overall
   id: 18
-  results_template_id: 2
-  results_category_id: 3
   position: 2
   fixed_position:
 results_template_category_19:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: male_up_to_29
   id: 19
-  results_template_id: 2
-  results_category_id: 34
   position: 3
   fixed_position:
 results_template_category_20:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: female_up_to_29
   id: 20
-  results_template_id: 2
-  results_category_id: 35
   position: 4
   fixed_position:
 results_template_category_21:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: male_30_to_39
   id: 21
-  results_template_id: 2
-  results_category_id: 26
   position: 5
   fixed_position:
 results_template_category_22:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: female_30_to_39
   id: 22
-  results_template_id: 2
-  results_category_id: 27
   position: 6
   fixed_position:
 results_template_category_23:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: male_40_to_49_2
   id: 23
-  results_template_id: 2
-  results_category_id: 28
   position: 7
   fixed_position:
 results_template_category_24:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: female_40_to_49_2
   id: 24
-  results_template_id: 2
-  results_category_id: 29
   position: 8
   fixed_position:
 results_template_category_25:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: male_50_to_59
   id: 25
-  results_template_id: 2
-  results_category_id: 30
   position: 9
   fixed_position:
 results_template_category_26:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: female_50_to_59
   id: 26
-  results_template_id: 2
-  results_category_id: 31
   position: 10
   fixed_position:
 results_template_category_27:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: male_60_and_up
   id: 27
-  results_template_id: 2
-  results_category_id: 10
   position: 11
   fixed_position:
 results_template_category_28:
+  results_template: overall_30s_40s_50s_seniors
+  results_category: female_60_and_up
   id: 28
-  results_template_id: 2
-  results_category_id: 11
   position: 12
   fixed_position:
 results_template_category_29:
+  results_template: sub_masters_masters_and_grandmasters
+  results_category: male_overall
   id: 29
-  results_template_id: 3
-  results_category_id: 2
   position: 1
   fixed_position:
 results_template_category_30:
+  results_template: sub_masters_masters_and_grandmasters
+  results_category: female_overall
   id: 30
-  results_template_id: 3
-  results_category_id: 3
   position: 2
   fixed_position:
 results_template_category_31:
+  results_template: sub_masters_masters_and_grandmasters
+  results_category: male_up_to_39
   id: 31
-  results_template_id: 3
-  results_category_id: 36
   position: 3
   fixed_position:
 results_template_category_32:
+  results_template: sub_masters_masters_and_grandmasters
+  results_category: female_up_to_39
   id: 32
-  results_template_id: 3
-  results_category_id: 37
   position: 4
   fixed_position:
 results_template_category_33:
+  results_template: sub_masters_masters_and_grandmasters
+  results_category: male_40_to_49
   id: 33
-  results_template_id: 3
-  results_category_id: 6
   position: 5
   fixed_position:
 results_template_category_34:
+  results_template: sub_masters_masters_and_grandmasters
+  results_category: female_40_to_49
   id: 34
-  results_template_id: 3
-  results_category_id: 7
   position: 6
   fixed_position:
 results_template_category_35:
+  results_template: sub_masters_masters_and_grandmasters
+  results_category: male_50_and_up
   id: 35
-  results_template_id: 3
-  results_category_id: 8
   position: 7
   fixed_position:
 results_template_category_36:
+  results_template: sub_masters_masters_and_grandmasters
+  results_category: female_50_and_up
   id: 36
-  results_template_id: 3
-  results_category_id: 9
   position: 8
   fixed_position:
 results_template_category_37:
+  results_template: masters_and_grandmasters
+  results_category: male_overall
   id: 37
-  results_template_id: 4
-  results_category_id: 2
   position: 1
   fixed_position:
 results_template_category_38:
+  results_template: masters_and_grandmasters
+  results_category: female_overall
   id: 38
-  results_template_id: 4
-  results_category_id: 3
   position: 2
   fixed_position:
 results_template_category_39:
+  results_template: masters_and_grandmasters
+  results_category: male_40_to_49
   id: 39
-  results_template_id: 4
-  results_category_id: 6
   position: 3
   fixed_position:
 results_template_category_40:
+  results_template: masters_and_grandmasters
+  results_category: female_40_to_49
   id: 40
-  results_template_id: 4
-  results_category_id: 7
   position: 4
   fixed_position:
 results_template_category_41:
+  results_template: masters_and_grandmasters
+  results_category: male_50_and_up
   id: 41
-  results_template_id: 4
-  results_category_id: 8
   position: 5
   fixed_position:
 results_template_category_42:
+  results_template: masters_and_grandmasters
+  results_category: female_50_and_up
   id: 42
-  results_template_id: 4
-  results_category_id: 9
   position: 6
   fixed_position:
 results_template_category_61:
+  results_template: simple
+  results_category: male_overall
   id: 61
-  results_template_id: 7
-  results_category_id: 2
   position: 1
   fixed_position:
 results_template_category_62:
+  results_template: simple
+  results_category: female_overall
   id: 62
-  results_template_id: 7
-  results_category_id: 3
   position: 2
   fixed_position:
 results_template_category_63:
+  results_template: simple_with_nonbinary
+  results_category: male_overall
   id: 63
-  results_template_id: 8
-  results_category_id: 2
   position: 1
   fixed_position:
 results_template_category_64:
+  results_template: simple_with_nonbinary
+  results_category: female_overall
   id: 64
-  results_template_id: 8
-  results_category_id: 3
   position: 2
   fixed_position:
 results_template_category_65:
+  results_template: simple_with_nonbinary
+  results_category: nonbinary_overall
   id: 65
-  results_template_id: 8
-  results_category_id: 38
   position: 3
   fixed_position:
 results_template_category_66:
+  results_template: masters_and_grandmasters_with_nonbinary
+  results_category: male_overall
   id: 66
-  results_template_id: 9
-  results_category_id: 2
   position: 1
   fixed_position:
 results_template_category_67:
+  results_template: masters_and_grandmasters_with_nonbinary
+  results_category: female_overall
   id: 67
-  results_template_id: 9
-  results_category_id: 3
   position: 2
   fixed_position:
 results_template_category_68:
+  results_template: masters_and_grandmasters_with_nonbinary
+  results_category: male_40_to_49
   id: 68
-  results_template_id: 9
-  results_category_id: 6
   position: 4
   fixed_position:
 results_template_category_69:
+  results_template: masters_and_grandmasters_with_nonbinary
+  results_category: female_40_to_49
   id: 69
-  results_template_id: 9
-  results_category_id: 7
   position: 5
   fixed_position:
 results_template_category_70:
+  results_template: masters_and_grandmasters_with_nonbinary
+  results_category: male_50_and_up
   id: 70
-  results_template_id: 9
-  results_category_id: 8
   position: 6
   fixed_position:
 results_template_category_71:
+  results_template: masters_and_grandmasters_with_nonbinary
+  results_category: female_50_and_up
   id: 71
-  results_template_id: 9
-  results_category_id: 9
   position: 7
   fixed_position:
 results_template_category_72:
+  results_template: masters_and_grandmasters_with_nonbinary
+  results_category: nonbinary_overall
   id: 72
-  results_template_id: 9
-  results_category_id: 38
   position: 3
   fixed_position:

--- a/spec/fixtures/results_templates.yml
+++ b/spec/fixtures/results_templates.yml
@@ -1,6 +1,5 @@
 ---
 masters_and_decades:
-  id: 1
   organization_id:
   name: Masters and Decades
   aggregation_method: 0
@@ -8,7 +7,6 @@ masters_and_decades:
   point_system:
   slug: masters-and-decades
 overall_30s_40s_50s_seniors:
-  id: 2
   organization_id:
   name: Overall, 30s, 40s, 50s, Seniors
   aggregation_method: 0
@@ -16,7 +14,6 @@ overall_30s_40s_50s_seniors:
   point_system:
   slug: overall-30s-40s-50s-seniors
 sub_masters_masters_and_grandmasters:
-  id: 3
   organization_id:
   name: Sub-Masters, Masters, and Grandmasters
   aggregation_method: 0
@@ -24,7 +21,6 @@ sub_masters_masters_and_grandmasters:
   point_system:
   slug: sub-masters-masters-and-grandmasters
 masters_and_grandmasters:
-  id: 4
   organization_id:
   name: Masters and Grandmasters
   aggregation_method: 0
@@ -32,7 +28,6 @@ masters_and_grandmasters:
   point_system:
   slug: masters-and-grandmasters
 simple:
-  id: 7
   organization_id:
   name: Simple
   aggregation_method: 0
@@ -40,7 +35,6 @@ simple:
   point_system:
   slug: simple
 simple_with_nonbinary:
-  id: 8
   organization_id:
   name: Simple With Nonbinary
   aggregation_method: 0
@@ -48,7 +42,6 @@ simple_with_nonbinary:
   point_system:
   slug: simple-with-nonbinary
 masters_and_grandmasters_with_nonbinary:
-  id: 9
   organization_id:
   name: Masters and Grandmasters with Nonbinary
   aggregation_method: 0


### PR DESCRIPTION
This PR allows us to designate "portable" fixture tables, which will be built without any reference to an integer `id` but rather will live in the fixtures yaml file using only the title (derived from the slug).

These portable fixture files should allow us to quickly import new fixtures into a production environment, which will be helpful for reference-type data such as Results Categories and Results Templates.