### PR TITLE
Remove created_by from SplitTime model

### DIFF
--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -139,7 +139,7 @@ class EffortsController < ApplicationController
     authorize @effort
 
     effort = Effort.where(id: @effort.id).includes(event: :splits).first
-    response = Interactors::RebuildEffortTimes.perform!(effort: effort, current_user_id: current_user.id)
+    response = Interactors::RebuildEffortTimes.perform!(effort: effort)
     set_flash_message(response)
 
     respond_to do |format|

--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -157,7 +157,7 @@ class EffortsController < ApplicationController
     authorize @effort
 
     start_time = params[:actual_start_time]
-    response = ::Interactors::StartEfforts.perform!(efforts: [@effort], start_time: start_time, current_user_id: current_user.id)
+    response = ::Interactors::StartEfforts.perform!(efforts: [@effort], start_time: start_time)
     set_flash_message(response)
     @effort.reload
 

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -369,7 +369,7 @@ class EventGroupsController < ApplicationController
     filtered_efforts = Effort.from(efforts, :efforts).where(filter)
     start_time = params[:actual_start_time]
 
-    start_response = ::Interactors::StartEfforts.perform!(efforts: filtered_efforts, start_time: start_time, current_user_id: current_user.id)
+    start_response = ::Interactors::StartEfforts.perform!(efforts: filtered_efforts, start_time: start_time)
 
     # Need to pick up the new start split time before setting status
     filtered_efforts = filtered_efforts.includes(split_times: :split)

--- a/app/madmin/resources/split_time_resource.rb
+++ b/app/madmin/resources/split_time_resource.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
+
 class SplitTimeResource < Madmin::Resource
   # Attributes
   attribute :id, form: false
   attribute :data_status
   attribute :created_at, form: false
   attribute :updated_at, form: false
-  attribute :created_by
   attribute :sub_split_bitkey
   attribute :pacer
   attribute :remarks

--- a/app/models/split_time.rb
+++ b/app/models/split_time.rb
@@ -4,6 +4,8 @@ class SplitTime < ApplicationRecord
   enum data_status: [:bad, :questionable, :good, :confirmed]
   strip_attributes collapse_spaces: true
 
+  self.ignored_columns = %w[created_by]
+
   # See app/concerns/data_status_methods for related scopes and methods
   VALID_STATUSES = [nil, data_statuses[:good], data_statuses[:confirmed]].freeze
 
@@ -14,7 +16,6 @@ class SplitTime < ApplicationRecord
   include DelegatedConcealable
   include Delegable
   include DataStatusMethods
-  include Auditable
 
   zonable_attributes :absolute_time, :absolute_estimate_early, :absolute_estimate_late
   has_paper_trail

--- a/app/models/split_time.rb
+++ b/app/models/split_time.rb
@@ -4,8 +4,6 @@ class SplitTime < ApplicationRecord
   enum data_status: [:bad, :questionable, :good, :confirmed]
   strip_attributes collapse_spaces: true
 
-  self.ignored_columns = %w[created_by]
-
   # See app/concerns/data_status_methods for related scopes and methods
   VALID_STATUSES = [nil, data_statuses[:good], data_statuses[:confirmed]].freeze
 

--- a/app/services/interactors/start_efforts.rb
+++ b/app/services/interactors/start_efforts.rb
@@ -11,12 +11,11 @@ module Interactors
 
     def initialize(args)
       ArgsValidator.validate(params: args,
-                             required: [:efforts, :current_user_id],
-                             exclusive: [:efforts, :start_time, :current_user_id],
+                             required: [:efforts],
+                             exclusive: [:efforts, :start_time],
                              class: self.class)
       @efforts = args[:efforts]
       @start_time = args[:start_time]
-      @current_user_id = args[:current_user_id]
       @errors = []
       @saved_split_times = []
       validate_setup
@@ -34,7 +33,7 @@ module Interactors
 
     private
 
-    attr_reader :efforts, :start_time, :current_user_id, :errors, :saved_split_times
+    attr_reader :efforts, :start_time, :errors, :saved_split_times
 
     def start_effort(effort)
       split_time = SplitTime.find_or_initialize_by(
@@ -45,7 +44,6 @@ module Interactors
       )
 
       split_time.absolute_time = effort_start_time(effort)
-      split_time.created_by = current_user_id
 
       if split_time.save
         saved_split_times << split_time

--- a/lib/etl/loaders/base_loader.rb
+++ b/lib/etl/loaders/base_loader.rb
@@ -35,6 +35,8 @@ module ETL
       end
 
       def add_audit_attributes(record)
+        return unless record.respond_to?(:created_by)
+
         record.created_by = current_user_id if record.new_record?
       end
 

--- a/lib/etl/loaders/split_time_upsert_strategy.rb
+++ b/lib/etl/loaders/split_time_upsert_strategy.rb
@@ -50,7 +50,6 @@ module ETL
         existing_split_time = effort.split_times.find { |st| st.time_point == time_point }
 
         proto_split_time[:id] = existing_split_time.id if existing_split_time&.id
-        proto_split_time[:created_by] = current_user_id unless existing_split_time
         proto_split_time[:_destroy] = true if proto_split_time.record_action == :destroy
       end
     end

--- a/spec/lib/etl/loaders/split_time_upsert_strategy_spec.rb
+++ b/spec/lib/etl/loaders/split_time_upsert_strategy_spec.rb
@@ -97,7 +97,6 @@ RSpec.describe ETL::Loaders::SplitTimeUpsertStrategy do
         expect(subject_split_times.map(&:split_id).sort).to eq(split_ids.cycle.first(subject_split_times.size).sort)
         expect(subject_split_times.map(&:absolute_time)).to eq([0, 2581, 6308, 9463, 13_571, 16_655, 17_736].map { |e| start_time + e })
         expect(subject_split_times.map(&:effort_id)).to all eq(effort_1.id)
-        expect(subject_split_times.map(&:created_by)).to all eq(options[:current_user_id])
       end
 
       it "returns saved parent records in the saved_records array" do

--- a/spec/models/split_time_spec.rb
+++ b/spec/models/split_time_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe SplitTime, kind: :model do
   include BitkeyDefinitions
 
   it_behaves_like "data_status_methods"
-  it_behaves_like "auditable"
   it { is_expected.to localize_time_attribute(:absolute_time) }
   it { is_expected.to localize_time_attribute(:absolute_estimate_early) }
   it { is_expected.to localize_time_attribute(:absolute_estimate_late) }

--- a/spec/services/interactors/rebuild_effort_times_spec.rb
+++ b/spec/services/interactors/rebuild_effort_times_spec.rb
@@ -5,9 +5,8 @@ require "rails_helper"
 RSpec.describe Interactors::RebuildEffortTimes do
   include BitkeyDefinitions
 
-  subject { described_class.new(effort: effort, current_user_id: current_user_id) }
+  subject { described_class.new(effort: effort) }
   let(:effort) { efforts(:rufa_2017_12h_progress_lap2) }
-  let(:current_user_id) { 1 }
   let(:ordered_split_times) { effort.ordered_split_times }
   let(:ordered_split_ids) { effort.event.ordered_splits.map(&:id) }
   let(:id_1) { ordered_split_ids.first }
@@ -15,7 +14,7 @@ RSpec.describe Interactors::RebuildEffortTimes do
   let(:id_3) { ordered_split_ids.third }
 
   describe "#initialize" do
-    context "when effort and current_user_id arguments are provided" do
+    context "when effort argument is provided" do
       it "initializes" do
         expect { subject }.not_to raise_error
       end

--- a/spec/services/interactors/start_efforts_spec.rb
+++ b/spec/services/interactors/start_efforts_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Interactors::StartEfforts do
   include BitkeyDefinitions
 
   describe ".perform!" do
-    subject { Interactors::StartEfforts.new(efforts: subject_efforts, start_time: start_time, current_user_id: current_user_id) }
-    let(:current_user_id) { rand(1..100) }
+    subject { Interactors::StartEfforts.new(efforts: subject_efforts, start_time: start_time) }
     let(:home_time_zone) { subject_efforts.first.home_time_zone }
 
     context "when all provided efforts are valid" do
@@ -17,7 +16,7 @@ RSpec.describe Interactors::StartEfforts do
         context "when start_time is provided as a string with no time zone" do
           let(:start_time) { "2017-09-23 08:00:00" }
 
-          it "creates start split_times for each effort, assigns user_id to created_by, and returns a successful response" do
+          it "creates start split_times for each effort and returns a successful response" do
             expect(subject_efforts.map(&:starting_split_time)).to all be_nil
             response = subject.perform!
 
@@ -27,7 +26,6 @@ RSpec.describe Interactors::StartEfforts do
             subject_efforts.each(&:reload)
             split_times = subject_efforts.map(&:starting_split_time)
             expect(split_times).to all be_present
-            expect(split_times.map(&:created_by)).to all eq(current_user_id)
             expect(split_times.map(&:absolute_time)).to all eq(start_time.in_time_zone(home_time_zone))
           end
         end


### PR DESCRIPTION
Part of the ongoing effort to simplify OST. We do not use `created_by` on the SplitTime model for anything useful. This PR is the first step in getting rid of it.