### PR TITLE
Make the spread gender dropdown dynamic

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -308,11 +308,15 @@ module DropdownHelper
   end
 
   def gender_dropdown_menu(view_object)
-    dropdown_items = %w[combined male female].map do |gender|
+    genders = view_object.event_genders
+    genders.unshift("combined")
+
+    dropdown_items = genders.map do |gender|
       { name: gender.titleize,
         link: request.params.merge(filter: { gender: gender }, page: nil),
         active: view_object.gender_text == gender }
     end
+
     build_dropdown_menu(nil, dropdown_items, button: true)
   end
 

--- a/app/presenters/event_spread_display.rb
+++ b/app/presenters/event_spread_display.rb
@@ -37,6 +37,10 @@ class EventSpreadDisplay < EventWithEffortsPresenter
     effort_times_rows.map(&:id)
   end
 
+  def event_genders
+    @event_genders ||= event_efforts.distinct.pluck(:gender).sort
+  end
+
   def lap_splits
     @lap_splits ||= event.required_lap_splits.presence || event.lap_splits_through(highest_lap)
   end

--- a/app/views/events/spread.html.erb
+++ b/app/views/events/spread.html.erb
@@ -7,9 +7,9 @@
     <div class="ost-heading row">
       <div class="col">
         <div class="ost-title">
-          <h1><strong><%= [@presenter.name, nil].compact.join(': ') %></strong></h1>
+          <h1><strong><%= [@presenter.name, nil].compact.join(": ") %></strong></h1>
           <ul class="breadcrumb breadcrumb-ost">
-            <li class="breadcrumb-item"><%= link_to 'Organizations', organizations_path %></li>
+            <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
             <li class="breadcrumb-item"><%= link_to @presenter.organization.name, organization_path(@presenter.organization) %></li>
             <% if @presenter.multiple_events? %>
               <li class="breadcrumb-item"><%= link_to @presenter.event_group.name, event_group_path(@presenter.event_group) %></li>
@@ -18,14 +18,14 @@
             <li class="breadcrumb-item active">Full results</li>
           </ul>
         </div>
-        <%= render 'time_and_course_info' %>
+        <%= render "time_and_course_info" %>
       </div>
       <aside class="col-auto">
         <%= link_to_beacon_button(@presenter) %>
       </aside>
     </div>
     <!-- Navigation -->
-    <%= render 'view_buttons', view_object: @presenter %>
+    <%= render "view_buttons", view_object: @presenter %>
   </div>
 </header>
 
@@ -33,7 +33,7 @@
 <aside class="ost-toolbar">
   <div class="container">
     <div class="row">
-      <%= render 'event_groups/event_widget', events: @presenter.ordered_events_within_group, current_event: @presenter.event %>
+      <%= render "event_groups/event_widget", events: @presenter.ordered_events_within_group, current_event: @presenter.event %>
       <div class="col d-inline-flex">
         <div>
           <%= explore_dropdown_menu(@presenter) %>
@@ -51,7 +51,7 @@
 </aside>
 
 <% if @presenter.notice_text? %>
-  <%= render 'results_notice', notice_text: @presenter.notice_text %>
+  <%= render "results_notice", notice_text: @presenter.notice_text %>
 <% end %>
 
 <% if @presenter.show_partner_banners? %>
@@ -63,11 +63,11 @@
     <table class="table table-sm table-striped">
       <thead>
       <tr>
-        <th>O/G<br/><%= link_to_reversing_sort_heading('Place', :overall_rank, @presenter.existing_sort) %></th>
-        <th><%= link_to_reversing_sort_heading('Bib', :bib_number, @presenter.existing_sort) %></th>
-        <th><%= link_to_reversing_sort_heading('Name', 'last_name,first_name', @presenter.existing_sort) %></th>
-        <th><%= link_to_reversing_sort_heading('Category', 'gender,age', @presenter.existing_sort) %></th>
-        <th><%= link_to_reversing_sort_heading('From', :state_code, @presenter.existing_sort) %></th>
+        <th>O/G<br/><%= link_to_reversing_sort_heading("Place", :overall_rank, @presenter.existing_sort) %></th>
+        <th><%= link_to_reversing_sort_heading("Bib", :bib_number, @presenter.existing_sort) %></th>
+        <th><%= link_to_reversing_sort_heading("Name", "last_name,first_name", @presenter.existing_sort) %></th>
+        <th><%= link_to_reversing_sort_heading("Category", "gender,age", @presenter.existing_sort) %></th>
+        <th><%= link_to_reversing_sort_heading("From", :state_code, @presenter.existing_sort) %></th>
         <th>Status</th>
         <% spread_relevant_elements(@presenter.split_header_data).each do |header| %>
           <th class="text-nowrap text-center">

--- a/spec/system/results/spread_view_spec.rb
+++ b/spec/system/results/spread_view_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "visit the spread page" do
 
     verify_efforts_present(subject_efforts.female)
     verify_efforts_absent(subject_efforts.male)
+    verify_efforts_absent(subject_efforts.nonbinary)
   end
 
   scenario "A user chooses different display styles" do


### PR DESCRIPTION
Currently, the gender dropdown in the spread view is static, always showing "Combined", "Male", and "Female".

This PR makes it dynamic so it will show "Combined" plus all genders that exist in the event.