### PR TITLE
Convert effort delete to Turbo

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -242,12 +242,6 @@ module DropdownHelper
         data: { confirm: "This will delete all split times and attempt to rebuild them from the " +
           "#{pluralize(view_object.raw_times_count, 'raw time')} related to this effort. This action cannot be undone. Proceed?" },
         visible: view_object.multiple_laps? && view_object.raw_times_count.positive? },
-      { role: :separator },
-      { name: "Delete Entrant",
-        link: effort_path(view_object.effort),
-        method: :delete,
-        data: { confirm: "This action cannot be undone. Proceed?" },
-        class: "text-danger" }
     ]
     build_dropdown_menu("Actions", dropdown_items, button: true)
   end

--- a/app/policies/effort_policy.rb
+++ b/app/policies/effort_policy.rb
@@ -20,6 +20,10 @@ class EffortPolicy < ApplicationPolicy
     @effort = effort
   end
 
+  def destroy?
+    user.authorized_to_edit?(record)
+  end
+
   def delete_photo?
     user.authorized_to_edit?(effort)
   end

--- a/app/views/efforts/_actions_kebab.html.erb
+++ b/app/views/efforts/_actions_kebab.html.erb
@@ -5,5 +5,5 @@
                data: { bs_toggle: "dropdown" } %>
 <div class="dropdown-menu dropdown-menu-end" style="min-width:inherit">
   <%= link_to "Edit", edit_effort_path(effort), class: "dropdown-item", data: { turbo_frame: "form_modal" } %>
-  <%= link_to "Delete", effort_path(effort), class: "dropdown-item", data: { method: :delete, confirm: "This cannot be undone. Proceed?" } %>
+  <%= link_to "Delete", effort_path(effort), class: "dropdown-item", data: { turbo_method: :delete, turbo_confirm: "This cannot be undone. Proceed?" } %>
 </div>

--- a/spec/system/event_group_construction/edit_and_delete_entrants_spec.rb
+++ b/spec/system/event_group_construction/edit_and_delete_entrants_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "reconcile entrants from the reconcile view", js: true do
+  include ActionView::RecordIdentifier
+  include ActiveJob::TestHelper
+
+  let(:steward) { users(:fifth_user) }
+
+  before { organization.stewards << steward }
+
+  let(:event_group) { event_groups(:rufa_2016) }
+  let(:organization) { event_group.organization }
+  let(:entrant) { event_group.efforts.find_by(first_name: "Finished", last_name: "First") }
+
+  scenario "Edit an entrant" do
+    login_as steward, scope: :user
+    visit_page
+
+    within("##{dom_id(entrant, :event_group_setup)}") do
+      button = page.find("button.dropdown-toggle")
+      button.click
+      click_link "Edit"
+    end
+
+    expect(page).to have_content("Edit Entrant - #{entrant.full_name}")
+    fill_in "effort_last_name", with: "New Last Name"
+    expect do
+      click_button "Update Entrant"
+      # Wait for the update to complete
+      expect(page).to have_css(".bg-highlight")
+    end.to change { entrant.reload.last_name }.from("First").to("New Last Name")
+
+    expect(page).to have_content(entrant.reload.full_name)
+  end
+
+  scenario "Delete an entrant" do
+    login_as steward, scope: :user
+    visit_page
+
+    perform_enqueued_jobs do
+      expect do
+        within("##{dom_id(entrant, :event_group_setup)}") do
+          button = page.find("button.dropdown-toggle")
+          button.click
+          click_link "Delete"
+          accept_confirm
+        end
+
+        expect(page).not_to have_content(entrant.full_name)
+      end.to change { event_group.efforts.count }.by(-1)
+    end
+  end
+
+  def visit_page
+    visit entrants_event_group_path(event_group)
+  end
+end


### PR DESCRIPTION
This was missed during the Turbo conversion. This PR converts the Event Group Entrant Delete link to Turbo.

It also removes the ability to delete an effort from the Efforts > Show view.