### PR TITLE
All Event Group status changes happen through the Setup Status/Summary view

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -351,42 +351,36 @@ module DropdownHelper
 
   def event_group_actions_dropdown(view_object)
     dropdown_items = [
-      { name: "Edit/Delete Group",
-        link: edit_organization_event_group_path(view_object.organization, view_object.event_group) },
-      { name: "Duplicate Group",
+      {
+        name: "Edit/Delete Group",
+        link: edit_organization_event_group_path(view_object.organization, view_object.event_group),
+      },
+      {
+        name: "Duplicate Group",
         link: new_duplicate_event_group_path(existing_id: view_object.event_group.id),
-        visible: view_object.events.present? },
-      { role: :separator,
-        visible: view_object.events.present? },
-      { name: "Make Public",
-        link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { concealed: false }),
         visible: view_object.events.present?,
-        data: { confirm: I18n.t("event_groups.setup.make_public_confirm", event_group_name: view_object.event_group_name) },
-        disabled: !view_object.concealed?,
-        method: :put },
-      { name: "Make Private",
-        link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { concealed: true }),
+      },
+      {
+        role: :separator,
         visible: view_object.events.present?,
-        data: { confirm: I18n.t("event_groups.setup.make_private_confirm", event_group_name: view_object.event_group_name) },
-        disabled: view_object.concealed?,
-        method: :put },
-      { role: :separator,
-        visible: view_object.events.present? },
-      { name: "Enable Live",
-        link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { available_live: true }),
+      },
+      {
+        name: "Make Public or Private",
+        link: setup_summary_event_group_path(view_object.event_group),
         visible: view_object.events.present?,
-        data: { confirm: I18n.t("event_groups.setup.enable_live_confirm", event_group_name: view_object.event_group_name) },
-        disabled: view_object.available_live?,
-        method: :put },
-      { name: "Disable Live",
-        link: organization_event_group_path(view_object.organization, view_object.event_group, event_group: { available_live: false }),
+      },
+      {
+        name: "Enable or Disable Live",
+        link: setup_summary_event_group_path(view_object.event_group),
         visible: view_object.events.present?,
-        data: { confirm: I18n.t("event_groups.setup.disable_live_confirm", event_group_name: view_object.event_group_name) },
-        disabled: !view_object.available_live?,
-        method: :put },
-      { role: :separator },
-      { name: "Add/Remove Stewards",
-        link: organization_path(view_object.organization, display_style: "stewards") }
+      },
+      {
+        role: :separator,
+      },
+      {
+        name: "Add/Remove Stewards",
+        link: organization_path(view_object.organization, display_style: "stewards"),
+      },
     ]
     build_dropdown_menu("Group Actions", dropdown_items, button: true)
   end

--- a/app/helpers/event_group_setup_widget_helper.rb
+++ b/app/helpers/event_group_setup_widget_helper.rb
@@ -108,7 +108,7 @@ module EventGroupSetupWidgetHelper
       icon_only = true
     else
       type = :regular
-      tooltip = "View a summary of your Event Group"
+      tooltip = "Change public/private status, enable and disable live entry, and see a summary of your Event Group"
       icon_only = false
     end
 

--- a/app/views/event_groups/_setup_widget.html.erb
+++ b/app/views/event_groups/_setup_widget.html.erb
@@ -27,7 +27,7 @@
 
     <!-- Summary Card-->
     <div class="col">
-      <%= render "event_groups/setup_widget_header", title: "Summary" %>
+      <%= render "event_groups/setup_widget_header", title: "Status" %>
       <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_summary(presenter) %>
     </div>
   </div>


### PR DESCRIPTION
Currently, we can change Event Group public/private status and live entry enabled/disabled status from the Event Group Summary page or from the Group Actions menu in the Event Group Setup Overview page.

The menu items in the Group Actions menu were never updated for Turbo, so they do not work.

Rather than fix them, this PR removes them in favor of links to the Event Group Summary page. 

This PR also renames that page from Summary to Status and improves the tooltip.