### PR TITLE
Redirect event group GET actions that break if no event is present

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -3,6 +3,7 @@
 class EventGroupsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show, :follow, :traffic, :drop_list]
   before_action :set_event_group, except: [:index, :new, :create]
+  before_action :redirect_if_no_events, only: [:roster, :raw_times, :split_raw_times, :finish_line, :stats, :drop_list, :follow, :traffic]
   after_action :verify_authorized, except: [:index, :show, :new, :follow, :traffic, :drop_list, :efforts]
 
   # GET /event_groups
@@ -440,6 +441,12 @@ class EventGroupsController < ApplicationController
   def bib_assignment_hash(params_hash)
     params_hash.select { |key, _| key.include?("bib_for") }
                .transform_keys { |key| key.delete("^0-9").to_i }
+  end
+
+  def redirect_if_no_events
+    if @event_group.events.none?
+      redirect_to setup_event_group_path(@event_group), alert: "No events exist for this event group."
+    end
   end
 
   def set_event_group


### PR DESCRIPTION
This PR redirects attempted visits to any of several event_group pages if no events exist yet.

Resolves #1066 