### PR TITLE
Harden the Podium view and change "Fastest Times" to "Best Performance"

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -171,7 +171,7 @@ class EventsController < ApplicationController
   # GET /events/1/podium
   def podium
     template = Results::FillEventTemplate.perform(@event)
-    @presenter = PodiumPresenter.new(@event, template, prepared_params, current_user)
+    @presenter = PodiumPresenter.new(@event, view_context, template: template)
   end
 
   # Actions related to the event/effort/split_time relationship

--- a/app/models/results_category.rb
+++ b/app/models/results_category.rb
@@ -29,10 +29,10 @@ class ResultsCategory < ApplicationRecord
     new(standard_attributes.merge(attributes))
   end
 
-  def fastest_seconds
-    return INF unless efforts.present?
+  def best_performance
+    return "0" unless efforts.present?
 
-    efforts.first.final_elapsed_seconds
+    efforts.first.overall_performance
   end
 
   def age_range

--- a/app/parameters/effort_parameters.rb
+++ b/app/parameters/effort_parameters.rb
@@ -36,7 +36,7 @@ class EffortParameters < BaseParameters
      :final_distance, :finished, :stopped, :dropped, :overall_rank, :gender_rank, :full_name, :bio_historic,
      :prior_to_here_info, :stopped_here_info, :dropped_here_info, :recorded_here_info, :after_here_info,
      :expected_here_info, :due_next_info, :last_reported_info, :state_and_country, :ready_to_start,
-     :scheduled_start_time, :assumed_start_time, :actual_start_time, :fastest_times, :search]
+     :scheduled_start_time, :assumed_start_time, :actual_start_time, :best_performance, :search]
   end
 
   def self.permitted

--- a/app/presenters/podium_presenter.rb
+++ b/app/presenters/podium_presenter.rb
@@ -8,62 +8,70 @@ class PodiumPresenter < BasePresenter
   delegate :available_live, :multiple_events?, to: :event_group
   delegate :course_groups, to: :course
 
-  def initialize(event, template, params, current_user)
+  def initialize(event, view_context, template:)
     @event = event
+    @params = view_context.prepared_params
     @template = template
-    @params = params
-    @current_user = current_user
   end
 
+  # @return [Array<Results::Category>]
   def categories
     template&.results_categories || []
   end
 
+  # @return [Array<Results::Category>]
   def sorted_categories
-    if fastest_seconds_sort?
-      fastest_seconds_sorted_categories
+    if performance_sort?
+      performance_sorted_categories
     else
       categories
     end
   end
 
+  # @return [Symbol]
   def sort_method
     params[:sort].keys.first&.to_sym || :category
   end
 
+  # @return [String]
   def template_name
     template&.name
   end
 
+  # @return [Boolean]
   def point_system?
     template&.point_system.present?
   end
 
   private
 
-  def fastest_seconds_sort?
-    sort_method == :fastest_times
+  attr_reader :template, :params
+
+  # @return [Boolean]
+  def performance_sort?
+    sort_method == :best_performance
   end
 
-  def fastest_seconds_sorted_categories
+  # @return [Array<Results::Category>]
+  def performance_sorted_categories
     ordered_fixed_categories + ordered_floating_categories
   end
 
+  # @return [Array<Results::Category>]
   def ordered_fixed_categories
     categories.select(&:fixed_position?)
         .group_by { |c| [c.low_age, c.high_age] }.values
-        .map { |category_pair| category_pair.sort_by(&:fastest_seconds) }
+        .map { |category_pair| category_pair.sort_by(&:best_performance) }
         .flatten
   end
 
+  # @return [Array<Results::Category>]
   def ordered_floating_categories
     categories.reject(&:fixed_position?)
         .partition(&:male?)
-        .map { |gender_group| gender_group.sort_by(&:fastest_seconds) }
+        .map { |gender_group| gender_group.sort_by(&:best_performance).reverse }
         .transpose
-        .map { |category_pair| category_pair.sort_by(&:fastest_seconds) }
+        .map { |category_pair| category_pair.sort_by(&:best_performance).reverse }
         .flatten
   end
-
-  attr_reader :template, :params, :current_user
 end

--- a/app/views/events/podium.html.erb
+++ b/app/views/events/podium.html.erb
@@ -7,9 +7,9 @@
     <div class="ost-heading row">
       <div class="col">
         <div class="ost-title">
-        <h1><strong><%= [@presenter.name, nil].compact.join(': ') %></strong></h1>
+        <h1><strong><%= [@presenter.name, nil].compact.join(": ") %></strong></h1>
           <ul class="breadcrumb breadcrumb-ost">
-            <li class="breadcrumb-item"><%= link_to 'Organizations', organizations_path %></li>
+            <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
             <li class="breadcrumb-item"><%= link_to @presenter.organization.name, organization_path(@presenter.organization) %></li>
             <% if @presenter.multiple_events? %>
               <li class="breadcrumb-item"><%= link_to @presenter.event_group.name, event_group_path(@presenter.event_group) %></li>
@@ -18,24 +18,24 @@
             <li class="breadcrumb-item active">Podium</li>
           </ul>
         </div>
-        <%= render 'time_and_course_info' %>
+        <%= render "time_and_course_info" %>
       </div>
     </div>
     <!-- Navigation -->
-    <%= render 'view_buttons', view_object: @presenter %>
+    <%= render "view_buttons", view_object: @presenter %>
   </div>
 </header>
 
 <aside class="ost-toolbar d-print-none">
   <div class="container">
     <div class="row">
-      <%= render 'event_groups/event_widget', events: @presenter.ordered_events_within_group, current_event: @presenter.event %>
+      <%= render "event_groups/event_widget", events: @presenter.ordered_events_within_group, current_event: @presenter.event %>
       <div class="col d-inline-flex">
         <%= explore_dropdown_menu(@presenter) %>
       </div>
       <div class="col text-end">
         <div class="btn-group btn-group-ost">
-          <% [:category, :fastest_times].each do |sort_method| %>
+          <% [:category, :best_performance].each do |sort_method| %>
             <%= link_to sort_method.to_s.titleize,
                         request.params.merge(sort: sort_method),
                         class: "btn #{ @presenter.sort_method == sort_method ? 'btn-primary' : 'btn-outline-secondary' }" %>
@@ -50,7 +50,7 @@
   <% if @presenter.template_name %>
     <table class="table table-sm table-striped">
       <% @presenter.sorted_categories.each do |category| %>
-        <%= render 'podium_category', category: category %>
+        <%= render "podium_category", category: category %>
       <% end %>
     </table>
   <% else %>

--- a/spec/system/results/podium_view_spec.rb
+++ b/spec/system/results/podium_view_spec.rb
@@ -9,22 +9,42 @@ RSpec.describe "visit the podium page" do
   let(:subject_efforts) { event.efforts.ranking_subquery }
 
   scenario "A visitor views the podium page" do
-    visit podium_event_path(event)
+    visit_page
     verify_podium_view
   end
 
   scenario "A user views the podium page" do
     login_as user, scope: :user
 
-    visit podium_event_path(event)
+    visit_page
     verify_podium_view
   end
 
   scenario "An admin views the podium page" do
     login_as admin, scope: :user
 
-    visit podium_event_path(event)
+    visit_page
     verify_podium_view
+  end
+
+  scenario "Page displays correctly when an effort has no start time" do
+    effort = efforts(:rufa_2017_24h_progress_lap1)
+    effort.starting_split_time.destroy!
+
+    visit_page
+    expect(page).to have_content(effort.full_name)
+    verify_podium_view
+  end
+
+  scenario "Best Performance works" do
+    visit_page
+    tables = page.all("table")
+    within(tables[0]) { expect(page).to have_content "Overall Men" }
+
+    click_link "Best Performance"
+
+    tables = page.all("table")
+    within(tables[0]) { expect(page).to have_content "Overall Women" }
   end
 
   def verify_podium_view
@@ -45,5 +65,9 @@ RSpec.describe "visit the podium page" do
 
     overall_women_2_row = podium_table.find_by_id("overall_women_2")
     expect(overall_women_2_row).to have_content("Multiple Stops")
+  end
+
+  def visit_page
+    visit podium_event_path(event)
   end
 end


### PR DESCRIPTION
This PR uses `overall_performance` to sort runners in the Podium view. This allows us to avoid problems where a runner with no start time is in the Podium. It also sorts things correctly in multi-lap races.

Resolves #1074 