### PR TITLE
Event Group Construction - Upgrade the Entrant Create/Edit UX

### DIFF
--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -32,26 +32,37 @@ class EffortsController < ApplicationController
 
   def new
     event = Event.find(params[:event_id])
-    @effort = event.efforts.new
-    authorize @effort
+    effort = event.efforts.new
+    authorize effort
+
+    render :new, locals: { effort: effort }
   end
 
   def edit
     authorize @effort
     @effort = Effort.where(id: @effort).includes(event: { event_group: :events }).first
+
+    render :edit, locals: { effort: @effort }
   end
 
   def create
-    @effort = Effort.new(permitted_params)
-    authorize @effort
+    effort = Effort.new(permitted_params)
+    authorize effort
 
-    if @effort.save
+    if effort.save
       respond_to do |format|
-        format.html { redirect_to entrants_event_group_path(@effort.event_group) }
-        format.turbo_stream { @presenter = EventGroupSetupPresenter.new(@effort.event_group, view_context) }
+        format.html { redirect_to entrants_event_group_path(effort.event_group) }
+        format.turbo_stream do
+          render :create, locals: { effort: effort, presenter: EventGroupSetupPresenter.new(effort.event_group, view_context) }
+        end
       end
     else
-      render "new", status: :unprocessable_entity
+      respond_to do |format|
+        format.html { render :new, status: :unprocessable_entity }
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace("form_modal", partial: "efforts/new_modal", locals: { effort: effort }), status: :unprocessable_entity
+        end
+      end
     end
   end
 
@@ -77,17 +88,19 @@ class EffortsController < ApplicationController
         new_event_id = permitted_params.delete(:event_id)&.to_i
         success = effort.update(permitted_params)
 
-        if success && new_event_id && new_event_id != effort.event_id
-          new_event = Event.find(new_event_id)
+        if success && new_event_id && (new_event_id != effort.event_id)
+          new_event = effort.event_group.events.find(new_event_id)
           response = Interactors::ChangeEffortEvent.perform!(effort: effort, new_event: new_event)
           success = response.successful?
-          set_flash_message_now(response)
+          effort.errors.add(:event_id, response.error_report) unless success
         end
 
-        presenter = ::EventGroupRosterPresenter.new(effort.event_group, view_context)
-        status = success ? :ok : :unprocessable_entity
-
-        render :update, locals: { effort: effort, presenter: presenter }, status: status
+        if success
+          presenter = ::EventGroupRosterPresenter.new(effort.event_group, view_context)
+          render :update, locals: { effort: effort, presenter: presenter }
+        else
+          render turbo_stream: turbo_stream.replace("form_modal", partial: "efforts/edit_modal", locals: { effort: effort }), status: :unprocessable_entity
+        end
       end
     end
   end

--- a/app/javascript/controllers/flatpickr_controller.js
+++ b/app/javascript/controllers/flatpickr_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
     const controller = this
     const selector = `#${this.element.id}`
     const dateFormat = this.enableTimeValue ? "m/d/Y H:i:S" : "m/d/Y"
-    const datetime = new Date(this.element.value)
+    const datetime = this.element.value ? new Date(this.element.value) : null
 
     flatpickr(selector, {
       allowInput: true,

--- a/app/services/interactors/errors.rb
+++ b/app/services/interactors/errors.rb
@@ -140,7 +140,7 @@ module Interactors
 
     def split_name_mismatch_error(child, new_parent)
       {title: "Split names do not match",
-       detail: {messages: ["#{child} cannot be assigned to #{new_parent} because split names do not coincide"]}}
+       detail: {messages: ["#{child} cannot be assigned to #{new_parent} because #{child} has split times corresponding to split names that do not coincide with splits for #{new_parent}"]}}
     end
 
     def sub_split_mismatch_error(child, new_parent)

--- a/app/views/efforts/_edit_modal.html.erb
+++ b/app/views/efforts/_edit_modal.html.erb
@@ -1,0 +1,10 @@
+<%# locals: (effort:) %>
+
+<%= turbo_frame_tag "form_modal" do %>
+  <div class="modal-header" data-form-modal-target="resizeIndicator">
+    <div class="modal-title h4 fw-bold">Edit Entrant - <%= effort.full_name %></div>
+  </div>
+  <div class="modal-body">
+    <%= render "form", effort: effort %>
+  </div>
+<% end %>

--- a/app/views/efforts/_form.html.erb
+++ b/app/views/efforts/_form.html.erb
@@ -1,14 +1,16 @@
-<%= render "shared/errors", obj: @effort %>
+<%# locals: (effort:) %>
+
+<%= render "shared/errors", obj: effort %>
 
 <div class="container">
   <div class="row">
     <div class="col-md-12">
-      <%= form_for(@effort, html: { class: "form-horizontal", role: "form" }) do |f| %>
+      <%= form_for(effort, html: { class: "form-horizontal", role: "form" }) do |f| %>
         <div class="row">
           <div class="col-md-6 mb-3">
             <%= f.label :event, class: "required" %>
             <%= f.select :event_id,
-                         @effort.events_within_group.map { |event| [event.guaranteed_short_name, event.id] },
+                         effort.events_within_group.map { |event| [event.guaranteed_short_name, event.id] },
                          { prompt: true },
                          { class: "form-control dropdown-select-field" } %>
           </div>
@@ -118,7 +120,7 @@
         <br/>
         <div class="row mb-3">
           <div class="col">
-            <%= f.submit(@effort.new_record? ? "Create Entrant" : "Update Entrant", class: "btn btn-primary btn-large") %>
+            <%= f.submit(effort.new_record? ? "Create Entrant" : "Update Entrant", class: "btn btn-primary btn-large") %>
             <%= button_tag "Cancel",
                            type: :button,
                            data: { action: "click->form-modal#hide" },

--- a/app/views/efforts/_new_modal.html.erb
+++ b/app/views/efforts/_new_modal.html.erb
@@ -1,0 +1,10 @@
+<%# locals: (effort:) %>
+
+<%= turbo_frame_tag "form_modal" do %>
+  <div class="modal-header" data-form-modal-target="resizeIndicator">
+    <div class="modal-title h4 fw-bold">Add an Entrant</div>
+  </div>
+  <div class="modal-body">
+    <%= render "form", effort: effort %>
+  </div>
+<% end %>

--- a/app/views/efforts/create.turbo_stream.erb
+++ b/app/views/efforts/create.turbo_stream.erb
@@ -1,3 +1,5 @@
+<%# locals: (effort:, presenter:) %>
+
 <%= turbo_stream.prepend("entrants",
                          partial: "efforts/entrant_for_setup",
-                         locals: { presenter: @presenter, effort: @effort }) %>
+                         locals: { presenter: presenter, effort: effort }) %>

--- a/app/views/efforts/edit.html.erb
+++ b/app/views/efforts/edit.html.erb
@@ -1,23 +1,25 @@
+<%# locals: (effort:) %>
+
 <% content_for :title do %>
-  <% "OpenSplitTime: Edit Entrant - #{@effort.full_name}" %>
+  <% "OpenSplitTime: Edit Entrant - #{effort.full_name}" %>
 <% end %>
 
-<%= render "shared/mode_widget", event_group: @effort.event_group %>
+<%= render "shared/mode_widget", event_group: effort.event_group %>
 
 <header class="ost-header">
   <div class="container">
     <div class="ost-heading row">
       <div class="col">
         <div class="ost-title">
-          <h1><strong>Edit Entrant - <%= @effort.full_name %></strong></h1>
+          <h1><strong>Edit Entrant - <%= effort.full_name %></strong></h1>
           <ul class="breadcrumb breadcrumb-ost">
             <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
-            <li class="breadcrumb-item"><%= link_to @effort.event.event_group.organization.name, organization_path(@effort.event.event_group.organization) %></li>
-            <% if @effort.event_group.multiple_events? %>
-              <li class="breadcrumb-item"><%= link_to @effort.event_group.name, event_group_path(@effort.event_group) %></li>
+            <li class="breadcrumb-item"><%= link_to effort.event.event_group.organization.name, organization_path(effort.event.event_group.organization) %></li>
+            <% if effort.event_group.multiple_events? %>
+              <li class="breadcrumb-item"><%= link_to effort.event_group.name, event_group_path(effort.event_group) %></li>
             <% end %>
-            <li class="breadcrumb-item"><%= link_to @effort.event.guaranteed_short_name, event_path(@effort.event) %></li>
-            <li class="breadcrumb-item"><%= link_to @effort.full_name, effort_path(@effort) %></li>
+            <li class="breadcrumb-item"><%= link_to effort.event.guaranteed_short_name, event_path(effort.event) %></li>
+            <li class="breadcrumb-item"><%= link_to effort.full_name, effort_path(effort) %></li>
             <li class="breadcrumb-item active">Edit</li>
           </ul>
         </div>
@@ -27,12 +29,5 @@
 </header>
 
 <article class="ost-article container">
-  <%= turbo_frame_tag "form_modal" do %>
-    <div class="modal-header" data-form-modal-target="resizeIndicator">
-      <div class="modal-title h4 fw-bold">Edit Entrant - <%= @effort.full_name %></div>
-    </div>
-    <div class="modal-body">
-      <%= render "form" %>
-    </div>
-  <% end %>
+  <%= render "edit_modal", effort: effort %>
 </article>

--- a/app/views/efforts/new.html.erb
+++ b/app/views/efforts/new.html.erb
@@ -1,8 +1,10 @@
+<%# locals: (effort:) %>
+
 <% content_for :title do %>
   <% "OpenSplitTime: New effort" %>
 <% end %>
 
-<%= render "shared/mode_widget", event_group: @effort.event_group %>
+<%= render "shared/mode_widget", event_group: effort.event_group %>
 
 <header class="ost-header">
   <div class="container">
@@ -12,11 +14,11 @@
           <h1><strong>New Entrant</strong></h1>
           <ul class="breadcrumb breadcrumb-ost">
             <li class="breadcrumb-item"><%= link_to "Organizations", organizations_path %></li>
-            <li class="breadcrumb-item"><%= link_to @effort.event.event_group.organization.name, organization_path(@effort.event.event_group.organization) %></li>
-            <% if @effort.event_group.multiple_events? %>
-              <li class="breadcrumb-item"><%= link_to @effort.event_group.name, event_group_path(@effort.event_group) %></li>
+            <li class="breadcrumb-item"><%= link_to effort.event.event_group.organization.name, organization_path(effort.event.event_group.organization) %></li>
+            <% if effort.event_group.multiple_events? %>
+              <li class="breadcrumb-item"><%= link_to effort.event_group.name, event_group_path(effort.event_group) %></li>
             <% end %>
-            <li class="breadcrumb-item"><%= link_to @effort.event.guaranteed_short_name, event_path(@effort.event) %></li>
+            <li class="breadcrumb-item"><%= link_to effort.event.guaranteed_short_name, event_path(effort.event) %></li>
             <li class="breadcrumb-item active">New effort</li>
           </ul>
         </div>
@@ -26,12 +28,5 @@
 </header>
 
 <article class="ost-article container">
-  <%= turbo_frame_tag "form_modal" do %>
-    <div class="modal-header" data-modal-css-modifier="modal-lg">
-      <div class="modal-title h4 fw-bold">Add an Entrant</div>
-    </div>
-    <div class="modal-body">
-      <%= render "form" %>
-    </div>
-  <% end %>
+  <%= render "new_modal", effort: effort %>
 </article>

--- a/app/views/efforts/update.turbo_stream.erb
+++ b/app/views/efforts/update.turbo_stream.erb
@@ -1,13 +1,15 @@
 <%# locals: (effort:, presenter:) -%>
 
 <%= turbo_stream.replace dom_id(effort, :check_in_button),
-                        partial: "check_in_button",
-                        locals: { effort: effort } %>
+                         partial: "check_in_button",
+                         locals: { effort: effort } %>
 
 <%= turbo_stream.replace dom_id(effort.event_group, :start_ready_efforts_button),
-                        partial: "event_groups/start_ready_efforts_button",
-                        locals: { presenter: presenter } %>
+                         partial: "event_groups/start_ready_efforts_button",
+                         locals: { presenter: presenter } %>
 
 <%= turbo_stream.replace dom_id(effort, :event_group_setup),
                          partial: "efforts/entrant_for_setup",
                          locals: { presenter: presenter, effort: effort } %>
+
+<%= turbo_stream.replace "flash", partial: "layouts/flash" %>

--- a/spec/services/interactors/change_effort_event_spec.rb
+++ b/spec/services/interactors/change_effort_event_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Interactors::ChangeEffortEvent do
         new_event.reload
         response = subject.perform!
         expect(response).not_to be_successful
-        expect(response.errors.first[:detail][:messages]).to include(/split names do not coincide/)
+        expect(response.errors.first[:detail][:messages]).to include(/split times corresponding to split names that do not coincide/)
       end
 
       it "raises an error if sub_splits do not coincide" do

--- a/spec/services/interactors/change_event_course_spec.rb
+++ b/spec/services/interactors/change_event_course_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Interactors::ChangeEventCourse do
         expect(event.aid_stations).to match_array(existing_aid_stations)
         expect(event.splits).to match_array(existing_splits)
         expect(response).not_to be_successful
-        expect(response.errors.first[:detail][:messages]).to include(/names do not coincide/)
+        expect(response.errors.first[:detail][:messages]).to include(/split times corresponding to split names that do not coincide/)
       end
 
       it "makes no changes and raises an error if sub_splits do not coincide" do

--- a/spec/system/event_group_construction/create_entrants_spec.rb
+++ b/spec/system/event_group_construction/create_entrants_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "create an entrant from the event group entrants view", js: true do
+  include ActionView::RecordIdentifier
+  include ActiveJob::TestHelper
+
+  let(:steward) { users(:fifth_user) }
+
+  before { organization.stewards << steward }
+
+  let(:event_group) { event_groups(:rufa_2016) }
+  let(:organization) { event_group.organization }
+  let(:entrant) { event_group.efforts.find_by(first_name: "Finished", last_name: "First") }
+
+  scenario "Create an entrant" do
+    login_as steward, scope: :user
+    visit_page
+
+    click_link "Add"
+    expect(page).to have_content("Add an Entrant")
+
+    fill_in "effort_first_name", with: "Fred"
+    fill_in "effort_last_name", with: "Flintstone"
+    select "Male", from: "effort_gender"
+
+    expect do
+      click_button "Create Entrant"
+      # Wait for the update to complete
+      expect(page).to have_css(".bg-highlight")
+    end.to change { event_group.efforts.count }.by(1)
+
+    expect(page).to have_content(entrant.reload.full_name)
+  end
+
+  def visit_page
+    visit entrants_event_group_path(event_group)
+  end
+end

--- a/spec/system/event_group_construction/edit_entrant_change_event_spec.rb
+++ b/spec/system/event_group_construction/edit_entrant_change_event_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "change an entrant's event", js: true do
+  include ActionView::RecordIdentifier
+  include ActiveJob::TestHelper
+
+  let(:steward) { users(:fifth_user) }
+
+  before { organization.stewards << steward }
+
+  let(:event_group) { event_groups(:sum) }
+  let(:organization) { event_group.organization }
+  let(:entrant) { event_group.efforts.find_by(first_name: "Progress", last_name: "Cascade") }
+
+  context "when the entrant has not yet started" do
+    before do
+      entrant.split_times.delete_all
+      entrant.reload
+    end
+
+    scenario "Change an entrant's event" do
+      login_as steward, scope: :user
+      visit_page
+
+      within("##{dom_id(entrant, :event_group_setup)}") do
+        button = page.find("button.dropdown-toggle")
+        button.click
+        click_link "Edit"
+      end
+
+      expect(page).to have_content("Edit Entrant - #{entrant.full_name}")
+      select "55K", from: "effort_event_id"
+      sleep 0.5
+      expect do
+        click_button "Update Entrant"
+        expect(page).not_to have_css("#form_modal .modal-header")
+      end.to change { entrant.reload.event }.from(events(:sum_100k)).to(events(:sum_55k))
+
+      within("##{dom_id(entrant, :event_group_setup)}") do
+        expect(page).to have_content(events(:sum_55k).short_name)
+      end
+    end
+  end
+
+  context "when the entrant has started but has no other split times" do
+    before do
+      entrant.split_times.includes(:split).where.not(split: { kind: :start }).delete_all
+      entrant.reload
+    end
+
+    scenario "Change an entrant's event" do
+      login_as steward, scope: :user
+      visit_page
+
+      within("##{dom_id(entrant, :event_group_setup)}") do
+        button = page.find("button.dropdown-toggle")
+        button.click
+        click_link "Edit"
+      end
+
+      expect(page).to have_content("Edit Entrant - #{entrant.full_name}")
+      select "55K", from: "effort_event_id"
+      sleep 0.5
+      expect do
+        click_button "Update Entrant"
+        expect(page).not_to have_css("#form_modal .modal-header")
+      end.to change { entrant.reload.event }.from(events(:sum_100k)).to(events(:sum_55k))
+
+      within("##{dom_id(entrant, :event_group_setup)}") do
+        expect(page).to have_content(events(:sum_55k).short_name)
+      end
+    end
+  end
+
+  context "when the entrant has split times beyond start that match the split names of the other event" do
+    before do
+      entrant.split_times.where(split: splits(:sum_100k_course_cascade_creek_rd_aid3)).delete_all
+      entrant.reload
+    end
+
+    scenario "Change an entrant's event" do
+      login_as steward, scope: :user
+      visit_page
+
+      within("##{dom_id(entrant, :event_group_setup)}") do
+        button = page.find("button.dropdown-toggle")
+        button.click
+        click_link "Edit"
+      end
+
+      expect(page).to have_content("Edit Entrant - #{entrant.full_name}")
+      select "55K", from: "effort_event_id"
+      sleep 0.5
+      expect do
+        click_button "Update Entrant"
+        expect(page).not_to have_css("#form_modal .modal-header")
+      end.to change { entrant.reload.event }.from(events(:sum_100k)).to(events(:sum_55k))
+
+      within("##{dom_id(entrant, :event_group_setup)}") do
+        expect(page).to have_content(events(:sum_55k).short_name)
+      end
+    end
+  end
+
+  context "when the entrant has split times that do not match the split names of the other event" do
+    scenario "Fail to change an entrant's event" do
+      login_as steward, scope: :user
+      visit_page
+
+      within("##{dom_id(entrant, :event_group_setup)}") do
+        button = page.find("button.dropdown-toggle")
+        button.click
+        click_link "Edit"
+      end
+
+      expect(page).to have_content("Edit Entrant - #{entrant.full_name}")
+      select "55K", from: "effort_event_id"
+      sleep 0.5
+      expect do
+        click_button "Update Entrant"
+        expect(page).to have_content("split times corresponding to split names that do not coincide")
+      end.not_to change { entrant.reload.event }.from(events(:sum_100k))
+
+      expect(page).to have_css("#form_modal .modal-header")
+    end
+  end
+
+  def visit_page
+    visit entrants_event_group_path(event_group)
+  end
+end


### PR DESCRIPTION
Currently, it is not possible from the Edit Entrant modal to change an Entrant's event if the entrant has any split times. This bug also highlighted some additional problems in the related UX, for example, errors were not being reported when validation failed.

This PR does the following:
- Makes it possible to change an entrant's event from the Edit Entrant modal
- Reports errors properly in the form
- Fixes JS warning that was being produced when a date or datetime field was empty
- Adds system specs around entrant create/edit/delete functionality

Resolves #1083 