### PR TITLE
Use the effort id instead of slug for effort update form submissions

### DIFF
--- a/app/views/efforts/_form.html.erb
+++ b/app/views/efforts/_form.html.erb
@@ -5,7 +5,7 @@
 <div class="container">
   <div class="row">
     <div class="col-md-12">
-      <%= form_for(effort, html: { class: "form-horizontal", role: "form" }) do |f| %>
+      <%= form_with(model: effort, url: effort.new_record? ? efforts_path : effort_path(effort.id)) do |f| %>
         <div class="row">
           <div class="col-md-6 mb-3">
             <%= f.label :event, class: "required" %>

--- a/spec/system/event_group_construction/edit_and_delete_entrants_spec.rb
+++ b/spec/system/event_group_construction/edit_and_delete_entrants_spec.rb
@@ -35,6 +35,35 @@ RSpec.describe "edit and delete entrants from the event group entrants view", js
     expect(page).to have_content(entrant.reload.full_name)
   end
 
+  scenario "Edit an entrant with failed attempt" do
+    login_as steward, scope: :user
+    visit_page
+
+    within("##{dom_id(entrant, :event_group_setup)}") do
+      button = page.find("button.dropdown-toggle")
+      button.click
+      click_link "Edit"
+    end
+
+    expect(page).to have_content("Edit Entrant - #{entrant.full_name}")
+    fill_in "effort_last_name", with: "New Last Name"
+    fill_in "effort_birthdate", with: "1/1/3000"
+    click_button "Update Entrant"
+    # Wait for the update to complete
+    expect(page).to have_content("Birthdate can't be today or in the future")
+
+    fill_in "effort_birthdate", with: "1/1/2000"
+
+    expect do
+      click_button "Update Entrant"
+      # Wait for the update to complete
+      expect(page).to have_css(".bg-highlight")
+    end.to change { entrant.reload.last_name }.from("First").to("New Last Name")
+             .and change { entrant.reload.birthdate }.to("2000-01-01".to_date)
+
+    expect(page).to have_content(entrant.reload.full_name)
+  end
+
   scenario "Delete an entrant" do
     login_as steward, scope: :user
     visit_page


### PR DESCRIPTION
For models that use the FriendlyId gem for slugs, we run into a potential problem updating records. If a component of the slug is changed (like the `first_name` for an Effort) but validations fail, the form is re-rendered using the Effort in memory, with a new slug reflecting the changed `first_name` field. The re-rendered form points to a url with the new slug, which doesn't exist in the database.

It is safer to use the numeric `id` for these records, though it's a bit awkward having to use both `model:` and `url:` arguments for the `form_with`.

This PR does that for the efforts/_form partial. We'll probably need to do similar work for splits and several other models that use FriendlyId.