### PR TITLE
Make the Plan Effort view more mobile-friendly

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -80,7 +80,7 @@ class CoursesController < ApplicationController
 
     respond_to do |format|
       format.html do
-        session[:return_to] = plan_effort_organization_course_path(@organization, @course)
+        flash[:warning] = "Please enter your expected finish time." if params.key?(:expected_time) && params[:expected_time].blank?
       end
       format.csv do
         csv_stream = render_to_string(partial: "plan", formats: :csv)

--- a/app/views/courses/_plan_detail.html.erb
+++ b/app/views/courses/_plan_detail.html.erb
@@ -1,8 +1,10 @@
+<%# locals: (presenter:) %>
+
 <table class="table table-striped">
   <thead>
   <tr>
     <th>Split</th>
-    <th class="text-end"><%= pdu('singular').titleize %></th>
+    <th class="text-end"><%= pdu("singular").titleize %></th>
     <th class="text-center">Time of Day</th>
     <th class="text-center">Elapsed Time</th>
     <th class="text-center">Segment</th>
@@ -38,12 +40,12 @@
       </td>
       <td class="text-center">
         <span class="<%= 'brackets' if row.not_in_event %>">
-          <%= strong_conditional row.absolute_times_local.map(&method(:day_time_format)).join(' / '), row.finish? %>
+          <%= strong_conditional row.absolute_times_local.map(&method(:day_time_format)).join(" / "), row.finish? %>
         </span>
       </td>
       <td class="text-center">
         <span class="<%= 'brackets' if row.not_in_event %>">
-          <%= strong_conditional row.times_from_start.map(&method(:time_format_hhmm)).join(' / '), row.finish? %>
+          <%= strong_conditional row.times_from_start.map(&method(:time_format_hhmm)).join(" / "), row.finish? %>
         </span>
       </td>
       <td class="text-center">

--- a/app/views/courses/_time_input.html.erb
+++ b/app/views/courses/_time_input.html.erb
@@ -1,15 +1,17 @@
+<%# locals: (presenter:) %>
+
 <%= form_with url: plan_effort_organization_course_path, local: true, method: :get, role: "form" do |form| %>
 
   <div class="mb-3 row">
-    <%= form.label :start_time, "Event start time", class: "col-3 col-form-label" %>
-    <div class="col-6">
+    <%= form.label :start_time, "Event start time", class: "col-12 col-md-3 col-form-label" %>
+    <div class="col col-md-4">
       <%= form.datetimepicker_field :start_time, object: presenter %>
     </div>
   </div>
   <% if presenter.multiple_laps? %>
     <div class="mb-3 row">
-      <%= label :expected_laps, "Expected laps", class: "col-3 col-form-label" %>
-      <div class="col-2">
+      <%= label :expected_laps, "Expected laps", class: "col-12 col-md-3 col-form-label" %>
+      <div class="col col-md-4">
         <%= form.text_field :expected_laps,
                             value: presenter.expected_laps,
                             placeholder: "number of laps",
@@ -20,8 +22,8 @@
   <% end %>
 
   <div class="mb-3 row">
-    <%= label :expected_time, "Expected time", class: "col-3 col-form-label" %>
-    <div class="col-2">
+    <%= label :expected_time, "Expected time", class: "col-12 col-md-3 col-form-label" %>
+    <div class="col col-md-4">
       <%= form.text_field :expected_time,
                           value: presenter.cleaned_time,
                           placeholder: "hh:mm",

--- a/app/views/courses/plan_effort.html.erb
+++ b/app/views/courses/plan_effort.html.erb
@@ -11,7 +11,7 @@
 
 <article class="ost-article container">
   <% if @presenter.event %>
-    <%= render 'time_input', presenter: @presenter %>
+    <%= render "time_input", presenter: @presenter %>
 
     <hr>
   <% end %>
@@ -26,14 +26,14 @@
                     "#{@presenter.event_years_analyzed.to_sentence}" %></h5>
         </div>
         <div class="col-2 text-end">
-          <%= link_to 'Export plan', request.params.merge(format: :csv), class: 'btn btn-success' %>
+          <%= link_to "Export plan", request.params.merge(format: :csv), class: "btn btn-success" %>
         </div>
       </div>
     <% end %>
 
     <% if @presenter.expected_time %>
       <% if @presenter.ordered_split_times.present? %>
-        <%= render 'plan_detail', presenter: @presenter %>
+        <%= render "plan_detail", presenter: @presenter %>
       <% else %>
         <h4>Insufficient data to create a plan.</h4>
       <% end %>


### PR DESCRIPTION
Currently, the Plan Effort view is not very mobile-friendly. This PR improves reactivity of the input fields.

<details><summary>Screenshots</summary>
<p>

### Before:
<img width="412" alt="Screenshot 2023-06-26 at 6 45 30 AM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/480df549-9236-4027-ba00-9d41fb64bc27">

### After:
<img width="412" alt="Screenshot 2023-06-26 at 6 45 20 AM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/96da3d8d-6f7c-499a-b6ef-4004d33d617f">

</p>
</details> 
Resolves #1088