### PR TITLE
Remove babel warnings from build log

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -49,6 +49,12 @@ module.exports = function(api) {
                 }
             ],
             [
+                '@babel/plugin-proposal-private-methods',
+                {
+                    loose: true
+                }
+            ],
+            [
                 '@babel/plugin-proposal-private-property-in-object',
                 {
                     loose: true

--- a/babel.config.js
+++ b/babel.config.js
@@ -28,6 +28,7 @@ module.exports = function(api) {
             (isProductionEnv || isDevelopmentEnv) && [
                 '@babel/preset-env',
                 {
+                    loose: true,
                     forceAllTransforms: true,
                     useBuiltIns: 'entry',
                     corejs: 3,
@@ -43,6 +44,12 @@ module.exports = function(api) {
             '@babel/plugin-transform-destructuring',
             [
                 '@babel/plugin-proposal-class-properties',
+                {
+                    loose: true
+                }
+            ],
+            [
+                '@babel/plugin-proposal-private-property-in-object',
                 {
                     loose: true
                 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@hotwired/stimulus": "^3.0.1",
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "@hotwired/turbo-rails": "^7.0.1",


### PR DESCRIPTION
We are seeing many copies of this warning when building in Heroku CI:
```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-property-in-object.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```

This PR follows guidance found in [this issue](https://github.com/rails/webpacker/issues/3008) to fix the warnings.