### PR TITLE
Callbacks to notify subscribers of event updates

### DIFF
--- a/app/jobs/notify_event_update_job.rb
+++ b/app/jobs/notify_event_update_job.rb
@@ -3,19 +3,12 @@
 class NotifyEventUpdateJob < ApplicationJob
   def perform(event_id)
     @event_id = event_id
-
     return unless event_id.present? && event.present?
 
     response = EventUpdateNotifier.publish(topic_arn: topic_resource_key, event: event)
 
-    if response.successful?
-      notification = Notification.new(kind: :event_update, event: event, follower_ids: event.followers.ids,
-                                      subject: response.resources[:subject], notice_text: response.resources[:notice_text],
-                                      topic_resource_key: topic_resource_key)
-      unless notification.save
-        logger.error "  Unable to create notification for #{event}"
-        logger.error "  #{notification.errors.full_messages}"
-      end
+    unless response.successful?
+      raise "Failed to send event update notification for #{event.name} (#{event.id}): #{response.message_with_error_report}"
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -42,6 +42,8 @@ class Event < ApplicationRecord
   before_validation :conform_changed_course
   before_save :add_all_course_splits
   after_save :validate_event_group
+  after_touch :notify_event_update
+  after_update_commit :notify_event_update
 
   scope :name_search, -> (search_param) { where("events.name ILIKE ?", "%#{search_param}%") }
   scope :select_with_params, lambda { |search_param|
@@ -167,6 +169,10 @@ class Event < ApplicationRecord
 
   def add_all_course_splits
     splits << course.splits if splits.empty?
+  end
+
+  def notify_event_update
+    NotifyEventUpdateJob.perform_later(self.id)
   end
 
   def generate_new_topic_resource?

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,7 +3,7 @@
 class Notification < ApplicationRecord
   include Auditable
 
-  enum kind: [:participation, :progress]
+  enum kind: [:participation, :progress, :event_update]
 
   belongs_to :effort
   has_one :event, through: :effort


### PR DESCRIPTION
This PR adds callbacks to send event update notifications via Amazon SNS.

Addresses a portion of #1091 