### PR TITLE
Make the spread container fluid

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,6 +17,7 @@
         }
       ],
       "env": {
+        "GOOGLE_CHROME_CHANNEL": "stable",
         "WD_CHROME_PATH": "/app/.apt/usr/bin/google-chrome-stable"
       },
       "formation": {

--- a/app/views/events/spread.html.erb
+++ b/app/views/events/spread.html.erb
@@ -58,9 +58,9 @@
   <%= render "partners/bottom_banner", partner: @presenter.partner_with_banner %>
 <% end %>
 
-<article class="ost-article container">
+<article class="ost-article container-fluid">
   <% cache @presenter.cache_key do %>
-    <table class="table table-sm table-striped">
+    <table class="table table-sm table-striped mx-sm-4">
       <thead>
       <tr>
         <th>O/G<br/><%= link_to_reversing_sort_heading("Place", :overall_rank, @presenter.existing_sort) %></th>


### PR DESCRIPTION
The full spread view is often wide and can benefit from a wide browser window. But currently, with the bootstrap `container` class, the left side of the spread view retains an unused margin area. This PR uses the container-fluid class to allow the spread to fill the entire window.

### Before
<img width="1585" alt="Screenshot 2023-07-18 at 5 31 45 PM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/12c7fb47-9f66-498f-bc98-be7c23148ed7">

### After
<img width="1585" alt="Screenshot 2023-07-18 at 5 32 09 PM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/8ef96cbf-4739-4e4b-aea3-f7be838d70af">
