### PR TITLE
Use selenium-webdriver gem instead of webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ group :test do
   gem "factory_bot_rails", "~> 5.2", ">= 5.2.0", require: false
   gem "pry"
   gem "vcr", "~> 4.0"
-  gem "webdrivers", ">= 4.5.0"
+  gem "selenium-webdriver"
   gem "webmock", "~> 3.5"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,10 +531,6 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -622,6 +618,7 @@ DEPENDENCIES
   sassc-rails
   scenic (>= 1.5.4)
   scout_apm
+  selenium-webdriver
   sendgrid-ruby
   sentry-rails
   sentry-ruby
@@ -640,7 +637,6 @@ DEPENDENCIES
   turbo-rails
   vcr (~> 4.0)
   web-console (~> 3.7, >= 3.7.0)
-  webdrivers (>= 4.5.0)
   webmock (~> 3.5)
   webpacker (< 6.0)
   will_paginate (~> 3.3)


### PR DESCRIPTION
Heroku CI is throwing errors because of [this issue](https://github.com/titusfortner/webdrivers/issues/247) with the webdrivers gem.

This PR removes the webdrivers gem in favor of directly including selenium-webdriver as suggested in [this comment](https://github.com/titusfortner/webdrivers/issues/247#issuecomment-1641139415).