### PR TITLE
Rely on absolute time and home time zone when possible in audit view

### DIFF
--- a/app/models/concerns/time_recordable.rb
+++ b/app/models/concerns/time_recordable.rb
@@ -42,6 +42,8 @@ module TimeRecordable
   end
 
   def military_time(zone = nil)
+    zone ||= home_time_zone
+
     if absolute_time && zone
       TimeConversion.absolute_to_hms(absolute_time.in_time_zone(zone))
     else

--- a/app/models/raw_time.rb
+++ b/app/models/raw_time.rb
@@ -140,6 +140,6 @@ class RawTime < ApplicationRecord
   end
 
   def home_time_zone
-    @home_time_zone ||= attributes["home_time_zone"] || event_group.home_time_zone
+    @home_time_zone ||= attributes["home_time_zone"] || event_group&.home_time_zone
   end
 end

--- a/spec/support/concerns/time_recordable.rb
+++ b/spec/support/concerns/time_recordable.rb
@@ -41,34 +41,52 @@ RSpec.shared_examples_for "time_recordable" do
   end
 
   describe "#military_time" do
+    let(:result) { resource.military_time(zone) }
+    let(:zone) { nil }
+
     context "when absolute_time exists and a zone string argument is passed" do
+      let(:resource) { build_stubbed(model_name, absolute_time: "2017-07-31 09:30:45 -0000", entered_time: "0123") }
+      let(:zone) { "Eastern Time (US & Canada)" }
+
       it "returns the time component in hh:mm:ss format in the specified time zone" do
-        resource = build_stubbed(model_name, absolute_time: "2017-07-31 09:30:45 -0000", entered_time: "0123")
-        zone = "Eastern Time (US & Canada)"
-        expect(resource.military_time(zone)).to eq("05:30:45")
+        expect(result).to eq("05:30:45")
       end
     end
 
     context "when absolute_time exists and a TimeZone object argument is passed" do
+      let(:resource) { build_stubbed(model_name, absolute_time: "2017-07-31 09:30:45 -0000", entered_time: "0123") }
+      let(:zone) { ActiveSupport::TimeZone["Eastern Time (US & Canada)"] }
+
       it "returns the time component in hh:mm:ss format in the specified time zone" do
-        resource = build_stubbed(model_name, absolute_time: "2017-07-31 09:30:45 -0000", entered_time: "0123")
-        zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
-        expect(resource.military_time(zone)).to eq("05:30:45")
+        expect(result).to eq("05:30:45")
       end
     end
 
-    context "when absolute_time exists but zone does not exist" do
+    context "when absolute_time exists, zone is not passed as an argument, and zone does not exist for the including class object" do
+      let(:resource) { build_stubbed(model_name, absolute_time: "2017-07-31 09:30:45 -0000", entered_time: "01:23") }
+
+      before { allow(resource).to receive(:home_time_zone).and_return(nil) }
+
       it "returns the entered_time in hh:mm:ss format" do
-        resource = build_stubbed(model_name, absolute_time: "2017-07-31 09:30:45 -0000", entered_time: "01:23")
-        zone = nil
-        expect(resource.military_time(zone)).to eq("01:23:00")
+        expect(result).to eq("01:23:00")
+      end
+    end
+
+    context "when absolute_time exists, zone is not passed as an argument, and zone exists for the including class object" do
+      let(:resource) { build_stubbed(model_name, absolute_time: "2017-07-31 09:30:45 -0000", entered_time: "01:23") }
+
+      before { allow(resource).to receive(:home_time_zone).and_return("Eastern Time (US & Canada)") }
+
+      it "returns the time component in hh:mm:ss format in the specified time zone" do
+        expect(result).to eq("05:30:45")
       end
     end
 
     context "when no absolute_time exists" do
+      let(:resource) { build_stubbed(model_name, absolute_time: nil, entered_time: "16:30:45") }
+
       it "returns the entered_time in hh:mm:ss format" do
-        resource = build_stubbed(model_name, absolute_time: nil, entered_time: "16:30:45")
-        expect(resource.military_time).to eq("16:30:45")
+        expect(result).to eq("16:30:45")
       end
     end
   end


### PR DESCRIPTION
This PR should fix the issue in which the audit view sometimes shows a time discrepancy when none exists. The issue was that entered time sometimes uses a different time zone than the home time zone for the event, which can result in military_time being computed differently for some raw times.

This PR changes `TimeRecordable#military_time` to rely on the underlying `home_time_zone` of the raw time whenever it exists and `absolute_time` has been set.