### PR TITLE
Course setup cleanup and restrict unused JS

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,12 +11,16 @@ class ApplicationController < ActionController::Base
   before_action :set_sentry_context
   before_action :sample_requests_for_scout_apm
   after_action :store_user_location!, if: :storable_location?
-  helper_method :prepared_params
+  helper_method :prepared_params, :google_maps_enabled?
 
   rescue_from ::Pundit::NotAuthorizedError, with: :user_not_authorized
   rescue_from ::ActionController::UnknownFormat, with: :not_acceptable_head
 
   impersonates :user
+
+  def google_maps_enabled?
+    @google_maps_enabled == true
+  end
 
   def process_action(*args)
     super
@@ -46,6 +50,10 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :email])
     devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name, :email])
+  end
+
+  def enable_google_maps
+    @google_maps_enabled = true
   end
 
   # It's important that the location is NOT stored if:

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -11,6 +11,7 @@ class CoursesController < ApplicationController
   end
 
   def show
+    enable_google_maps
     course = @organization.courses.where(id: @course).includes(:splits).first
 
     respond_to do |format|

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -84,6 +84,7 @@ class EventsController < ApplicationController
   # GET /event_groups/1/events/1/setup_course
   def setup_course
     authorize @event
+    enable_google_maps
 
     @presenter = EventSetupCoursePresenter.new(@event, view_context)
   end

--- a/app/helpers/splits_helper.rb
+++ b/app/helpers/splits_helper.rb
@@ -2,11 +2,18 @@
 
 module SplitsHelper
   def link_to_event_split_delete(event, split)
-    link_to_delete_resource(fa_icon("trash-alt"), event_group_event_split_path(event.event_group, event, split),
+    url = event_group_event_split_path(event.event_group, event, split)
+    tooltip = "Delete this split"
+    link_to_delete_resource(fa_icon("trash"), url,
                             resource: split,
                             noteworthy_associations: [:split_times],
                             additional_warning: "NOTE: This applies to the current Event and to all Events that are now using or have used this Split in the past.",
-                            class: "btn btn-sm btn-outline-danger")
+                            class: "btn btn-sm btn-outline-danger",
+                            data: {
+                              controller: "tooltip",
+                              bs_placement: :bottom,
+                              bs_original_title: tooltip,
+                            })
   end
 
   def link_to_event_split_edit(event, split)

--- a/app/helpers/strong_confirm_helper.rb
+++ b/app/helpers/strong_confirm_helper.rb
@@ -10,7 +10,7 @@ module StrongConfirmHelper
 
     link_to name, strong_confirm_path(params),
             class: options[:class],
-            data: { turbo_frame: "form_modal" }
+            data: { turbo_frame: "form_modal" }.merge(options[:data] || {})
   end
 
   def link_to_delete_resource(name, path_on_confirm, options)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,9 +4,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title><%= content_for?(:title) ? yield(:title) : "OpenSplitTime" %></title>
   <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "OpenSplitTime" %>">
-  <% if @current_user %>
-    <script id="current_user" type="text/json"><%= raw(::Api::V1::UserSerializer.new(@current_user).to_json) %></script>
-  <% end %>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
   <%= render "layouts/google_maps_api_js" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
   <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "OpenSplitTime" %>">
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
-  <%= render "layouts/google_maps_api_js" %>
+  <%= render "layouts/google_maps_api_js" if google_maps_enabled? %>
   <%= csrf_meta_tags %>
   <%= render "layouts/cloudflare_analytics" if Rails.env.production? %>
   <%= render "layouts/favicon" %>


### PR DESCRIPTION
This PR does two main things:

1. Restores the trash icon to the event course split row (and adds a tooltip)
2. Does not load google maps api JS except on pages that require it