### PR TITLE
Generate the confirmation link using the base uri

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -3,4 +3,8 @@
 <p><%= t('.instruction', :default => "Please confirm your email by clicking the link below:") %></p>
 
 <p><%= link_to t('.action', :default => "Confirm my account"),
-         confirmation_url(@resource, :confirmation_token => @token, locale: I18n.locale) %></p>
+               Rails.application.routes.url_helpers.user_confirmation_url(
+                 host: OstConfig.base_uri,
+                 :confirmation_token => @token,
+                 locale: I18n.locale) %>
+</p>


### PR DESCRIPTION
#1120 fixed the email sending problem, but the confirmation link for staging was using the production URL.

This PR manually builds the confirmation link using `OstConfig.base_uri` as the host.

Follow-on to #1119