### PR TITLE
Fix flatpicker css and icon

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -9,6 +9,9 @@
 @import "./vendor/animate";
 @import "./vendor/simple-sidebar";
 
+@import "flatpickr/dist/flatpickr.css";
+@import "flatpickr_font";
+
 // Custom bootstrap variables must be set or imported *before* bootstrap.
 @import "bootstrap/scss/bootstrap";
 

--- a/app/helpers/datetimepicker_helper.rb
+++ b/app/helpers/datetimepicker_helper.rb
@@ -25,7 +25,7 @@ module DatetimepickerHelper
                                    flatpickr_enable_time_value: options[:enable_time],
                                  }
 
-    icon = content_tag(:span, nil, class: "input-group-text far fa-calendar-alt")
+    icon = fa_icon("calendar", class: "input-group-text")
 
     content_tag(:div, nil, class: "input-group") do
       text_field + icon


### PR DESCRIPTION
The flatpickr CSS was left out when we converted to esbuild. In addition, the calendar icon name needed to be updated for fontawesome 6.

Resolves #1122 