### PR TITLE
Fix Split Form "In and Out" time recording

### DIFF
--- a/app/views/splits/_form.html.erb
+++ b/app/views/splits/_form.html.erb
@@ -59,12 +59,12 @@
           <%= tooltip("Choose 'Time In' if times will be recorded here only once. Choose 'Time In and Out' if times will be recorded twice, once coming in and once coming out") %>
           <div class="split-time-recording-wrap">
             <label class="custom-radio">
-              <%= form.radio_button :sub_split_bitmap, 1 %>
+              <%= form.radio_button :sub_split_bitmap, SubSplit::IN_BITKEY %>
               <span class="custom-radio-indicator"></span>
               <span class="custom-radio-label">Time In</span>
             </label>
             <label class="custom-radio ms-3">
-              <%= form.radio_button :sub_split_bitmap, 64 %>
+              <%= form.radio_button :sub_split_bitmap, (SubSplit::IN_BITKEY | SubSplit::OUT_BITKEY) %>
               <span class="custom-radio-indicator"></span>
               <span class="custom-radio-label">Time In and Out</span>
             </label>

--- a/app/views/splits/_form.html.erb
+++ b/app/views/splits/_form.html.erb
@@ -23,8 +23,12 @@
   </div>
 
   <div class="col-12 col-lg-6 col-lg-pull-6">
+    <h3 class="fw-bold">
+      <%= split.persisted? ? "Update #{split.base_name}" : "New Split" %>
+    </h3>
+
     <%= form_with model: [event.event_group, event, split],
-                  data: { action: "turbo:submit-end->course-setup--split-location#dispatchSplitTableModified"} do |form| %>
+                  data: { action: "turbo:submit-end->course-setup--split-location#dispatchSplitTableModified" } do |form| %>
       <hr/>
       <div class="row">
         <div class="mb-3 col-6">

--- a/spec/system/event_group_construction/setup_course_edit_splits_spec.rb
+++ b/spec/system/event_group_construction/setup_course_edit_splits_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "create and edit splits from the events setup_course view", js: true do
+  let(:owner) { users(:third_user) }
+
+  before { organization.update(created_by: owner.id) }
+
+  let(:event_group) { event_groups(:sum) }
+  let(:organization) { event_group.organization }
+  let(:event) { events(:sum_100k) }
+  let(:course) { event.course }
+  let(:existing_split) { splits(:sum_100k_course_molas_pass_aid1) }
+
+  scenario "Create a new split" do
+    login_as owner, scope: :user
+    visit_page
+
+    expect do
+      click_link "Add", href: new_event_group_event_split_path(event_group, event)
+      expect(page).to have_content("New Split")
+
+      fill_in "split_base_name", with: "Another Aid Station"
+      fill_in "split_distance_in_preferred_units", with: "25"
+
+      # Wait for things to settle
+      sleep 0.2
+
+      click_button "Create Split"
+
+      # Wait for the modal to close
+      expect(page).not_to have_content("New Split")
+
+      # Wait for the update to complete
+      expect(page).not_to have_css(".bg-highlight")
+    end.to change { event.reload.splits.size }.by(1)
+
+    expect(page).to have_content("Another Aid Station")
+  end
+
+  scenario "Update an existing split" do
+    login_as owner, scope: :user
+    visit_page
+
+    expect do
+      click_link href: edit_event_group_event_split_path(event_group, event, existing_split)
+      expect(page).to have_content("Update Molas Pass (Aid1)")
+
+      fill_in "split_distance_in_preferred_units", with: "12.5"
+
+      # Wait for things to settle
+      sleep 0.2
+
+      click_button "Update Split"
+
+      # Wait for the modal to close
+      expect(page).not_to have_content("Update Molas Pass (Aid1)")
+
+      # Wait for the update to complete
+      expect(page).not_to have_css(".bg-highlight")
+    end.to change { existing_split.reload.distance_from_start }.from(18347).to(20117)
+
+    expect(page).to have_content("12.5")
+  end
+
+  def visit_page
+    visit setup_course_event_group_event_path(event_group, event)
+  end
+end


### PR DESCRIPTION
Currently, the Split form is submitting the wrong value for "In and Out" sub splits.

This PR fixes that problem. It also adds a title to the Split form and adds a system spec to watch for problems in the future.