### PR TITLE
Show time recording sub splits in Event Course Setup splits table

### DIFF
--- a/app/helpers/splits_helper.rb
+++ b/app/helpers/splits_helper.rb
@@ -2,6 +2,14 @@
 
 module SplitsHelper
   def link_to_event_split_delete(event, split)
+    if split.start? || split.finish?
+      link_to_event_split_delete_disabled
+    else
+      link_to_event_split_delete_enabled(event, split)
+    end
+  end
+
+  def link_to_event_split_delete_enabled(event, split)
     url = event_group_event_split_path(event.event_group, event, split)
     tooltip = "Delete this split"
     link_to_delete_resource(fa_icon("trash"), url,
@@ -11,9 +19,21 @@ module SplitsHelper
                             class: "btn btn-sm btn-outline-danger",
                             data: {
                               controller: "tooltip",
-                              bs_placement: :bottom,
+                              bs_placement: :left,
                               bs_original_title: tooltip,
                             })
+  end
+
+  def link_to_event_split_delete_disabled
+    tooltip = "Start and Finish splits cannot be deleted."
+
+    content_tag(:span, data: {
+      controller: "tooltip",
+      bs_placement: :left,
+      bs_original_title: tooltip,
+    }) do
+      link_to fa_icon("trash"), "#", class: "btn btn-sm btn-outline-danger disabled"
+    end
   end
 
   def link_to_event_split_edit(event, split)
@@ -21,7 +41,7 @@ module SplitsHelper
     tooltip = "Edit this split"
     options = { data: { turbo_frame: "form_modal",
                         controller: "tooltip",
-                        bs_placement: :bottom,
+                        bs_placement: :left,
                         bs_original_title: tooltip },
                 class: "btn btn-sm btn-outline-primary" }
     link_to fa_icon("pencil-alt"), url, options

--- a/app/views/events/_course_setup_split.html.erb
+++ b/app/views/events/_course_setup_split.html.erb
@@ -15,6 +15,7 @@
   <td><%= "#{e(split.vert_loss_from_start)} #{peu}" if split.vert_loss_from_start.present? %></td>
   <td><%= "#{e(split.elevation)} #{peu}" if split.elevation.present? %></td>
   <td><%= "#{split.latitude} / #{split.longitude}" if split.latitude.present? && split.longitude.present? %></td>
+  <td class="text-center"><%= split.sub_split_kinds.map { |kind| badge_with_text(kind, color: :secondary) }.join(" / ").html_safe %></td>
   <td class="text-end">
     <%= link_to_event_split_edit(event, split) %>
     <%= link_to_event_split_delete(event, split) %>

--- a/app/views/events/_course_setup_splits.html.erb
+++ b/app/views/events/_course_setup_splits.html.erb
@@ -13,6 +13,7 @@
     <th>Loss<br/>From Start</th>
     <th>Elevation</th>
     <th>Lat / Lon</th>
+    <th class="text-center">Recording</th>
     <th></th>
   </tr>
   </thead>


### PR DESCRIPTION
Currently, we cannot see what sub splits have been selected for time recording in the Splits table in the Event Course Setup view.

This PR adds a column to indicate those sub splits.

This PR also disables the Delete button for start and finish splits.

Resolves #1132 