### PR TITLE
Improve Import Job view

### DIFF
--- a/app/views/import_jobs/_form.html.erb
+++ b/app/views/import_jobs/_form.html.erb
@@ -1,23 +1,36 @@
-<%= render "shared/errors", obj: @import_job %>
+<%# locals: (import_job:) %>
+
+<%= render "shared/errors", obj: import_job %>
 
 <div class="row">
   <div class="col-md-12">
-    <%= form_with(model: @import_job, local: true, html: { class: "form-horizontal", data: { turbo: false } }) do |f| %>
-      <div class="row">
-        <div class="mb-3 col-md-4">
-          <%= f.label :file_name %>
-          <%= f.file_field :files, class: "form-control", autofocus: true %>
+    <%= form_with(model: import_job, local: true, html: { class: "form-horizontal", data: { turbo: false } }) do |f| %>
+      <div class="row text-center">
+
+        <div class="mb-3 text-center">
+          <div class="dropzone dropzone-default dz-clickable"
+               data-controller="dropzone"
+               data-dropzone-max-file-size="1"
+               data-dropzone-max-files="1"
+               data-dropzone-accepted-files=".csv"
+               data-action="dropzone:success->form-disable-submit#enableSubmitButton"
+          >
+            <%= f.file_field :files, direct_upload: true, data: { "dropzone-target" => "input" } %>
+            <div class="dropzone-msg dz-message needsclick text-muted">
+              <h3 class="dropzone-msg-title">Drag here to upload or click here to browse</h3>
+              <span class="dropzone-msg-desc text-sm">0.5 MB file size maximum. File must be a csv file.</span>
+            </div>
+          </div>
         </div>
+
         <%= f.hidden_field :parent_type %>
         <%= f.hidden_field :parent_id %>
         <%= f.hidden_field :format %>
       </div>
 
-      <div class="row mb-3">
-        <div class="col">
-          <%= f.submit("Import", class: "btn btn-primary") %>
-          <%= link_to "Cancel", request.referrer || import_jobs_path, class: "btn btn-outline-secondary" %>
-        </div>
+      <div class="mb-3 text-center">
+        <%= f.submit("Import", class: "btn btn-primary") %>
+        <%= link_to "Cancel", request.referrer || import_jobs_path, class: "btn btn-outline-secondary" %>
       </div>
     <% end %>
   </div>

--- a/app/views/import_jobs/new.html.erb
+++ b/app/views/import_jobs/new.html.erb
@@ -20,5 +20,23 @@
 </header>
 
 <article class="ost-article container">
-  <%= render "form" %>
+  <%= render partial: "shared/callout_with_link",
+             locals: {
+               icon_name: "info-circle",
+               icon_color: "info",
+               callout_color: "info",
+               detail_paragraphs: [t(".callout_detail_paragraph")]
+             } %>
+
+  <div class="card my-3">
+    <div class="card-header">
+      <h4 class="h4 fw-bold">New Import Job</h4>
+    </div>
+    <div class="card-body">
+      <div><span class="fw-bold">Importing into: </span><span><%= "#{@import_job.parent_type.titleize} #{@import_job.parent_name}" %></span></div>
+      <div><span class="fw-bold">Using format: </span><span class="font-monospace"><%= @import_job.format %></span></div>
+    </div>
+  </div>
+
+  <%= render partial: "form", locals: { import_job: @import_job } %>
 </article>

--- a/app/views/shared/_callout_with_link.html.erb
+++ b/app/views/shared/_callout_with_link.html.erb
@@ -5,6 +5,7 @@
 <% icon_name ||= nil %>
 <% main_text ||= nil %>
 <% detail_paragraphs ||= [] %>
+<% detail_paragraphs = Array.wrap(detail_paragraphs) %>
 <% link ||= nil %>
 
 <div class="callout callout-<%= callout_color %>">

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -25,6 +25,10 @@ en:
       pending_subscription_warning: "If a webhook subscription is pending, you will not receive notifications until you confirm the subscription. You can confirm the subscription by following the link in the subscription confirmation that was sent to your endpoint when you created the subscription."
       no_webhooks_available: "Webhooks are not available for this event at this time because it has no assigned topic resource. Please contact support for assistance."
 
+  import_jobs:
+    new:
+      callout_detail_paragraph: 'Import Jobs run in the background, allowing you to do other work while the import is ongoing. You can check the status of any of your import jobs at any time by clicking "Imports" on the top menu bar.'
+
   subscriptions:
     tooltips:
       confirmed: "This subscription is confirmed."

--- a/spec/system/event_group_construction/import_entrants_spec.rb
+++ b/spec/system/event_group_construction/import_entrants_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Import entrants from the event group setup view", type: :system,
   end
 
   def validate_import_job_created
-    attach_file("import_job[files]", file_fixture("test_efforts_utf_8.csv"))
+    find(".dropzone").drop(file_fixture("test_efforts_utf_8.csv"))
     expect { click_button "Import" }.to change(ImportJob, :count).by(1)
     expect(current_path).to eq(import_jobs_path)
   end


### PR DESCRIPTION
The existing New Import Job view does not provide much guidance. 

This PR improves the view by adding some inline documentation, including more information about the Import Job that is about to be created, and switching the file upload over to dropzone.

Begins to address #1135 