### PR TITLE
Improve Credentials UI

### DIFF
--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -8,22 +8,35 @@ class CredentialsController < ApplicationController
   # POST /credentials
   def create
     @credential = current_user.credentials.new(credential_params)
+    @credential.save
 
-    if @credential.save
-      redirect_to user_settings_credentials_path, notice: "Credential was successfully created."
-    else
-      redirect_to user_settings_credentials_path, notice: "Credential could not be created: #{@credential.errors.full_messages}"
+    respond_to do |format|
+      format.html do
+        notice = @credential.errors.blank? ?
+                   "Credential was successfully created." :
+                   "Credential could not be created: #{credential.errors.full_messages}"
+
+        redirect_to user_settings_credentials_path, notice: notice
+      end
+
+      format.turbo_stream { render :create, locals: { credential: @credential, user: current_user } }
     end
   end
 
   # PATCH/PUT /credentials/1
   def update
     @credential = current_user.credentials.find(params[:id])
+    @credential.update(credential_params)
 
-    if @credential.update(credential_params)
-      redirect_to user_settings_credentials_path, notice: "Credential was successfully updated."
-    else
-      redirect_to user_settings_credentials_path, notice: "Credential could not be updated: #{@credential.errors.full_messages}"
+    respond_to do |format|
+      format.html do
+        notice = @credential.errors.blank? ?
+                   "Credential was successfully updated." :
+                   "Credential could not be updated: #{credential.errors.full_messages}"
+        redirect_to user_settings_credentials_path, notice: notice
+      end
+
+      format.turbo_stream { render :update, locals: { credential: @credential, user: current_user } }
     end
   end
 
@@ -32,7 +45,13 @@ class CredentialsController < ApplicationController
     @credential = current_user.credentials.find(params[:id])
     @credential.destroy
 
-    redirect_to user_settings_credentials_path, notice: "Credential was successfully destroyed."
+    respond_to do |format|
+      format.html { redirect_to user_settings_credentials_path, notice: "Credential was successfully destroyed." }
+      format.turbo_stream do
+        new_credential = current_user.credentials.new(service_identifier: @credential.service_identifier, key: @credential.key, updated_at: Time.current)
+        render :destroy, locals: { credential: new_credential, user: current_user }
+      end
+    end
   end
 
   private

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -17,7 +17,6 @@ class UserSettingsController < ApplicationController
 
   # GET /user_settings/credentials
   def credentials
-    @user = current_user
   end
 
   def update

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -24,13 +24,8 @@ class UserSettingsController < ApplicationController
   def credentials_new_service
     respond_to do |format|
       format.turbo_stream do
-        service_identifier = params[:service_identifier]
-        render turbo_stream: turbo_stream.prepend("credentials_list",
-                                                  partial: "user_settings/credentials_service_card",
-                                                  locals: {
-                                                    service: Connectors::Service::BY_IDENTIFIER[service_identifier],
-                                                    user: current_user
-                                                  })
+        service = Connectors::Service::BY_IDENTIFIER[params[:service_identifier]]
+        render :credentials_new_service, locals: { service: service, user: current_user }
       end
     end
   end

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -17,6 +17,22 @@ class UserSettingsController < ApplicationController
 
   # GET /user_settings/credentials
   def credentials
+    @presenter = UserSettings::CredentialsPresenter.new(current_user)
+  end
+
+  # GET /user_settings/credentials_new_service
+  def credentials_new_service
+    respond_to do |format|
+      format.turbo_stream do
+        service_identifier = params[:service_identifier]
+        render turbo_stream: turbo_stream.prepend("credentials_list",
+                                                  partial: "user_settings/credentials_service_card",
+                                                  locals: {
+                                                    service: Connectors::Service::BY_IDENTIFIER[service_identifier],
+                                                    user: current_user
+                                                  })
+      end
+    end
   end
 
   def update
@@ -41,13 +57,13 @@ class UserSettingsController < ApplicationController
 
   def settings_update_params
     params.require(:user)
-          .permit(
-            :first_name,
-            :last_name,
-            :email,
-            :phone,
-            :pref_distance_unit,
-            :pref_elevation_unit,
-          )
+      .permit(
+        :first_name,
+        :last_name,
+        :email,
+        :phone,
+        :pref_distance_unit,
+        :pref_elevation_unit,
+      )
   end
 end

--- a/app/javascript/controllers/visibility_controller.js
+++ b/app/javascript/controllers/visibility_controller.js
@@ -6,42 +6,50 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
 
-    static targets = ["button", "element"]
-    static values = {
-        buttonHideClass: String,
-        buttonHideText: String,
-        buttonShowClass: String,
-        buttonShowText: String,
+  static targets = ["button", "element"]
+  static values = {
+    buttonHideClass: String,
+    buttonHideText: String,
+    buttonShowClass: String,
+    buttonShowText: String,
+    initialStateVisible: {
+      type: Boolean,
+      default: false,
     }
+  }
 
-    connect() {
-        this.showButton()
-        this.hideElement()
+  connect() {
+    this.showButton()
+    if (this.initialStateVisibleValue) {
+      this.showElement()
+    } else {
+      this.hideElement()
     }
+  }
 
-    toggleElement() {
-        if (this.elementTarget.classList.contains("d-none")) {
-            this.showElement();
-        } else {
-            this.hideElement();
-        }
+  toggleElement() {
+    if (this.elementTarget.classList.contains("d-none")) {
+      this.showElement();
+    } else {
+      this.hideElement();
     }
+  }
 
-    showButton() {
-        this.buttonTarget.classList.remove("d-none")
-    }
+  showButton() {
+    this.buttonTarget.classList.remove("d-none")
+  }
 
-    hideElement() {
-        this.elementTarget.classList.add("d-none")
-        this.buttonTarget.innerText = this.buttonShowTextValue
-        this.buttonTarget.classList.remove(this.buttonHideClassValue)
-        this.buttonTarget.classList.add(this.buttonShowClassValue)
-    }
+  hideElement() {
+    this.elementTarget.classList.add("d-none")
+    this.buttonTarget.innerText = this.buttonShowTextValue
+    this.buttonTarget.classList.remove(this.buttonHideClassValue)
+    this.buttonTarget.classList.add(this.buttonShowClassValue)
+  }
 
-    showElement() {
-        this.elementTarget.classList.remove("d-none")
-        this.buttonTarget.innerText = this.buttonHideTextValue
-        this.buttonTarget.classList.remove(this.buttonShowClassValue)
-        this.buttonTarget.classList.add(this.buttonHideClassValue)
-    }
+  showElement() {
+    this.elementTarget.classList.remove("d-none")
+    this.buttonTarget.innerText = this.buttonHideTextValue
+    this.buttonTarget.classList.remove(this.buttonShowClassValue)
+    this.buttonTarget.classList.add(this.buttonHideClassValue)
+  }
 }

--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -46,4 +46,10 @@ class Credential < ApplicationRecord
 
     records.first&.value
   end
+
+  # Allows us to use a Credential object in dom_id, for example,
+  # dom_id(Credential.new(service_identifier: "foo", key: "bar")) => "credential_foo_bar"
+  def to_key
+    [service_identifier, key]
+  end
 end

--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -28,7 +28,7 @@ class Credential < ApplicationRecord
             if: :key?,
             inclusion: {
               in: ->(record) do
-                Connectors::Service::BY_IDENTIFIER[record.service_identifier]&.credentials || []
+                Connectors::Service::BY_IDENTIFIER[record.service_identifier]&.credential_keys || []
               end,
               message: ->(record, _) do
                 "Invalid key #{record.key} for service_identifier #{record.service_identifier}"

--- a/app/policies/user_settings_policy.rb
+++ b/app/policies/user_settings_policy.rb
@@ -18,6 +18,10 @@ class UserSettingsPolicy < ApplicationPolicy
     user.present?
   end
 
+  def credentials_new_service?
+    credentials?
+  end
+
   def update?
     preferences?
   end

--- a/app/presenters/user_settings/credentials_presenter.rb
+++ b/app/presenters/user_settings/credentials_presenter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module UserSettings
+  class CredentialsPresenter
+    def initialize(user)
+      @user = user
+    end
+
+    attr_reader :user
+
+    def existing_user_services
+      @existing_user_services ||= user.credentials.pluck(:service_identifier).uniq.map do |service_identifier|
+        Connectors::Service::BY_IDENTIFIER[service_identifier]
+      end
+    end
+
+    def not_existing_user_services
+      @not_existing_user_services ||= Connectors::Service.all - existing_user_services
+    end
+  end
+end

--- a/app/views/credentials/_form.html.erb
+++ b/app/views/credentials/_form.html.erb
@@ -15,7 +15,7 @@
     <div class="col-12 col-lg-3 my-2 text-lg-end">
       <%= form.submit "Save", class: "btn btn-primary" %>
       <% if credential.persisted? %>
-        <%= link_to "Clear", credential_path(credential), method: :delete, class: "btn btn-outline-danger" %>
+        <%= link_to "Clear", credential_path(credential), data: { turbo_method: :delete}, class: "btn btn-outline-danger" %>
       <% else %>
         <%= link_to "Clear", "#", class: "btn btn-outline-danger", disabled: true %>
       <% end %>

--- a/app/views/credentials/_form.html.erb
+++ b/app/views/credentials/_form.html.erb
@@ -2,7 +2,7 @@
 
 <% credential = user.credentials.find_or_initialize_by(service_identifier: service_identifier, key: key) %>
 
-<%= form_with(model: credential) do |form| %>
+<%= form_with model: credential, data: { controller: "form-disable-submit" } do |form| %>
   <%= form.hidden_field :service_identifier %>
   <%= form.hidden_field :key %>
   <div class="row">

--- a/app/views/credentials/_form.html.erb
+++ b/app/views/credentials/_form.html.erb
@@ -1,24 +1,30 @@
-<%# locals: (user:, service_identifier:, key:) -%>
+<%# locals: (credential:, user:) -%>
 
-<% credential = user.credentials.find_or_initialize_by(service_identifier: service_identifier, key: key) %>
+<div id="<%= dom_id(credential) %>"
+     class="px-3"
+     data-controller="highlight"
+     data-highlight-timestamp-value="<%= credential.updated_at.to_i %>"
+     data-highlight-fast-value="true"
+>
 
-<%= form_with model: credential, data: { controller: "form-disable-submit" } do |form| %>
-  <%= form.hidden_field :service_identifier %>
-  <%= form.hidden_field :key %>
-  <div class="row">
-    <div class="col-12 col-lg">
-      <div class="input-group my-2 font-monospace">
-        <div class="input-group-text w-50 border border-secondary"><%= key %></div>
-        <%= form.text_field :value, class: "px-2 px-lg-3 w-50 border border-secondary" %>
+  <%= form_with model: credential, data: { controller: "form-disable-submit" } do |form| %>
+    <%= form.hidden_field :service_identifier %>
+    <%= form.hidden_field :key %>
+    <div class="row">
+      <div class="col-12 col-lg">
+        <div class="input-group my-2 font-monospace">
+          <div class="input-group-text w-50 border border-secondary"><%= credential.key %></div>
+          <%= form.text_field :value, class: "px-2 px-lg-3 w-50 border border-secondary" %>
+        </div>
+      </div>
+      <div class="col-12 col-lg-3 my-2 text-lg-end">
+        <%= form.submit "Save", class: "btn btn-primary" %>
+        <% if credential.persisted? %>
+          <%= link_to "Clear", credential_path(credential), data: { turbo_method: :delete }, class: "btn btn-outline-danger" %>
+        <% else %>
+          <%= link_to "Clear", "#", class: "btn btn-outline-danger", disabled: true %>
+        <% end %>
       </div>
     </div>
-    <div class="col-12 col-lg-3 my-2 text-lg-end">
-      <%= form.submit "Save", class: "btn btn-primary" %>
-      <% if credential.persisted? %>
-        <%= link_to "Clear", credential_path(credential), data: { turbo_method: :delete}, class: "btn btn-outline-danger" %>
-      <% else %>
-        <%= link_to "Clear", "#", class: "btn btn-outline-danger", disabled: true %>
-      <% end %>
-    </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/credentials/create.turbo_stream.erb
+++ b/app/views/credentials/create.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%# locals: (credential:, user:) %>
+
+<%= turbo_stream.replace(dom_id(credential),
+                         partial: "credentials/form",
+                         locals: {
+                           credential: credential,
+                           user: user,
+                         }) %>

--- a/app/views/credentials/destroy.turbo_stream.erb
+++ b/app/views/credentials/destroy.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%# locals: (credential:, user:) %>
+
+<%= turbo_stream.replace(dom_id(credential),
+                         partial: "credentials/form",
+                         locals: {
+                           credential: credential,
+                           user: user,
+                         }) %>

--- a/app/views/credentials/update.turbo_stream.erb
+++ b/app/views/credentials/update.turbo_stream.erb
@@ -1,0 +1,8 @@
+<%# locals: (credential:, user:) %>
+
+<%= turbo_stream.replace(dom_id(credential),
+                         partial: "credentials/form",
+                         locals: {
+                           credential: credential,
+                           user: user,
+                         }) %>

--- a/app/views/shared/_callout_with_link.html.erb
+++ b/app/views/shared/_callout_with_link.html.erb
@@ -10,7 +10,7 @@
 
 <div class="callout callout-<%= callout_color %>">
   <div class="row">
-    <div class="col-12 col-md-9">
+    <div class="col-12 col-md">
       <div class="d-block d-md-inline-flex">
         <% if icon_name.present? %>
           <div class="text-center py-2 py-md-0 me-md-2">

--- a/app/views/user_settings/_credentials_service_card.html.erb
+++ b/app/views/user_settings/_credentials_service_card.html.erb
@@ -1,11 +1,14 @@
-<%# locals: (service:, user:) %>
+<%# locals: (service:, user:, initial_state_visible:) %>
+
+<% initial_state_visible ||= false %>
 
 <div class="card mt-4"
      data-controller="visibility"
      data-visibility-button-hide-class-value="btn-primary"
      data-visibility-button-hide-text-value="Hide"
      data-visibility-button-show-class-value="btn-outline-primary"
-     data-visibility-button-show-text-value="Reveal">
+     data-visibility-button-show-text-value="Reveal"
+     data-visibility-initial-state-visible-value="<%= initial_state_visible %>">
   <div class="card-header">
     <div class="row pt-1">
       <div class="col">

--- a/app/views/user_settings/_credentials_service_card.html.erb
+++ b/app/views/user_settings/_credentials_service_card.html.erb
@@ -1,0 +1,28 @@
+<%# locals: (service:, user:) %>
+
+<div class="card mt-4"
+     data-controller="visibility"
+     data-visibility-button-hide-class-value="btn-primary"
+     data-visibility-button-hide-text-value="Hide"
+     data-visibility-button-show-class-value="btn-outline-primary"
+     data-visibility-button-show-text-value="Reveal">
+  <div class="card-header">
+    <div class="row pt-1">
+      <div class="col">
+        <h4 class="pt-1"><strong><%= service.name %></strong></h4>
+      </div>
+      <div class="col-4 col-lg-2 text-end d-grid">
+        <%= button_tag nil,
+                       class: "btn d-none",
+                       "data-action": "visibility#toggleElement",
+                       "data-visibility-target": "button" %>
+      </div>
+    </div>
+  </div>
+  <div class="card-body table-responsive" data-visibility-target="element">
+    <%= render partial: "credentials/form",
+               collection: service.credential_keys,
+               as: :key,
+               locals: { user: user, service_identifier: service.identifier } %>
+  </div>
+</div>

--- a/app/views/user_settings/_credentials_service_card.html.erb
+++ b/app/views/user_settings/_credentials_service_card.html.erb
@@ -1,9 +1,12 @@
 <%# locals: (service:, user:, initial_state_visible:) %>
 
 <% initial_state_visible ||= false %>
+<% credentials = service.credential_keys.map { |key| user.credentials.find_or_initialize_by(service_identifier: service.identifier, key: key) } %>
 
 <div class="card mt-4"
-     data-controller="visibility"
+     data-controller="highlight visibility"
+     data-highlight-timestamp-value="<%= initial_state_visible ? Time.current.to_i : nil %>"
+     data-highlight-fast-value="true"
      data-visibility-button-hide-class-value="btn-primary"
      data-visibility-button-hide-text-value="Hide"
      data-visibility-button-show-class-value="btn-outline-primary"
@@ -24,8 +27,8 @@
   </div>
   <div class="card-body table-responsive" data-visibility-target="element">
     <%= render partial: "credentials/form",
-               collection: service.credential_keys,
-               as: :key,
-               locals: { user: user, service_identifier: service.identifier } %>
+               collection: credentials,
+               as: :credential,
+               locals: { user: user } %>
   </div>
 </div>

--- a/app/views/user_settings/credentials.html.erb
+++ b/app/views/user_settings/credentials.html.erb
@@ -23,7 +23,10 @@
         <div class="card-body">
           <% if @presenter.not_existing_user_services.present? %>
             <p class="card-text">Choose the service for which you want to add your credentials:</p>
-            <%= form_with url: user_settings_credentials_new_service_path, method: :get, data: { turbo_stream: true } do |form| %>
+
+            <%= form_with url: user_settings_credentials_new_service_path,
+                          method: :get,
+                          data: { controller: "form-disable-submit", turbo_stream: true } do |form| %>
               <div class="row">
                 <div class="col">
                   <%= form.select :service_identifier,

--- a/app/views/user_settings/credentials.html.erb
+++ b/app/views/user_settings/credentials.html.erb
@@ -9,33 +9,10 @@
     <%= render "sidebar" %>
     <div class="col">
       <p>Credentials are stored securely and encrypted at rest in the OpenSplitTime database. Credentials are used only as needed to connect with outside services.</p>
-      <% Connectors::Service.all.each do |service| %>
-        <div class="card mt-4"
-             data-controller="visibility"
-             data-visibility-button-hide-class-value="btn-primary"
-             data-visibility-button-hide-text-value="Hide"
-             data-visibility-button-show-class-value="btn-outline-primary"
-             data-visibility-button-show-text-value="Reveal">
-          <div class="card-header">
-            <div class="row pt-1">
-              <div class="col">
-                <h3><strong><%= service.name %></strong></h3>
-              </div>
-              <div class="col-4 col-lg-2 text-end d-grid">
-                <%= button_tag nil,
-                               class: "btn d-none",
-                               "data-action": "visibility#toggleElement",
-                               "data-visibility-target": "button" %>
-              </div>
-            </div>
-          </div>
-          <div class="card-body table-responsive" data-visibility-target="element">
-            <%= render partial: "credentials/form",
-                       collection: service.credentials,
-                       as: :key,
-                       locals: { user: @user, service_identifier: service.identifier } %>
-          </div>
-        </div>
+
+      <% current_user.credentials.pluck(:service_identifier).uniq.each do |service_identifier| %>
+        <%= render partial: "user_settings/credentials_service_card",
+                   locals: { service: Connectors::Service::BY_IDENTIFIER[service_identifier], user: current_user } %>
       <% end %>
     </div>
   </div>

--- a/app/views/user_settings/credentials.html.erb
+++ b/app/views/user_settings/credentials.html.erb
@@ -2,18 +2,54 @@
   <% "OpenSplitTime: User Credentials" %>
 <% end %>
 
-<%= render "header", title: "Password" %>
+<%= render "header", title: "Credentials" %>
 
 <article class="ost-article container">
   <div class="row flex-nowrap">
     <%= render "sidebar" %>
     <div class="col">
-      <p>Credentials are stored securely and encrypted at rest in the OpenSplitTime database. Credentials are used only as needed to connect with outside services.</p>
+      <%= render partial: "shared/callout_with_link", locals: {
+        main_text: t(".credentials_callout.main_text"),
+        detail_paragraphs: [t(".credentials_callout.detail_paragraph_1"), t(".credentials_callout.detail_paragraph_2")],
+        callout_color: "info",
+        icon_color: "info",
+        icon_name: "info-circle",
+      } %>
 
-      <% current_user.credentials.pluck(:service_identifier).uniq.each do |service_identifier| %>
-        <%= render partial: "user_settings/credentials_service_card",
-                   locals: { service: Connectors::Service::BY_IDENTIFIER[service_identifier], user: current_user } %>
-      <% end %>
+      <div class="card">
+        <div class="card-header">
+          <h4 class="card-title fw-bold mt-1">Add Credentials</h4>
+        </div>
+        <div class="card-body">
+          <% if @presenter.not_existing_user_services.present? %>
+            <p class="card-text">Choose the service for which you want to add your credentials:</p>
+            <%= form_with url: user_settings_credentials_new_service_path, method: :get, data: { turbo_stream: true } do |form| %>
+              <div class="row">
+                <div class="col">
+                  <%= form.select :service_identifier,
+                                  @presenter.not_existing_user_services.map { |service| [service.name, service.identifier] },
+                                  { prompt: true },
+                                  class: "form-control form-select"
+                  %>
+                </div>
+                <div class="col-2">
+                  <%= form.submit "Add", class: "btn btn-outline-success form-control" %>
+                </div>
+              </div>
+            <% end %>
+          <% else %>
+            <p>You have added credentials for all available services.</p>
+            <p>You may edit or remove credentials by revealing them in the cards below.</p>
+          <% end %>
+        </div>
+      </div>
+
+      <div id="credentials_list">
+        <% @presenter.existing_user_services.each do |service| %>
+          <%= render partial: "user_settings/credentials_service_card",
+                     locals: { service: service, user: @presenter.user } %>
+        <% end %>
+      </div>
     </div>
   </div>
 </article>

--- a/app/views/user_settings/credentials_new_service.turbo_stream.erb
+++ b/app/views/user_settings/credentials_new_service.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%# locals: (service:, user:) %>
+
+<%= turbo_stream.prepend("credentials_list",
+                         partial: "user_settings/credentials_service_card",
+                         locals: {
+                           service: service,
+                           user: user,
+                           initial_state_visible: true,
+                         }) %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -34,3 +34,10 @@ en:
       confirmed: "This subscription is confirmed."
       no_topic: "This subscription does not have a resource key. Click Actions > Refresh to attempt to generate one, or delete this subscription and create a new one."
       pending: "This subscription is pending confirmation. If you have confirmed the endpoint, click Actions > Refresh to change its status here."
+
+  user_settings:
+    credentials:
+      credentials_callout:
+        detail_paragraph_1: "Credentials are used to connect your OpenSplitTime resource (such as an Event Group or an Event) with an external service, like Runsignup. This makes it easy to sync data from the external service into OpenSplitTime."
+        detail_paragraph_2: "Credentials are stored securely and are only used to access the external service. They are not used for any other purpose."
+        main_text: "Using Credentials in OpenSplitTime"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     get :preferences
     get :password
     get :credentials
+    get :credentials_new_service
     put :update
   end
 

--- a/lib/connectors/service.rb
+++ b/lib/connectors/service.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
 module Connectors
-  Service = Struct.new(:identifier, :name, :credentials, keyword_init: true) do
+  Service = Struct.new(:identifier, :name, :credential_keys, keyword_init: true) do
     def self.all
       [
         new(
+          identifier: "rattlesnake_ramble",
+          name: "Rattlesnake Ramble",
+          credential_keys: %w[email password]
+        ),
+        new(
           identifier: "runsignup",
           name: "RunSignup",
-          credentials: %w[api_key api_secret]
-        )
+          credential_keys: %w[api_key api_secret]
+        ),
       ]
     end
 


### PR DESCRIPTION
Currently, we can view credentials in a rudimentary way, but we are showing all possible services whether or not credentials exist for those services.

This PR adds a Turbo-powered UI to intuitively create, update, and destroy credentials. It also shows only those services that have credentials associated with them, offering the ability to create credentials for additional services.