### PR TITLE
Remove obsolete import_csv_raw_times endpoint

### DIFF
--- a/app/policies/event_group_policy.rb
+++ b/app/policies/event_group_policy.rb
@@ -168,10 +168,6 @@ class EventGroupPolicy < ApplicationPolicy
     user.present?
   end
 
-  def import_csv_raw_times?
-    user.authorized_to_edit?(event_group)
-  end
-
   def submit_raw_time_rows?
     user.authorized_to_edit?(event_group)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -285,7 +285,6 @@ Rails.application.routes.draw do
           post :enrich_raw_time_row
           get :not_expected
           post :import
-          post :import_csv_raw_times
           post :submit_raw_time_rows
           patch :pull_raw_times
         end


### PR DESCRIPTION
The `import_csv_raw_times` endpoint has long been unused. This PR removes it.