### PR TITLE
Better status and error reporting for connections

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -151,6 +151,13 @@ class User < ApplicationRecord
     credentials.for_service(service_identifier).exists?
   end
 
+  def all_credentials_for?(service_identifier)
+    service = Connectors::Service::BY_IDENTIFIER[service_identifier]
+    return false if service.blank?
+
+    credentials.for_service(service_identifier).pluck(:key).sort == service.credential_keys.sort
+  end
+
   def from_omniauth?
     provider? && uid?
   end

--- a/app/views/event_groups/connect_service/rattlesnake_ramble/_event_group_card.html.erb
+++ b/app/views/event_groups/connect_service/rattlesnake_ramble/_event_group_card.html.erb
@@ -2,9 +2,38 @@
 
 <div class="card" id="event_group_card">
   <div class="card-header">
-    <h4 class="card-title mt-1"><%= "Event Group: #{connect_service_presenter.event_group_name}" %></h4>
+    <div class="row">
+      <div class="col">
+        <h4 class="card-title mt-1"><%= "Event Group: #{connect_service_presenter.event_group_name}" %></h4>
+      </div>
+      <div class="col text-end">
+        <% if connect_service_presenter.all_credentials_present? %>
+          <%= fa_icon("circle-check", type: :regular, text: "Credentials are present", class: "text-success") %>
+        <% else %>
+          <%= fa_icon("circle-xmark", type: :regular, text: "Credentials are missing", class: "text-danger") %>
+        <% end %>
+        <br/>
+        <% if connect_service_presenter.error_message.present? %>
+          <%= fa_icon("circle-xmark", type: :regular, text: connect_service_presenter.error_message, class: "text-danger") %>
+        <% elsif connect_service_presenter.all_credentials_present? %>
+          <%= fa_icon("circle-check", type: :regular, text: "Credentials were accepted", class: "text-success") %>
+        <% end %>
+      </div>
+    </div>
   </div>
+
   <div class="card-body">
-    <p>Connect the Events below to the corresponding Race Editions.</p>
+    <% if connect_service_presenter.connection_invalid? %>
+      <p>There is a problem with the connection. Please check that your <%= link_to "credentials", user_settings_credentials_path %>
+        are entered and accurate and try again.</p>
+    <% elsif connect_service_presenter.no_events_found? %>
+      <p>No external events were returned. Please check with the owner of <%= connect_service_presenter.service_name %> for further
+        assistance.</p>
+    <% elsif connect_service_presenter.no_events_in_time_frame? %>
+      <p>External events were returned, but none were within the timeframe of <%= connect_service_presenter.event_group_name %>.
+        Please check with the owner of <%= connect_service_presenter.service_name %> for further assistance.</p>
+    <% else %>
+      <p>Connect the Events below to the corresponding Race Editions.</p>
+    <% end %>
   </div>
 </div>

--- a/app/views/event_groups/connect_service/runsignup/_event_group_card.html.erb
+++ b/app/views/event_groups/connect_service/runsignup/_event_group_card.html.erb
@@ -2,8 +2,20 @@
 
 <div class="card" id="event_group_card">
   <div class="card-header">
-    <h4 class="card-title mt-1"><%= "Event Group: #{connect_service_presenter.event_group_name}" %></h4>
+    <div class="row">
+      <div class="col">
+        <h4 class="card-title mt-1"><%= "Event Group: #{connect_service_presenter.event_group_name}" %></h4>
+      </div>
+      <div class="col text-end">
+        <% if connect_service_presenter.all_credentials_present? %>
+          <%= fa_icon("circle-check", type: :regular, text: "Credentials are present", class: "text-success") %>
+        <% else %>
+          <%= fa_icon("circle-xmark", type: :regular, text: "Credentials are missing", class: "text-danger") %>
+        <% end %>
+      </div>
+    </div>
   </div>
+
   <div class="card-body">
     <%= render partial: "event_groups/connections/form",
                locals: {

--- a/spec/lib/connectors/rattlesnake_ramble/client_spec.rb
+++ b/spec/lib/connectors/rattlesnake_ramble/client_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ::Connectors::RattlesnakeRamble::Client do
     context "when credentials are invalid" do
       it "returns an error and unauthorized status" do
         VCR.use_cassette("rattlesnake_ramble/get_race_editions/not_authorized") do
-          expect { result }.to raise_error(Connectors::Errors::NotAuthorized)
+          expect { result }.to raise_error(Connectors::Errors::NotAuthenticated)
         end
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe ::Connectors::RattlesnakeRamble::Client do
     context "when credentials are invalid" do
       it "raises NotAuthorized" do
         VCR.use_cassette("rattlesnake_ramble/get_race_edition/not_authorized") do
-          expect { result }.to raise_error(Connectors::Errors::NotAuthorized)
+          expect { result }.to raise_error(Connectors::Errors::NotAuthenticated)
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -176,4 +176,32 @@ RSpec.describe User, type: :model do
       it { expect(result).to eq(false) }
     end
   end
+
+  describe "#all_credentials_for?" do
+    let(:user) { users(:third_user) }
+    let(:result) { user.all_credentials_for?(service_identifier) }
+    let(:service_identifier) { "runsignup" }
+
+    context "when all credentials exist for the requested service" do
+      it { expect(result).to eq(true) }
+    end
+
+    context "when one credential is missing" do
+      before { user.credentials.for_service(service_identifier).first.destroy! }
+
+      it { expect(result).to eq(false) }
+    end
+
+    context "when the user has no credentials" do
+      before { user.credentials.delete_all }
+
+      it { expect(result).to eq(false) }
+    end
+
+    context "when the user has credentials but not for the requested service" do
+      let(:service_identifier) { "another_service" }
+
+      it { expect(result).to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
Currently, if credentials are present but invalid, the app crashes when visiting the Rattlesnake Ramble connections page.

This PR introduces much improved error handling and reporting for the Rattlesnake Ramble connector and slightly improved error reporting for RunSignup.