### PR TITLE
Connection toggle switches

### DIFF
--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -26,6 +26,9 @@ class ConnectionsController < ApplicationController
 
     @connection = @destination.connections.new(permitted_params)
     set_connection_attributes
+    # source_name is passed in as a param because it is not persisted in the database.
+    # It is needed to re-render the switch.
+    @connection.source_name = source_name
     @connection.save
 
     render_destination_create_view

--- a/app/controllers/events/connections_controller.rb
+++ b/app/controllers/events/connections_controller.rb
@@ -7,10 +7,8 @@ module Events
     def render_destination_create_view
       render "events/connections/create",
              locals: {
-               event_group: @destination.event_group,
                event: @destination,
-               external_id: params.dig(:connection, :source_id),
-               external_name: params.dig(:connection, :external_name),
+               connection: @connection,
                service_identifier: @connection.service_identifier,
              }
     end

--- a/app/javascript/controllers/event_connections/switch_controller.js
+++ b/app/javascript/controllers/event_connections/switch_controller.js
@@ -1,0 +1,53 @@
+// Creates or deletes an aid station when the checkbox is checked or unchecked
+
+import { Controller } from "@hotwired/stimulus"
+import { post, destroy } from "@rails/request.js"
+
+export default class extends Controller {
+  static values = {
+    eventGroupId: Number,
+    eventId: Number,
+    connectionId: Number,
+    sourceId: String,
+    sourceName: String,
+    serviceIdentifier: String,
+  }
+
+  connect() {
+    this.element.addEventListener("change", this.createOrDeleteConnection.bind(this))
+  }
+
+  createOrDeleteConnection(event) {
+    if (event.target.checked) {
+      this.createConnection()
+    } else {
+      this.deleteConnection()
+    }
+  }
+
+  async createConnection() {
+    const url = `/event_groups/${this.eventGroupIdValue}/events/${this.eventIdValue}/connections`;
+
+    await post(url, {
+      body: {
+        connection: {
+          service_identifier: this.serviceIdentifierValue,
+          source_id: this.sourceIdValue,
+          source_name: this.sourceNameValue,
+        },
+      },
+      responseKind: "turbo-stream",
+    })
+  }
+
+  async deleteConnection() {
+    const url = `/event_groups/${this.eventGroupIdValue}/events/${this.eventIdValue}/connections/${this.connectionIdValue}`;
+
+    await destroy(url, {
+      responseKind: "turbo-stream",
+      query: {
+        "connection[source_name]": this.sourceNameValue,
+      }
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -34,6 +34,9 @@ application.register("course-setup--splits-table", CourseSetup__SplitsTableContr
 import DropzoneController from "./dropzone_controller"
 application.register("dropzone", DropzoneController)
 
+import EventConnections__SwitchController from "./event_connections/switch_controller"
+application.register("event-connections--switch", EventConnections__SwitchController)
+
 import EventSetupController from "./event_setup_controller"
 application.register("event-setup", EventSetupController)
 

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -3,5 +3,7 @@
 class Connection < ApplicationRecord
   belongs_to :destination, polymorphic: true
 
+  attribute :source_name, :string
+
   scope :from_service, ->(service_identifier) { where(service_identifier: service_identifier) }
 end

--- a/app/views/event_groups/connections/index.html.erb
+++ b/app/views/event_groups/connections/index.html.erb
@@ -31,7 +31,7 @@
                     <h4 class="card-title mt-1"><%= service.name %></h4>
                   </div>
                   <div class="col text-end">
-                    <%= link_to fa_icon("list-check", type: :regular, text: "Manage Connection"),
+                    <%= link_to fa_icon("list-check", type: :regular, text: "Manage and Sync"),
                                 event_group_connect_service_path(presenter.event_group, service.identifier),
                                 class: "btn btn-outline-primary" %>
                   </div>

--- a/app/views/events/connections/_syncable_switch.html.erb
+++ b/app/views/events/connections/_syncable_switch.html.erb
@@ -1,23 +1,21 @@
-<%# locals: (event_group:, event:, external_id:, external_name:, service:) -%>
+<%# locals: (event:, connection:) -%>
 
-<div id='<%= "toggle_event_#{event.id}_external_id_#{external_id}" %>' class="custom-control custom-switch">
-  <% if event.connections.from_service(service.identifier).where(source_id: external_id).exists? %>
-    <%= form_with(model: [event_group, event, event.connections.from_service(service.identifier).find_by(source_id: external_id)],
-                  html: { method: :delete, data: { controller: "form-auto-submit" } }) do |f| %>
-      <%= f.hidden_field :source_id, value: external_id %>
-      <%= f.hidden_field :external_name, value: external_name %>
-      <%= check_box_tag "delete", "1", true, class: "custom-control-input", id: "delete_toggle_event_#{event.id}_external_id_#{external_id}" %>
-      <label class="custom-control-label" for='<%= "delete_toggle_event_#{event.id}_external_id_#{external_id}" %>'><%= external_name %></label>
-    <% end %>
-  <% else %>
-    <%= form_with(model: [event_group, event, ::Connection.new], html: { method: :post, data: { controller: "form-auto-submit" } }) do |f| %>
-      <%= f.hidden_field :service_identifier, value: service.identifier %>
-      <%= f.hidden_field :source_type, value: service.resource_map[Event] %>
-      <%= f.hidden_field :source_id, value: external_id %>
-      <%= f.hidden_field :external_name, value: external_name %>
-
-      <%= check_box_tag "create", "0", false, class: "custom-control-input", id: "create_toggle_event_#{event.id}_external_id_#{external_id}" %>
-      <label class="custom-control-label" for='<%= "create_toggle_event_#{event.id}_external_id_#{external_id}" %>'><%= external_name %></label>
-    <% end %>
-  <% end %>
+<div class="d-flex" id='<%= dom_id(connection, "switch_wrapper_#{connection.service_identifier}") %>'>
+  <div class="form-check form-switch">
+    <label class="form-check-label" for='<%= dom_id(connection, "switch_#{connection.service_identifier}") %>'><%= connection.source_name %></label>
+    <input class="form-check-input"
+           type="checkbox"
+           id="<%= dom_id(connection, "switch_#{connection.service_identifier}") %>"
+           data-controller="event-connections--switch tooltip"
+           data-bs-placement="top"
+           data-bs-original-title="<%= connection.persisted? ? 'Remove this connection' : 'Create this connection' %>"
+           data-event-connections--switch-event-group-id-value="<%= event.event_group_id %>"
+           data-event-connections--switch-event-id-value="<%= event.id %>"
+           data-event-connections--switch-connection-id-value="<%= connection.id %>"
+           data-event-connections--switch-source-id-value="<%= connection.source_id %>"
+           data-event-connections--switch-source-name-value="<%= connection.source_name %>"
+           data-event-connections--switch-service-identifier-value="<%= connection.service_identifier %>"
+           <%= connection.persisted? ? "checked" : "" %>
+    >
+  </div>
 </div>

--- a/app/views/events/connections/_toggle_switch.html.erb
+++ b/app/views/events/connections/_toggle_switch.html.erb
@@ -1,11 +1,11 @@
 <%# locals: (event:, connection:) -%>
 
-<div class="d-flex" id='<%= dom_id(connection, "switch_wrapper_#{connection.service_identifier}") %>'>
+<div class="d-flex" id='<%= dom_id(event, "switch_wrapper_#{connection.source_id}") %>'>
   <div class="form-check form-switch">
-    <label class="form-check-label" for='<%= dom_id(connection, "switch_#{connection.service_identifier}") %>'><%= connection.source_name %></label>
+    <label class="form-check-label" for='<%= dom_id(event, "switch_#{connection.source_id}") %>'><%= connection.source_name %></label>
     <input class="form-check-input"
            type="checkbox"
-           id="<%= dom_id(connection, "switch_#{connection.service_identifier}") %>"
+           id="<%= dom_id(event, "switch_#{connection.source_id}") %>"
            data-controller="event-connections--switch tooltip"
            data-bs-placement="top"
            data-bs-original-title="<%= connection.persisted? ? 'Remove this connection' : 'Create this connection' %>"

--- a/app/views/events/connections/_toggle_switch.html.erb
+++ b/app/views/events/connections/_toggle_switch.html.erb
@@ -2,7 +2,7 @@
 
 <div class="d-flex"
      data-controller="highlight"
-     data-highlight-timestamp-value="<%= connection.updated_at.to_i %>"
+     data-highlight-timestamp-value="<%= connection.destroyed? ? Time.current.to_i : connection.updated_at.to_i %>"
      data-highlight-fast-value="true"
      id='<%= dom_id(event, "switch_wrapper_#{connection.source_id}") %>'>
   <div class="form-check form-switch">

--- a/app/views/events/connections/_toggle_switch.html.erb
+++ b/app/views/events/connections/_toggle_switch.html.erb
@@ -1,6 +1,10 @@
 <%# locals: (event:, connection:) -%>
 
-<div class="d-flex" id='<%= dom_id(event, "switch_wrapper_#{connection.source_id}") %>'>
+<div class="d-flex"
+     data-controller="highlight"
+     data-highlight-timestamp-value="<%= connection.updated_at.to_i %>"
+     data-highlight-fast-value="true"
+     id='<%= dom_id(event, "switch_wrapper_#{connection.source_id}") %>'>
   <div class="form-check form-switch">
     <label class="form-check-label" for='<%= dom_id(event, "switch_#{connection.source_id}") %>'><%= connection.source_name %></label>
     <input class="form-check-input"

--- a/app/views/events/connections/create.turbo_stream.erb
+++ b/app/views/events/connections/create.turbo_stream.erb
@@ -1,15 +1,15 @@
-<%# locals: (event_group:, event:, external_id:, external_name:, service_identifier:) -%>
+<%# locals: (event:, connection:, service_identifier:) -%>
 
-<%= turbo_stream.replace "toggle_event_#{event.id}_external_id_#{external_id}",
+<%= turbo_stream.replace dom_id(connection, "switch_wrapper_#{connection.service_identifier}"),
                          partial: "events/connections/syncable_switch",
                          locals: {
-                           event_group: event_group,
                            event: event,
-                           external_id: external_id,
-                           external_name: external_name,
-                           service: ::Connectors::Service::BY_IDENTIFIER[service_identifier]
+                           connection: connection,
                          } %>
 
 <%= turbo_stream.replace dom_id(event, :preview_sync),
                          partial: "events/connectors/services/preview_sync_button",
-                         locals: { event: event, service_identifier: service_identifier } %>
+                         locals: {
+                           event: event,
+                           service_identifier: service_identifier,
+                         } %>

--- a/app/views/events/connections/create.turbo_stream.erb
+++ b/app/views/events/connections/create.turbo_stream.erb
@@ -1,7 +1,7 @@
 <%# locals: (event:, connection:, service_identifier:) -%>
 
-<%= turbo_stream.replace dom_id(connection, "switch_wrapper_#{connection.service_identifier}"),
-                         partial: "events/connections/syncable_switch",
+<%= turbo_stream.replace dom_id(event, "switch_wrapper_#{connection.source_id}"),
+                         partial: "events/connections/toggle_switch",
                          locals: {
                            event: event,
                            connection: connection,

--- a/app/views/events/connectors/services/_sync_efforts_card.html.erb
+++ b/app/views/events/connectors/services/_sync_efforts_card.html.erb
@@ -27,7 +27,7 @@
         <div class="col">
           <label class="fw-bold mb-2">Select corresponding external events</label>
           <% presenter.connections_with_blanks(event).each do |connection| %>
-            <%= render partial: "events/connections/syncable_switch",
+            <%= render partial: "events/connections/toggle_switch",
                        locals: {
                          event: event,
                          connection: connection,

--- a/app/views/events/connectors/services/_sync_efforts_card.html.erb
+++ b/app/views/events/connectors/services/_sync_efforts_card.html.erb
@@ -25,15 +25,12 @@
     <div class="card-body">
       <div class="row">
         <div class="col">
-          <label>Select corresponding external events</label>
-          <% presenter.external_events(event).each do |external_event| %>
+          <label class="fw-bold mb-2">Select corresponding external events</label>
+          <% presenter.connections_with_blanks(event).each do |connection| %>
             <%= render partial: "events/connections/syncable_switch",
                        locals: {
-                         event_group: presenter.event_group,
                          event: event,
-                         external_id: external_event.id,
-                         external_name: external_event.name,
-                         service: presenter.service,
+                         connection: connection,
                        } %>
           <% end %>
         </div>


### PR DESCRIPTION
Currently, we are using checkboxes for connections. Switches would provide a better UI that better indicates that the connections are persisted when chosen.

This PR changes the checkboxes to switches. It uses a stimulus controller to submit create and delete requests, similar to how aid stations are created and deleted in the event course setup screen.