### PR TITLE
Handle RunSignup connector errors

### DIFF
--- a/app/controllers/events/connectors/services_controller.rb
+++ b/app/controllers/events/connectors/services_controller.rb
@@ -5,8 +5,8 @@ module Events
 
     # GET /events/1/connector_services/:service_identifier/preview_sync
     def preview_sync
-      presenter = ::EventSyncPreviewPresenter.new(@connectable, view_context, previewer: event_syncing_interactor)
-      render :preview_sync, locals: { event: @connectable, presenter: presenter }
+      preview_presenter = ::EventSyncPreviewPresenter.new(@connectable, view_context, previewer: event_syncing_interactor)
+      render :preview_sync, locals: { event: @connectable, presenter: preview_presenter }
     end
 
     # POST /events/1/connector_services/:service_identifier/sync

--- a/app/presenters/connect_service_presenter.rb
+++ b/app/presenters/connect_service_presenter.rb
@@ -63,6 +63,10 @@ class ConnectServicePresenter < BasePresenter
     service&.name
   end
 
+  def successful_connection?
+    all_credentials_present? && error_message.blank?
+  end
+
   def connection
     @connection ||= event_group.connections.find_or_initialize_by(service_identifier: service_identifier) do |connection|
       connection.source_type = event_group_source_type

--- a/app/presenters/event_sync_preview_presenter.rb
+++ b/app/presenters/event_sync_preview_presenter.rb
@@ -29,12 +29,12 @@ class EventSyncPreviewPresenter
     preview_response.resources[:updated_efforts]
   end
 
+  def preview_response
+    @preview_response ||= previewer.preview(event, current_user)
+  end
+
   private
 
   attr_reader :previewer, :view_context
   delegate :current_user, to: :view_context, private: true
-
-  def preview_response
-    @preview_response ||= previewer.preview(event, current_user)
-  end
 end

--- a/app/services/interactors/errors.rb
+++ b/app/services/interactors/errors.rb
@@ -22,6 +22,11 @@ module Interactors
        detail: {error_message: "Bib number #{bib_number} for filename #{filename} was not found"}}
     end
 
+    def connectors_base_error(exception)
+      {title: "A connection error occurred",
+       detail: {exception: exception.message}}
+    end
+
     def database_error(error_message)
       {title: "A database error occurred",
        detail: {error_message: error_message}}

--- a/app/services/interactors/sync_rattlesnake_ramble_entries.rb
+++ b/app/services/interactors/sync_rattlesnake_ramble_entries.rb
@@ -113,7 +113,7 @@ module Interactors
       response.message = if errors.present?
                             "Sync completed with errors"
                           elsif preview_only
-                            "Sync preview completed successfully"
+                            "Preview completed successfully"
                           else
                             "Sync completed successfully"
                          end

--- a/app/services/interactors/sync_runsignup_participants.rb
+++ b/app/services/interactors/sync_runsignup_participants.rb
@@ -61,7 +61,11 @@ module Interactors
 
     def find_and_create_entrants
       participants = runsignup_event_ids.flat_map do |runsignup_event_id|
-        ::Connectors::Runsignup::FetchEventParticipants.perform(race_id: runsignup_race_id, event_id: runsignup_event_id, user: current_user)
+        ::Connectors::Runsignup::FetchEventParticipants.perform(
+          race_id: runsignup_race_id,
+          event_id: runsignup_event_id,
+          user: current_user,
+        )
       end
 
       participants.sort_by! { |participant| [participant.last_name, participant.first_name] }

--- a/app/views/event_groups/connect_service/_event_cards.html.erb
+++ b/app/views/event_groups/connect_service/_event_cards.html.erb
@@ -1,8 +1,0 @@
-<%# locals: (connect_service_presenter:) %>
-
-<div id="event_cards">
-  <%= render partial: "events/connectors/services/sync_efforts_card",
-             locals: { presenter: connect_service_presenter },
-             collection: connect_service_presenter.event_group.events.order(:scheduled_start_time),
-             as: :event %>
-</div>

--- a/app/views/event_groups/connect_service/_events_list.html.erb
+++ b/app/views/event_groups/connect_service/_events_list.html.erb
@@ -1,0 +1,19 @@
+<%# locals: (connect_service_presenter:) %>
+
+<% if connect_service_presenter.successful_connection? %>
+  <hr/>
+  <h4 class="fw-bold">Events</h4>
+  <%= render partial: "events/connectors/services/sync_efforts_card",
+             locals: { presenter: connect_service_presenter },
+             collection: connect_service_presenter.event_group.events.order(:scheduled_start_time),
+             as: :event %>
+
+  <hr/>
+  <div class="row mb-3">
+    <div class="col">
+      <%= link_to "Back to connections",
+                  event_group_connections_path(connect_service_presenter.event_group),
+                  class: "btn btn-outline-secondary" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/event_groups/connect_service/show.html.erb
+++ b/app/views/event_groups/connect_service/show.html.erb
@@ -21,22 +21,11 @@
                connect_service_presenter: connect_service_presenter
              } %>
 
-  <% if connect_service_presenter.successful_connection? %>
-    <hr/>
-    <h4 class="fw-bold">Events</h4>
-    <%= render partial: "event_groups/connect_service/event_cards",
+  <div id="<%= dom_id(event_group_setup_presenter.event_group, :connect_service_events_list) %>">
+    <%= render partial: "events_list",
                locals: {
                  event_group_setup_presenter: event_group_setup_presenter,
                  connect_service_presenter: connect_service_presenter
                } %>
-
-    <hr/>
-    <div class="row mb-3">
-      <div class="col">
-        <%= link_to "Back to connections",
-                    event_group_connections_path(event_group_setup_presenter.event_group),
-                    class: "btn btn-outline-secondary" %>
-      </div>
-    </div>
-  <% end %>
+  </div>
 </article>

--- a/app/views/event_groups/connect_service/show.html.erb
+++ b/app/views/event_groups/connect_service/show.html.erb
@@ -21,20 +21,22 @@
                connect_service_presenter: connect_service_presenter
              } %>
 
-  <hr/>
-  <h4 class="fw-bold">Events</h4>
-  <%= render partial: "event_groups/connect_service/event_cards",
-             locals: {
-               event_group_setup_presenter: event_group_setup_presenter,
-               connect_service_presenter: connect_service_presenter
-             } %>
+  <% if connect_service_presenter.successful_connection? %>
+    <hr/>
+    <h4 class="fw-bold">Events</h4>
+    <%= render partial: "event_groups/connect_service/event_cards",
+               locals: {
+                 event_group_setup_presenter: event_group_setup_presenter,
+                 connect_service_presenter: connect_service_presenter
+               } %>
 
-  <hr/>
-  <div class="row mb-3">
-    <div class="col">
-      <%= link_to "Back to connections",
-                  event_group_connections_path(event_group_setup_presenter.event_group),
-                  class: "btn btn-outline-secondary" %>
+    <hr/>
+    <div class="row mb-3">
+      <div class="col">
+        <%= link_to "Back to connections",
+                    event_group_connections_path(event_group_setup_presenter.event_group),
+                    class: "btn btn-outline-secondary" %>
+      </div>
     </div>
-  </div>
+  <% end %>
 </article>

--- a/app/views/event_groups/connections/create.turbo_stream.erb
+++ b/app/views/event_groups/connections/create.turbo_stream.erb
@@ -11,8 +11,8 @@
                            connect_service_presenter: connect_service_presenter,
                          }) %>
 
-<%= turbo_stream.replace("event_cards",
-                         partial: "event_groups/connect_service/event_cards",
-                         locals: {
-                           connect_service_presenter: connect_service_presenter,
-                         }) %>
+<%= turbo_stream.update(dom_id(event_group, :connect_service_events_list),
+                        partial: "event_groups/connect_service/events_list",
+                        locals: {
+                          connect_service_presenter: connect_service_presenter,
+                        }) %>

--- a/app/views/event_groups/connections/destroy.turbo_stream.erb
+++ b/app/views/event_groups/connections/destroy.turbo_stream.erb
@@ -11,8 +11,8 @@
                            connect_service_presenter: connect_service_presenter,
                          }) %>
 
-<%= turbo_stream.replace("event_cards",
-                         partial: "event_groups/connect_service/event_cards",
-                         locals: {
-                           connect_service_presenter: connect_service_presenter,
-                         }) %>
+<%= turbo_stream.update(dom_id(event_group, :connect_service_events_list),
+                        partial: "event_groups/connect_service/events_list",
+                        locals: {
+                          connect_service_presenter: connect_service_presenter,
+                        }) %>

--- a/app/views/events/connectors/services/_sync_efforts_card.html.erb
+++ b/app/views/events/connectors/services/_sync_efforts_card.html.erb
@@ -9,16 +9,8 @@
         <div class="col">
           <h4 class="mt-1"><%= event.name %></h4>
         </div>
-        <div class="col">
-          <% if interactor_response.present? %>
-            <div class="text-end">
-              <% if interactor_response.successful? %>
-                <%= fa_icon("circle-check", type: :regular, class: "text-success", text: interactor_response.message) %>
-              <% else %>
-                <%= fa_icon("triangle-xmark", type: :solid, class: "text-warning", text: interactor_response.message_with_error_report) %>
-              <% end %>
-            </div>
-          <% end %>
+        <div class="col" id="<%= dom_id(event, :sync_efforts_response) %>">
+          <%= render partial: "events/connectors/services/sync_efforts_response", locals: { interactor_response: interactor_response } %>
         </div>
       </div>
     </div>

--- a/app/views/events/connectors/services/_sync_efforts_response.html.erb
+++ b/app/views/events/connectors/services/_sync_efforts_response.html.erb
@@ -1,0 +1,13 @@
+<%# locals: (interactor_response:) -%>
+
+<% if interactor_response.present? %>
+  <div class="text-end">
+    <% if interactor_response.successful? %>
+      <%= fa_icon("circle-check", type: :regular, class: "text-success", text: interactor_response.message) %>
+    <% else %>
+      <% interactor_response.errors.each do |error| %>
+        <%= fa_icon("circle-xmark", type: :solid, class: "text-danger", text: [error.dig(:title), error.dig(:detail, :exception)].compact.join(": ")) %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/events/connectors/services/preview_sync.turbo_stream.erb
+++ b/app/views/events/connectors/services/preview_sync.turbo_stream.erb
@@ -11,3 +11,9 @@
                         locals: {
                           presenter: presenter,
                         }) %>
+
+<%= turbo_stream.update(dom_id(event, :sync_efforts_response),
+                        partial: "events/connectors/services/sync_efforts_response",
+                        locals: {
+                          interactor_response: presenter.preview_response,
+                        }) %>

--- a/lib/connectors/runsignup/client.rb
+++ b/lib/connectors/runsignup/client.rb
@@ -26,14 +26,19 @@ class Connectors::Runsignup::Client
   private
 
   attr_reader :user
-  attr_accessor :request, :response
+  attr_accessor :request, :response, :response_code, :raw_error_message
 
   # @return [String]
   def make_request
     self.response = ::RestClient.get(url, { params: params })
-    check_response_validity!
+    self.response_code = response.code
 
     response.body
+  rescue RestClient::Exception => e
+    self.response_code = e.http_code
+    self.raw_error_message = e.message
+  ensure
+    check_response_validity!
   end
 
   # @return [Hash]
@@ -66,13 +71,13 @@ class Connectors::Runsignup::Client
   end
 
   def check_response_validity!
-    case response.code
+    case response_code
     when 401
-      raise Connectors::Errors::NotAuthenticated
+      raise Connectors::Errors::NotAuthenticated, "Credentials were not accepted"
     when 403
-      raise Connectors::Errors::NotAuthorized
+      raise Connectors::Errors::NotAuthorized, "Access is not authorized"
     when 404
-      raise Connectors::Errors::NotFound
+      raise Connectors::Errors::NotFound, "Resource not found"
     when 200
       if runsignup_error_code.present?
         if RUNSIGNUP_ERROR_MAPPING[runsignup_error_code].present?


### PR DESCRIPTION
Currently, we can link and sync with the RunSignup connector, but we don't get error reporting when there is a problem, and it's possible to get a 500 response.

This PR adds error handling and should make the RunSignup connector usable as a beta feature for end users.