### PR TITLE
Add a callout to the Raw Times index view when no raw times exist

### DIFF
--- a/app/views/event_groups/_raw_times_list.html.erb
+++ b/app/views/event_groups/_raw_times_list.html.erb
@@ -30,15 +30,28 @@
     </div>
   <% end %>
 
-  <div class="row">
-    <div class="col-xs-8">
-      <% if view_object.filtered_raw_times_count == view_object.raw_times_count %>
-        <h4><%= "#{view_object.raw_times_count} raw times" %></h4>
-      <% else %>
-        <h4><%= "Showing #{view_object.filtered_raw_times_unpaginated_count} of #{view_object.raw_times_count} raw times" %></h4>
-      <% end %>
+  <% if view_object.raw_times.none? %>
+    <%= render partial: "shared/callout_with_link",
+               locals: {
+                 callout_color: "info",
+                 icon_color: "info",
+                 icon_name: "circle-info",
+                 main_text: t("raw_times.index.no_raw_times_main"),
+                 detail_paragraphs: [t("raw_times.index.no_raw_times_detail_1"), t("raw_times.index.no_raw_times_detail_2")],
+                 link: link_to("Enable or Disable Live", setup_summary_event_group_path(view_object.event_group), class: "btn btn-outline-info"),
+               } %>
+    <br/>
+  <% else %>
+    <div class="row">
+      <div class="col-xs-8">
+        <% if view_object.filtered_raw_times_count == view_object.raw_times_count %>
+          <h4><%= "#{view_object.raw_times_count} raw times" %></h4>
+        <% else %>
+          <h4><%= "Showing #{view_object.filtered_raw_times_unpaginated_count} of #{view_object.raw_times_count} raw times" %></h4>
+        <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <table class="table table-striped">
     <thead>
@@ -78,13 +91,13 @@
                    home_time_zone: view_object.home_time_zone,
                  }
       %>
-    <% else %>
+      </tbody>
+    <% elsif view_object.raw_times.exists? %>
       <tr class="fw-bold">
         <td colspan="100">No results match that search.</td>
       </tr>
     <% end %>
-    </tbody>
-  </table>
+    </table>
 
   <%= render "shared/pager", next_page_url: @presenter.next_page_url %>
 </article>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -35,6 +35,12 @@ en:
     new:
       callout_detail_paragraph: 'Import Jobs run in the background, allowing you to do other work while the import is ongoing. You can check the status of any of your import jobs at any time by clicking "Imports" on the top menu bar.'
 
+  raw_times:
+    index:
+      no_raw_times_main: "No raw times have been recorded for this Event Group"
+      no_raw_times_detail_1: "When Raw Times are submitted, whether or not they are valid and whether or not they are converted to Split Times for display to the public, they will appear here."
+      no_raw_times_detail_2: "When your Event Group has Live Entry enabled, you can use OST Remote to submit Raw Times from your iOS device or the Live Entry view to submit Raw Times from the website. If Live Entry is enabled for your Event Group, you will see the \"Live Updating\" indicator at the top of the page, meaning that Raw Times will appear here without a page refresh."
+
   subscriptions:
     tooltips:
       confirmed: "This subscription is confirmed."


### PR DESCRIPTION
The Raw Times index view is a bit confusing when no Raw Times yet exist.

This PR adds an explanatory callout to the view when no Raw Times exist. The callout also provides a link to the Setup Summary page, where Live Entry can be enabled or disabled.