### PR TITLE
Display an error if no RunSignup events are returned

### DIFF
--- a/app/presenters/connect_service_presenter.rb
+++ b/app/presenters/connect_service_presenter.rb
@@ -141,8 +141,16 @@ class ConnectServicePresenter < BasePresenter
   end
 
   def all_runsignup_events
-    race_id = event_group.connections.from_service(:runsignup).where(source_type: "Race").first&.source_id
-    ::Connectors::Runsignup::FetchRaceEvents.perform(race_id: race_id, user: current_user)
+    if runsignup_race_id.blank?
+      @error_message = "RunSignup Race ID is required"
+      return []
+    end
+
+    ::Connectors::Runsignup::FetchRaceEvents.perform(race_id: runsignup_race_id, user: current_user)
+  end
+
+  def runsignup_race_id
+    event_group.connections.from_service(:runsignup).where(source_type: "Race").first&.source_id
   end
 
   def event_group_source_type

--- a/app/views/event_groups/connect_service/runsignup/_event_group_card.html.erb
+++ b/app/views/event_groups/connect_service/runsignup/_event_group_card.html.erb
@@ -12,6 +12,10 @@
         <% else %>
           <%= fa_icon("circle-xmark", type: :regular, text: "Credentials are missing", class: "text-danger") %>
         <% end %>
+        <% if connect_service_presenter.error_message.present? %>
+          <br/>
+          <%= fa_icon("circle-xmark", type: :regular, text: connect_service_presenter.error_message, class: "text-danger") %>
+        <% end %>
       </div>
     </div>
   </div>
@@ -22,5 +26,32 @@
                  connection: connect_service_presenter.connection,
                  service: connect_service_presenter.service,
                } %>
+    <% if connect_service_presenter.error_message.blank? %>
+      <div class="px-3">
+        <% if connect_service_presenter.no_sources_found? %>
+          <%= render partial: "shared/callout_with_link",
+                     locals: {
+                       callout_color: "warning",
+                       icon_name: "triangle-exclamation",
+                       icon_color: "warning",
+                       detail_paragraphs: t(".no_events_returned")
+                     } %>
+        <% elsif connect_service_presenter.no_sources_in_time_frame? %>
+          <%= render partial: "shared/callout_with_link",
+                     locals: {
+                       callout_color: "warning",
+                       icon_name: "triangle-exclamation",
+                       icon_color: "warning",
+                       detail_paragraphs: t(".no_events_in_timeframe", event_group_name: connect_service_presenter.event_group_name)
+                     } %>
+        <% else %>
+          <%= render partial: "shared/callout_with_link",
+                     locals: {
+                       icon_name: "circle-check",
+                       detail_paragraphs: t(".connect_to_events")
+                     } %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/event_groups/connect_service/runsignup/_event_group_card.html.erb
+++ b/app/views/event_groups/connect_service/runsignup/_event_group_card.html.erb
@@ -8,9 +8,9 @@
       </div>
       <div class="col text-end">
         <% if connect_service_presenter.all_credentials_present? %>
-          <%= fa_icon("circle-check", type: :regular, text: "Credentials are present", class: "text-success") %>
+          <%= fa_icon("circle-check", type: :regular, text: t(".credentials_present"), class: "text-success") %>
         <% else %>
-          <%= fa_icon("circle-xmark", type: :regular, text: "Credentials are missing", class: "text-danger") %>
+          <%= fa_icon("circle-xmark", type: :regular, text: t(".credentials_missing"), class: "text-danger") %>
         <% end %>
         <% if connect_service_presenter.error_message.present? %>
           <br/>

--- a/app/views/event_groups/connections/_form.html.erb
+++ b/app/views/event_groups/connections/_form.html.erb
@@ -13,7 +13,11 @@
       </div>
       <div class="col-12 col-lg-3 my-2 text-lg-end">
         <% if connection.new_record? %>
-          <%= form.submit "Save", class: "btn btn-primary" %>
+          <%= form.submit "Save",
+                          data: {
+                            turbo_submits_with: "Saving...",
+                          },
+                          class: "btn btn-primary" %>
         <% else %>
           <%= link_to "Remove",
                       event_group_connection_path(connection.destination, connection),

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -6,6 +6,12 @@ en:
           main_text: "Using Connections in OpenSplitTime"
           detail_paragraph_1: "Connections provide a simple way to keep your data synchronized with an outside source (like Runsignup) or an internal source (like an OpenSplitTime Lottery)."
           detail_paragraph_2: "You can manage connections for your Event Group from this page."
+    connect_service:
+      runsignup:
+        event_group_card:
+          no_events_returned: "No RunSignup events were returned. Please check the Race ID and ensure your credentials are valid."
+          connect_to_events: "Connect your OpenSplitTime Events below to the corresponding RunSignup Events."
+          no_events_in_timeframe: "External events were returned, but none were within the timeframe of %{event_group_name}. Please check the RunSignup Race ID, the date of your Event in OpenSplitTime, and the date of the Race in RunSignup and try again."
     setup:
       enable_live_confirm: "NOTE: This will enable live entry actions for %{event_group_name}, and will also enable live follower notifications by email and SMS text when new times are added. Are you sure you want to proceed?"
       disable_live_confirm: "NOTE: This will suspend all live entry actions for %{event_group_name}, including any that may be in process, and will disable live follower notifications by email and SMS text when new times are added. Are you sure you want to proceed?"

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -9,6 +9,8 @@ en:
     connect_service:
       runsignup:
         event_group_card:
+          credentials_present: "Credentials are present"
+          credentials_missing: "Credentials are missing"
           no_events_returned: "No RunSignup events were returned. Please check the Race ID and ensure your credentials are valid."
           connect_to_events: "Connect your OpenSplitTime Events below to the corresponding RunSignup Events."
           no_events_in_timeframe: "External events were returned, but none were within the timeframe of %{event_group_name}. Please check the RunSignup Race ID, the date of your Event in OpenSplitTime, and the date of the Race in RunSignup and try again."

--- a/lib/connectors/errors.rb
+++ b/lib/connectors/errors.rb
@@ -7,4 +7,5 @@ module Connectors::Errors
   class NotAuthorized < Base; end
   class NotFound < Base; end
   class BadRequest < Base; end
+  class BadConnection < Base; end
 end

--- a/lib/connectors/runsignup/client.rb
+++ b/lib/connectors/runsignup/client.rb
@@ -71,6 +71,8 @@ class Connectors::Runsignup::Client
   end
 
   def check_response_validity!
+    raise Connectors::Errors::BadConnection, "The service did not respond; please check your internet connection" if response.nil?
+
     case response_code
     when 401
       raise Connectors::Errors::NotAuthenticated, "Credentials were not accepted"
@@ -87,7 +89,7 @@ class Connectors::Runsignup::Client
         end
       end
     else
-      raise Connectors::Errors::BadRequest, "#{response.code}: #{response.body}"
+      raise Connectors::Errors::BadRequest, "#{response_code}: #{response.body}"
     end
   end
 


### PR DESCRIPTION
Currently, error reporting from the RunSignup connector is less than ideal. In particular, there are some situations where no events are returned but no error is reported.

This PR adds better reporting in any of various situations, for example, if credentials are not valid or if events are not returned.

<details><summary>Screenshots</summary>
<p>

#### Credentials not valid

<img width="1364" alt="Screenshot 2023-09-24 at 3 12 24 PM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/f44992be-955a-4ba1-a4d6-f4ce4739361a">

#### Race ID not provided
<img width="1364" alt="Screenshot 2023-09-24 at 3 12 47 PM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/8a7ba495-8888-48e4-9719-2a5e20cea873">

#### Race not found
<img width="1364" alt="Screenshot 2023-09-24 at 3 13 10 PM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/18b3b976-d9a0-4c5b-a7ab-f7d90883b726">

#### No Events in the relevant timeframe
<img width="1364" alt="Screenshot 2023-09-24 at 3 13 31 PM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/bd624334-9264-484e-8303-6ab8f57d8935">

#### Events returned and ready to connect
<img width="1364" alt="Screenshot 2023-09-24 at 3 14 16 PM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/04d93487-ea6f-4615-9220-8bf5d5d6871b">


</p>
</details> 

Resolves #1158 