### PR TITLE
Event preview should not be syncable if an error exists

### DIFF
--- a/app/presenters/event_sync_preview_presenter.rb
+++ b/app/presenters/event_sync_preview_presenter.rb
@@ -14,7 +14,7 @@ class EventSyncPreviewPresenter
   end
 
   def syncable?
-    created_efforts.present? || deleted_efforts.present? || updated_efforts.present?
+    preview_response.successful? && (created_efforts.present? || deleted_efforts.present? || updated_efforts.present?)
   end
 
   def created_efforts


### PR DESCRIPTION
Currently, if a connector service sync preview results in an error, the user has the option to click the "Sync" button. This would often result in all entrants being deleted, because errored previews indicate no records were returned.

This PR makes a simple change that requires the interactor response contain no errors in order for a connector preview to be syncable.

<details><summary>Screenshots</summary>
<p>

#### Before: Preview errors but Sync button is available
<img width="1364" alt="Screenshot 2023-09-24 at 3 53 54 PM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/83ef0cec-a29a-4d97-8ed9-feee3a70de83">


#### After: Preview errors and Sync button is not available
<img width="1364" alt="Screenshot 2023-09-24 at 3 53 13 PM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/980085fc-50cd-4adc-b59f-5d307a4ad87d">


</p>
</details> 