### PR TITLE
Adilas import - add update option

### DIFF
--- a/lib/etl/importer.rb
+++ b/lib/etl/importer.rb
@@ -21,21 +21,21 @@ module ETL
     def import
       case format
       when :race_result_full
-        import_with(source_data, Extractors::RaceResultStrategy, Transformers::RaceResultSplitTimesStrategy, Loaders::InsertStrategy, {delete_blank_times: true}.merge(options))
+        import_with(source_data, Extractors::RaceResultStrategy, Transformers::RaceResultSplitTimesStrategy, Loaders::InsertStrategy, { delete_blank_times: true }.merge(options))
       when :race_result_entrants
-        import_with(source_data, Extractors::RaceResultStrategy, Transformers::RaceResultEntrantsStrategy, Loaders::UpsertStrategy, {delete_blank_times: false, unique_key: [:event_id, :bib_number]}.merge(options))
+        import_with(source_data, Extractors::RaceResultStrategy, Transformers::RaceResultEntrantsStrategy, Loaders::UpsertStrategy, { delete_blank_times: false, unique_key: [:event_id, :bib_number] }.merge(options))
       when :race_result_api_times
-        import_with(source_data, Extractors::RaceResultApiStrategy, Transformers::RaceResultApiSplitTimesStrategy, Loaders::SplitTimeUpsertStrategy, {delete_blank_times: true}.merge(options))
+        import_with(source_data, Extractors::RaceResultApiStrategy, Transformers::RaceResultApiSplitTimesStrategy, Loaders::SplitTimeUpsertStrategy, { delete_blank_times: true }.merge(options))
       when :adilas_bear_times
-        import_with(source_data, Extractors::AdilasBearHTMLStrategy, Transformers::AdilasBearStrategy, Loaders::InsertStrategy, options)
+        import_with(source_data, Extractors::AdilasBearHTMLStrategy, Transformers::AdilasBearStrategy, Loaders::UpsertStrategy, { unique_key: [:event_id, :bib_number] }.merge(options))
       when :its_your_race_times
         import_with(source_data, Extractors::ItsYourRaceHTMLStrategy, Transformers::ElapsedIncrementalAidStrategy, Loaders::InsertStrategy, options)
       when :csv_splits
-        import_with(source_data, Extractors::CsvFileStrategy, Transformers::GenericResourcesStrategy, Loaders::UpsertStrategy, {model: :split}.merge(default_unique_key(:split)).merge(options))
+        import_with(source_data, Extractors::CsvFileStrategy, Transformers::GenericResourcesStrategy, Loaders::UpsertStrategy, { model: :split }.merge(default_unique_key(:split)).merge(options))
       when :csv_raw_times
-        import_with(source_data, Extractors::CsvFileStrategy, Transformers::GenericResourcesStrategy, Loaders::UpsertStrategy, {model: :raw_time}.merge(default_unique_key(:raw_time)).merge(options))
+        import_with(source_data, Extractors::CsvFileStrategy, Transformers::GenericResourcesStrategy, Loaders::UpsertStrategy, { model: :raw_time }.merge(default_unique_key(:raw_time)).merge(options))
       when :csv_efforts
-        import_with(source_data, Extractors::CsvFileStrategy, Transformers::GenericResourcesStrategy, Loaders::UpsertStrategy, {model: :effort}.merge(default_unique_key(:effort)).merge(options))
+        import_with(source_data, Extractors::CsvFileStrategy, Transformers::GenericResourcesStrategy, Loaders::UpsertStrategy, { model: :effort }.merge(default_unique_key(:effort)).merge(options))
       when :jsonapi_batch
         import_with(source_data, Extractors::PassThroughStrategy, Transformers::JsonapiBatchStrategy, Loaders::UpsertStrategy, options)
       else
@@ -72,7 +72,7 @@ module ETL
     end
 
     def default_unique_key(model_name)
-      {unique_key: params_class(model_name).unique_key}
+      { unique_key: params_class(model_name).unique_key }
     end
 
     def params_class(model_name)

--- a/lib/etl/importer.rb
+++ b/lib/etl/importer.rb
@@ -27,7 +27,9 @@ module ETL
       when :race_result_api_times
         import_with(source_data, Extractors::RaceResultApiStrategy, Transformers::RaceResultApiSplitTimesStrategy, Loaders::SplitTimeUpsertStrategy, { delete_blank_times: true }.merge(options))
       when :adilas_bear_times
-        import_with(source_data, Extractors::AdilasBearHTMLStrategy, Transformers::AdilasBearStrategy, Loaders::UpsertStrategy, { unique_key: [:event_id, :bib_number] }.merge(options))
+        import_with(source_data, Extractors::AdilasBearHTMLStrategy, Transformers::AdilasBearStrategy, Loaders::InsertStrategy, options)
+      when :adilas_bear_times_update
+        import_with(source_data, Extractors::AdilasBearHTMLStrategy, Transformers::AdilasBearStrategy, Loaders::SplitTimeUpsertStrategy, options)
       when :its_your_race_times
         import_with(source_data, Extractors::ItsYourRaceHTMLStrategy, Transformers::ElapsedIncrementalAidStrategy, Loaders::InsertStrategy, options)
       when :csv_splits

--- a/lib/tasks/pull_event_data.rake
+++ b/lib/tasks/pull_event_data.rake
@@ -27,7 +27,7 @@ namespace :pull_event do
     start_time = Time.current
     begin_id = args[:begin_adilas_id]&.to_i
     end_id = args[:end_adilas_id]&.to_i
-    unless begin_id && end_id && begin_id&.positive? && end_id >= begin_id
+    unless begin_id.present? && end_id.present? && begin_id.positive? && end_id >= begin_id
       abort("Aborted: combination of begin adilas id #{begin_id} and end adilas id #{end_id} is invalid")
     end
 

--- a/spec/lib/etl/loaders/upsert_strategy_spec.rb
+++ b/spec/lib/etl/loaders/upsert_strategy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ETL::Loaders::UpsertStrategy do


### PR DESCRIPTION
We use a special importer for The Bear 100 times. Currently, that importer uses a pure insert strategy, meaning that to update times, the existing effort must be destroyed. 

This PR adds an update-only option to the adilas import strategy.