### PR TITLE
Better reactivity for spread navigation elements

### DIFF
--- a/app/views/event_groups/_event_widget.html.erb
+++ b/app/views/event_groups/_event_widget.html.erb
@@ -1,11 +1,12 @@
-<!-- Event Selector Widget: Requires locals :events and :current_event -->
+<%# locals: (events:, current_event:) %>
+
 <% if events&.many? %>
-  <div class="col-auto">
+  <div class="col-12 col-md mb-2 mb-md-0">
     <div class="btn-group btn-group-ost">
       <% events.each do |event| %>
         <%= link_to event.guaranteed_short_name,
                     request.params.merge(id: event.to_param, page: nil),
-                    class: "btn #{ event == current_event ? 'btn-primary' : 'btn-outline-secondary' }" %>
+                    class: "btn #{ event == current_event ? "btn-primary" : "btn-outline-secondary" }" %>
       <% end %>
     </div>
   </div>

--- a/app/views/event_groups/_event_widget.html.erb
+++ b/app/views/event_groups/_event_widget.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (events:, current_event:) %>
 
 <% if events&.many? %>
-  <div class="col-12 col-md mb-2 mb-md-0">
+  <div class="col-12 col-md-auto mb-2 mb-md-0">
     <div class="btn-group btn-group-ost">
       <% events.each do |event| %>
         <%= link_to event.guaranteed_short_name,

--- a/app/views/events/spread.html.erb
+++ b/app/views/events/spread.html.erb
@@ -34,13 +34,13 @@
   <div class="container">
     <div class="row">
       <%= render "event_groups/event_widget", events: @presenter.ordered_events_within_group, current_event: @presenter.event %>
-      <div class="col d-inline-flex">
+      <div class="col-12 col-md-auto d-inline-flex mb-2 mb-md-0">
         <div>
           <%= explore_dropdown_menu(@presenter) %>
           <%= link_to_download_spread_csv(@presenter, current_user) %>
         </div>
       </div>
-      <div class="col text-end">
+      <div class="col-12 col-md text-md-end">
         <div>
           <%= gender_dropdown_menu(@presenter) %>
           <%= display_style_dropdown_menu(@presenter) %>


### PR DESCRIPTION
Currently, spread navigation elements look good on a full screen, but they can become wonky at mobile widths.

This PR improves spread navigation elements for mobile.

<details><summary>Screenshots</summary>
<p>

### Before
<img width="315" alt="Screenshot 2023-10-01 at 9 19 56 AM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/a49b7797-5828-4f78-a3e4-646f10f9da70">

### After
<img width="315" alt="Screenshot 2023-10-01 at 9 20 07 AM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/95001f7c-a69f-4ddd-8bc1-90f33d788eb2">

</p>
</details> 