### PR TITLE
Remove all CSRF checks from API endpoints

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -3,7 +3,7 @@
 class ApiController < ::ApplicationController
   include Rails::Pagination
   protect_from_forgery with: :null_session
-  skip_before_action :verify_authenticity_token, if: :json_web_token_present?
+  skip_before_action :verify_authenticity_token
   before_action :authenticate_user!
   after_action :verify_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found_json
@@ -21,9 +21,5 @@ class ApiController < ::ApplicationController
   def live_entry_unavailable(resource)
     {reportText: "Live entry for #{resource.name} is currently unavailable. " +
       "Please enable live entry access through the admin/settings page."}
-  end
-
-  def json_web_token_present?
-    !!current_user&.has_json_web_token
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,8 +81,6 @@ class User < ApplicationRecord
           "#{search_param}%", "#{search_param}%", "%#{search_param}%")
   end
 
-  attr_accessor :has_json_web_token
-
   def to_s
     slug
   end

--- a/config/initializers/core_extensions/devise/strategies/jwt_strategy.rb
+++ b/config/initializers/core_extensions/devise/strategies/jwt_strategy.rb
@@ -11,7 +11,6 @@ module Devise
 
         env["devise.skip_trackable"] = true
         user = User.find(payload["sub"])
-        user.has_json_web_token = true
         success! user
       rescue JWT::ExpiredSignature
         fail! "Auth token has expired"


### PR DESCRIPTION
CSRF protection isn't necessary for JSON API endpoints. I think I did not fully understand that when I wrote this `json_web_token_present?` logic. 

This PR removes that logic and skips the CSRF action entirely for all API endpoints.