### PR TITLE
Show progress bars in public lottery draw page

### DIFF
--- a/app/models/lottery_division.rb
+++ b/app/models/lottery_division.rb
@@ -63,7 +63,8 @@ class LotteryDivision < ApplicationRecord
   private
 
   def broadcast_lottery_draw_header
-    broadcast_replace_to self, :lottery_draw_header, target: "draw_tickets_header_lottery_division_#{id}", partial: "lottery_divisions/draw_tickets_header", locals: {division: self}
+    broadcast_replace_to self, :lottery_draw_header, target: "draw_tickets_header_lottery_division_#{id}", partial: "lottery_divisions/draw_tickets_header", locals: { division: self }
+    broadcast_replace_to self, :lottery_header, target: "lottery_header_lottery_division_#{id}", partial: "lottery_divisions/tickets_progress_bars", locals: { division: self, show_pre_selected: false }
   end
 
   def ordered_drawn_entrants

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -110,6 +110,16 @@
         </div>
       <% end %>
 
+      <div class="row">
+        <% @presenter.ordered_divisions.each do |division| %>
+          <%= turbo_stream_from division, :lottery_header, class: "d-none" %>
+          <div class="col-12 col-md-6 col-lg-4 col-xl">
+            <%= render partial: "lottery_divisions/tickets_progress_bars", locals: { division: division, show_pre_selected: false } %>
+          </div>
+        <% end %>
+      </div>
+      <hr/>
+
       <div id="lottery_draws">
         <%= render partial: "lottery_draws/lottery_draw", collection: @presenter.lottery_draws_ordered %>
       </div>

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -110,10 +110,12 @@
         </div>
       <% end %>
 
+      <hr/>
       <div class="row">
         <% @presenter.ordered_divisions.each do |division| %>
           <%= turbo_stream_from division, :lottery_header, class: "d-none" %>
           <div class="col-12 col-md-6 col-lg-4 col-xl">
+            <h5 class="fw-bold"><%= division.name %></h5>
             <%= render partial: "lottery_divisions/tickets_progress_bars", locals: { division: division, show_pre_selected: false } %>
           </div>
         <% end %>

--- a/app/views/lottery_divisions/_draw_tickets_header.html.erb
+++ b/app/views/lottery_divisions/_draw_tickets_header.html.erb
@@ -28,41 +28,6 @@
     </div>
   </div>
 
-  <div class="card mt-3">
-    <div class="card-body">
-      <div class="row">
-        <div class="col-8">
-          <h6 class="fw-bold">Accepted</h6>
-        </div>
-        <div class="col-4">
-          <h6 class="text-end"><%= "(#{division.accepted_entrants.count}/#{division.maximum_entries})" %></h6>
-        </div>
-      </div>
-      <div class="progress">
-        <%= bootstrap_progress_bar(min_value: 0, max_value: division.maximum_entries, current_value: division.accepted_entrants.count, color: "success") %>
-      </div>
-      <div class="row mt-2">
-        <div class="col-8">
-          <h6 class="fw-bold">Wait List</h6>
-        </div>
-        <div class="col-4">
-          <h6 class="text-end"><%= "(#{division.wait_list_entrants.count}/#{division.maximum_wait_list})" %></h6>
-        </div>
-      </div>
-      <div class="progress">
-        <%= bootstrap_progress_bar(min_value: 0, max_value: division.maximum_wait_list, current_value: division.wait_list_entrants.count, color: "warning") %>
-      </div>
-      <div class="row mt-2">
-        <div class="col-8">
-          <h6 class="fw-bold">Pre-selected</h6>
-        </div>
-        <div class="col-4">
-          <h6 class="text-end"><%= "(#{division.entrants.pre_selected.drawn.count}/#{division.entrants.pre_selected.count})" %></h6>
-        </div>
-      </div>
-      <div class="progress">
-        <%= bootstrap_progress_bar(min_value: 0, max_value: division.entrants.pre_selected.count, current_value: division.entrants.pre_selected.drawn.count, color: "secondary") %>
-      </div>
-    </div>
-  </div>
+  <%= render partial: "lottery_divisions/tickets_progress_bars", locals: { division: division, show_pre_selected: true} %>
+
 </div>

--- a/app/views/lottery_divisions/_tickets_progress_bars.html.erb
+++ b/app/views/lottery_divisions/_tickets_progress_bars.html.erb
@@ -1,0 +1,41 @@
+<%# locals: (division:, show_pre_selected:) -%>
+
+<div id="<%= dom_id(division, :lottery_header) %>" class="card mt-3">
+  <div class="card-body">
+    <div class="row">
+      <div class="col-8">
+        <h6 class="fw-bold">Accepted</h6>
+      </div>
+      <div class="col-4">
+        <h6 class="text-end"><%= "(#{division.accepted_entrants.count}/#{division.maximum_entries})" %></h6>
+      </div>
+    </div>
+    <div class="progress">
+      <%= bootstrap_progress_bar(min_value: 0, max_value: division.maximum_entries, current_value: division.accepted_entrants.count, color: "success") %>
+    </div>
+    <div class="row mt-2">
+      <div class="col-8">
+        <h6 class="fw-bold">Wait List</h6>
+      </div>
+      <div class="col-4">
+        <h6 class="text-end"><%= "(#{division.wait_list_entrants.count}/#{division.maximum_wait_list})" %></h6>
+      </div>
+    </div>
+    <div class="progress">
+      <%= bootstrap_progress_bar(min_value: 0, max_value: division.maximum_wait_list, current_value: division.wait_list_entrants.count, color: "warning") %>
+    </div>
+    <% if show_pre_selected %>
+      <div class="row mt-2">
+        <div class="col-8">
+          <h6 class="fw-bold">Pre-selected</h6>
+        </div>
+        <div class="col-4">
+          <h6 class="text-end"><%= "(#{division.entrants.pre_selected.drawn.count}/#{division.entrants.pre_selected.count})" %></h6>
+        </div>
+      </div>
+      <div class="progress">
+        <%= bootstrap_progress_bar(min_value: 0, max_value: division.entrants.pre_selected.count, current_value: division.entrants.pre_selected.drawn.count, color: "secondary") %>
+      </div>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
Currently, we have nice progress bars showing lottery draw progress for the Admin Draw Tickets view. In the Public lottery draws view, we do not show progress bars.

This PR adds progress bars to the public lottery view. It does not show pre-selected runner progress bars to the public.

<details><summary>Screenshots</summary>
<p>

### Before
<img width="1015" alt="Screenshot 2023-11-27 at 9 17 13 AM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/1bc0513d-0090-4de1-86d4-d19f7ca2556c">


### After
<img width="1015" alt="Screenshot 2023-11-27 at 9 16 40 AM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/d3f0b685-0a95-4435-a1a7-01e320f85c20">


</p>
</details> 