### PR TITLE
Add a banner to the top of the home screen for 2024 Hardrock lottery

### DIFF
--- a/app/views/visitors/_hardrock_lottery_link.html.erb
+++ b/app/views/visitors/_hardrock_lottery_link.html.erb
@@ -1,0 +1,14 @@
+<% hardrock = Organization.find_by(slug: "hardrock") %>
+<% lottery = hardrock.present? ? hardrock.lotteries.find_by(scheduled_start_date: "2023-12-02") : nil %>
+
+<% if hardrock.present? && lottery.present? && Date.today == lottery.scheduled_start_date %>
+  <aside class="navbar bg-warning">
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col">
+          <%= link_to "Live Hardrock 2024 Lottery", organization_lottery_path(hardrock, lottery), class: "btn btn-outline-secondary" %>
+        </div>
+      </div>
+    </div>
+  </aside>
+<% end %>

--- a/app/views/visitors/index.html.erb
+++ b/app/views/visitors/index.html.erb
@@ -2,6 +2,9 @@
 <% end %>
 <% content_for(:container_type) do %>skip
 <% end %>
+
+<%= render partial: "hardrock_lottery_link" %>
+
 <div class="homepage">
   <div class="row first position-relative">
     <div class="over-text">


### PR DESCRIPTION
This PR adds a temporary banner to the top of the homepage to direct users to the 2024 Hardrock Lottery.

<details><summary>Screenshot</summary>
<p>

<img width="1463" alt="Screenshot 2023-12-02 at 7 08 21 AM" src="https://github.com/SplitTime/OpenSplitTime/assets/14797300/e95697bc-da91-4b06-a088-f6e943cc4227">


</p>
</details> 