### PR TITLE
Exclude hardcoded bib numbers from auto assign

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -73,6 +73,7 @@ class Effort < ApplicationRecord
   after_update_commit :broadcast_update
 
   pg_search_scope :search_bib, against: :bib_number, using: { tsearch: { any_word: true } }
+  scope :bib_not_hardcoded, -> { where(bib_number_hardcoded: [false, nil]) }
   scope :bib_number_among, -> (param) { param.present? ? search_bib(param) : all }
   scope :on_course, -> (course) { includes(:event).where(events: { course_id: course.id }) }
   scope :unreconciled, -> { where(person_id: nil) }

--- a/app/parameters/effort_parameters.rb
+++ b/app/parameters/effort_parameters.rb
@@ -40,8 +40,8 @@ class EffortParameters < BaseParameters
   end
 
   def self.permitted
-    [:id, :slug, :event_id, :person_id, :participant_id, :first_name, :last_name, :gender, :wave, :bib_number, :age, :birthdate,
-     :city, :state_code, :country_code, :finished, :start_time, :scheduled_start_time, :scheduled_start_time_local,
+    [:id, :slug, :event_id, :person_id, :participant_id, :first_name, :last_name, :gender, :wave, :bib_number, :bib_number_hardcoded,
+     :age, :birthdate, :city, :state_code, :country_code, :finished, :start_time, :scheduled_start_time, :scheduled_start_time_local,
      :scheduled_start_offset, :beacon_url, :report_url, :photo, :phone, :email, :checked_in, :emergency_contact, :emergency_phone,
      :comments, { split_times_attributes: [*SplitTimeParameters.permitted] }]
   end

--- a/app/services/compute_bib_assignments.rb
+++ b/app/services/compute_bib_assignments.rb
@@ -35,7 +35,7 @@ class ComputeBibAssignments
   attr_reader :event, :strategy, :result
 
   def compute_for_hardrock
-    efforts = event.efforts.select(:id, :person_id, :first_name, :last_name).to_a
+    efforts = event.efforts.bib_not_hardcoded.select(:id, :person_id, :first_name, :last_name).to_a
     prior_hardrock = event.organization.events.where("scheduled_start_time < ?", event.scheduled_start_time).order(scheduled_start_time: :desc).first
     ordered_prior_person_ids = prior_hardrock ? prior_hardrock.efforts.finished.ranked_order.pluck(:person_id) : []
 

--- a/app/views/efforts/_form.html.erb
+++ b/app/views/efforts/_form.html.erb
@@ -65,6 +65,10 @@
           <div class="col-md-2 mb-3">
             <%= f.label :bib_number, class: "mb-1" %>
             <%= f.number_field :bib_number, class: "form-control", placeholder: "Bib #" %>
+            <div class="form-check form-switch mt-2">
+              <label class="form-check-label" for="<%= dom_id(f.object, :bib_number_hardcoded_checkbox) %>">Hardcoded bib?</label>
+              <%= f.check_box :bib_number_hardcoded, class: "form-check-input", id: dom_id(f.object, :bib_number_hardcoded_checkbox) %>
+            </div>
           </div>
           <div class="col-md-6 mb-3">
             <%= f.label "Tracking Beacon URL", class: "mb-1" %>

--- a/spec/services/compute_bib_assignments_spec.rb
+++ b/spec/services/compute_bib_assignments_spec.rb
@@ -49,11 +49,32 @@ RSpec.describe ComputeBibAssignments do
             effort_1.id => 1,
             effort_2.id => 2,
             effort_3.id => 100,
-            effort_4.id => 101
+            effort_4.id => 101,
           }
         end
 
         it "computes bibs of prior year finishers starting at 1 and other bibs alphabetically starting at 100" do
+          expect(result).to eq(expected_result)
+        end
+      end
+
+      context "when an entrant has a hardcoded bib number" do
+        let(:prior_event) { events(:hardrock_2015) }
+
+        before do
+          event.efforts.ranked_order.last(15).each(&:destroy)
+          effort_1.update(bib_number: "85", bib_number_hardcoded: true)
+        end
+
+        let(:expected_result) do
+          {
+            effort_2.id => 100,
+            effort_3.id => 101,
+            effort_4.id => 102,
+          }
+        end
+
+        it "ignores hardcoded bib numbers" do
           expect(result).to eq(expected_result)
         end
       end


### PR DESCRIPTION
This PR excludes hardcoded bib numbers from the auto-assign algorithm. 

Resolves #1210 