### PR TITLE
Replace SMS subscription button with out-of-service message

### DIFF
--- a/app/views/efforts/_subscription_buttons.html.erb
+++ b/app/views/efforts/_subscription_buttons.html.erb
@@ -6,6 +6,6 @@
   </h5>
   <div class="card-body text-center d-inline-flex justify-content-center">
     <%= render "subscriptions/subscription_button", subscribable: effort, protocol: :email %>
-    <%= render "subscriptions/subscription_button", subscribable: effort, protocol: :sms %>
+    <span class="mx-3">SMS temporarily out of service.<br/>Please use email.</span>
   </div>
 </div>

--- a/spec/system/subscriptions/subscribe_to_effort_notifications_spec.rb
+++ b/spec/system/subscriptions/subscribe_to_effort_notifications_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "User subscribes to an effort's progress notifications", type: :s
 
   before { effort.update!(topic_resource_key: "anything") }
 
-  scenario "The user is not logged in and subscribes to sms" do
+  xscenario "The user is not logged in and subscribes to sms" do
     visit_page
 
     within("##{dom_id(effort, :sms)}") { click_button("sms") }
@@ -36,7 +36,7 @@ RSpec.describe "User subscribes to an effort's progress notifications", type: :s
     expect(page).to have_content("You have subscribed to email notifications for #{effort.full_name}.")
   end
 
-  scenario "The user is logged in and subscribes to sms without a phone number" do
+  xscenario "The user is logged in and subscribes to sms without a phone number" do
     login_as user, scope: :user
     visit_page
 
@@ -46,7 +46,7 @@ RSpec.describe "User subscribes to an effort's progress notifications", type: :s
     expect(page).to have_content("Please add a mobile phone number to receive sms text notifications.")
   end
 
-  scenario "The user is logged in and subscribes to sms with a phone number" do
+  xscenario "The user is logged in and subscribes to sms with a phone number" do
     user.update_columns(phone: "1234567890")
     login_as user, scope: :user
     visit_page


### PR DESCRIPTION
Addresses a portion of #1216 

<details><summary>Details</summary>
<p>

<img width="545" alt="Screenshot 2024-07-12 at 3 45 33 PM" src="https://github.com/user-attachments/assets/6383aaa2-4a95-4590-8582-4019f0c3538a">

</p>
</details> 