### PR TITLE
Fix Disassociate button by using button_to

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,7 +355,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (6.0.1)
-    puma (6.4.2)
+    puma (6.4.3)
       nio4r (~> 2.0)
     pundit (2.4.0)
       activesupport (>= 3.0.0)

--- a/app/views/efforts/_efforts_list_person.html.erb
+++ b/app/views/efforts/_efforts_list_person.html.erb
@@ -23,7 +23,7 @@
       <td><%= l(effort.event.scheduled_start_time.to_date, format: :full_with_weekday) %></td>
       <td class="text-end"><%= text_with_status_indicator(effort.finish_status, effort.data_status, data_type: :effort_time_data) %></td>
       <% if current_user&.admin? %>
-        <td class="text-end"><%= link_to "Disassociate",
+        <td class="text-end"><%= button_to "Disassociate",
                                            effort_path(effort,
                                                        effort: { person_id: nil },
                                                        button: :disassociate,


### PR DESCRIPTION
The "Disassociate" button was a straggler, still using `link_to`, which made it nonfunctional.

This PR updates the code to use `button_to`, which is compatible with modern Rails/Turbo.