### PR TITLE
Don't run js system specs in Heroku CI

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,7 +28,7 @@
       },
       "scripts": {
         "test-setup": "bin/rails assets:precompile",
-        "test": "bin/rspec"
+        "test": "bin/rspec spec --tag ~@js"
       }
     }
   }


### PR DESCRIPTION
System specs using JavaScript and Chrome in Heroku CI have become progressively more flaky, leading to nearly all test runs failing. The specs are much more consistent locally and in the GitHub CI.

This PR excludes JS system specs from the Heroku CI, which should greatly increase the chance of passing there. JS system specs will continue to be run in GitHub Actions and of course can be run locally as well.