### PR TITLE
Use organization historical_fact path for import job link

### DIFF
--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -40,7 +40,7 @@ class ImportJob < ApplicationRecord
 
     case parent_type
     when "Organization"
-      ::Rails.application.routes.url_helpers.organization_path(parent)
+      ::Rails.application.routes.url_helpers.organization_historical_facts_path(parent)
     when "Lottery"
       ::Rails.application.routes.url_helpers.setup_organization_lottery_path(parent.organization, parent)
     when "EventGroup"

--- a/spec/models/import_job_spec.rb
+++ b/spec/models/import_job_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe ImportJob, type: :model do
     context "when parent is an organization" do
       let(:parent) { organizations(:hardrock) }
 
-      it "returns an organization path" do
-        expect(result).to eq("/organizations/hardrock")
+      it "returns an organization historical fact path" do
+        expect(result).to eq("/organizations/hardrock/historical_facts")
       end
     end
 


### PR DESCRIPTION
This PR changes the link for Organization import jobs from the organization path to the organization historical fact path.