### PR TITLE
Add flexible geolocation to historical facts index

### DIFF
--- a/app/views/historical_facts/_historical_fact.html.erb
+++ b/app/views/historical_facts/_historical_fact.html.erb
@@ -5,6 +5,7 @@
   <td class="text-center"><%= fact.quantity %></td>
   <td><%= fact.comments %></td>
   <td><%= fact.full_name %></td>
-  <td><%= fact.gender %></td>
+  <td><%= fact.gender.titleize %></td>
+  <td><%= fact.flexible_geolocation %></td>
   <td><%= fact.birthdate %></td>
 </tr>

--- a/app/views/historical_facts/_historical_facts_list.html.erb
+++ b/app/views/historical_facts/_historical_facts_list.html.erb
@@ -30,6 +30,7 @@
     <th>Comments</th>
     <th>Name</th>
     <th>Gender</th>
+    <th>From</th>
     <th>Birthdate</th>
   </tr>
   </thead>


### PR DESCRIPTION
To help differentiate between similar names, this PR adds the flexible geolocation (city/state/country) to the historical facts index page.