### PR TITLE
Record historical DNF and finishes

### DIFF
--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -17,6 +17,8 @@ class HistoricalFact < ApplicationRecord
     provided_previous_name: 6,
     lottery_ticket_count_legacy: 7,
     lottery_division_legacy: 8,
+    dnf: 9,
+    finished: 10,
   }
 
   include Auditable

--- a/app/models/proto_record.rb
+++ b/app/models/proto_record.rb
@@ -98,6 +98,7 @@ class ProtoRecord
     when :historical_fact
       organization = options[:organization]
       normalize_gender!
+      clear_zero_values!(:email, :phone, :address, :city, :state_code, :country_code)
       normalize_country_code!
       normalize_state_code!
       create_country_from_state!

--- a/lib/etl/transformable.rb
+++ b/lib/etl/transformable.rb
@@ -44,6 +44,15 @@ module ETL
       self[:scheduled_start_time] ||= event_start_time + seconds
     end
 
+    def clear_zero_values!(*attributes)
+      attributes.each do |attribute|
+        return unless has_key?(attribute)
+        return unless self[attribute] == "0" || self[attribute] == 0
+
+        self[attribute] = nil
+      end
+    end
+
     def convert_split_distance!
       return unless self[:distance].present?
 

--- a/lib/etl/transformers/async/hardrock_historical_facts_strategy.rb
+++ b/lib/etl/transformers/async/hardrock_historical_facts_strategy.rb
@@ -88,8 +88,8 @@ module ETL::Transformers::Async
     end
 
     def record_emergency_contact(struct)
-      emergency_contact = struct[:Emergency_Contact]
-      emergency_phone = struct[:Emergency_Phone]
+      emergency_contact = struct[:Emergency_Contact].to_s == "0" ? nil : struct[:Emergency_Contact]
+      emergency_phone = struct[:Emergency_Phone].to_s == "0" ? nil : struct[:Emergency_Phone]
 
       if emergency_contact.present? || emergency_phone.present?
         proto_record = base_proto_record.deep_dup

--- a/spec/lib/etl/transformers/async/hardrock_historical_facts_strategy_spec.rb
+++ b/spec/lib/etl/transformers/async/hardrock_historical_facts_strategy_spec.rb
@@ -470,6 +470,16 @@ RSpec.describe ETL::Transformers::Async::HardrockHistoricalFactsStrategy do
         expect(dns_proto_records.count).to eq(12)
       end
 
+      it "returns one proto_record for each DNF" do
+        dnf_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :dnf }
+        expect(dnf_proto_records.count).to eq(1)
+      end
+
+      it "returns one proto_record for each finish" do
+        finished_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :finished }
+        expect(finished_proto_records.count).to eq(2)
+      end
+
       it "returns one proto_record for each legacy volunteer fact" do
         legacy_volunteer_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :volunteer_legacy }
         expect(legacy_volunteer_proto_records.count).to eq(1)

--- a/spec/lib/etl/transformers/async/hardrock_historical_facts_strategy_spec.rb
+++ b/spec/lib/etl/transformers/async/hardrock_historical_facts_strategy_spec.rb
@@ -435,8 +435,8 @@ RSpec.describe ETL::Transformers::Async::HardrockHistoricalFactsStrategy do
             :Country => "USA",
             :"Phone_#" => "776-426-2796",
             :Previous_names_applied_under => "Theresa Burley",
-            :Emergency_Contact => "",
-            :Emergency_Phone => "",
+            :Emergency_Contact => "0",
+            :Emergency_Phone => 0,
             :"#_Years_Vol_Claimed" => 1,
             :Vol_Diff => 0,
             :"#_Years_Claimed_Applied_in_Past" => "",
@@ -494,7 +494,7 @@ RSpec.describe ETL::Transformers::Async::HardrockHistoricalFactsStrategy do
         expect(reported_qualifier_proto_records.map { |pr| pr[:comments] }).to match_array(["2023 SEPT: Grindstone 100 Mile", "2023 SEPT: Bear 100"])
       end
 
-      it "returns one proto_record for each provided emergency contact" do
+      it "returns one proto_record for each provided emergency contact, ignoring '0'" do
         emergency_contact_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :provided_emergency_contact }
         expect(emergency_contact_proto_records.count).to eq(2)
         expect(emergency_contact_proto_records.map { |pr| pr[:comments] }).to match_array(["Shellie Krajcik, 4747239722", "Sonja Christiansen, 8615039757"])

--- a/spec/lib/etl/transformers/async/hardrock_historical_facts_strategy_spec.rb
+++ b/spec/lib/etl/transformers/async/hardrock_historical_facts_strategy_spec.rb
@@ -428,12 +428,12 @@ RSpec.describe ETL::Transformers::Async::HardrockHistoricalFactsStrategy do
             :Female_Finished_Tickets => 0,
             :Female_Never_Tickets => 0,
             :DOB => "09/10/1997",
-            :email_address => "woodrow@runte.ca",
-            :Street_Address => "028 Kunze Freeway",
-            :City => "Tamartown",
-            :State => "IA",
-            :Country => "USA",
-            :"Phone_#" => "776-426-2796",
+            :email_address => "0",
+            :Street_Address => "0",
+            :City => "0",
+            :State => "0",
+            :Country => "0",
+            :"Phone_#" => 0,
             :Previous_names_applied_under => "Theresa Burley",
             :Emergency_Contact => "0",
             :Emergency_Phone => 0,
@@ -462,6 +462,16 @@ RSpec.describe ETL::Transformers::Async::HardrockHistoricalFactsStrategy do
 
         %i[first_name last_name gender birthdate address state_code country_code email].each do |expected_key|
           expect(keys).to include(expected_key)
+        end
+      end
+
+      it "ignores zero values in affected fields" do
+        valid_address_proto_record = proto_records.find { |pr| pr[:first_name] == "Antony" }
+        invalid_address_proto_record = proto_records.find { |pr| pr[:first_name] == "Theresa" }
+
+        %i[address city state_code country_code email phone].each do |key|
+          expect(valid_address_proto_record[key]).to be_present
+          expect(invalid_address_proto_record[key]).to be_nil
         end
       end
 

--- a/spec/support/concerns/transformable.rb
+++ b/spec/support/concerns/transformable.rb
@@ -90,6 +90,39 @@ RSpec.shared_examples_for "transformable" do
     end
   end
 
+  describe "#clear_zero_values!" do
+    context "when values are zero strings" do
+      let(:attributes) { { email: "0", city: "0", finishes: "0" } }
+
+      it "removes the values from only the provided keys" do
+        subject.clear_zero_values!(:email, :city)
+        expect(subject[:email]).to be_nil
+        expect(subject[:city]).to be_nil
+        expect(subject[:finishes]).to eq("0")
+      end
+    end
+
+    context "when values are zero integers" do
+      let(:attributes) { { email: 0, city: 0, finishes: 0 } }
+
+      it "removes the values from only the provided keys" do
+        subject.clear_zero_values!(:email, :city)
+        expect(subject[:email]).to be_nil
+        expect(subject[:city]).to be_nil
+        expect(subject[:finishes]).to eq(0)
+      end
+    end
+
+    context "when provided attribute does not exist" do
+      let(:attributes) { { email: "0", city: "0", finishes: "0" } }
+
+      it "ignores the attribute" do
+        subject.clear_zero_values!(:phone)
+        expect(subject).not_to have_key(:phone)
+      end
+    end
+  end
+
   describe "#convert_split_distance!" do
     context "when the provided attributes include distance" do
       let(:attributes) { {distance: 10} }


### PR DESCRIPTION
This PR adds DNF and Finished to the recorded historical facts for a Hardrock historical fact import. This will allow for better cross-checking of existing effort data in OST.

This PR also blanks out `"0"` and `0` values from address, email, and phone fields.