### PR TITLE
Historical facts reconcile logic

### DIFF
--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -209,22 +209,45 @@ module DropdownHelper
     build_dropdown_menu(nil, dropdown_items, button: true)
   end
 
-  def historical_facts_filter_dropdown
+  def historical_facts_kinds_filter_dropdown
     items = [
-      { text: "All", kinds: [] },
-      { text: "Outcome", kinds: [:dns, :dnf, :finished] },
-      { text: "Volunteer", kinds: [:volunteer_minor, :volunteer_major, :volunteer_legacy] },
-      { text: "Provided", kinds: [:reported_qualifier_finish, :provided_emergency_contact, :provided_previous_names] },
-      { text: "Legacy", kinds: [:lottery_ticket_count_legacy, :lottery_division_legacy] },
+      { text: "All kinds", kinds: [] },
+      { text: "Outcome", kinds: %w[dns dnf finished] },
+      { text: "Volunteer", kinds: %w[volunteer_minor volunteer_major volunteer_legacy] },
+      { text: "Provided", kinds: %w[reported_qualifier_finish provided_emergency_contact provided_previous_names] },
+      { text: "Legacy", kinds: %w[lottery_ticket_count_legacy lottery_division_legacy] },
     ]
 
     dropdown_items = items.map do |item|
-      { name: item[:text],
+      {
+        name: item[:text],
         link: request.params.merge(kind: item[:kinds], page: nil),
-        active: params[:kind] == item[:kinds] }
+        active: (params[:kind].presence == item[:kinds].presence)
+      }
     end
 
-    build_dropdown_menu("Kind", dropdown_items, button: true)
+    build_dropdown_menu(nil, dropdown_items, button: true)
+  end
+
+  def historical_facts_reconciled_filter_dropdown
+    items = [
+      { icon_name: "circle", type: :regular, color: :secondary, text: "All", reconciled: nil },
+      { icon_name: "circle-minus", type: :solid, color: :warning, text: "Unreconciled", reconciled: false },
+      { icon_name: "circle-check", type: :regular, color: :success, text: "Reconciled", reconciled: true },
+    ]
+
+    dropdown_items = items.map do |item|
+      {
+        name: fa_icon(item[:icon_name], text: item[:text], type: item[:type], color: item[:color]),
+        link: request.params.merge(
+          reconciled: item[:reconciled],
+          page: nil
+        ),
+        active: params[:reconciled]&.to_boolean == item[:reconciled]
+      }
+    end
+
+    build_dropdown_menu(nil, dropdown_items, button: true)
   end
 
   def explore_dropdown_menu(view_object)

--- a/app/jobs/historical_facts_auto_reconcile_job.rb
+++ b/app/jobs/historical_facts_auto_reconcile_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class HistoricalFactsAutoReconcileJob < ApplicationJob
+  queue_as :default
+
+  def perform(parent, current_user:)
+    set_current_user(current_user: current_user)
+
+    HistoricalFactAutoReconciler.reconcile(parent)
+  end
+end

--- a/app/jobs/import_async_job.rb
+++ b/app/jobs/import_async_job.rb
@@ -5,6 +5,8 @@ require "etl/etl"
 class ImportAsyncJob < ApplicationJob
   def perform(import_job_id)
     import_job = ImportJob.find(import_job_id)
+    set_current_user(current_user: import_job.user)
+
     ::ETL::AsyncImporter.import!(import_job)
   end
 end

--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -23,6 +23,7 @@ class HistoricalFact < ApplicationRecord
 
   include Auditable
   include CapitalizeAttributes
+  include Matchable
   include PersonalInfo
   include Searchable
 
@@ -36,6 +37,8 @@ class HistoricalFact < ApplicationRecord
 
   attr_writer :creator
 
+  scope :unreconciled, -> { where(person_id: nil) }
+
   def self.search(search_text)
     return all unless search_text.present?
 
@@ -46,5 +49,13 @@ class HistoricalFact < ApplicationRecord
     return @creator if defined?(@creator)
 
     @creator = User.find_by(id: created_by) if created_by?
+  end
+
+  def reconciled?
+    person_id.present?
+  end
+
+  def unreconciled?
+    !reconciled?
   end
 end

--- a/app/presenters/organization_historical_facts_presenter.rb
+++ b/app/presenters/organization_historical_facts_presenter.rb
@@ -69,8 +69,15 @@ class OrganizationHistoricalFactsPresenter < OrganizationPresenter
   end
 
   def matches_criteria?(fact)
-    return true unless params[:kind].present?
+    matches_kind_criteria?(fact) &&
+      matches_reconciled_criteria?(fact)
+  end
 
-    fact.kind.in?(params[:kind])
+  def matches_kind_criteria?(fact)
+    params[:kind].blank? || fact.kind.in?(params[:kind])
+  end
+
+  def matches_reconciled_criteria?(fact)
+    params[:reconciled].blank? || fact.reconciled? == params[:reconciled].to_boolean
   end
 end

--- a/app/services/historical_fact_auto_reconciler.rb
+++ b/app/services/historical_fact_auto_reconciler.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class HistoricalFactAutoReconciler
+  PERSONAL_ATTRIBUTES = [:first_name, :last_name, :gender, :birthdate, :email, :phone].freeze
+
+  def self.reconcile(parent)
+    new(parent).reconcile
+  end
+
+  def initialize(parent)
+    @parent = parent
+  end
+
+  def reconcile
+    historical_facts.unreconciled.find_each do |fact|
+      # In case a race condition in which a fact is reconciled by another process
+      next if fact.reconciled?
+
+      matching_person = fact.definitive_matching_person || fact.exact_matching_person
+
+      person = if matching_person.present?
+                 matching_person
+               elsif fact.possible_matching_people.blank?
+                 Person.new
+               else
+                 nil
+               end
+
+      next if person.nil?
+
+      ::Interactors::PullAttributes.perform(fact, person, PERSONAL_ATTRIBUTES)
+      ::Interactors::PullGeoAttributes.perform(fact, person)
+
+      person.historical_facts << fact
+      person.save
+    end
+  end
+
+  private
+
+  attr_reader :parent
+  delegate :historical_facts, to: :parent, private: true
+end

--- a/app/views/historical_facts/_historical_fact.html.erb
+++ b/app/views/historical_facts/_historical_fact.html.erb
@@ -1,6 +1,11 @@
 <%# locals: (fact:) %>
 
 <tr class="align-middle">
+  <td class="text-center">
+    <%= fact.unreconciled? ?
+          fa_icon("circle-minus", type: :solid, class: "text-warning", data: { controller: "tooltip" }, title: "Unreconciled") :
+          fa_icon("circle-check", type: :regular, class: "text-success", data: { controller: "tooltip" }, title: "Reconciled") %>
+  </td>
   <td><%= historical_fact_kind_badge(fact.kind) %></td>
   <td class="text-center"><%= fact.quantity %></td>
   <td><%= fact.comments %></td>

--- a/app/views/historical_facts/_historical_facts_list.html.erb
+++ b/app/views/historical_facts/_historical_facts_list.html.erb
@@ -25,6 +25,7 @@
 <table class="table">
   <thead>
   <tr>
+    <th></th>
     <th>Kind</th>
     <th class="text-center">Quantity</th>
     <th>Comments</th>

--- a/app/views/historical_facts/index.html.erb
+++ b/app/views/historical_facts/index.html.erb
@@ -19,7 +19,8 @@
       </div>
       <!-- Filter Widget -->
       <div class="col">
-        <%= historical_facts_filter_dropdown %>
+        <%= historical_facts_kinds_filter_dropdown %>
+        <%= historical_facts_reconciled_filter_dropdown %>
       </div>
       <!-- Search Widget -->
       <div class="col">

--- a/spec/services/historical_fact_auto_reconciler_spec.rb
+++ b/spec/services/historical_fact_auto_reconciler_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HistoricalFactAutoReconciler do
+  subject { described_class.new(parent) }
+  let(:parent) { organizations(:hardrock) }
+  let(:person_1) { people(:bruno_fadel) }
+  let(:person_2) { people(:robby_gerlach) }
+
+  describe "#reconcile" do
+    context "for historical facts that are definitive matches with a person" do
+      let!(:fact_1) { create(:historical_fact, organization: parent, first_name: person_1.first_name, last_name: person_1.last_name, gender: person_1.gender, birthdate: person_1.birthdate, kind: :dns, comments: "2018") }
+      let!(:fact_2) { create(:historical_fact, organization: parent, first_name: person_2.first_name, last_name: person_2.last_name, gender: person_2.gender, birthdate: person_2.birthdate, kind: :dns, comments: "2019") }
+
+      it "assigns the fact to the person" do
+        subject.reconcile
+
+        expect(fact_1.reload.person).to eq(person_1)
+        expect(fact_2.reload.person).to eq(person_2)
+      end
+    end
+
+    context "for historical facts that are exact but not definitive matches with a person" do
+      let!(:fact_1) { create(:historical_fact, organization: parent, first_name: person_1.first_name, last_name: person_1.last_name, gender: person_1.gender, state_code: person_1.state_code, kind: :dns, comments: "2018") }
+      let!(:fact_2) { create(:historical_fact, organization: parent, first_name: person_2.first_name, last_name: person_2.last_name, gender: person_2.gender, state_code: person_2.state_code, kind: :dns, comments: "2019") }
+
+      it "assigns the fact to the person" do
+        subject.reconcile
+
+        expect(fact_1.reload.person).to eq(person_1)
+        expect(fact_2.reload.person).to eq(person_2)
+      end
+    end
+
+    context "for historical facts that have no close matches with existing people" do
+      let!(:fact_1) { create(:historical_fact, organization: parent, first_name: "Barney", last_name: "Fife", gender: "male", kind: :dns, comments: "2018") }
+      let!(:fact_2) { create(:historical_fact, organization: parent, first_name: "Andy", last_name: "Griffith", gender: "male", kind: :dns, comments: "2019") }
+
+      it "creates a new person and assigns the person to the fact" do
+        expect { subject.reconcile }.to change(Person, :count).by(2)
+
+        new_person_1 = Person.last(2).first
+        new_person_2 = Person.last
+
+        expect(fact_1.reload.person).to eq(new_person_1)
+        expect(fact_2.reload.person).to eq(new_person_2)
+      end
+    end
+
+    context "for historical facts that are ambiguous matches with one or more people" do
+      let!(:fact_1) { create(:historical_fact, organization: parent, first_name: person_1.first_name, last_name: person_1.last_name, gender: person_1.gender, kind: :dns, comments: "2018") }
+      let!(:fact_2) { create(:historical_fact, organization: parent, first_name: person_2.first_name, last_name: person_2.last_name, gender: person_2.gender, kind: :dns, comments: "2019") }
+
+      it "does not create a new person and does not assign the facts to any person" do
+        expect { subject.reconcile }.not_to change(Person, :count)
+
+        expect(fact_1.reload.person).to be_nil
+        expect(fact_2.reload.person).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds logic to auto-reconcile historical facts with existing person records in the `people` table.

This PR also improves filtering in the historical records index by adding a Reconciled/Unreconciled filter.