### PR TITLE
Include email and phone for definitive_matching_person

### DIFF
--- a/app/services/historical_fact_auto_reconciler.rb
+++ b/app/services/historical_fact_auto_reconciler.rb
@@ -12,7 +12,7 @@ class HistoricalFactAutoReconciler
   end
 
   def reconcile
-    historical_facts.unreconciled.find_each do |fact|
+    historical_facts.unreconciled.find_each(batch_size: 100) do |fact|
       # In case a race condition in which a fact is reconciled by another process
       next if fact.reconciled?
 


### PR DESCRIPTION
This PR expands `definitive_matching_person` to use either email or phone, in addition to birthdate, as a definitive matching data item. 