### PR TITLE
Convert page and per_page params to defaults if they are 0

### DIFF
--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -42,11 +42,13 @@ class BasePresenter
   end
 
   def page
-    params[:page]&.to_i || FIRST_PAGE
+    result = params[:page]&.to_i || FIRST_PAGE
+    result == 0 ? FIRST_PAGE : result
   end
 
   def per_page
-    params[:per_page]&.to_i || DEFAULT_PER_PAGE
+    result = params[:per_page]&.to_i || DEFAULT_PER_PAGE
+    result == 0 ? DEFAULT_PER_PAGE : result
   end
 
   def request_params_digest


### PR DESCRIPTION
We are seeing errors resulting from the `page` param coming through as `0`, which raises an error.

This PR converts `0` into `FIRST_PAGE` (i.e., `1`). For good measure, it also converts `0` to `DEFAULT_PER_PAGE` (i.e., `50`) if the `per_page` param comes through as `0`.