### PR TITLE
Better discrimination in matching algorithms

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -13,6 +13,9 @@ module Searchable
     scope :country_matches, -> (param) { where(arel_table["country_code"].matches(country_code_for(param).to_s)) }
     scope :state_matches, -> (param) { where(arel_table["state_code"].matches(state_code_for(param).to_s)) }
     scope :email_matches, -> (param) { where(arel_table["email"].matches("%#{param}%")) }
+    scope :email_matches_or_nil, -> (param) { where(arel_table["email"].matches("%#{param}%")).or(where(email: nil)) }
+    scope :phone_matches, -> (param) { where(arel_table["phone"].matches("%#{param}%")) }
+    scope :phone_matches_or_nil, -> (param) { where(arel_table["phone"].matches("%#{param}%")).or(where(phone: nil)) }
     scope :first_name_matches, -> (param) { where(arel_table["first_name"].matches("%#{param}%")) }
     scope :first_name_matches_exact, -> (param) { where(arel_table["first_name"].matches(param.to_s)) }
     scope :last_name_matches, -> (param) { where(arel_table["last_name"].matches("#{param}%")) }

--- a/spec/models/historical_fact_spec.rb
+++ b/spec/models/historical_fact_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 RSpec.describe HistoricalFact, type: :model do
   it_behaves_like "auditable"
+  it_behaves_like "matchable"
+
   it { is_expected.to capitalize_attribute(:first_name) }
   it { is_expected.to capitalize_attribute(:last_name) }
   it { is_expected.to capitalize_attribute(:city) }

--- a/spec/support/concerns/matchable.rb
+++ b/spec/support/concerns/matchable.rb
@@ -5,34 +5,62 @@ RSpec.shared_examples_for "matchable" do
 
   describe "#possible_matching_people" do
     it "returns records for which first and last names match, regardless of middle name and regardless of other attributes" do
-      subject_attributes = {first_name: "Billy Bob", last_name: "Williams"}
-      matching_attributes = [{first_name: "Billy Bob", last_name: "Williams"}, {first_name: "Billy", last_name: "Bob Williams"}]
-      differing_attributes = [{first_name: "Joey", last_name: "Jones"}, {first_name: "Billy Bob", last_name: "Jones"}]
+      subject_attributes = { first_name: "Billy Bob", last_name: "Williams" }
+      matching_attributes = [{ first_name: "Billy Bob", last_name: "Williams" }, { first_name: "Billy", last_name: "Bob Williams" }]
+      differing_attributes = [{ first_name: "Joey", last_name: "Jones" }, { first_name: "Billy Bob", last_name: "Jones" }]
       verify_matching_people(subject_attributes, matching_attributes, differing_attributes)
     end
 
     it "for female efforts, returns records for which first name, age, gender, and state are the same, but last name differs" do
-      subject_attributes = {first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO"}
-      matching_attributes = [{first_name: "Jane", last_name: "Goodall", gender: "female", birthdate: "1967-07-01", state_code: "CO"},
-                             {first_name: "Jane", last_name: "Eyre", gender: "female", birthdate: "1967-03-01", state_code: "CO"}]
-      differing_attributes = [{first_name: "Betty", last_name: "Boop", gender: "female", birthdate: "1967-07-01", state_code: "CO"},
-                              {first_name: "Jane", last_name: "Goodall", gender: "female", birthdate: "1999-07-01", state_code: "CO"},
-                              {first_name: "Jane", last_name: "Johnson", gender: "female", birthdate: "1967-07-01", state_code: "NM"}]
+      subject_attributes = { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO" }
+      matching_attributes = [
+        { first_name: "Jane", last_name: "Goodall", gender: "female", birthdate: "1967-07-01", state_code: "CO" },
+        { first_name: "Jane", last_name: "Eyre", gender: "female", birthdate: "1967-03-01", state_code: "CO" },
+      ]
+      differing_attributes = [
+        { first_name: "Betty", last_name: "Boop", gender: "female", birthdate: "1967-07-01", state_code: "CO" },
+        { first_name: "Jane", last_name: "Goodall", gender: "female", birthdate: "1999-07-01", state_code: "CO" },
+        { first_name: "Jane", last_name: "Johnson", gender: "female", birthdate: "1967-07-01", state_code: "NM" },
+      ]
       verify_matching_people(subject_attributes, matching_attributes, differing_attributes)
     end
 
     it "for male efforts, does not return records for which first name, age, gender, and state are the same, but last name differs" do
-      subject_attributes = {first_name: "George", last_name: "Jetson", gender: "male", birthdate: "1967-07-01", state_code: "CO"}
-      matching_attributes = [{first_name: "George", last_name: "Jetson", gender: "male", birthdate: "1967-07-01", state_code: "CO"}]
-      differing_attributes = [{first_name: "George", last_name: "Clooney", gender: "male", birthdate: "1967-07-01", state_code: "CO"}]
+      subject_attributes = { first_name: "George", last_name: "Jetson", gender: "male", birthdate: "1967-07-01", state_code: "CO" }
+      matching_attributes = [{ first_name: "George", last_name: "Jetson", gender: "male", birthdate: "1967-07-01", state_code: "CO" }]
+      differing_attributes = [{ first_name: "George", last_name: "Clooney", gender: "male", birthdate: "1967-07-01", state_code: "CO" }]
       verify_matching_people(subject_attributes, matching_attributes, differing_attributes)
     end
 
     it "returns records for which last name, age, and gender are the same, but first name differs" do
-      subject_attributes = {first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01"}
-      matching_attributes = [{first_name: "Judy", last_name: "Jetson", gender: "female", birthdate: "1967-07-01"},
-                             {first_name: "Jillian", last_name: "Jetson", gender: "female", birthdate: "1966-07-01"}]
-      differing_attributes = [{first_name: "Judy", last_name: "Jetson", gender: "female", birthdate: "2001-07-01"}]
+      subject_attributes = { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01" }
+      matching_attributes = [
+        { first_name: "Judy", last_name: "Jetson", gender: "female", birthdate: "1967-07-01" },
+        { first_name: "Jillian", last_name: "Jetson", gender: "female", birthdate: "1966-07-01" },
+      ]
+      differing_attributes = [{ first_name: "Judy", last_name: "Jetson", gender: "female", birthdate: "2001-07-01" }]
+      verify_matching_people(subject_attributes, matching_attributes, differing_attributes)
+    end
+
+    it "does not return records where email is present in both records but differs" do
+      subject_attributes = { first_name: "Jane", last_name: "Jetson", gender: "female", email: "jane@jetson.com" }
+      matching_attributes = [
+        { first_name: "Jane", last_name: "Jetson", gender: "female", email: nil },
+        { first_name: "Jane", last_name: "Jetson", gender: "female", email: "jane@jetson.com" },
+      ]
+      differing_attributes = [{ first_name: "Jane", last_name: "Jetson", gender: "female", email: "jane@gmail.com" }]
+
+      verify_matching_people(subject_attributes, matching_attributes, differing_attributes)
+    end
+
+    it "does not return records where phone is present in both records but differs" do
+      subject_attributes = { first_name: "Jane", last_name: "Jetson", gender: "female", phone: "3035551212" }
+      matching_attributes = [
+        { first_name: "Jane", last_name: "Jetson", gender: "female", phone: nil },
+        { first_name: "Jane", last_name: "Jetson", gender: "female", phone: "3035551212" },
+      ]
+      differing_attributes = [{ first_name: "Jane", last_name: "Jetson", gender: "female", phone: "8887776666" }]
+
       verify_matching_people(subject_attributes, matching_attributes, differing_attributes)
     end
 
@@ -46,22 +74,92 @@ RSpec.shared_examples_for "matchable" do
     end
   end
 
+  describe "#definitive_matching_person" do
+    it "returns a record for which first and last names and gender and birthdate match" do
+      subject_attributes =
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", email: "jane@jetson.com", phone: "3035551212" }
+      matching_attributes =
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01" }
+
+      differing_attributes = [
+        { first_name: "Jeanie", last_name: "Jetson", gender: "female", birthdate: "1967-07-01" },
+        { first_name: "Jane", last_name: "Gleason", gender: "female", birthdate: "1967-07-01" },
+        { first_name: "Jane", last_name: "Jetson", gender: "male", birthdate: "1967-07-01" },
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1999-07-01" },
+      ]
+      verify_definitive_matching_person(subject_attributes, matching_attributes, differing_attributes)
+    end
+
+    it "returns a record for which first and last names and gender and email match" do
+      subject_attributes =
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", email: "jane@jetson.com", phone: "3035551212" }
+      matching_attributes =
+        { first_name: "Jane", last_name: "Jetson", gender: "female", email: "jane@jetson.com" }
+
+      differing_attributes = [
+        { first_name: "Jeanie", last_name: "Jetson", gender: "female", email: "jane@jetson.com" },
+        { first_name: "Jane", last_name: "Gleason", gender: "female", email: "jane@jetson.com" },
+        { first_name: "Jane", last_name: "Jetson", gender: "male", email: "jane@jetson.com" },
+        { first_name: "Jane", last_name: "Jetson", gender: "female", email: "jane@gmail.com" },
+      ]
+      verify_definitive_matching_person(subject_attributes, matching_attributes, differing_attributes)
+    end
+
+    it "returns a record for which first and last names and gender and phone match" do
+      subject_attributes =
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", email: "jane@jetson.com", phone: "3035551212" }
+      matching_attributes =
+        { first_name: "Jane", last_name: "Jetson", gender: "female", phone: "+13035551212" }
+
+      differing_attributes = [
+        { first_name: "Jeanie", last_name: "Jetson", gender: "female", phone: "3035551212" },
+        { first_name: "Jane", last_name: "Gleason", gender: "female", phone: "3035551212" },
+        { first_name: "Jane", last_name: "Jetson", gender: "male", phone: "3035551212" },
+        { first_name: "Jane", last_name: "Jetson", gender: "female", phone: "8887776666" },
+      ]
+      verify_definitive_matching_person(subject_attributes, matching_attributes, differing_attributes)
+    end
+
+    it "returns nil if more than one record is turned up" do
+      subject_attributes = { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01" }
+      matching_attributes = nil
+      differing_attributes = [
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "NM" },
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO" },
+      ]
+      verify_definitive_matching_person(subject_attributes, matching_attributes, differing_attributes)
+    end
+
+    def verify_definitive_matching_person(subject_attributes, matching_attributes, differing_attributes)
+      subject = described_class.new(subject_attributes)
+      matching_person = matching_attributes ? create(:person, matching_attributes) : nil
+      differing_people = differing_attributes.map { |attribute_set| create(:person, attribute_set) }
+      person = subject.definitive_matching_person
+      expect(person).to eq(matching_person)
+      differing_people.each { |differing_person| expect(person).not_to eq(differing_person) }
+    end
+  end
+
   describe "#exact_matching_person" do
     it "returns a record for which first and last names and gender match, and either state_code or age matches" do
-      subject_attributes = {first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO"}
+      subject_attributes = { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO" }
       matching_attributes = subject_attributes
-      differing_attributes = [{first_name: "Jeanie", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO"},
-                              {first_name: "Jane", last_name: "Gleason", gender: "female", birthdate: "1967-07-01", state_code: "CO"},
-                              {first_name: "Jane", last_name: "Jetson", gender: "male", birthdate: "1967-07-01", state_code: "CO"},
-                              {first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1999-07-01", state_code: "NM"}]
+      differing_attributes = [
+        { first_name: "Jeanie", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO" },
+        { first_name: "Jane", last_name: "Gleason", gender: "female", birthdate: "1967-07-01", state_code: "CO" },
+        { first_name: "Jane", last_name: "Jetson", gender: "male", birthdate: "1967-07-01", state_code: "CO" },
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1999-07-01", state_code: "NM" },
+      ]
       verify_exact_matching_person(subject_attributes, matching_attributes, differing_attributes)
     end
 
     it "returns nil if more than one record is turned up" do
-      subject_attributes = {first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO"}
+      subject_attributes = { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO" }
       matching_attributes = nil
-      differing_attributes = [{first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "NM"},
-                              {first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO"}]
+      differing_attributes = [
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "NM" },
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO" },
+      ]
       verify_exact_matching_person(subject_attributes, matching_attributes, differing_attributes)
     end
 


### PR DESCRIPTION
Currently, `possible_matching_people` returns every person with a similar name, even if there are strong indications to the contrary, like differing phone or email.

This PR removes from the set of `possible_matching_people` anyone whose phone or email both exists and is different from the subject's phone or email.