### PR TITLE
Callback to fill personal_info_hash

### DIFF
--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -37,6 +37,8 @@ class HistoricalFact < ApplicationRecord
 
   attr_writer :creator
 
+  before_save :fill_personal_info_hash
+
   scope :unreconciled, -> { where(person_id: nil) }
 
   def self.search(search_text)
@@ -64,5 +66,10 @@ class HistoricalFact < ApplicationRecord
   # Needed to keep PersonalInfo#bio from breaking
   def current_age_approximate
     nil
+  end
+
+  def fill_personal_info_hash
+    string = [first_name, last_name, gender, birthdate, state_code].compact.join(",")
+    self.personal_info_hash = Digest::MD5.hexdigest(string)
   end
 end

--- a/spec/factories/historical_fact.rb
+++ b/spec/factories/historical_fact.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :historical_fact do
+    organization
     first_name { FFaker::Name.first_name }
     last_name { FFaker::Name.last_name }
     birthdate { FFaker::Time.date(years_back: 70, latest_year: 2005) }

--- a/spec/models/historical_fact_spec.rb
+++ b/spec/models/historical_fact_spec.rb
@@ -16,4 +16,20 @@ RSpec.describe HistoricalFact, type: :model do
   it { is_expected.to strip_attribute(:state_code).collapse_spaces }
   it { is_expected.to strip_attribute(:country_code).collapse_spaces }
   it { is_expected.to strip_attribute(:comments).collapse_spaces }
+
+  describe "callbacks" do
+    subject { build(:historical_fact) }
+
+    it "creates a personal_info_hash when a new record is created" do
+      expect(subject.personal_info_hash).to be_nil
+      subject.save!
+      expect(subject.personal_info_hash).not_to be_nil
+    end
+
+    it "updates the personal_info_hash when an existing record is updated" do
+      subject.save!
+      subject.first_name = subject.first_name + "(updated)"
+      expect { subject.save! }.to change { subject.personal_info_hash }
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a `before_save` callback to fill or update the `personal_info_hash`.