### PR TITLE
Match historical facts based on efforts and related facts

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -22,6 +22,7 @@ class Effort < ApplicationRecord
   include DataStatusMethods
   include CapitalizeAttributes
   include Auditable
+  include Structpluck
   extend FriendlyId
 
   strip_attributes collapse_spaces: true

--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -39,6 +39,7 @@ class HistoricalFact < ApplicationRecord
 
   before_save :fill_personal_info_hash
 
+  scope :reconciled, -> { where.not(person_id: nil) }
   scope :unreconciled, -> { where(person_id: nil) }
 
   def self.search(search_text)
@@ -51,6 +52,10 @@ class HistoricalFact < ApplicationRecord
     return @creator if defined?(@creator)
 
     @creator = User.find_by(id: created_by) if created_by?
+  end
+
+  def related_facts
+    organization.historical_facts.where(personal_info_hash: personal_info_hash)
   end
 
   def reconciled?

--- a/app/services/historical_fact_auto_reconciler.rb
+++ b/app/services/historical_fact_auto_reconciler.rb
@@ -2,6 +2,7 @@
 
 class HistoricalFactAutoReconciler
   PERSONAL_ATTRIBUTES = [:first_name, :last_name, :gender, :birthdate, :email, :phone].freeze
+  RESULT_KINDS = ["dns", "dnf", "finished"].freeze
 
   def self.reconcile(parent)
     new(parent).reconcile
@@ -16,7 +17,12 @@ class HistoricalFactAutoReconciler
       # In case a race condition in which a fact is reconciled by another process
       next if fact.reconciled?
 
-      matching_person = fact.definitive_matching_person || fact.exact_matching_person
+      matching_person_id = person_id_from_effort(fact)
+      matching_person_id ||= person_id_from_related_facts(fact)
+
+      matching_person = person_from_id(matching_person_id) ||
+        fact.definitive_matching_person ||
+        fact.exact_matching_person
 
       person = if matching_person.present?
                  matching_person
@@ -40,4 +46,46 @@ class HistoricalFactAutoReconciler
 
   attr_reader :parent
   delegate :historical_facts, to: :parent, private: true
+
+  # @return [Hash<Array,Struct>]
+  def indexed_effort_structs
+    @indexed_effort_structs ||=
+      organization_efforts.struct_pluck(:person_id, :first_name, :last_name, :gender, :scheduled_start_time, :started, :finished).index_by { |struct| [struct.first_name, struct.last_name, struct.scheduled_start_time&.year] }
+  end
+
+  # @return [ActiveRecord::Relation<Effort>]
+  def organization_efforts
+    Effort.where(event: parent.events)
+  end
+
+  def person_from_id(matching_person_id)
+    Person.find_by(id: matching_person_id)
+  end
+
+  def person_id_from_effort(fact)
+    return unless fact.kind.in?(RESULT_KINDS)
+
+    key = [fact.first_name, fact.last_name, fact.comments.to_i]
+    effort = indexed_effort_structs[key]
+
+    if effort.present?
+      case fact.kind
+      when "dns"
+        matching_person_id = effort.person_id if !effort.started
+      when "dnf"
+        matching_person_id = effort.person_id if effort.started && !effort.finished
+      when "finished"
+        matching_person_id = effort.person_id if effort.finished
+      else
+        matching_person_id = nil
+      end
+    end
+    matching_person_id
+  end
+
+  # @param [HistoricalFact] fact
+  # @return [Integer, nil]
+  def person_id_from_related_facts(fact)
+    fact.related_facts.reconciled.pluck(:person_id).first
+  end
 end

--- a/spec/factories/historical_fact.rb
+++ b/spec/factories/historical_fact.rb
@@ -5,8 +5,11 @@ FactoryBot.define do
     organization
     first_name { FFaker::Name.first_name }
     last_name { FFaker::Name.last_name }
-    birthdate { FFaker::Time.date(years_back: 70, latest_year: 2005) }
     gender { %w[male female].sample }
     kind { "dns" }
+
+    trait :with_birthdate do
+      birthdate { FFaker::Time.date(years_back: 70, latest_year: 2005) }
+    end
   end
 end


### PR DESCRIPTION
This PR should greatly improve historical fact matching. It introduces two new matching algorithms:

1. Match on first name, last name, year, and result of a prior effort
2. Match on a related fact (same personal_info_hash) being matched