### PR TITLE
Add StateCountrySyncable module to HistoricalFact model

### DIFF
--- a/app/models/concerns/state_country_syncable.rb
+++ b/app/models/concerns/state_country_syncable.rb
@@ -15,8 +15,6 @@ module StateCountrySyncable
   private
 
   def sync_state_and_country
-    return unless will_save_change_to_state_code? || will_save_change_to_country_code?
-
     sync_state
     sync_country
   end

--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -26,6 +26,7 @@ class HistoricalFact < ApplicationRecord
   include Matchable
   include PersonalInfo
   include Searchable
+  include StateCountrySyncable
 
   strip_attributes collapse_spaces: true
   strip_attributes only: [:phone, :emergency_phone], regex: /[^0-9|+]/

--- a/spec/models/historical_fact_spec.rb
+++ b/spec/models/historical_fact_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe HistoricalFact, type: :model do
   it_behaves_like "auditable"
   it_behaves_like "matchable"
+  it_behaves_like "state_country_syncable"
 
   it { is_expected.to capitalize_attribute(:first_name) }
   it { is_expected.to capitalize_attribute(:last_name) }

--- a/spec/support/concerns/state_country_syncable.rb
+++ b/spec/support/concerns/state_country_syncable.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for "state_country_syncable" do
+  let(:model) { described_class }
+  let(:model_name) { model.name.underscore.to_sym }
+  subject { build_stubbed(model_name, state_code: state_code, country_code: country_code) }
+  let(:state_code) { "CO" }
+  let(:country_code) { "US" }
+
+  describe "before validation" do
+    context "when state_code and country_code are blank" do
+      let(:state_code) { nil }
+      let(:country_code) { nil }
+
+      it "makes no changes to state_name or country_name" do
+        subject.run_callbacks(:save)
+        expect(subject.state_name).to be_nil
+        expect(subject.country_name).to be_nil
+      end
+    end
+
+    context "when only state_code is blank" do
+      let(:state_code) { nil }
+
+      it "makes no changes to state_name but adds country_name" do
+        subject.run_callbacks(:save)
+        expect(subject.state_name).to be_nil
+        expect(subject.country_name).to eq("United States")
+      end
+    end
+
+    context "when only country_code is blank" do
+      let(:country_code) { nil }
+
+      it "makes no changes to state_name or country_name" do
+        subject.run_callbacks(:save)
+        expect(subject.state_name).to be_nil
+        expect(subject.country_name).to be_nil
+      end
+    end
+
+    context "when both state_code and country_code are updated" do
+      it "resets state_name and country_name to match" do
+        subject.run_callbacks(:save)
+        expect(subject.state_name).to eq("Colorado")
+        expect(subject.country_name).to eq("United States")
+
+        subject.state_code = "BC"
+        subject.country_code = "CA"
+
+        subject.run_callbacks(:save)
+        expect(subject.state_name).to eq("British Columbia")
+        expect(subject.country_name).to eq("Canada")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the StateCountrySyncable module to the HistoricalFact model. This will update `state_name` and `country_name` to keep them in sync with `state_code` and `country_code`, respectively.

We will need to manually update existing records in the database.