### PR TITLE
Rake task to merge duplicate people in the database

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationRecord < ActiveRecord::Base
+  include Structpluck
+
   self.abstract_class = true
 
   scope :standard_includes, -> { all } # May be overriden in models

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -22,7 +22,6 @@ class Effort < ApplicationRecord
   include DataStatusMethods
   include CapitalizeAttributes
   include Auditable
-  include Structpluck
   extend FriendlyId
 
   strip_attributes collapse_spaces: true

--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class LotteryEntrant < ApplicationRecord
-  include Structpluck
   include StateCountrySyncable
   include Searchable
   include PersonalInfo

--- a/lib/tasks/maintenance/merge_duplicate_people.rake
+++ b/lib/tasks/maintenance/merge_duplicate_people.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+namespace :maintenance do
+  desc "Merges all duplicate people in the database"
+  task merge_duplicate_people: :environment do
+    puts "Attempting to merge all duplicate people in the database"
+
+    email_counts = ::Person.select("first_name, last_name, email, count(email) as duplicates").group("first_name, last_name, email")
+    duplicate_structs = ::Person.where("duplicates > ?", 1).from(email_counts, "people").struct_pluck(:email, :first_name, :last_name)
+    duplicate_count = duplicate_structs.size
+
+    puts "Found #{duplicate_count} duplicated people"
+
+    progress_bar = ::ProgressBar.new(duplicate_count)
+
+    duplicate_structs.each do |struct|
+      progress_bar.increment!
+      people_to_merge = ::Person.where(email: struct.email, first_name: struct.first_name, last_name: struct.last_name).order(:id).to_a
+      master_record = people_to_merge.shift
+
+      people_to_merge.each { |target| ::Interactors::MergePeople.perform!(master_record, target) }
+    rescue ActiveRecordError => e
+      puts "Could not merge person with email #{email}:"
+      puts e
+    end
+  end
+end


### PR DESCRIPTION
We are getting many duplicate people in the database, evidenced by duplicate first_name, last_name, and email. This may be occurring because race directors are not reconciling entrants in a timely manner and then re-importing the same entrant lists.

This PR adds a rake task that finds duplicate people and merges them into the first of the records that was created.