### PR TITLE
Orphaned people are those without efforts or historical facts

### DIFF
--- a/lib/tasks/maintenance/delete_orphaned_people.rake
+++ b/lib/tasks/maintenance/delete_orphaned_people.rake
@@ -5,7 +5,9 @@ namespace :maintenance do
   task delete_orphaned_people: :environment do
     puts "Attempting to delete all orphaned person records from the database"
 
-    orphaned_people = ::Person.left_joins(:efforts).where(efforts: {person_id: nil})
+    orphaned_people = ::Person.left_joins(:efforts, :historical_facts)
+      .where(efforts: { person_id: nil }, historical_facts: { person_id: nil })
+      .distinct
     orphan_count = orphaned_people.count
 
     puts "Found #{orphan_count} orphaned people"


### PR DESCRIPTION
Currently, the `maintenance:delete_orphaned_people` rake task defines `orphaned_people` as those having no efforts.

This PR redefines the term to mean only those people having no efforts and no historical facts.