### PR TITLE
New person button for historical facts reconcile

### DIFF
--- a/app/controllers/historical_facts_controller.rb
+++ b/app/controllers/historical_facts_controller.rb
@@ -60,7 +60,7 @@ class HistoricalFactsController < ApplicationController
     redirect_hash = params[:redirect_hash]
     personal_info_hash = params[:personal_info_hash]
     person_id = params[:person_id]
-    person = Person.find(person_id)
+    person = person_id == "new" ? Person.new : Person.find(person_id)
 
     if personal_info_hash.present? && person.present?
       HistoricalFactsReconcileJob.perform_later(
@@ -71,12 +71,12 @@ class HistoricalFactsController < ApplicationController
       )
 
       if redirect_hash.present?
-        redirect_to reconcile_organization_historical_facts_path(@organization, personal_info_hash: redirect_hash), success: "Matching facts with #{person.full_name}"
+        redirect_to reconcile_organization_historical_facts_path(@organization, personal_info_hash: redirect_hash), flash: { success: "Matching facts with #{person.full_name.presence || 'new Person'}" }
       else
-        redirect_to organization_historical_facts_path(@organization), notice: "Nothing to reconcile."
+        redirect_to organization_historical_facts_path(@organization), flash: { warning: "Nothing to reconcile." }
       end
     else
-      redirect_to reconcile_organization_historical_facts_path(@organization), warning: "Unable to match person_id: #{person_id || '[missing]'} and personal_info_hash: #{personal_info_hash || '[missing'}"
+      redirect_to reconcile_organization_historical_facts_path(@organization), flash: { danger: "Unable to match person_id: #{person_id || '[missing]'} and personal_info_hash: #{personal_info_hash || '[missing'}" }
     end
   end
 

--- a/app/services/historical_fact_reconciler.rb
+++ b/app/services/historical_fact_reconciler.rb
@@ -14,7 +14,8 @@ class HistoricalFactReconciler
   end
 
   def reconcile
-    person = Person.find_by(id: person_id)
+    person = Person.new if person_id == "new"
+    person ||= Person.find_by(id: person_id)
     return if person.nil?
 
     historical_facts.each do |fact|

--- a/app/views/historical_facts/_possible_matching_person_card.html.erb
+++ b/app/views/historical_facts/_possible_matching_person_card.html.erb
@@ -3,9 +3,9 @@
 <div class="card mb-3">
   <div class="card-header">
     <div class="row">
-      <div class="col h5 fw-bold">
+    <div class="col-auto">
         <span><%= badge_with_text(person.id, color: :secondary) %></span>
-        <span><%= person.full_name %></span>
+        <span class="h5 fw-bold"><%= person.full_name %></span>
         <span><%= "(#{person.bio})" %></span>
       </div>
       <div class="col text-end">
@@ -17,11 +17,12 @@
                         redirect_hash: presenter.next_personal_info_hash || presenter.previous_personal_info_hash,
                       ),
                       method: :patch,
+                      data: { turbo: false},
                       class: "btn btn-sm btn-outline-primary" %>
       </div>
     </div>
     <div class="row">
-      <div class="col">
+      <div class="col-auto">
         <%= person.flexible_geolocation %>
       </div>
       <div class="col text-end">

--- a/app/views/historical_facts/_reconcile_card.html.erb
+++ b/app/views/historical_facts/_reconcile_card.html.erb
@@ -1,0 +1,36 @@
+<%# locals: (presenter:) %>
+
+<div class="card">
+  <div class="card-header">
+    <div class="row">
+      <div class="col">
+        <span class="h5 fw-bold"><%= presenter.full_name %></span>
+        <span><%= "(#{presenter.bio})" %></span>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <%= presenter.flexible_geolocation %>
+      </div>
+      <div class="col text-end">
+        <%= "#{presenter.email}, #{presenter.phone}" %>
+      </div>
+    </div>
+  </div>
+  <div class="card-body">
+    <table class="table">
+      <thead>
+      <tr>
+        <th></th>
+        <th>Kind</th>
+        <th class="text-center">Quantity</th>
+        <th>Comments</th>
+        <th class="text-end">Person</th>
+      </tr>
+      </thead>
+      <tbody>
+      <%= render partial: "reconcile_row", collection: presenter.relevant_historical_facts, as: :fact %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/historical_facts/reconcile.html.erb
+++ b/app/views/historical_facts/reconcile.html.erb
@@ -36,55 +36,50 @@
   <div class="row">
     <% if @presenter.personal_info_hash %>
 
-    <div class="col">
-      <div class="h3 pb-3">Historical Facts</div>
-      <div class="card">
-        <div class="card-header">
-          <div class="row">
-            <div class="col h5 fw-bold">
-              <span><%= @presenter.full_name %></span>
-              <span><%= "(#{@presenter.bio})" %></span>
-            </div>
+      <div class="col">
+        <div class="h3 pb-3">Historical Facts</div>
+        <%= render partial: "reconcile_card", locals: { presenter: @presenter } %>
+      </div>
+
+      <div class="col">
+        <div class="row">
+          <div class="col">
+            <div class="h3 pb-3">Possible Matching People</div>
           </div>
-          <div class="row">
-            <div class="col">
-              <%= @presenter.flexible_geolocation %>
-            </div>
-            <div class="col text-end">
-              <%= "#{@presenter.email}, #{@presenter.phone}" %>
-            </div>
+          <div class="col text-end">
+            <%= button_to "Create new person",
+                          match_organization_historical_facts_path(
+                            @presenter.organization,
+                            personal_info_hash: @presenter.personal_info_hash,
+                            person_id: "new",
+                            redirect_hash: @presenter.next_personal_info_hash || @presenter.previous_personal_info_hash,
+                            ),
+                          method: :patch,
+                          data: { turbo: false},
+                          class: "btn btn-sm btn-outline-primary" %>
           </div>
         </div>
-        <div class="card-body">
-          <table class="table">
-            <thead>
-            <tr>
-              <th></th>
-              <th>Kind</th>
-              <th class="text-center">Quantity</th>
-              <th>Comments</th>
-              <th class="text-end">Person</th>
-            </tr>
-            </thead>
-            <tbody>
-            <%= render partial: "reconcile_row", collection: @presenter.relevant_historical_facts, as: :fact %>
-            </tbody>
-          </table>
+        <div class="row">
+          <div class="col">
+            <%= render partial: "possible_matching_person_card",
+                       collection: @presenter.possible_matching_people.order(:id),
+                       as: :person,
+                       locals: { presenter: @presenter } %>
+          </div>
         </div>
       </div>
-    </div>
-
-    <div class="col">
-      <div class="h3 pb-3">Possible Matching People</div>
-      <%= render partial: "possible_matching_person",
-                 collection: @presenter.possible_matching_people.order(:id),
-                 as: :person,
-                 locals: { presenter: @presenter } %>
-    </div>
-  <% else %>
-<div class="col">
-  <div class="h3 pb-3">Nothing to reconcile</div>
-</div>
-  <% end %>
+    <% else %>
+      <div class="col">
+        <%= render partial: "shared/callout_with_link",
+                   locals: {
+                     callout_color: "info",
+                     icon_color: "info",
+                     icon_name: "circle-info",
+                     main_text: "All historical facts have been reconciled",
+                     detail_paragraphs: ["If any historical facts need to be reconciled, they will appear here."],
+                     link: link_to("Back", organization_historical_facts_path(@presenter.organization), class: "btn btn-outline-primary"),
+                   } %>
+      </div>
+    <% end %>
   </div>
 </article>

--- a/spec/services/historical_fact_reconciler_spec.rb
+++ b/spec/services/historical_fact_reconciler_spec.rb
@@ -45,5 +45,15 @@ RSpec.describe HistoricalFactReconciler do
         expect(fact_2.reload.person_id).to be_nil
       end
     end
+
+    context "when the person_id is 'new'" do
+      let(:person_id) { "new" }
+      # New person slug is colliding with existing person slug and causing the spec to fail
+      before { person.update(slug: "bruno-fadel-1") }
+
+      it "creates a new Person record and backfills information from historical facts" do
+        expect { subject.reconcile }.to change(Person, :count).by(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Historical facts reconcile is working, but we have no way to create a new person if none of the possible matches is correct.

This PR adds a "New person" button in the manual reconcile view.