### PR TITLE
Historical facts reconcile UI improvements

### DIFF
--- a/app/views/efforts/_reconcile_row.html.erb
+++ b/app/views/efforts/_reconcile_row.html.erb
@@ -2,6 +2,6 @@
 
 <tr class="align-middle">
   <td><%= effort.event_name %></td>
-  <td class="text-center"><%= effort.scheduled_start_time %></td>
-  <td><%= effort.finished? %></td>
+  <td class="text-center"><%= effort.scheduled_start_time.year %></td>
+  <td><%= badgeize_boolean(effort.finished?) %></td>
 </tr>

--- a/app/views/historical_facts/_possible_matching_person_card.html.erb
+++ b/app/views/historical_facts/_possible_matching_person_card.html.erb
@@ -34,9 +34,9 @@
     <table class="table">
       <thead>
       <tr>
-        <th>Kind</th>
-        <th class="text-center">Quantity</th>
-        <th>Comments</th>
+        <th>Event</th>
+        <th class="text-center">Year</th>
+        <th>Finished?</th>
       </tr>
       </thead>
       <tbody>

--- a/app/views/historical_facts/_possible_matching_person_card.html.erb
+++ b/app/views/historical_facts/_possible_matching_person_card.html.erb
@@ -41,7 +41,7 @@
       </thead>
       <tbody>
       <% if person.efforts.present? %>
-        <%= render partial: "efforts/reconcile_row", collection: person.efforts.includes(:event), as: :effort %>
+        <%= render partial: "efforts/reconcile_row", collection: person.efforts.joins(:event).includes(:event).order("events.scheduled_start_time"), as: :effort %>
       <% else %>
         <tr>
           <td colspan="3">No Efforts</td>

--- a/app/views/historical_facts/_reconcile_card.html.erb
+++ b/app/views/historical_facts/_reconcile_card.html.erb
@@ -29,7 +29,7 @@
       </tr>
       </thead>
       <tbody>
-      <%= render partial: "reconcile_row", collection: presenter.relevant_historical_facts, as: :fact %>
+      <%= render partial: "reconcile_row", collection: presenter.relevant_historical_facts.order(:kind, :comments), as: :fact %>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
This PR makes a few improvements to historical fact reconcile:

- Fixes column names on possible matching person card
- Better formatting of effort information on possible matching person card
- Better ordering of efforts and historical facts on all cards