### PR TITLE
Use event_start_time instead of scheduled_start_time

### DIFF
--- a/app/views/efforts/_reconcile_row.html.erb
+++ b/app/views/efforts/_reconcile_row.html.erb
@@ -2,6 +2,6 @@
 
 <tr class="align-middle">
   <td><%= effort.event_name %></td>
-  <td class="text-center"><%= effort.scheduled_start_time.year %></td>
+  <td class="text-center"><%= effort.event_start_time.year %></td>
   <td><%= badgeize_boolean(effort.finished?) %></td>
 </tr>


### PR DESCRIPTION
Fixes a nil handling problem when an effort has no scheduled start time.