### PR TITLE
Allow phone numbers to accept ++ at the start

### DIFF
--- a/app/services/historical_fact_reconciler.rb
+++ b/app/services/historical_fact_reconciler.rb
@@ -23,7 +23,7 @@ class HistoricalFactReconciler
       ::Interactors::PullGeoAttributes.perform(fact, person)
 
       person.historical_facts << fact
-      person.save
+      person.save!
     end
   end
 

--- a/config/initializers/my_constants.rb
+++ b/config/initializers/my_constants.rb
@@ -1,2 +1,2 @@
 VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
-VALID_PHONE_REGEX = /\A\+?\d+\z/.freeze
+VALID_PHONE_REGEX = /\A\+{0,2}\d+\z/.freeze

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Person, type: :model do
     end
 
     it "rejects implausible birthdates" do
-      bad_birthdates = {"1880-01-01" => "can't be before 1900",
-                        1.day.from_now => "can't be today or in the future"}
+      bad_birthdates = { "1880-01-01" => "can't be before 1900",
+                         1.day.from_now => "can't be today or in the future" }
       bad_birthdates.each do |birthdate, error_message|
         person = Person.new(birthdate: birthdate)
         expect(person).not_to be_valid
@@ -72,6 +72,25 @@ RSpec.describe Person, type: :model do
     it "permits plausible birthdates" do
       person = build_stubbed(:person, birthdate: "1977-01-01")
       expect(person).to be_valid
+    end
+
+    it "rejects invalid phone numbers" do
+      bad_phone_numbers = %w[0+0 +++123 555+333]
+
+      bad_phone_numbers.each do |phone|
+        person = build_stubbed(:person, phone: phone)
+        expect(person).not_to be_valid
+        expect(person.errors[:phone]).to include("is invalid")
+      end
+    end
+
+    it "accepts valid phone numbers" do
+      good_phone_numbers = %w[3035551212 13035551212 +13035551212 ++442345678]
+
+      good_phone_numbers.each do |phone|
+        person = build_stubbed(:person, phone: phone)
+        expect(person).to be_valid
+      end
     end
   end
 end


### PR DESCRIPTION
Some foreign phone numbers start with `++`. This PR allows those numbers to be accepted.

It also raises an error in the historical facts reconciler when a person cannot be saved.