### PR TITLE
Use correct scoping for historical facts pagination

### DIFF
--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -40,6 +40,16 @@ class HistoricalFact < ApplicationRecord
 
   before_save :fill_personal_info_hash
 
+  scope :by_kind, ->(kinds) { where(kind: kinds) if kinds.present? }
+  scope :by_reconciled, ->(reconciled_boolean) do
+    if reconciled_boolean == true
+      where.not(person_id: nil)
+    elsif reconciled_boolean == false
+      where(person_id: nil)
+    else
+      all
+    end
+  end
   scope :reconciled, -> { where.not(person_id: nil) }
   scope :unreconciled, -> { where(person_id: nil) }
 

--- a/spec/models/historical_fact_spec.rb
+++ b/spec/models/historical_fact_spec.rb
@@ -33,4 +33,97 @@ RSpec.describe HistoricalFact, type: :model do
       expect { subject.save! }.to change { subject.personal_info_hash }
     end
   end
+
+  describe "scopes" do
+    describe ".by_kind" do
+      subject { described_class.by_kind(kinds) }
+
+      let(:kinds) { [] }
+      let!(:fact_1) { create(:historical_fact, kind: :dns) }
+      let!(:fact_2) { create(:historical_fact, kind: :dnf) }
+      let!(:fact_3) { create(:historical_fact, kind: :finished) }
+
+      context "when kinds is an empty array" do
+        it "returns all historical facts" do
+          expect(subject.count).to eq(HistoricalFact.count)
+        end
+      end
+
+      context "when kinds is nil" do
+        let(:kinds) { nil }
+
+        it "returns all historical facts" do
+          expect(subject.count).to eq(HistoricalFact.count)
+        end
+      end
+
+      context "when kinds contains a single value" do
+        let(:kinds) { [:dns] }
+
+        it "returns historical facts having that kind" do
+          expect(subject.count).to eq(1)
+          expect(subject.first.kind).to eq("dns")
+        end
+      end
+
+      context "when kinds contains more than one value" do
+        let(:kinds) { [:dns, :dnf] }
+
+        it "returns historical facts having those kinds" do
+          expect(subject.count).to eq(2)
+          expect(subject.pluck(:kind)).to match_array %w[dns dnf]
+        end
+      end
+
+      context "when kinds contains all available values" do
+        let(:kinds) { [:dns, :dnf, :finished] }
+
+        it "returns all historical facts" do
+          expect(subject.count).to eq(3)
+          expect(subject.pluck(:kind)).to match_array %w[dns dnf finished]
+        end
+      end
+    end
+
+    describe ".by_reconciled" do
+      subject { described_class.by_reconciled(reconciled_booleans) }
+
+      let(:reconciled_booleans) { nil }
+      let!(:fact_1) { create(:historical_fact, person: person) }
+      let!(:fact_2) { create(:historical_fact, person: nil) }
+      let(:person) { people(:bruno_fadel) }
+
+      context "when reconciled_booleans is nil" do
+        it "returns all historical facts" do
+          expect(subject.count).to eq(HistoricalFact.count)
+        end
+      end
+
+      context "when reconciled_booleans is false" do
+        let(:reconciled_booleans) { false }
+
+        it "returns historical facts that are not reconciled" do
+          expect(subject.count).to eq(1)
+          expect(subject.first).to eq(fact_2)
+        end
+      end
+
+      context "when reconciled_booleans is true" do
+        let(:reconciled_booleans) { true }
+
+        it "returns historical facts that are reconciled" do
+          expect(subject.count).to eq(1)
+          expect(subject.first).to eq(fact_1)
+        end
+      end
+
+      context "when reconciled_booleans is anything else" do
+        let(:reconciled_booleans) { "nonsense" }
+
+        it "returns all historical facts" do
+          expect(subject.count).to eq(HistoricalFact.count)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, pagination in the historical facts index is not working efficiently. The page is loading historical facts without limit, then performing an `Array#select` in memory, then paginating from there.

This PR moves the filtering logic for kinds and reconciled status into proper scopes on the model, so that the filtering logic is performed at the database level before pagination.