### PR TITLE
Historical facts show year and fix rake task

### DIFF
--- a/app/views/historical_facts/_historical_fact.html.erb
+++ b/app/views/historical_facts/_historical_fact.html.erb
@@ -7,12 +7,12 @@
           fa_icon("circle-check", type: :regular, class: "text-success", data: { controller: "tooltip" }, title: "Reconciled") %>
   </td>
   <td><%= historical_fact_kind_badge(fact.kind) %></td>
+  <td class="text-center"><%= fact.year %></td>
   <td class="text-center"><%= fact.quantity %></td>
-  <td><%= fact.comments %></td>
+  <td><%= fact.comments&.truncate(20) %></td>
   <td><%= fact.full_name %></td>
   <td><%= fact.gender.titleize %></td>
   <td><%= fact.flexible_geolocation %></td>
-  <td><%= fact.birthdate %></td>
   <td><%= fact.email %></td>
   <td><%= fact.phone %></td>
 </tr>

--- a/app/views/historical_facts/_historical_facts_list.html.erb
+++ b/app/views/historical_facts/_historical_facts_list.html.erb
@@ -27,12 +27,12 @@
   <tr>
     <th></th>
     <th>Kind</th>
+    <th class="text-center">Year</th>
     <th class="text-center">Quantity</th>
     <th>Comments</th>
     <th>Name</th>
     <th>Gender</th>
     <th>From</th>
-    <th>Birthdate</th>
     <th>Email</th>
     <th>Phone</th>
   </tr>

--- a/lib/tasks/temp/migrate_historical_facts_year.rake
+++ b/lib/tasks/temp/migrate_historical_facts_year.rake
@@ -7,7 +7,7 @@ namespace :temp do
 
     relevant_kinds = %w[dns dnf finished]
 
-    historical_facts = HistoricalFact.where(kind: relevant_kinds).count
+    historical_facts = HistoricalFact.where(kind: relevant_kinds)
     hf_count = historical_facts.count
 
     puts "Found #{hf_count} historical facts needing migration"


### PR DESCRIPTION
This PR exposes the `year` column in the historical facts index. It also fixes a bug in the temporary rake task.