### PR TITLE
Historical facts ultrasignup import

### DIFF
--- a/app/helpers/badge_helper.rb
+++ b/app/helpers/badge_helper.rb
@@ -47,27 +47,27 @@ module BadgeHelper
       title = "Finish"
       color = :primary
       tooltip_text = "Finished"
-    when "volunteer_minor"
-      title = "VMinor"
+    when "volunteer_year"
+      title = "VYear"
       color = :secondary
-      tooltip_text = "Minor volunteer work for a specific event"
-    when "volunteer_major"
-      title = "VMajor"
+      tooltip_text = "Volunteer work for a specific year"
+    when "volunteer_year_major"
+      title = "VYearMaj"
       color = :secondary
-      tooltip_text = "Major volunteer work for a specific event"
-    when "volunteer_legacy"
-      title = "VLegacy"
+      tooltip_text = "Major volunteer work for a specific year"
+    when "volunteer_multi"
+      title = "VMulti"
       color = :secondary
-      tooltip_text = "Years of legacy volunteer work (no event specified)"
-    when "reported_qualifier_finish"
+      tooltip_text = "Multiple years of volunteer work (as reported in a specific year)"
+    when "qualifier_finish"
       title = "Qualifier"
       color = :success
       tooltip_text = "Reported qualifier finished"
-    when "provided_emergency_contact"
+    when "emergency_contact"
       title = "Contact"
       color = :success
       tooltip_text = "Provided emergency contact"
-    when "provided_previous_name"
+    when "previous_name"
       title = "PrevName"
       color = :success
       tooltip_text = "Provided previous name"

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -213,8 +213,8 @@ module DropdownHelper
     items = [
       { text: "All kinds", kinds: [] },
       { text: "Outcome", kinds: %w[dns dnf finished] },
-      { text: "Volunteer", kinds: %w[volunteer_minor volunteer_major volunteer_legacy] },
-      { text: "Provided", kinds: %w[reported_qualifier_finish provided_emergency_contact provided_previous_names] },
+      { text: "Volunteer", kinds: %w[volunteer_year volunteer_year_major volunteer_multi] },
+      { text: "Provided", kinds: %w[qualifier_finish emergency_contact previous_names] },
       { text: "Legacy", kinds: %w[lottery_ticket_count_legacy lottery_division_legacy] },
     ]
 

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -448,6 +448,8 @@ module DropdownHelper
         link: new_import_job_path(import_job: { parent_type: "Organization", parent_id: view_object.organization.id, format: :historical_facts }) },
       { name: "Hardrock legacy format",
         link: new_import_job_path(import_job: { parent_type: "Organization", parent_id: view_object.organization.id, format: :hardrock_historical_facts }) },
+      { name: "Ultrasignup format",
+        link: new_import_job_path(import_job: { parent_type: "Organization", parent_id: view_object.organization.id, format: :ultrasignup_historical_facts }) },
     ]
 
     build_dropdown_menu("Import", dropdown_items, button: true)

--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -21,7 +21,7 @@ class HistoricalFact < ApplicationRecord
     finished: 10,
     lottery_application: 11,
     ever_finished: 12,
-    dns_since_finished: 13,
+    dns_since_finish: 13,
   }
 
   include Auditable

--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -50,6 +50,7 @@ class HistoricalFact < ApplicationRecord
       all
     end
   end
+  scope :ordered, -> { order(:last_name, :first_name, :state_code, :year, :kind) }
   scope :reconciled, -> { where.not(person_id: nil) }
   scope :unreconciled, -> { where(person_id: nil) }
 

--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -9,16 +9,19 @@ class HistoricalFact < ApplicationRecord
 
   enum kind: {
     dns: 0,
-    volunteer_minor: 1,
-    volunteer_major: 2,
-    volunteer_legacy: 3,
-    reported_qualifier_finish: 4,
-    provided_emergency_contact: 5,
-    provided_previous_name: 6,
+    volunteer_year: 1,
+    volunteer_year_major: 2,
+    volunteer_multi: 3,
+    qualifier_finish: 4,
+    emergency_contact: 5,
+    previous_name: 6,
     lottery_ticket_count_legacy: 7,
     lottery_division_legacy: 8,
     dnf: 9,
     finished: 10,
+    lottery_application: 11,
+    ever_finished: 12,
+    dns_since_finished: 13,
   }
 
   include Auditable

--- a/app/presenters/organization_historical_facts_presenter.rb
+++ b/app/presenters/organization_historical_facts_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OrganizationHistoricalFactsPresenter < OrganizationPresenter
-  DEFAULT_ORDER = { last_name: :asc, first_name: :asc, state_code: :asc }
+  DEFAULT_ORDER = { last_name: :asc, first_name: :asc, state_code: :asc, year: :asc }
 
   attr_reader :request
 

--- a/app/presenters/organization_historical_facts_presenter.rb
+++ b/app/presenters/organization_historical_facts_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OrganizationHistoricalFactsPresenter < OrganizationPresenter
-  DEFAULT_ORDER = { last_name: :asc, first_name: :asc, state_code: :asc, year: :asc }
+  DEFAULT_ORDER = { last_name: :asc, first_name: :asc, state_code: :asc, year: :asc, kind: :asc }
 
   attr_reader :request
 

--- a/app/views/historical_facts/_reconcile_card.html.erb
+++ b/app/views/historical_facts/_reconcile_card.html.erb
@@ -23,13 +23,14 @@
       <tr>
         <th></th>
         <th>Kind</th>
+        <th class="text-center">Year</th>
         <th class="text-center">Quantity</th>
         <th>Comments</th>
         <th class="text-end">Person</th>
       </tr>
       </thead>
       <tbody>
-      <%= render partial: "reconcile_row", collection: presenter.relevant_historical_facts.order(:kind, :comments), as: :fact %>
+      <%= render partial: "reconcile_row", collection: presenter.relevant_historical_facts.order(:year, :kind), as: :fact %>
       </tbody>
     </table>
   </div>

--- a/app/views/historical_facts/_reconcile_card.html.erb
+++ b/app/views/historical_facts/_reconcile_card.html.erb
@@ -30,7 +30,7 @@
       </tr>
       </thead>
       <tbody>
-      <%= render partial: "reconcile_row", collection: presenter.relevant_historical_facts.order(:year, :kind), as: :fact %>
+      <%= render partial: "reconcile_row", collection: presenter.relevant_historical_facts.ordered, as: :fact %>
       </tbody>
     </table>
   </div>

--- a/app/views/historical_facts/_reconcile_row.html.erb
+++ b/app/views/historical_facts/_reconcile_row.html.erb
@@ -7,6 +7,7 @@
           fa_icon("circle-check", type: :regular, class: "text-success", data: { controller: "tooltip" }, title: "Reconciled") %>
   </td>
   <td><%= historical_fact_kind_badge(fact.kind) %></td>
+  <td class="text-center"><%= fact.year %></td>
   <td class="text-center"><%= fact.quantity %></td>
   <td><%= fact.comments %></td>
   <td class="text-end"><%= badge_with_text(fact.person_id, color: :secondary) %></td>

--- a/lib/etl/async_importer.rb
+++ b/lib/etl/async_importer.rb
@@ -54,6 +54,10 @@ module ETL
         self.extract_strategy = Extractors::CsvFileStrategy
         self.transform_strategy = Transformers::Async::HardrockHistoricalFactsStrategy
         self.load_strategy = Loaders::AsyncInsertStrategy
+      when :ultrasignup_historical_facts
+        self.extract_strategy = Extractors::CsvFileStrategy
+        self.transform_strategy = Transformers::Async::UltrasignupHistoricalFactsStrategy
+        self.load_strategy = Loaders::AsyncInsertStrategy
       when :lottery_entrants
         self.extract_strategy = Extractors::CsvFileStrategy
         self.transform_strategy = Transformers::LotteryEntrantsStrategy

--- a/lib/etl/transformers/async/hardrock_historical_facts_strategy.rb
+++ b/lib/etl/transformers/async/hardrock_historical_facts_strategy.rb
@@ -58,7 +58,8 @@ module ETL::Transformers::Async
         if year_outcome.present?
           proto_record = base_proto_record.deep_dup
           proto_record[:kind] = year_outcome
-          proto_record[:year] = year
+          proto_record[:year] = year.to_s.to_i
+
           proto_records << proto_record
         end
       end
@@ -72,6 +73,7 @@ module ETL::Transformers::Async
         proto_record[:kind] = :volunteer_multi
         proto_record[:quantity] = year_count
         proto_record[:comments] = struct[:Description_of_service]
+
         proto_records << proto_record
       end
     end
@@ -83,6 +85,7 @@ module ETL::Transformers::Async
         proto_record = base_proto_record.deep_dup
         proto_record[:kind] = :qualifier_finish
         proto_record[:comments] = reported_qualifier
+
         proto_records << proto_record
       end
     end
@@ -95,6 +98,7 @@ module ETL::Transformers::Async
         proto_record = base_proto_record.deep_dup
         proto_record[:kind] = :emergency_contact
         proto_record[:comments] = [emergency_contact.presence, emergency_phone.presence].compact.join(", ")
+
         proto_records << proto_record
       end
     end
@@ -108,6 +112,7 @@ module ETL::Transformers::Async
         proto_record = base_proto_record.deep_dup
         proto_record[:kind] = :previous_name
         proto_record[:comments] = previous_names
+
         proto_records << proto_record
       end
     end
@@ -118,6 +123,7 @@ module ETL::Transformers::Async
       proto_record = base_proto_record.deep_dup
       proto_record[:kind] = :lottery_ticket_count_legacy
       proto_record[:quantity] = legacy_count
+
       proto_records << proto_record
     end
 
@@ -127,6 +133,7 @@ module ETL::Transformers::Async
       proto_record = base_proto_record.deep_dup
       proto_record[:kind] = :lottery_division_legacy
       proto_record[:comments] = legacy_division
+
       proto_records << proto_record
     end
   end

--- a/lib/etl/transformers/async/hardrock_historical_facts_strategy.rb
+++ b/lib/etl/transformers/async/hardrock_historical_facts_strategy.rb
@@ -58,7 +58,7 @@ module ETL::Transformers::Async
         if year_outcome.present?
           proto_record = base_proto_record.deep_dup
           proto_record[:kind] = year_outcome
-          proto_record[:comments] = year
+          proto_record[:year] = year
           proto_records << proto_record
         end
       end

--- a/lib/etl/transformers/async/hardrock_historical_facts_strategy.rb
+++ b/lib/etl/transformers/async/hardrock_historical_facts_strategy.rb
@@ -24,7 +24,7 @@ module ETL::Transformers::Async
       parsed_structs.each.with_index(1) do |struct, row_index|
         set_base_proto_record(struct)
         record_prior_year_outcomes(struct)
-        record_volunteer_legacy(struct)
+        record_volunteer_multi(struct)
         record_2024_qualifier(struct)
         record_emergency_contact(struct)
         record_previous_names(struct)
@@ -64,13 +64,13 @@ module ETL::Transformers::Async
       end
     end
 
-    def record_volunteer_legacy(struct)
-      volunteer_legacy_count = struct[:Years_Volunteering]
+    def record_volunteer_multi(struct)
+      year_count = struct[:Years_Volunteering]
 
-      if volunteer_legacy_count.present? && volunteer_legacy_count.positive?
+      if year_count.present? && year_count.positive?
         proto_record = base_proto_record.deep_dup
-        proto_record[:kind] = :volunteer_legacy
-        proto_record[:quantity] = volunteer_legacy_count
+        proto_record[:kind] = :volunteer_multi
+        proto_record[:quantity] = year_count
         proto_record[:comments] = struct[:Description_of_service]
         proto_records << proto_record
       end
@@ -81,7 +81,7 @@ module ETL::Transformers::Async
 
       if reported_qualifier.present?
         proto_record = base_proto_record.deep_dup
-        proto_record[:kind] = :reported_qualifier_finish
+        proto_record[:kind] = :qualifier_finish
         proto_record[:comments] = reported_qualifier
         proto_records << proto_record
       end
@@ -93,7 +93,7 @@ module ETL::Transformers::Async
 
       if emergency_contact.present? || emergency_phone.present?
         proto_record = base_proto_record.deep_dup
-        proto_record[:kind] = :provided_emergency_contact
+        proto_record[:kind] = :emergency_contact
         proto_record[:comments] = [emergency_contact.presence, emergency_phone.presence].compact.join(", ")
         proto_records << proto_record
       end
@@ -106,7 +106,7 @@ module ETL::Transformers::Async
         return if previous_names.downcase.strip.in? JUNK_PREVIOUS_NAMES
 
         proto_record = base_proto_record.deep_dup
-        proto_record[:kind] = :provided_previous_name
+        proto_record[:kind] = :previous_name
         proto_record[:comments] = previous_names
         proto_records << proto_record
       end

--- a/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
+++ b/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
@@ -46,12 +46,12 @@ module ETL::Transformers::Async
       self.base_proto_record = ProtoRecord.new(**struct.to_h)
 
       base_proto_record.transform_as(:historical_fact, organization: organization)
+      base_proto_record[:year] = Date.current.year
     end
 
     def record_lottery_application(struct)
       proto_record = base_proto_record.deep_dup
       proto_record[:kind] = :lottery_application
-      proto_record[:year] = lottery_year
       proto_record[:comments] = "Ultrasignup order id: #{struct[:Order_ID]}"
 
       proto_records << proto_record
@@ -63,7 +63,6 @@ module ETL::Transformers::Async
       if years_count.present? && years_count.positive?
         proto_record = base_proto_record.deep_dup
         proto_record[:kind] = :volunteer_multi
-        proto_record[:year] = Date.current.year
         proto_record[:quantity] = years_count
         proto_record[:comments] = struct[:Volunteer_description]
 
@@ -77,7 +76,6 @@ module ETL::Transformers::Async
       if reported_qualifier.present?
         proto_record = base_proto_record.deep_dup
         proto_record[:kind] = :qualifier_finish
-        proto_record[:year] = Date.current.year
         proto_record[:comments] = reported_qualifier
 
         proto_records << proto_record
@@ -91,7 +89,6 @@ module ETL::Transformers::Async
       if emergency_contact.present? || emergency_phone.present?
         proto_record = base_proto_record.deep_dup
         proto_record[:kind] = :emergency_contact
-        proto_record[:year] = Date.current.year
         proto_record[:comments] = [emergency_contact.presence, emergency_phone.presence].compact.join(", ")
 
         proto_records << proto_record
@@ -107,7 +104,6 @@ module ETL::Transformers::Async
 
           proto_record = base_proto_record.deep_dup
           proto_record[:kind] = :previous_name
-          proto_record[:year] = Date.current.year
           proto_record[:comments] = previous_names
 
           proto_records << proto_record
@@ -121,7 +117,6 @@ module ETL::Transformers::Async
       unless reported_ever_finished.blank?
         proto_record = base_proto_record.deep_dup
         proto_record[:kind] = :ever_finished
-        proto_record[:year] = Date.current.year
         proto_record[:comments] = reported_ever_finished.to_s.downcase
 
         proto_records << proto_record
@@ -134,15 +129,10 @@ module ETL::Transformers::Async
       if reported_dns_since_finish.present? && reported_dns_since_finish.to_s.numeric?
         proto_record = base_proto_record.deep_dup
         proto_record[:kind] = :dns_since_finish
-        proto_record[:year] = Date.current.year
         proto_record[:quantity] = reported_dns_since_finish
 
         proto_records << proto_record
       end
-    end
-
-    def lottery_year
-      @lottery_year ||= Date.current.year + 1
     end
   end
 end

--- a/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
+++ b/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module ETL::Transformers::Async
+  class UltrasignupHistoricalFactsStrategy < ETL::Transformers::BaseTransformer
+    JUNK_VALUES = ["no", "n", "n/a", "na", "none"].freeze
+    PRIOR_YEAR_OUTCOMES = {
+      dns: :dns,
+      dnf: :dnf,
+      f: :finished,
+    }.with_indifferent_access.freeze
+
+    def initialize(parsed_structs, options)
+      @parsed_structs = parsed_structs
+      @options = options
+      @import_job = options[:import_job]
+      @proto_records = []
+      @errors = []
+    end
+
+    def transform
+      return [] if errors.present?
+
+      parsed_structs.each.with_index(1) do |struct, row_index|
+        set_base_proto_record(struct)
+        record_volunteer_reported(struct)
+        record_2025_qualifier(struct)
+        record_emergency_contact(struct)
+        record_previous_names(struct)
+      rescue StandardError => e
+        import_job.increment!(:failed_count)
+        errors << transform_failed_error(e, row_index)
+      end
+
+      proto_records
+    end
+
+    private
+
+    attr_reader :parsed_structs, :options, :import_job, :proto_records
+    attr_accessor :base_proto_record
+
+    def set_base_proto_record(struct)
+      self.base_proto_record = ProtoRecord.new(**struct.to_h)
+
+      base_proto_record.transform_as(:historical_fact, organization: organization)
+    end
+
+    def record_volunteer_legacy(struct)
+      volunteer_legacy_count = struct[:Years_Volunteering]
+
+      if volunteer_legacy_count.present? && volunteer_legacy_count.positive?
+        proto_record = base_proto_record.deep_dup
+        proto_record[:kind] = :volunteer_legacy
+        proto_record[:quantity] = volunteer_legacy_count
+        proto_record[:comments] = struct[:Description_of_service]
+        proto_records << proto_record
+      end
+    end
+
+    def record_2024_qualifier(struct)
+      reported_qualifier = struct[:"2024_Qualifier"]
+
+      if reported_qualifier.present?
+        proto_record = base_proto_record.deep_dup
+        proto_record[:kind] = :reported_qualifier_finish
+        proto_record[:comments] = reported_qualifier
+        proto_records << proto_record
+      end
+    end
+
+    def record_emergency_contact(struct)
+      emergency_contact = struct[:Emergency_Contact].to_s == "0" ? nil : struct[:Emergency_Contact]
+      emergency_phone = struct[:Emergency_Phone].to_s == "0" ? nil : struct[:Emergency_Phone]
+
+      if emergency_contact.present? || emergency_phone.present?
+        proto_record = base_proto_record.deep_dup
+        proto_record[:kind] = :provided_emergency_contact
+        proto_record[:comments] = [emergency_contact.presence, emergency_phone.presence].compact.join(", ")
+        proto_records << proto_record
+      end
+    end
+
+    def record_previous_names(struct)
+      previous_names = struct[:Previous_names_applied_under]
+
+      if previous_names.present?
+        return if previous_names.downcase.strip.in? JUNK_PREVIOUS_NAMES
+
+        proto_record = base_proto_record.deep_dup
+        proto_record[:kind] = :provided_previous_name
+        proto_record[:comments] = previous_names
+        proto_records << proto_record
+      end
+    end
+
+    def record_legacy_ticket_count(struct)
+      legacy_count = struct[:Total_tickets]
+
+      proto_record = base_proto_record.deep_dup
+      proto_record[:kind] = :lottery_ticket_count_legacy
+      proto_record[:quantity] = legacy_count
+      proto_records << proto_record
+    end
+
+    def record_legacy_division(struct)
+      legacy_division = struct[:Which_Lottery?]
+
+      proto_record = base_proto_record.deep_dup
+      proto_record[:kind] = :lottery_division_legacy
+      proto_record[:comments] = legacy_division
+      proto_records << proto_record
+    end
+  end
+end

--- a/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
+++ b/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
@@ -27,6 +27,8 @@ module ETL::Transformers::Async
         record_current_qualifier(struct)
         record_emergency_contact(struct)
         record_previous_names(struct)
+        record_ever_finished(struct)
+        record_dns_since_finish(struct)
       rescue StandardError => e
         import_job.increment!(:failed_count)
         errors << transform_failed_error(e, row_index)
@@ -110,6 +112,32 @@ module ETL::Transformers::Async
 
           proto_records << proto_record
         end
+      end
+    end
+
+    def record_ever_finished(struct)
+      reported_ever_finished = struct[:Ever_finished]
+
+      unless reported_ever_finished.blank?
+        proto_record = base_proto_record.deep_dup
+        proto_record[:kind] = :ever_finished
+        proto_record[:year] = Date.current.year
+        proto_record[:comments] = reported_ever_finished.to_s.downcase
+
+        proto_records << proto_record
+      end
+    end
+
+    def record_dns_since_finish(struct)
+      reported_dns_since_finish = struct[:DNS_since_finish]
+
+      if reported_dns_since_finish.present? && reported_dns_since_finish.to_s.numeric?
+        proto_record = base_proto_record.deep_dup
+        proto_record[:kind] = :dns_since_finish
+        proto_record[:year] = Date.current.year
+        proto_record[:quantity] = reported_dns_since_finish
+
+        proto_records << proto_record
       end
     end
 

--- a/lib/tasks/temp/migrate_historical_facts_year.rake
+++ b/lib/tasks/temp/migrate_historical_facts_year.rake
@@ -14,7 +14,7 @@ namespace :temp do
 
     progress_bar = ::ProgressBar.new(hf_count)
 
-    historical_facts.each do |fact|
+    historical_facts.find_each do |fact|
       progress_bar.increment!
 
       abort "Comments are not numeric for HistoricalFact id: #{fact.id}" unless fact.comments.numeric?

--- a/spec/fixtures/files/ultrasignup_historical_facts.csv
+++ b/spec/fixtures/files/ultrasignup_historical_facts.csv
@@ -1,0 +1,9 @@
+Order ID,First Name,Last Name,gender,DOB,Email,Address,City,State,Country,Phone,emergency_name,emergency_phone,Volunteer description,Ever finished,Previous names 1,Previous names 2,DNS since finish,Qualifier,Years volunteered
+26861,Emanuel,Nicolas,M,2003-12-18,shea_skiles@steubergreenfelder.name,7463 Carmella Lakes,North Donna,CO,UZ,(796)778-1767 x7154,Dallas Lubowitz,518.496.6485,,No,,,3,2023 OCT: Diagonale des Fous (Reunion Is),0
+26864,Dave,Conroy,M,1973-07-11,zulema@satterfield.name,14181 Calvin Cove,Zacktown,MS,DE,453-682-9576,Carleen Paucek,922-294-5943,,No,,,1,2023 AUG: Bigfoot 200,0
+26868,Louis,Benoit,M,04/22/1993,louis@gmail.com,678 Allée du bois,ARNAS,,FRA,+33688547410,Françoise Benoit,+33682847631,,No,,,0,2023 SEPT: Tor de Geants (Italy),0
+26891,Marie,Sanjust,F,07/07/1999,marie@gmail.com,"54 Majestic Valley Road, Aneia",Johannesburg,Gauteng,ZAF,+27833123123,Promo,+27724373177,,No,,,0,2023 Nov: Ultra-Trail Cape Town,0
+26893,Trena,Beatty,F,1951-02-28,arnoldo@nicolas.us,9542 Raleigh Drives,Harberchester,OR,USA,461-541-5493,Jackelyn Spinka,614-571-5082,,No,,,5,2023 AUG: UTMB (163 km),0
+26895,Jacquline,Franecki,M,1964-05-16,connie@lockman.biz,292 Hills Harbor,Misstown,IN,USA,423-336-2084,Charlott Frami,718-236-7567,,No,Jacquline Smythe,Jacquline Franecki Smythe,4,2024 AUG: Swiss Alps 100,0
+26899,Di,Chon,M,08/01/1955,dio16@gmail.com,4444 SW Panorama Dr.,Shulan,CHN,CHN,53021444332,Yuanyuan Cui,53024443356,,No,,,3,2024 SEPT: Tor de Geants (Italy),0
+26944,Nella,Gislason,M,1959-07-16,cherelle_conn@nicolas.ca,432 Peake St,Charlotte,BC,CAN,9026223422,Loretta Gislason,902343243,,No,,,0,2024 AUG: UTMB (163 km),0

--- a/spec/lib/etl/async_importer_spec.rb
+++ b/spec/lib/etl/async_importer_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe ETL::AsyncImporter do
 
       expect(hf_1).to be_present
       expect(hf_1.gender).to eq("male")
-      expect(hf_1.comments).to eq("2019")
+      expect(hf_1.year).to eq(2019)
     end
 
     it "sets import job attributes properly" do

--- a/spec/lib/etl/extractors/csv_file_strategy_spec.rb
+++ b/spec/lib/etl/extractors/csv_file_strategy_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ETL::Extractors::CsvFileStrategy do
       end
     end
 
-    context "when an ultrasignup file is provided" do
+    context "when an ultrasignup efforts file is provided" do
       let(:file) { file_fixture("ultrasignup_efforts.csv") }
       let(:expected_array) do
         [:Order_ID, :Registration_Date, :distance, :Quantity, :Price, :Price_Option, :order_type, :Coupon, :First_Name, :Last_Name, :gender,
@@ -74,6 +74,25 @@ RSpec.describe ETL::Extractors::CsvFileStrategy do
       it "returns raw data in OpenStruct format with expected keys" do
         expect(subject.errors).to be_empty
         expect(raw_data.size).to eq(11)
+        expect(raw_data).to all be_a(OpenStruct)
+
+        record = raw_data.first.to_h
+        expect(record.keys).to match_array(expected_array)
+      end
+    end
+
+    context "when an ultrasignup historical facts file is provided" do
+      let(:file) { file_fixture("ultrasignup_historical_facts.csv") }
+      let(:expected_array) do
+        [
+          :Order_ID, :First_Name, :Last_Name, :gender, :DOB, :Email, :Address, :City, :State, :Country, :Phone, :emergency_name, :emergency_phone,
+          :Volunteer_description, :Ever_finished, :Previous_names_1, :Previous_names_2, :DNS_since_finish, :Qualifier, :Years_volunteered,
+        ]
+      end
+
+      it "returns raw data in OpenStruct format with expected keys" do
+        expect(subject.errors).to be_empty
+        expect(raw_data.size).to eq(8)
         expect(raw_data).to all be_a(OpenStruct)
 
         record = raw_data.first.to_h

--- a/spec/lib/etl/transformers/async/hardrock_historical_facts_strategy_spec.rb
+++ b/spec/lib/etl/transformers/async/hardrock_historical_facts_strategy_spec.rb
@@ -490,8 +490,8 @@ RSpec.describe ETL::Transformers::Async::HardrockHistoricalFactsStrategy do
         expect(finished_proto_records.count).to eq(2)
       end
 
-      it "returns one proto_record for each legacy volunteer fact" do
-        legacy_volunteer_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :volunteer_legacy }
+      it "returns one proto_record for each multi-year volunteer fact" do
+        legacy_volunteer_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :volunteer_multi }
         expect(legacy_volunteer_proto_records.count).to eq(1)
         proto_record = legacy_volunteer_proto_records.first
         expect(proto_record[:quantity]).to eq(1)
@@ -499,19 +499,19 @@ RSpec.describe ETL::Transformers::Async::HardrockHistoricalFactsStrategy do
       end
 
       it "returns one proto_record for each reported 2024 qualifier" do
-        reported_qualifier_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :reported_qualifier_finish }
+        reported_qualifier_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :qualifier_finish }
         expect(reported_qualifier_proto_records.count).to eq(2)
         expect(reported_qualifier_proto_records.map { |pr| pr[:comments] }).to match_array(["2023 SEPT: Grindstone 100 Mile", "2023 SEPT: Bear 100"])
       end
 
       it "returns one proto_record for each provided emergency contact, ignoring '0'" do
-        emergency_contact_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :provided_emergency_contact }
+        emergency_contact_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :emergency_contact }
         expect(emergency_contact_proto_records.count).to eq(2)
         expect(emergency_contact_proto_records.map { |pr| pr[:comments] }).to match_array(["Shellie Krajcik, 4747239722", "Sonja Christiansen, 8615039757"])
       end
 
       it "returns one proto_record for each provided previous name" do
-        previous_name_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :provided_previous_name }
+        previous_name_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :previous_name }
         expect(previous_name_proto_records.count).to eq(1)
         expect(previous_name_proto_records.first[:comments]).to eq("Theresa Burley")
       end

--- a/spec/lib/etl/transformers/async/hardrock_historical_facts_strategy_spec.rb
+++ b/spec/lib/etl/transformers/async/hardrock_historical_facts_strategy_spec.rb
@@ -475,19 +475,22 @@ RSpec.describe ETL::Transformers::Async::HardrockHistoricalFactsStrategy do
         end
       end
 
-      it "returns one proto_record for each DNS" do
+      it "returns one proto_record for each DNS with the year set" do
         dns_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :dns }
         expect(dns_proto_records.count).to eq(12)
+        expect(dns_proto_records.map { |pr| pr[:year] }).to match_array([2015, 2016, 2016, 2017, 2017, 2018, 2018, 2019, 2019, 2019, 2021, 2022])
       end
 
       it "returns one proto_record for each DNF" do
         dnf_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :dnf }
         expect(dnf_proto_records.count).to eq(1)
+        expect(dnf_proto_records.first[:year]).to eq(2014)
       end
 
       it "returns one proto_record for each finish" do
         finished_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :finished }
         expect(finished_proto_records.count).to eq(2)
+        expect(finished_proto_records.map { |pr| pr[:year] }).to match_array([2015, 2016])
       end
 
       it "returns one proto_record for each multi-year volunteer fact" do

--- a/spec/lib/etl/transformers/async/ultrasignup_historical_facts_strategy_spec.rb
+++ b/spec/lib/etl/transformers/async/ultrasignup_historical_facts_strategy_spec.rb
@@ -160,6 +160,18 @@ RSpec.describe ETL::Transformers::Async::UltrasignupHistoricalFactsStrategy do
         expect(previous_name_proto_records.count).to eq(3)
         expect(previous_name_proto_records.map { |pr| pr[:comments] }).to match_array(["David Conroy", "Marie Antoinette", "Maria Sanjust"])
       end
+
+      it "returns one proto_record per struct for ever finished" do
+        previous_name_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :ever_finished }
+        expect(previous_name_proto_records.count).to eq(4)
+        expect(previous_name_proto_records.map { |pr| pr[:comments] }).to match_array(["no", "no", "no", "yes"])
+      end
+
+      it "returns one proto_record per struct for DNS since finish" do
+        previous_name_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :dns_since_finish }
+        expect(previous_name_proto_records.count).to eq(4)
+        expect(previous_name_proto_records.map { |pr| pr[:quantity] }).to match_array([0,0,1,3])
+      end
     end
 
     context "when no structs are provided" do

--- a/spec/lib/etl/transformers/async/ultrasignup_historical_facts_strategy_spec.rb
+++ b/spec/lib/etl/transformers/async/ultrasignup_historical_facts_strategy_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ETL::Transformers::Async::UltrasignupHistoricalFactsStrategy do
+  subject { described_class.new(structs, options) }
+
+  let(:options) do
+    {
+      import_job: import_job,
+      parent: organization,
+    }
+  end
+  let(:import_job) { create(:import_job, parent_type: "Organization", parent_id: organization&.id) }
+  let(:organization) { organizations(:hardrock) }
+  let(:proto_records) { subject.transform }
+  let(:keys) { proto_records.first.to_h.keys }
+
+  describe "#transform" do
+    context "when given valid data" do
+      let(:structs) do
+        [
+          OpenStruct.new(
+            :Order_ID => 26861,
+            :First_Name => "Emanuel",
+            :Last_Name => "Nicolas",
+            :gender => "M",
+            :DOB => "2003-12-18",
+            :Email => "shea_skiles@steubergreenfelder.name",
+            :Address => "7463 Carmella Lakes",
+            :City => "North Donna",
+            :State => "CO",
+            :Country => "UZ",
+            :Phone => "(796)778-1767 x7154",
+            :emergency_name => "No",
+            :emergency_phone => "NA",
+            :Volunteer_description => "Cunningham 2021, 2022, 2023",
+            :Ever_finished => "No",
+            :Previous_names_1 => "NONE",
+            :Previous_names_2 => "",
+            :DNS_since_finish => 3,
+            :Qualifier => "2023 OCT: Diagonale des Fous (Reunion Is)",
+            :Years_volunteered => 3
+          ),
+          OpenStruct.new(
+            :Order_ID => 26864,
+            :First_Name => "Dave",
+            :Last_Name => "Conroy",
+            :gender => "M",
+            :DOB => "1973-07-11",
+            :Email => "zulema@satterfield.name",
+            :Address => "14181 Calvin Cove",
+            :City => "Zacktown",
+            :State => "MS",
+            :Country => "DE",
+            :Phone => "453-682-9576",
+            :emergency_name => "Carleen Paucek",
+            :emergency_phone => "None",
+            :Volunteer_description => "",
+            :Ever_finished => "No",
+            :Previous_names_1 => "David Conroy",
+            :Previous_names_2 => "",
+            :DNS_since_finish => 1,
+            :Qualifier => "2023 AUG: Bigfoot 200",
+            :Years_volunteered => 0
+          ),
+          OpenStruct.new(
+            :Order_ID => 26868,
+            :First_Name => "Louis",
+            :Last_Name => "Benoit",
+            :gender => "M",
+            :DOB => "04/22/1993",
+            :Email => "louis@gmail.com",
+            :Address => "678 Allée du bois",
+            :City => "ARNAS",
+            :State => "",
+            :Country => "FRA",
+            :Phone => 33688547410,
+            :emergency_name => "Françoise Benoit",
+            :emergency_phone => 33682847631,
+            :Volunteer_description => "",
+            :Ever_finished => "No",
+            :Previous_names_1 => "N/A",
+            :Previous_names_2 => "",
+            :DNS_since_finish => 0,
+            :Qualifier => "2023 SEPT: Tor de Geants (Italy)",
+            :Years_volunteered => 0
+          ),
+          OpenStruct.new(
+            :Order_ID => 26891,
+            :First_Name => "Marie",
+            :Last_Name => "Sanjust",
+            :gender => "F",
+            :DOB => "07/07/1999",
+            :Email => "marie@gmail.com",
+            :Address => "54 Majestic Valley Road, Aneia",
+            :City => "Johannesburg",
+            :State => "Gauteng",
+            :Country => "ZAF",
+            :Phone => 27833123123,
+            :emergency_name => "Promo",
+            :emergency_phone => 27724373177,
+            :Volunteer_description => "",
+            :Ever_finished => "Yes",
+            :Previous_names_1 => "Marie Antoinette",
+            :Previous_names_2 => "Maria Sanjust",
+            :DNS_since_finish => 0,
+            :Qualifier => "2023 Nov: Ultra-Trail Cape Town",
+            :Years_volunteered => 0
+          )
+        ]
+      end
+
+      it "does not report errors" do
+        subject.transform
+        expect(subject.errors).to be_empty
+      end
+
+      it "returns proto_records and correct keys" do
+        expect(proto_records).to be_present
+        expect(proto_records).to all be_a(ProtoRecord)
+        expect(proto_records.map { |pr| pr[:organization_id] }).to all eq(organization.id)
+
+        %i[first_name last_name gender birthdate address state_code country_code email].each do |expected_key|
+          expect(keys).to include(expected_key)
+        end
+      end
+
+      it "returns one proto_record for each struct for lottery applications" do
+        lottery_application_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :lottery_application }
+        expect(lottery_application_proto_records.size).to eq(structs.size)
+        proto_record = lottery_application_proto_records.first
+        expect(proto_record[:comments]).to eq("Ultrasignup order id: 26861")
+      end
+
+      it "returns one proto_record for each multi-year volunteer fact" do
+        volunteer_multi_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :volunteer_multi }
+        expect(volunteer_multi_proto_records.count).to eq(1)
+        proto_record = volunteer_multi_proto_records.first
+        expect(proto_record[:quantity]).to eq(3)
+        expect(proto_record[:year]).to eq(2024)
+        expect(proto_record[:comments]).to eq("Cunningham 2021, 2022, 2023")
+      end
+
+      it "returns one proto_record for each reported qualifier" do
+        qualifier_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :qualifier_finish }
+        expect(qualifier_proto_records.count).to eq(4)
+        expect(qualifier_proto_records.map { |pr| pr[:comments] })
+          .to match_array(["2023 AUG: Bigfoot 200", "2023 Nov: Ultra-Trail Cape Town", "2023 OCT: Diagonale des Fous (Reunion Is)", "2023 SEPT: Tor de Geants (Italy)"])
+      end
+
+      it "returns one proto_record for each provided emergency contact" do
+        emergency_contact_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :emergency_contact }
+        expect(emergency_contact_proto_records.count).to eq(3)
+        expect(emergency_contact_proto_records.map { |pr| pr[:comments] }).to match_array(["Carleen Paucek", "Françoise Benoit, 33682847631", "Promo, 27724373177"])
+      end
+
+      it "returns one proto_record for each provided previous name" do
+        previous_name_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :previous_name }
+        expect(previous_name_proto_records.count).to eq(3)
+        expect(previous_name_proto_records.map { |pr| pr[:comments] }).to match_array(["David Conroy", "Marie Antoinette", "Maria Sanjust"])
+      end
+    end
+
+    context "when no structs are provided" do
+      let(:structs) { [] }
+
+      it "returns an empty array of proto_records without returning an error" do
+        expect(proto_records).to eq([])
+        expect(subject.errors).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR makes it possible to import historical facts from an Ultrasignup export.

Historical facts will then be reconciled with People and then used to produce lottery entrants complete with divisions and ticket counts.