### PR TITLE
Better de-duplication of names in the ultrasignup historical facts transformer

### DIFF
--- a/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
+++ b/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
@@ -96,11 +96,14 @@ module ETL::Transformers::Async
     end
 
     def record_previous_names(struct)
-      previous_names_array = [struct[:Previous_names_1], struct[:Previous_names_2]]
+      names_1 = struct[:Previous_names_1]
+      names_2 = struct[:Previous_names_2]
+      names_2 = nil if names_2.downcase.strip == names_1.downcase.strip
+      previous_names_array = [names_1, names_2]
 
       previous_names_array.each do |previous_names|
         if previous_names.present?
-          next if previous_names.downcase.strip.in? JUNK_VALUES
+          next if name_is_junk(previous_names) || name_is_identical(previous_names, struct)
 
           proto_record = base_proto_record.deep_dup
           proto_record[:kind] = :previous_name
@@ -109,6 +112,14 @@ module ETL::Transformers::Async
           proto_records << proto_record
         end
       end
+    end
+
+    def name_is_junk(previous_names)
+      previous_names.downcase.strip.in? JUNK_VALUES
+    end
+
+    def name_is_identical(previous_names, struct)
+      previous_names.downcase.strip == "#{struct[:First_Name]} #{struct[:Last_Name]}".downcase.strip
     end
 
     def record_ever_finished(struct)

--- a/spec/lib/etl/transformers/async/ultrasignup_historical_facts_strategy_spec.rb
+++ b/spec/lib/etl/transformers/async/ultrasignup_historical_facts_strategy_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ETL::Transformers::Async::UltrasignupHistoricalFactsStrategy do
             :Volunteer_description => "",
             :Ever_finished => "No",
             :Previous_names_1 => "David Conroy",
-            :Previous_names_2 => "",
+            :Previous_names_2 => "david conroy",
             :DNS_since_finish => 1,
             :Qualifier => "2023 AUG: Bigfoot 200",
             :Years_volunteered => 0
@@ -80,7 +80,7 @@ RSpec.describe ETL::Transformers::Async::UltrasignupHistoricalFactsStrategy do
             :emergency_phone => 33682847631,
             :Volunteer_description => "",
             :Ever_finished => "No",
-            :Previous_names_1 => "N/A",
+            :Previous_names_1 => "louis benoit",
             :Previous_names_2 => "",
             :DNS_since_finish => 0,
             :Qualifier => "2023 SEPT: Tor de Geants (Italy)",
@@ -155,7 +155,7 @@ RSpec.describe ETL::Transformers::Async::UltrasignupHistoricalFactsStrategy do
         expect(emergency_contact_proto_records.map { |pr| pr[:comments] }).to match_array(["Carleen Paucek", "Françoise Benoit, 33682847631", "Promo, 27724373177"])
       end
 
-      it "returns one proto_record for each provided previous name" do
+      it "returns one proto_record for each provided previous name, ignoring junk and identical names" do
         previous_name_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :previous_name }
         expect(previous_name_proto_records.count).to eq(3)
         expect(previous_name_proto_records.map { |pr| pr[:comments] }).to match_array(["David Conroy", "Marie Antoinette", "Maria Sanjust"])


### PR DESCRIPTION
Currently, the ultrasignup historical facts transformer will happily take in duplicate names and build them as separate historical facts.

This PR provides some de-duplication logic to avoid those duplicates.