### PR TITLE
Fix historical fact vmulti duplicates

### DIFF
--- a/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
+++ b/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
@@ -62,7 +62,7 @@ module ETL::Transformers::Async
 
       if years_count.present? && years_count.positive?
         proto_record = base_proto_record.deep_dup
-        proto_record[:kind] = :volunteer_multi
+        proto_record[:kind] = :volunteer_multi_reported
         proto_record[:quantity] = years_count
         proto_record[:comments] = struct[:Volunteer_description]
 

--- a/lib/tasks/temp/historical_facts_fix_vmulti_duplicates.rake
+++ b/lib/tasks/temp/historical_facts_fix_vmulti_duplicates.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :temp do
+  desc "Changes imported volunteer_multi records to volunteer_multi_reported"
+  task historical_facts_fix_vmulti_duplicates: :environment do
+    puts "Changing volunteer_multi records to volunteer_multi_reported"
+
+    historical_facts = HistoricalFact.where(kind: :volunteer_multi, year: 2024)
+    hf_count = historical_facts.count
+
+    puts "Found #{hf_count} historical facts to update"
+
+    progress_bar = ::ProgressBar.new(hf_count)
+
+    historical_facts.find_each do |fact|
+      progress_bar.increment!
+      fact.update(kind: :volunteer_multi_reported)
+    rescue ActiveRecordError => e
+      puts "Could not update record for HistoricalFact id: #{fact.id}"
+      puts e
+    end
+  end
+end

--- a/spec/lib/etl/transformers/async/ultrasignup_historical_facts_strategy_spec.rb
+++ b/spec/lib/etl/transformers/async/ultrasignup_historical_facts_strategy_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe ETL::Transformers::Async::UltrasignupHistoricalFactsStrategy do
       end
 
       it "returns one proto_record for each multi-year volunteer fact" do
-        volunteer_multi_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :volunteer_multi }
+        volunteer_multi_proto_records = proto_records.select { |proto_record| proto_record.attributes[:kind] == :volunteer_multi_reported }
         expect(volunteer_multi_proto_records.count).to eq(1)
         proto_record = volunteer_multi_proto_records.first
         expect(proto_record[:quantity]).to eq(3)


### PR DESCRIPTION
When we imported records from Ultrasignup for the Hardrock 2025 lottery, we used the same historical fact kind (`volunteer_multi`) as we used when importing the Hardrock historical records. This resulted in duplicate records that cause confusion and increase the complexity of logic in calculating tickets.

This PR changes the Ultrasignup transform logic so future imports will assign these facts to a new kind, `volunteer_multi_reported`, which is for informational purposes only, not used for ticket calculations.

This PR also includes a temporary rake task that changes all 2024 `volunteer_multi` records to `volunteer_multi_reported`.