### PR TITLE
Lottery calculations prepare for personal access

### DIFF
--- a/app/helpers/badge_helper.rb
+++ b/app/helpers/badge_helper.rb
@@ -58,7 +58,7 @@ module BadgeHelper
     when "volunteer_multi"
       title = "VMulti"
       color = :success
-      tooltip_text = "Multiple years of volunteer work (as reported in a specific year)"
+      tooltip_text = "Multiple years of volunteer work (as of the year shown)"
     when "qualifier_finish"
       title = "Qualifier"
       color = :secondary

--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -55,6 +55,7 @@ class HistoricalFact < ApplicationRecord
     end
   end
   scope :ordered, -> { order(:last_name, :first_name, :state_code, :year, :kind) }
+  scope :ordered_within_person, -> { order(:year, :kind) }
   scope :reconciled, -> { where.not(person_id: nil) }
   scope :unreconciled, -> { where(person_id: nil) }
 

--- a/app/views/historical_facts/_reconcile_card.html.erb
+++ b/app/views/historical_facts/_reconcile_card.html.erb
@@ -30,7 +30,7 @@
       </tr>
       </thead>
       <tbody>
-      <%= render partial: "reconcile_row", collection: presenter.relevant_historical_facts.ordered, as: :fact %>
+      <%= render partial: "reconcile_row", collection: presenter.relevant_historical_facts.ordered_within_person, as: :fact %>
       </tbody>
     </table>
   </div>

--- a/app/views/lotteries/_calculations_applicant.html.erb
+++ b/app/views/lotteries/_calculations_applicant.html.erb
@@ -27,7 +27,7 @@
         </tr>
         </thead>
         <tbody>
-        <%= render partial: "historical_facts/calculations_row", collection: record.person.historical_facts.ordered, as: :fact %>
+        <%= render partial: "historical_facts/calculations_row", collection: record.person.historical_facts.ordered_within_person, as: :fact %>
         </tbody>
       </table>
     </div>

--- a/lib/tasks/maintenance/historical_facts_conform_applicant_emails.rake
+++ b/lib/tasks/maintenance/historical_facts_conform_applicant_emails.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+namespace :maintenance do
+  desc "Changes people emails to match historical facts emails for lottery applicants"
+  task historical_facts_conform_applicant_emails: :environment do
+    puts "Conforming people emails to match historical facts emails for lottery applicants"
+
+    people = Person.joins(:historical_facts)
+      .where(historical_facts: { kind: :lottery_application} )
+      .where("historical_facts.email is not null and historical_facts.email <> people.email")
+      .distinct
+    person_count = people.count
+
+    puts "Found #{person_count} people to update"
+
+    progress_bar = ::ProgressBar.new(person_count)
+
+    people.find_each do |person|
+      progress_bar.increment!
+
+      if person.user_id?
+        puts "Person #{person.id} has an associated user; skipping"
+        next
+      end
+
+      fact = person.historical_facts.find_by(kind: :lottery_application)
+      person.update(email: fact.email)
+    rescue ActiveRecordError => e
+      puts "Could not update record for Person id: #{person.id}"
+      puts e
+    end
+  end
+end


### PR DESCRIPTION
This PR provides correct ordering for historical facts within a single person. It also provides a rake task to conform person emails with lottery applicant emails (as evidenced by historical facts with kind: :lottery_application).