### PR TITLE
Provide a duplicate order error when order ids are duplicated

### DIFF
--- a/lib/etl/errors.rb
+++ b/lib/etl/errors.rb
@@ -96,6 +96,11 @@ module ETL
         detail: { messages: ["A required table was not found in the provided source data"] } }
     end
 
+    def orders_duplicated_error(ids)
+      { title: "Orders are duplicated",
+        detail: { messages: ["Order ids are duplicated in Ultrasignup: #{ids}"] } }
+    end
+
     def orders_missing_error(ids)
       { title: "Orders are missing",
         detail: { messages: ["Orders exist in Ultrasignup but are missing in OST: #{ids}"] } }

--- a/lib/etl/loaders/async/ultrasignup_order_id_compare_strategy.rb
+++ b/lib/etl/loaders/async/ultrasignup_order_id_compare_strategy.rb
@@ -43,9 +43,11 @@ module ETL::Loaders::Async
       lottery_application_facts = organization.historical_facts.where(kind: :lottery_application)
       existing_order_ids = lottery_application_facts.pluck(:comments).compact.map { |comment| comment.split(": ").last }.compact
 
+      duplicate_order_ids = ultrasignup_order_ids.count_by { |id| id }.keep_if { |_, count| count > 1 }
       missing_order_ids = ultrasignup_order_ids - existing_order_ids
       outdated_order_ids = existing_order_ids - ultrasignup_order_ids
 
+      errors << orders_duplicated_error(duplicate_order_ids) if duplicate_order_ids.present?
       errors << orders_missing_error(missing_order_ids) if missing_order_ids.any?
       errors << orders_outdated_error(outdated_order_ids) if outdated_order_ids.any?
     end

--- a/spec/lib/etl/loaders/async/ultrasignup_order_id_compare_strategy_spec.rb
+++ b/spec/lib/etl/loaders/async/ultrasignup_order_id_compare_strategy_spec.rb
@@ -51,6 +51,28 @@ RSpec.describe ETL::Loaders::Async::UltrasignupOrderIdCompareStrategy do
       end
     end
 
+    context "when some order ids are duplicates" do
+      let(:proto_records) do
+        [
+          ProtoRecord.new(
+            Order_ID: "123",
+            ),
+          ProtoRecord.new(
+            Order_ID: "456",
+            ),
+          ProtoRecord.new(
+            Order_ID: "456",
+            ),
+        ]
+      end
+
+      it "adds an order id duplicated error" do
+        subject.load_records
+        expect(subject.errors).to be_present
+        expect(subject.errors.first.dig(:detail, :messages).first).to include("456")
+      end
+    end
+
     context "when some order ids are missing from OST" do
       let(:proto_records) do
         [


### PR DESCRIPTION
This PR adds an error if Order IDs are duplicated in the ultrasignup compare import.