### PR TITLE
Fix missing argument bug in lotteries controller

### DIFF
--- a/app/controllers/lotteries_controller.rb
+++ b/app/controllers/lotteries_controller.rb
@@ -71,7 +71,7 @@ class LotteriesController < ApplicationController
   # POST /organizations/:organization_id/lotteries/:id/sync_calculations
   def sync_calculations
     if @lottery.calculation_class?
-      Lotteries::SyncCalculationsJob.perform_later(@lottery)
+      Lotteries::SyncCalculationsJob.perform_later(@lottery, current_user: current_user)
       redirect_to setup_organization_lottery_path(@organization, @lottery), notice: "Sync in progress"
     else
       redirect_to setup_organization_lottery_path(@organization, @lottery), alert: "Lottery does not have a calculations_class"


### PR DESCRIPTION
This PR replaces a missing argument needed for Lotteries::SyncCalculationsJob.