### PR TITLE
Don't run the lottery sync if any historical facts are unreconciled

### DIFF
--- a/app/services/lotteries/sync_calculations.rb
+++ b/app/services/lotteries/sync_calculations.rb
@@ -90,5 +90,9 @@ class Lotteries::SyncCalculations
     if non_existent_names.present?
       raise ArgumentError, "Calculated division names were not all found in the lottery: #{non_existent_names}"
     end
+
+    if lottery_calculation.where(person_id: nil).any?
+      raise ArgumentError, "Some historical facts underlying the lottery calculation are not reconciled."
+    end
   end
 end


### PR DESCRIPTION
Things break if lottery sync calculations are unreconciled. This PR raises an error before we get too far.