### PR TITLE
Clarify things in the lottery entrant detail card

### DIFF
--- a/app/views/lottery_entrants/_lottery_entrant_with_tickets.html.erb
+++ b/app/views/lottery_entrants/_lottery_entrant_with_tickets.html.erb
@@ -15,13 +15,17 @@
           <h6 class="text-end fw-bold"><%= "#{pluralize(presenter.number_of_tickets, 'ticket')}" %></h6>
         </div>
       </div>
+      <hr/>
       <% if current_user.present? && (current_user.admin? || current_user.steward_of?(presenter.organization) || current_user.email == presenter.email) %>
-        <hr/>
         <% if presenter.calculation.present? %>
           <%= render partial: "ticket_calculations_table", locals: { presenter: presenter } %>
           <hr/>
         <% end %>
-          <%= render partial: "historical_facts_table", locals: { presenter: presenter } %>
+        <%= render partial: "historical_facts_table", locals: { presenter: presenter } %>
+      <% else %>
+        <p class="fw-bold">If this entrant is you, please log in to see calculation details, or sign up if you don't have an OpenSplitTime
+          account.</p>
+        <p>You will need to use the same email that you used to apply to the lottery in Ultrasignup.</p>
       <% end %>
       <hr/>
       <div class="row">

--- a/app/views/lottery_entrants/_ticket_calculations_table.html.erb
+++ b/app/views/lottery_entrants/_ticket_calculations_table.html.erb
@@ -16,11 +16,11 @@
       </tr>
       <tr>
         <td><%= presenter.calculation.volunteer_ticket_count %></td>
-        <td>Years volunteering at Hardrock / 5 (rounded down)</td>
+        <td>Tickets for years volunteering at Hardrock (Years divided by 5, rounded down) For example, 3 years = 0 tickets and 10 years = 2 tickets.</td>
       </tr>
       <tr>
         <td><%= presenter.calculation.volunteer_major_ticket_count %></td>
-        <td>One-time service tickets (shown as VMajor)</td>
+        <td>One-time service tickets (shown as VYearMaj)</td>
       </tr>
       <tr>
         <td>1</td>
@@ -45,11 +45,11 @@
       </tr>
       <tr>
         <td><%= presenter.calculation.volunteer_ticket_count %></td>
-        <td>Years volunteering at Hardrock / 5 (rounded down)</td>
+        <td>Tickets for years volunteering at Hardrock (Years divided by 5, rounded down) For example, 3 years = 0 tickets and 10 years = 2 tickets.</td>
       </tr>
       <tr>
         <td><%= presenter.calculation.volunteer_major_ticket_count %></td>
-        <td>One-time service tickets (shown as VMajor)</td>
+        <td>One-time service tickets (shown as VYearMaj)</td>
       </tr>
       <tr class="fw-bold">
         <td><%= presenter.calculation.dns_ticket_count + presenter.calculation.volunteer_ticket_count + presenter.calculation.volunteer_major_ticket_count %></td>


### PR DESCRIPTION
This PR makes two small tweaks to the lottery entrants detail card:

- Includes a notice that to see detail, you have to be logged in
- Better language around volunteer years