### PR TITLE
Show stats even if lottery is in preview

### DIFF
--- a/app/views/lotteries/_acceptance_stats.html.erb
+++ b/app/views/lotteries/_acceptance_stats.html.erb
@@ -1,0 +1,46 @@
+<%# locals: (presenter:) %>
+
+<% presenter.stats.each do |division_name, division_stats| %>
+  <div class="card">
+    <h4 class="card-header fw-bold bg-primary text-white"><%= "#{division_name}" %></h4>
+    <div class="card-body">
+      <%= column_chart presenter.stats_chart_data(division_stats),
+                       stacked: true,
+                       xtitle: "Number of Tickets",
+                       ytitle: "Entrants",
+                       colors: ["#28a745", "#3A9DD1", "#bbb"] %>
+
+      <hr/>
+
+      <table class="table table-striped" style="width:80%">
+        <thead>
+        <tr class="fw-bold">
+          <th></th>
+          <th class="text-center">Entrants</th>
+          <th class="text-center">Accepted</th>
+          <th class="text-center">%</th>
+          <th class="text-center">Waitlisted</th>
+          <th class="text-center">%</th>
+          <th class="text-center">Not Drawn</th>
+          <th class="text-center">%</th>
+        </tr>
+        </thead>
+        <tbody>
+        <% division_stats.each do |division_stat| %>
+          <tr>
+            <td class="fw-bold"><%= pluralize(division_stat.number_of_tickets, "Ticket") %></td>
+            <td class="text-center border-end"><%= division_stat.entrants_count %></td>
+            <td class="text-center"><%= division_stat.accepted_entrants_count %></td>
+            <td class="text-center border-end"><%= (division_stat.accepted_entrants_count.to_f / division_stat.entrants_count * 100).round(1) %></td>
+            <td class="text-center"><%= division_stat.waitlisted_entrants_count %></td>
+            <td class="text-center border-end"><%= (division_stat.waitlisted_entrants_count.to_f / division_stat.entrants_count * 100).round(1) %></td>
+            <td class="text-center"><%= division_stat.undrawn_entrants_count %></td>
+            <td class="text-center"><%= (division_stat.undrawn_entrants_count.to_f / division_stat.entrants_count * 100).round(1) %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <br/>
+<% end %>

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -130,7 +130,9 @@
     <% end %>
 
   <% when "results" %>
-    <h4 class="mt-5"><span class="fw-bold">Lottery Results</span><span class="px-1 h5 fw-light text-muted"><%= " Last updated #{time_ago_in_words(@presenter.lottery.updated_at)} ago" %></span></h4>
+    <h4 class="mt-5">
+      <span class="fw-bold">Lottery Results</span><span class="px-1 h5 fw-light text-muted"><%= " Last updated #{time_ago_in_words(@presenter.lottery.updated_at)} ago" %></span>
+    </h4>
     <hr/>
     <% if @presenter.viewable_results? %>
       <% if @presenter.lottery_draws.exists? %>
@@ -174,54 +176,7 @@
   <% when "stats" %>
     <h4 class="mt-5"><strong>Lottery Stats</strong></h4>
     <hr/>
-    <% if @presenter.viewable_results? %>
-      <% @presenter.stats.each do |division_name, division_stats| %>
-        <div class="card">
-          <h4 class="card-header fw-bold bg-primary text-white"><%= "#{division_name}" %></h4>
-          <div class="card-body">
-            <%= column_chart @presenter.stats_chart_data(division_stats),
-                             stacked: true,
-                             xtitle: "Number of Tickets",
-                             ytitle: "Entrants",
-                             colors: ["#28a745", "#3A9DD1", "#bbb"] %>
-
-            <hr/>
-
-            <table class="table table-striped" style="width:80%">
-              <thead>
-              <tr class="fw-bold">
-                <th></th>
-                <th class="text-center">Entrants</th>
-                <th class="text-center">Accepted</th>
-                <th class="text-center">%</th>
-                <th class="text-center">Waitlisted</th>
-                <th class="text-center">%</th>
-                <th class="text-center">Not Drawn</th>
-                <th class="text-center">%</th>
-              </tr>
-              </thead>
-              <tbody>
-              <% division_stats.each do |division_stat| %>
-                <tr>
-                  <td class="fw-bold"><%= pluralize(division_stat.number_of_tickets, "Ticket") %></td>
-                  <td class="text-center border-end"><%= division_stat.entrants_count %></td>
-                  <td class="text-center"><%= division_stat.accepted_entrants_count %></td>
-                  <td class="text-center border-end"><%= (division_stat.accepted_entrants_count.to_f / division_stat.entrants_count * 100).round(1) %></td>
-                  <td class="text-center"><%= division_stat.waitlisted_entrants_count %></td>
-                  <td class="text-center border-end"><%= (division_stat.waitlisted_entrants_count.to_f / division_stat.entrants_count * 100).round(1) %></td>
-                  <td class="text-center"><%= division_stat.undrawn_entrants_count %></td>
-                  <td class="text-center"><%= (division_stat.undrawn_entrants_count.to_f / division_stat.entrants_count * 100).round(1) %></td>
-                </tr>
-              <% end %>
-              </tbody>
-            </table>
-          </div>
-        </div>
-        <br/>
-      <% end %>
-    <% else %>
-      <h6 class="text-center">This lottery is not yet live</h6>
-    <% end %>
+    <%= render partial: "acceptance_stats", locals: { presenter: @presenter } %>
   <% end %>
 </article>
 


### PR DESCRIPTION
Currently, lottery stats (ticket distributions, showing undrawn, accepted, and waitlisted) are visible only if the lottery is live or finished. But the information is still useful even if the lottery is not yet live.

This PR removes the conditional, allowing stats to be viewed regardless of lottery status. It also moves the chart and table portion of the view into its own partial.