### PR TITLE
Don't show ticket reference numbers unless lottery is live

### DIFF
--- a/app/views/lottery_entrants/_lottery_entrant_with_tickets.html.erb
+++ b/app/views/lottery_entrants/_lottery_entrant_with_tickets.html.erb
@@ -27,16 +27,18 @@
           account.</p>
         <p>You will need to use the same email that you used to apply to the lottery in Ultrasignup.</p>
       <% end %>
-      <% if presenter.lottery.live? || presenter.lottery.finished? %>
-        <hr/>
-        <div class="row">
+      <hr/>
+      <div class="row">
+        <% if presenter.lottery.preview? %>
+          <div class="h5 ms-2 text-center">Tickets will appear here once the lottery is live</div>
+        <% else %>
           <% presenter.tickets.each do |ticket| %>
             <div class="col-6 col-sm-3 col-md-2 text-center">
               <h4><span class="badge bg-primary text-center font-monospace p-3"><%= "##{ticket.reference_number}" %></span></h4>
             </div>
           <% end %>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/lottery_entrants/_lottery_entrant_with_tickets.html.erb
+++ b/app/views/lottery_entrants/_lottery_entrant_with_tickets.html.erb
@@ -27,14 +27,16 @@
           account.</p>
         <p>You will need to use the same email that you used to apply to the lottery in Ultrasignup.</p>
       <% end %>
-      <hr/>
-      <div class="row">
-        <% presenter.tickets.each do |ticket| %>
-          <div class="col-6 col-sm-3 col-md-2 text-center">
-            <h4><span class="badge bg-primary text-center font-monospace p-3"><%= "##{ticket.reference_number}" %></span></h4>
-          </div>
-        <% end %>
-      </div>
+      <% if presenter.lottery.live? || presenter.lottery.finished? %>
+        <hr/>
+        <div class="row">
+          <% presenter.tickets.each do |ticket| %>
+            <div class="col-6 col-sm-3 col-md-2 text-center">
+              <h4><span class="badge bg-primary text-center font-monospace p-3"><%= "##{ticket.reference_number}" %></span></h4>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/spec/system/lottery/visit_lottery_entrants_spec.rb
+++ b/spec/system/lottery/visit_lottery_entrants_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "visit a lottery entrants page" do
 
       visit_page
       verify_all_links_present
-      verify_ticket_link_works
+      verify_ticket_link_preview_works
     end
 
     scenario "The user is the owner of the organization" do
@@ -35,7 +35,7 @@ RSpec.describe "visit a lottery entrants page" do
 
       visit_page
       verify_all_links_present
-      verify_ticket_link_works
+      verify_ticket_link_preview_works
     end
 
     scenario "The user is a lottery manager of the organization" do
@@ -46,7 +46,7 @@ RSpec.describe "visit a lottery entrants page" do
 
       visit_page
       verify_all_links_present
-      verify_ticket_link_works
+      verify_ticket_link_preview_works
     end
 
     scenario "The user is a steward who is not a lottery manager of the organization" do
@@ -57,7 +57,7 @@ RSpec.describe "visit a lottery entrants page" do
       verify_public_links_present
       verify_live_links_absent
       verify_admin_links_absent
-      verify_ticket_link_works
+      verify_ticket_link_preview_works
     end
 
     scenario "The user is a visitor" do
@@ -66,7 +66,7 @@ RSpec.describe "visit a lottery entrants page" do
       verify_public_links_present
       verify_live_links_absent
       verify_admin_links_absent
-      verify_ticket_link_works
+      verify_ticket_link_preview_works
     end
   end
 
@@ -179,6 +179,19 @@ RSpec.describe "visit a lottery entrants page" do
   def verify_single_name_present
     verify_content_present(entrant_1, :full_name)
     other_entrants.each { |entrant| verify_content_absent(entrant, :full_name) }
+  end
+
+  def verify_ticket_link_preview_works
+    entrant_id = 6
+    entrant = ::LotteryEntrant.find(entrant_id)
+    entrant_card = find("#lottery_entrant_#{entrant_id}")
+    expect(entrant_card).to have_link("3 tickets")
+    ticket_numbers = entrant.tickets.pluck(:reference_number)
+    ticket_numbers.each { |ticket_number| expect(entrant_card).not_to have_content(ticket_number) }
+
+    entrant_card.click_link("3 tickets")
+
+    expect(entrant_card).to have_content("Tickets will appear here once the lottery is live")
   end
 
   def verify_ticket_link_works


### PR DESCRIPTION
When a lottery is in preview mode, there are situations where we want to generate tickets, make draws, and test that results are appearing correctly, then delete tickets and draws and regenerate tickets.

Because of this, it may be confusing if an entrant looks at ticket reference numbers and later sees different ticket reference numbers (after deleting and re-drawing).

This PR displays ticket reference numbers in the entrant detail view only if the lottery is in live or finished mode.