### PR TITLE
Lottery division rankings model and clean up scopes

### DIFF
--- a/app/models/lotteries/division_ranking.rb
+++ b/app/models/lotteries/division_ranking.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Lotteries::DivisionRanking < ApplicationRecord
+  self.primary_key = :lottery_entrant_id
+  self.table_name = "lotteries_division_rankings"
+
+  belongs_to :lottery_entrant
+
+  enum :draw_status,
+       {
+         accepted: 0,
+         waitlisted: 1,
+         drawn_beyond_waitlist: 2,
+         not_drawn: 3,
+       }
+
+end

--- a/app/models/lottery_division.rb
+++ b/app/models/lottery_division.rb
@@ -28,14 +28,14 @@ class LotteryDivision < ApplicationRecord
   end
 
   def all_entrants_drawn?
-    entrants.undrawn.empty?
+    entrants.not_drawn.empty?
   end
 
   def draw_ticket!
-    drawn_entrants = entrants.joins(tickets: :draw)
+    drawn_entrants = entrants.drawn
     eligible_tickets = tickets.where.not(lottery_entrant_id: drawn_entrants)
     selected_ticket_index = rand(eligible_tickets.count)
-    selected_ticket = eligible_tickets.offset(selected_ticket_index).first
+    selected_ticket = eligible_tickets.ordered_by_reference_number.offset(selected_ticket_index).first
 
     lottery.create_draw_for_ticket!(selected_ticket)
   end

--- a/app/models/lottery_simulation.rb
+++ b/app/models/lottery_simulation.rb
@@ -5,10 +5,10 @@ class LotterySimulation < ApplicationRecord
 
   def build
     results_array = simulation_run.divisions.ordered_by_name.map do |division|
-      accepted_male_ids = ::LotteryEntrant.from(division.accepted_entrants, :lottery_entrants).male.order(:drawn_at).pluck(:id)
-      accepted_female_ids = ::LotteryEntrant.from(division.accepted_entrants, :lottery_entrants).female.order(:drawn_at).pluck(:id)
-      wait_list_male_ids = ::LotteryEntrant.from(division.wait_list_entrants, :lottery_entrants).male.order(:drawn_at).pluck(:id)
-      wait_list_female_ids = ::LotteryEntrant.from(division.wait_list_entrants, :lottery_entrants).female.order(:drawn_at).pluck(:id)
+      accepted_male_ids = division.entrants.accepted.male.order(:division_rank).pluck(:id)
+      accepted_female_ids = division.entrants.accepted.female.order(:division_rank).pluck(:id)
+      waitlisted_male_ids = division.entrants.waitlisted.male.order(:division_rank).pluck(:id)
+      waitlisted_female_ids = division.entrants.waitlisted.female.order(:division_rank).pluck(:id)
 
       [
         division.name,
@@ -20,10 +20,10 @@ class LotterySimulation < ApplicationRecord
             female_entrant_ids: accepted_female_ids,
           },
           wait_list: {
-            male: wait_list_male_ids.size,
-            male_entrant_ids: wait_list_male_ids,
-            female: wait_list_female_ids.size,
-            female_entrant_ids: wait_list_female_ids,
+            male: waitlisted_male_ids.size,
+            male_entrant_ids: waitlisted_male_ids,
+            female: waitlisted_female_ids.size,
+            female_entrant_ids: waitlisted_female_ids,
           }
         }
       ]

--- a/app/models/lottery_ticket.rb
+++ b/app/models/lottery_ticket.rb
@@ -7,9 +7,9 @@ class LotteryTicket < ApplicationRecord
   belongs_to :entrant, class_name: "LotteryEntrant", foreign_key: "lottery_entrant_id"
   has_one :draw, class_name: "LotteryDraw", dependent: :destroy
 
-  scope :drawn, -> { with_drawn_at_attribute.where.not(drawn_at: nil) }
-  scope :undrawn, -> { with_drawn_at_attribute.where(drawn_at: nil) }
-  scope :with_drawn_at_attribute, -> { from(select("lottery_tickets.*, lottery_draws.created_at as drawn_at").left_joins(:draw), :lottery_tickets) }
+  scope :drawn, -> { left_joins(:draw).where.not(lottery_draws: { lottery_ticket_id: nil }) }
+  scope :not_drawn, -> { left_joins(:draw).where(lottery_draws: { lottery_ticket_id: nil }) }
+  scope :ordered_by_reference_number, -> { order(reference_number: :asc) }
   scope :with_sortable_entrant_attributes, lambda {
     from(select("lottery_tickets.*, lottery_divisions.name as division_name, first_name, last_name, gender, city, state_code, state_name, country_code, country_name")
            .joins(entrant: :division), :lottery_tickets)

--- a/lib/lottery_simulations/runner.rb
+++ b/lib/lottery_simulations/runner.rb
@@ -94,7 +94,7 @@ module LotterySimulations
     def draw_random_tickets
       divisions.each do |division|
         slots_available = division.maximum_slots - division.draws.count
-        undrawn_entrant_count = division.entrants.undrawn.count
+        undrawn_entrant_count = division.entrants.not_drawn.count
         ticket_count_needed = [slots_available, undrawn_entrant_count].min
 
         ticket_count_needed.times do |i|

--- a/spec/models/lottery_spec.rb
+++ b/spec/models/lottery_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Lottery, type: :model do
     let(:result) { subject.create_draw_for_ticket!(ticket) }
 
     context "when the ticket exists and has not been drawn" do
-      let(:ticket) { subject.tickets.undrawn.first }
+      let(:ticket) { subject.tickets.not_drawn.first }
       it "creates a draw" do
         expect { result }.to change { LotteryDraw.count }.by(1)
       end

--- a/spec/models/lottery_ticket_spec.rb
+++ b/spec/models/lottery_ticket_spec.rb
@@ -3,28 +3,47 @@
 require "rails_helper"
 
 RSpec.describe LotteryTicket, type: :model do
-  describe "drawn and undrawn scopes" do
+  describe "scopes" do
     let(:existing_scope) { division.tickets }
     let(:division) { LotteryDivision.find_by(name: division_name) }
-    let(:drawn_result) { existing_scope.drawn }
-    let(:undrawn_result) { existing_scope.undrawn }
 
-    context "when the existing scope includes drawn and undrawn tickets" do
-      let(:division_name) { "Elses" }
-      it "returns a collection of drawn and undrawn tickets respectively" do
-        expect(drawn_result.count).to eq(2)
-        expect(undrawn_result.count).to eq(6)
-        expect(drawn_result.map { |ticket| ticket.entrant.first_name }).to match_array(%w[Denisha Melina])
-        expect(undrawn_result.map { |ticket| ticket.entrant.first_name }).to match_array(%w[Denisha Melina Melina Shenika Abraham Maud])
+    describe ".drawn" do
+      let(:result) { existing_scope.drawn }
+
+      context "when the existing scope includes drawn and undrawn tickets" do
+        let(:division_name) { "Elses" }
+        it "returns a collection of drawn tickets" do
+          expect(result.count).to eq(2)
+          expect(result.map { |ticket| ticket.entrant.first_name }).to match_array(%w[Denisha Melina])
+        end
+      end
+
+      context "when the existing scope includes only undrawn tickets" do
+        let(:division_name) { "Veterans" }
+        it "returns an empty collection" do
+          expect(result).to be_empty
+        end
       end
     end
 
-    context "when the existing scope includes only undrawn tickets" do
-      let(:division_name) { "Veterans" }
-      it "returns a collection of drawn and undrawn tickets respectively" do
-        expect(drawn_result).to be_empty
-        expect(undrawn_result.count).to eq(7)
-        expect(undrawn_result.map { |ticket| ticket.entrant.first_name }).to match_array(%w[Veola Veola Blythe Ivette Jerrold Jerrold Jerrold])
+    describe ".not_drawn" do
+      let(:result) { existing_scope.not_drawn }
+
+      context "when the existing scope includes drawn and undrawn tickets" do
+        let(:division_name) { "Elses" }
+        it "returns a collection of not_drawn tickets" do
+          expect(result.count).to eq(6)
+          expect(result.map { |ticket| ticket.entrant.first_name }).to match_array(%w[Denisha Melina Melina Shenika Abraham Maud])
+        end
+      end
+
+      context "when the existing scope includes only drawn tickets" do
+        let(:division_name) { "Never Ever Evers" }
+        before { division.tickets.not_drawn.each(&:destroy) }
+
+        it "returns an empty collection" do
+          expect(result).to be_empty
+        end
       end
     end
   end

--- a/spec/system/lottery/monitor_lottery_draws_spec.rb
+++ b/spec/system/lottery/monitor_lottery_draws_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "monitor lottery draws", js: true do
   let(:lottery) { lotteries(:lottery_with_tickets_and_draws) }
   let(:division) { lottery.divisions.find_by(name: "Veterans") }
   let(:organization) { lottery.organization }
-  let(:entrant) { division.entrants.undrawn.first }
+  let(:entrant) { division.entrants.not_drawn.first }
 
   before do
     lottery.update(status: :live)

--- a/spec/system/lottery/visit_draw_tickets_view_spec.rb
+++ b/spec/system/lottery/visit_draw_tickets_view_spec.rb
@@ -61,6 +61,6 @@ RSpec.describe "visit a lottery draw tickets page" do
   def verify_all_content_present
     lottery.divisions.each { |division| verify_content_present(division) }
     lottery.entrants.drawn.each { |entrant| verify_content_present(entrant, :full_name) }
-    lottery.entrants.undrawn.each { |entrant| verify_content_absent(entrant, :full_name) }
+    lottery.entrants.not_drawn.each { |entrant| verify_content_absent(entrant, :full_name) }
   end
 end

--- a/spec/system/lottery/visit_lottery_draws_spec.rb
+++ b/spec/system/lottery/visit_lottery_draws_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "visit a lottery draws page" do
 
   def verify_public_content_present
     lottery.entrants.drawn.each { |entrant| verify_content_present(entrant, :full_name) }
-    lottery.entrants.undrawn.each { |entrant| verify_content_absent(entrant, :full_name) }
+    lottery.entrants.not_drawn.each { |entrant| verify_content_absent(entrant, :full_name) }
 
     verify_live_links_present
   end

--- a/spec/system/lottery/visit_lottery_results_spec.rb
+++ b/spec/system/lottery/visit_lottery_results_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "visit a lottery results page" do
   def verify_public_content_present
     lottery.divisions.each { |division| verify_content_present(division) }
     lottery.entrants.drawn.each { |entrant| verify_content_present(entrant, :full_name) }
-    lottery.entrants.undrawn.each { |entrant| verify_content_absent(entrant, :full_name) }
+    lottery.entrants.not_drawn.each { |entrant| verify_content_absent(entrant, :full_name) }
 
     verify_public_links_present
     verify_live_links_present

--- a/spec/system/lottery/visit_withdraw_entrants_view_spec.rb
+++ b/spec/system/lottery/visit_withdraw_entrants_view_spec.rb
@@ -61,6 +61,6 @@ RSpec.describe "visit a lottery withdraw entrants page" do
   def verify_all_content_present
     lottery.divisions.each { |division| verify_content_present(division) }
     lottery.entrants.drawn.each { |entrant| verify_content_present(entrant, :full_name) }
-    lottery.entrants.undrawn.each { |entrant| verify_content_absent(entrant, :full_name) }
+    lottery.entrants.not_drawn.each { |entrant| verify_content_absent(entrant, :full_name) }
   end
 end


### PR DESCRIPTION
This PR adds a `Lotteries::DivisionRanking` model for the new Postgres view, and uses this model to determine draw status (accepted, waitlisted, drawn beyond waitlist, or not drawn) for an entrant.