### PR TITLE
Move the Gender enum into PersonalInfo module

### DIFF
--- a/app/models/best_effort_segment.rb
+++ b/app/models/best_effort_segment.rb
@@ -5,7 +5,6 @@ class BestEffortSegment < ::ApplicationRecord
   include PersonalInfo
   include DatabaseRankable
 
-  enum gender: [:male, :female, :nonbinary]
   belongs_to :course
   belongs_to :effort
   belongs_to :person

--- a/app/models/course_group_finisher.rb
+++ b/app/models/course_group_finisher.rb
@@ -6,7 +6,6 @@ class CourseGroupFinisher < ::ApplicationRecord
 
   self.primary_key = :id
 
-  enum gender: [:male, :female, :nonbinary]
   belongs_to :person
   belongs_to :course_group
 

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -2,7 +2,6 @@
 
 class Effort < ApplicationRecord
   enum data_status: [:bad, :questionable, :good] # nil = unknown, 0 = bad, 1 = questionable, 2 = good
-  enum gender: [:male, :female, :nonbinary]
 
   # See app/concerns/data_status_methods for related scopes and methods
   VALID_STATUSES = [nil, data_statuses[:good]].freeze

--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class HistoricalFact < ApplicationRecord
-  enum gender: {
-    male: 0,
-    female: 1,
-    nonbinary: 2,
-  }
-
   enum kind: {
     dns: 0,
     volunteer_year: 1,

--- a/app/models/lotteries/calculations/base.rb
+++ b/app/models/lotteries/calculations/base.rb
@@ -5,12 +5,6 @@ class Lotteries::Calculations::Base < ApplicationRecord
 
   self.abstract_class = true
 
-  enum gender: {
-    male: 0,
-    female: 1,
-    nonbinary: 2,
-  }
-
   pg_search_scope :person_search,
                   associated_against: {
                     person: [:first_name, :last_name, :city, :state_name, :country_name]

--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -7,9 +7,6 @@ class LotteryEntrant < ApplicationRecord
   include Delegable
   include CapitalizeAttributes
 
-  has_person_name
-  enum gender: [:male, :female, :nonbinary]
-
   belongs_to :person, optional: true
   belongs_to :division, class_name: "LotteryDivision", foreign_key: "lottery_division_id", touch: true
   has_many :tickets, class_name: "LotteryTicket", dependent: :destroy

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -18,7 +18,6 @@ class Person < ApplicationRecord
   friendly_id :slug_candidates, use: [:slugged, :history]
   has_paper_trail
 
-  enum gender: [:male, :female, :nonbinary]
   has_many :efforts, dependent: :nullify
   has_many :historical_facts, dependent: :nullify
   has_many :lottery_entrants, dependent: :nullify

--- a/app/view_models/effort_times_row.rb
+++ b/app/view_models/effort_times_row.rb
@@ -3,7 +3,6 @@
 class EffortTimesRow
   include TimeFormats
   include Rankable
-  include PersonalInfo
 
   EXPORT_ATTRIBUTES = [:overall_rank, :gender_rank, :bib_number, :first_name, :last_name, :gender, :age, :state_code, :country_code, :flexible_geolocation].freeze
 
@@ -11,7 +10,7 @@ class EffortTimesRow
 
   delegate :id, :first_name, :last_name, :full_name, :gender, :bib_number, :age, :city, :state_code, :country_code, :data_status,
            :bad?, :questionable?, :good?, :confirmed?, :segment_time, :overall_rank, :gender_rank, :scheduled_start_offset,
-           :beyond_start?, :started?, :in_progress?, :stopped?, :dropped?, :finished?, to: :effort
+           :beyond_start?, :started?, :in_progress?, :stopped?, :dropped?, :finished?, :flexible_geolocation, to: :effort
 
   def initialize(args)
     ArgsValidator.validate(params: args,

--- a/app/view_models/effort_times_row.rb
+++ b/app/view_models/effort_times_row.rb
@@ -10,7 +10,7 @@ class EffortTimesRow
 
   delegate :id, :first_name, :last_name, :full_name, :gender, :bib_number, :age, :city, :state_code, :country_code, :data_status,
            :bad?, :questionable?, :good?, :confirmed?, :segment_time, :overall_rank, :gender_rank, :scheduled_start_offset,
-           :beyond_start?, :started?, :in_progress?, :stopped?, :dropped?, :finished?, :flexible_geolocation, to: :effort
+           :beyond_start?, :started?, :in_progress?, :stopped?, :dropped?, :finished?, :bio_historic, :flexible_geolocation, to: :effort
 
   def initialize(args)
     ArgsValidator.validate(params: args,

--- a/lib/personal_info.rb
+++ b/lib/personal_info.rb
@@ -1,5 +1,17 @@
+# frozen_string_literal: true
+
 module PersonalInfo
   extend ActiveSupport::Concern
+
+  included do
+    has_person_name
+
+    enum gender: {
+      male: 0,
+      female: 1,
+      nonbinary: 2,
+    }
+  end
 
   def bio
     [gender&.titlecase, current_age&.to_i].compact.join(", ")
@@ -14,13 +26,13 @@ module PersonalInfo
     return nil unless days.present?
 
     text = case days
-           when 0
-             "today"
-           when 1
-             "tomorrow"
-           when -1
-             "yesterday"
-           end
+    when 0
+      "today"
+    when 1
+      "tomorrow"
+    when -1
+      "yesterday"
+    end
 
     text ||= days.positive? ? "#{days} days from now" : "#{days.abs} days ago"
 
@@ -32,11 +44,12 @@ module PersonalInfo
   end
 
   def current_age
-    current_age_from_birthdate || (if has_attribute?("current_age_from_efforts")
-                                     attributes["current_age_from_efforts"]&.round
-                                   else
-                                     current_age_approximate
-                                   end)
+    current_age_from_birthdate || (
+      if has_attribute?("current_age_from_efforts")
+        attributes["current_age_from_efforts"]&.round
+      else
+        current_age_approximate
+      end)
   end
 
   def current_age_from_birthdate
@@ -62,6 +75,7 @@ module PersonalInfo
   def full_name
     [first_name, last_name].select(&:present?).join(" ")
   end
+
   alias name full_name
 
   def personal_info
@@ -79,7 +93,7 @@ module PersonalInfo
   private
 
   def country_abbreviations
-    {"United States" => "US"}
+    { "United States" => "US" }
   end
 
   def country_name_or_code


### PR DESCRIPTION
Every class that uses a `gender` enum also includes the `PersonalInfo` module.

This PR moves the enum into the module to avoid duplication.