### PR TITLE
Enable manage service button from lottery entrants view

### DIFF
--- a/app/presenters/lottery_entrant_presenter.rb
+++ b/app/presenters/lottery_entrant_presenter.rb
@@ -21,13 +21,29 @@ class LotteryEntrantPresenter < SimpleDelegator
     end
   end
 
+  # @return [Boolean]
+  def finisher?
+    division.name.include?("Finishers")
+  end
+
   # @return [ActiveRecord::Relation<HistoricalFact>]
   def relevant_historical_facts
     historical_facts.where(kind: RELEVANT_KINDS).ordered_within_person
   end
 
+  # @param [User] user
   # @return [Boolean]
-  def finisher?
-    division.name.include?("Finishers")
+  def service_manageable_by_user?(user)
+    return false if user.nil?
+
+    user.admin? || user.steward_of?(organization) || belongs_to_user?(user)
+  end
+
+  private
+
+  # @param [User] user
+  # @return [Boolean]
+  def belongs_to_user?(user)
+    lottery.entrants.belonging_to_user(user).include?(__getobj__)
   end
 end

--- a/app/views/lottery_entrants/_lottery_entrant_with_tickets.html.erb
+++ b/app/views/lottery_entrants/_lottery_entrant_with_tickets.html.erb
@@ -12,7 +12,7 @@
           <h6 class="text-end fw-bold"><%= "#{pluralize(presenter.number_of_tickets, 'ticket')}" %></h6>
         </div>
       </div>
-      <% if current_user.present? && (current_user.admin? || current_user.steward_of?(presenter.organization) || current_user.email == presenter.email) %>
+      <% if presenter.service_manageable_by_user?(current_user) %>
         <% if presenter.accepted? || presenter.waitlisted? %>
           <hr/>
           <div class="row">

--- a/spec/presenters/lottery_entrant_presenter_spec.rb
+++ b/spec/presenters/lottery_entrant_presenter_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LotteryEntrantPresenter do
+  subject { described_class.new(entrant) }
+  let(:entrant) { lottery_entrants(:lottery_entrant_0001) }
+  let(:organization) { entrant.division.lottery.organization }
+
+  describe "#service_manageable_by_user?" do
+    let(:result) { subject.service_manageable_by_user?(user) }
+
+    context "when the user is an admin" do
+      let(:user) { users(:admin_user) }
+
+      it { expect(result).to eq(true) }
+    end
+
+    context "when the user is not an admin" do
+      let(:user) { users(:third_user) }
+
+      context "when the user is a steward" do
+        before { organization.stewards << user }
+
+        it { expect(result).to eq(true) }
+      end
+
+      context "when the user has the same email as the entrant" do
+        before { user.update(email: entrant.email) }
+
+        it { expect(result).to eq(true) }
+      end
+
+      context "when the user is associated with the same person as the entrant" do
+        let(:person) { people(:bruno_fadel) }
+
+        before do
+          person.update(claimant: user)
+          entrant.update(person: person)
+        end
+
+        it { expect(result).to eq(true) }
+      end
+
+      context "when the user is not associated with the entrant" do
+        it { expect(result).to eq(false) }
+      end
+    end
+
+    context "when the user is nil" do
+      let(:user) { nil }
+
+      it { expect(result).to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
Currently, the "Manage Service" button is visible only to admins.

This PR makes the button visible to a logged-in user who is a steward of the organization or who is the same person (or same email) as the entrant.