### PR TITLE
Remove language from docs prohibiting electronic signatures

### DIFF
--- a/app/views/docs/visitors/_user_info_lotteries_1.html.erb
+++ b/app/views/docs/visitors/_user_info_lotteries_1.html.erb
@@ -39,9 +39,6 @@
         Service" button that appears on that card.
       </li>
       <li>Click the "Download" link to download a blank service form.</li>
-      <li>The form information may be filled out electronically, but <span class="fw-bold">all signatures must be manually obtained.</span> Electronic
-        signatures are not supported.
-      </li>
     </ol>
   </div>
 </div>


### PR DESCRIPTION
As it turns out, PDF electronic signatures work just fine. This PR removes the language saying they are not supported.