### PR TITLE
Migrate service_completed_date data

### DIFF
--- a/app/madmin/resources/lotteries/entrant_service_detail_resource.rb
+++ b/app/madmin/resources/lotteries/entrant_service_detail_resource.rb
@@ -7,10 +7,11 @@ class Lotteries::EntrantServiceDetailResource < Madmin::Resource
   attribute :form_rejected_comments
   attribute :created_at, form: false
   attribute :updated_at, form: false
-  attribute :completed_form, index: false
+  attribute :completed_date
 
   # Associations
   attribute :entrant
+  attribute :completed_form, index: false
 
   # Uncomment this to customize the display name of records in the admin area.
   # def self.display_name(record)

--- a/lib/tasks/temp/migrate_completed_service_date.rake
+++ b/lib/tasks/temp/migrate_completed_service_date.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+namespace :temp do
+  desc "Migrates lottery_entrants.service_completed_date to lotteries_entrant_service_detail.completed_date"
+  task migrate_service_completed_date: :environment do
+    puts "Migrating lottery_entrants.service_completed_date to lotteries_entrant_service_detail.completed_date"
+
+    entrants = LotteryEntrant.where.not(service_completed_date: nil)
+    entrants_count = entrants.count
+
+    puts "Found #{entrants_count} lottery entrants needing migration"
+
+    progress_bar = ::ProgressBar.new(entrants_count)
+
+    entrants.find_each do |entrant|
+      progress_bar.increment!
+
+      service_detail = entrant.service_detail || entrant.create_service_detail
+      service_detail.update(completed_date: entrant.service_completed_date)
+    rescue ActiveRecordError => e
+      puts "Could not update record for entrant id: #{entrant.id}"
+      puts e
+    end
+  end
+end


### PR DESCRIPTION
This PR contains a rake task that moves the data currently in `lottery_entrants.service_completed_date` into `lotteries_entrant_service_details.completed_date`.

It also updates the madmin resource for Lotteries::EntrantServiceDetail.