### PR TITLE
Lotteries::Calculations::Base needs a gender enum

### DIFF
--- a/app/models/lotteries/calculations/base.rb
+++ b/app/models/lotteries/calculations/base.rb
@@ -5,6 +5,12 @@ class Lotteries::Calculations::Base < ApplicationRecord
 
   self.abstract_class = true
 
+  enum gender: {
+    male: 0,
+    female: 1,
+    nonbinary: 2,
+  }
+
   pg_search_scope :person_search,
                   associated_against: {
                     person: [:first_name, :last_name, :city, :state_name, :country_name]

--- a/app/parameters/lottery_parameters.rb
+++ b/app/parameters/lottery_parameters.rb
@@ -3,6 +3,7 @@
 class LotteryParameters < BaseParameters
   def self.permitted
     [
+      :calculation_class,
       :concealed,
       :id,
       :name,


### PR DESCRIPTION
Currently, the lottery calculations preview page is broken because the gender enum was removed from the `Lotteries::Calculations::Base` class.

This PR restores the enum. It also adds `calculation_class` to LotteryParameters so that attribute can be changed via the form.