### PR TITLE
Use a Struct instead of OpenStruct in job

### DIFF
--- a/app/jobs/delete_topic_resource_key_job.rb
+++ b/app/jobs/delete_topic_resource_key_job.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "ostruct"
-
 class DeleteTopicResourceKeyJob < ApplicationJob
+  MockResource = Struct.new(:topic_resource_key, :slug, keyword_init: true)
+
   queue_as :default
 
   def perform(topic_resource_key, topic_manager_string: "SnsTopicManager")
     topic_manager = topic_manager_string.constantize
-    mock_resource = OpenStruct.new(topic_resource_key: topic_resource_key, slug: topic_resource_key)
+    mock_resource = MockResource.new(topic_resource_key: topic_resource_key, slug: topic_resource_key)
     topic_manager.delete(resource: mock_resource)
   end
 end

--- a/spec/jobs/delete_topic_resource_key_job_spec.rb
+++ b/spec/jobs/delete_topic_resource_key_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DeleteTopicResourceKeyJob do
 
   describe "#perform" do
     let(:perform_job) { subject.perform(topic_resource_key) }
-    let(:expected_mock_resource) { OpenStruct.new(topic_resource_key: topic_resource_key, slug: topic_resource_key) }
+    let(:expected_mock_resource) { described_class::MockResource.new(topic_resource_key: topic_resource_key, slug: topic_resource_key) }
 
     before { allow(SnsTopicManager).to receive(:delete) }
 


### PR DESCRIPTION
This PR should address the Sentry issue causing DeleteTopicResourceKeyJob to fail.

https://opensplittime.sentry.io/issues/6152593032/?project=3805803