### PR TITLE
Improve service form preparation instructions and bump file size to 5 MB

### DIFF
--- a/app/models/lotteries/entrant_service_detail.rb
+++ b/app/models/lotteries/entrant_service_detail.rb
@@ -7,8 +7,8 @@ class Lotteries::EntrantServiceDetail < ApplicationRecord
   has_one_attached :completed_form
 
   validates :completed_form,
-            content_type: { in: %w[image/png image/jpeg application/pdf], message: "must be a pdf, png, or jpeg file" },
-            size: { less_than: 2.megabytes, message: "must be less than 2 megabytes" }
+            content_type: { in: %w[image/png image/jpeg application/pdf], message: "must be a pdf, jpeg, or png file" },
+            size: { less_than: 5.megabytes, message: "must be less than 5 megabytes" }
 
   delegate :first_name, :last_name, :full_name, :organization, :lottery, to: :entrant
 

--- a/app/views/docs/visitors/_user_info_lotteries_1.html.erb
+++ b/app/views/docs/visitors/_user_info_lotteries_1.html.erb
@@ -40,6 +40,9 @@
       </li>
       <li>Click the "Download" link to download a blank service form.</li>
     </ol>
+    <p>The most efficient way to do this is to <span class="fw-bold">keep the PDF in electronic format</span>, fill it out on your phone or
+      computer, sign it electronically, and then forward it on to the other person or people for their required signatures.</p>
+    <p>Alternatively, you may print the form, fill it out and sign it manually, and forward it on for other required signatures.</p>
   </div>
 </div>
 <br/>
@@ -50,7 +53,10 @@
     <p>Once you have your service form completed and signed by all appropriate parties,
       <span class="fw-bold">here are the steps to upload the completed form:</span></p>
     <ol>
-      <li>Scan or take a photo of your completed form. <span class="fw-bold">The format must be jpeg, png, or pdf, and the file size must be less than 2 MB.</span></li>
+      <li>If your form is on paper, scan or take a photo of your completed form. If you've kept it in electronic format, then it should already be
+        good to go. In either case, <span class="fw-bold">the format must be pdf, jpeg, or png, and the file size must be less than 5 MB.</span> PDF
+        is preferred because of the smaller file size.
+      </li>
       <li>
         <span class="fw-bold">
           <%= user_signed_in? ?
@@ -58,7 +64,8 @@
                 link_to("Log in to OpenSplitTime", new_user_session_path, data: { turbo_frame: :form_modal })
           %>
         </span>
-        using the same account you used to download the form.</li>
+        using the same account you used to download the form.
+      </li>
       <li>Navigate to your Manage Service page as described above, and find the card with the heading that says, "Upload Completed Service Form".</li>
       <li>Drag your completed service form to the dropzone area, or click/tap the area and browse to find your file.</li>
       <li><span class="fw-bold">Click/tap the "Attach" button</span> at the bottom of the card.</li>

--- a/app/views/lotteries/entrant_service_details/_upload_service_form_card.html.erb
+++ b/app/views/lotteries/entrant_service_details/_upload_service_form_card.html.erb
@@ -41,7 +41,7 @@
           <div class="mb-3 text-center">
             <div class="dropzone dropzone-default dz-clickable"
                  data-controller="dropzone"
-                 data-dropzone-max-file-size="2"
+                 data-dropzone-max-file-size="5"
                  data-dropzone-max-files="1"
                  data-dropzone-accepted-files="image/*,.pdf"
                  data-action="dropzone:success->form-disable-submit#enableSubmitButton"
@@ -49,7 +49,7 @@
               <%= f.file_field :completed_form, direct_upload: true, data: { "dropzone-target" => "input" } %>
               <div class="dropzone-msg dz-message needsclick text-muted">
                 <h3 class="dropzone-msg-title">Drag here to upload or click here to browse</h3>
-                <span class="dropzone-msg-desc text-sm">2 MB file size maximum. File must be a pdf, jpeg, or png file.</span>
+                <span class="dropzone-msg-desc text-sm">5 MB file size maximum. File must be a pdf, jpeg, or png file.</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This PR addresses feedback on the service form instructions, making electronic signatures explicitly permitted and encouraging PDF form uploads.

This PR also bumps maximum file size to 5 MB for completed service form uploads.