### PR TITLE
Optimize lottery views

### DIFF
--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -39,6 +39,8 @@ class LotteryEntrant < ApplicationRecord
   validates_presence_of :first_name, :last_name, :gender, :number_of_tickets
   validates_with ::LotteryEntrantUniqueValidator
 
+  # @param [String] param
+  # @return [ActiveRecord::Relation<LotteryEntrant>]
   def self.search(param)
     return all unless param.present?
     return none unless param.size > 2
@@ -46,6 +48,8 @@ class LotteryEntrant < ApplicationRecord
     search_names_and_locations(param)
   end
 
+  # @param [String] param
+  # @return [ActiveRecord::Relation<LotteryEntrant>]
   def self.search_default_none(param)
     return none unless param && param.size > 2
 
@@ -56,6 +60,7 @@ class LotteryEntrant < ApplicationRecord
   delegate :organization, to: :lottery
   delegate :draw_status, :accepted?, :waitlisted?, to: :division_ranking
 
+  # @return [String]
   def division_name
     if attributes.key?("division_name")
       attributes["division_name"]
@@ -73,14 +78,17 @@ class LotteryEntrant < ApplicationRecord
     lottery.create_draw_for_ticket!(selected_ticket)
   end
 
+  # @return [Boolean]
   def drawn?
     tickets.joins(:draw).exists?
   end
 
+  # @return [Boolean]
   def service_completed?
     service_detail.present? && service_detail.completed_date?
   end
 
+  # @return [String]
   def to_s
     full_name
   end
@@ -88,6 +96,7 @@ class LotteryEntrant < ApplicationRecord
   private
 
   # Needed to keep PersonalInfo#bio from breaking
+  # @return [nil]
   def current_age_approximate
     nil
   end

--- a/app/presenters/lottery_presenter.rb
+++ b/app/presenters/lottery_presenter.rb
@@ -30,7 +30,7 @@ class LotteryPresenter < BasePresenter
   def lottery_entrants_default_none
     unfiltered_entrants = lottery.entrants
                                  .with_division_name
-                                 .includes(:division)
+                                 .includes(:division, :division_ranking)
     entrant_id = params[:entrant_id]
 
     if entrant_id.present?
@@ -41,7 +41,7 @@ class LotteryPresenter < BasePresenter
   end
 
   def lottery_entrants_paginated
-    @lottery_entrants_paginated ||= lottery_entrants_filtered.paginate(page: page, per_page: per_page).to_a
+    @lottery_entrants_paginated ||= lottery_entrants_filtered.paginate(page: page, per_page: per_page)
   end
 
   def next_page_url
@@ -124,7 +124,7 @@ class LotteryPresenter < BasePresenter
 
   def lottery_entrants_filtered
     lottery_entrants
-      .includes([:division_ranking, division: { lottery: :organization }])
+      .includes([:division_ranking, :service_detail, division: { lottery: :organization }])
       .search(search_text)
       .order(:last_name)
   end

--- a/app/presenters/lottery_presenter.rb
+++ b/app/presenters/lottery_presenter.rb
@@ -16,10 +16,12 @@ class LotteryPresenter < BasePresenter
     @params = view_context.prepared_params
   end
 
+  # @return [ActiveRecord::Relation<LotteryDivision>]
   def ordered_divisions
     @ordered_divisions ||= divisions.ordered_by_name
   end
 
+  # @return [ActiveRecord::Relation<LotteryDraw>]
   def lottery_draws_ordered
     lottery_draws
       .with_sortable_entrant_attributes
@@ -27,6 +29,7 @@ class LotteryPresenter < BasePresenter
       .most_recent_first
   end
 
+  # @return [ActiveRecord::Relation<LotteryEntrant>]
   def lottery_entrants_default_none
     unfiltered_entrants = lottery.entrants
                                  .with_division_name
@@ -40,18 +43,22 @@ class LotteryPresenter < BasePresenter
     end
   end
 
+  # @return [ActiveRecord::Relation<LotteryEntrant>]
   def lottery_entrants_paginated
     @lottery_entrants_paginated ||= lottery_entrants_filtered.paginate(page: page, per_page: per_page)
   end
 
+  # @return [String, nil]
   def next_page_url
     view_context.url_for(request.params.merge(page: page + 1)) if records_from_context_count == per_page
   end
 
+  # @return [ActiveRecord::Relation<Partner>]
   def partners
     @partners ||= lottery.partners.order(:name)
   end
 
+  # @return [ActiveRecord::Relation<LotteryEntrant>, ActiveRecord::Relation<LotteryDraw>]
   def records_from_context
     case display_style
     when "entrants"
@@ -59,14 +66,16 @@ class LotteryPresenter < BasePresenter
     when "draws"
       lottery_draws
     else
-      []
+      lottery_draws.none
     end
   end
 
+  # @return [Integer]
   def records_from_context_count
     @records_from_context_count ||= records_from_context.size
   end
 
+  # @return [Hash{String->Array<LotteryDivisionTicketStat>}]
   def stats
     @stats ||= ::LotteryDivisionTicketStat.where(lottery: lottery).order(:division_name, :number_of_tickets).group_by(&:division_name)
   end
@@ -88,14 +97,17 @@ class LotteryPresenter < BasePresenter
     ]
   end
 
+  # @return [Boolean]
   def viewable_results?
     lottery.live? || lottery.finished? || current_user&.authorized_for_lotteries?(lottery)
   end
 
+  # @return [String (frozen)]
   def display_style
     params[:display_style].presence || default_display_style
   end
 
+  # @return [String (frozen)]
   def default_display_style
     case status
     when "preview" then "entrants"
@@ -105,14 +117,17 @@ class LotteryPresenter < BasePresenter
     end
   end
 
+  # @return [Partner, nil]
   def partner_with_banner
     @partner_with_banner ||= lottery.pick_partner_with_banner
   end
 
+  # @return [Boolean]
   def show_partner_banners?
     lottery.live? && partner_with_banner.present?
   end
 
+  # @return [Boolean]
   def tickets_not_generated?
     @tickets_not_generated ||= lottery_tickets.empty?
   end
@@ -122,6 +137,7 @@ class LotteryPresenter < BasePresenter
   attr_reader :view_context
   delegate :current_user, :request, to: :view_context, private: true
 
+  # @return [ActiveRecord::Relation<LotteryEntrant>]
   def lottery_entrants_filtered
     lottery_entrants
       .includes([:division_ranking, :service_detail, division: { lottery: :organization }])

--- a/app/views/lotteries/_pre_selected_entrants_card.html.erb
+++ b/app/views/lotteries/_pre_selected_entrants_card.html.erb
@@ -24,7 +24,7 @@
       </div>
     </div>
     <div class="card-body table-responsive" data-visibility-target="element">
-      <%= render partial: "lottery_entrants/lottery_entrant_admin", collection: presenter.lottery_entrants.pre_selected, as: :record %>
+      <%= render partial: "lottery_entrants/lottery_entrant_admin", collection: presenter.lottery_entrants.pre_selected.includes(:division_ranking), as: :record %>
     </div>
   </div>
 </div>

--- a/app/views/lotteries/_results.html.erb
+++ b/app/views/lotteries/_results.html.erb
@@ -7,25 +7,25 @@
         <h4 class="card-header fw-bold bg-primary text-white"><%= "#{division.name}" %></h4>
         <div class="card-body">
           <h5>Accepted</h5>
-          <% if division.accepted_entrants.present? %>
+          <% if division.accepted_entrants.any? %>
             <ol>
-              <%= render partial: "entrant_for_results", collection: division.accepted_entrants, as: :entrant %>
+              <%= render partial: "entrant_for_results", collection: division.accepted_entrants.includes(:service_detail), as: :entrant %>
             </ol>
           <% else %>
             <p>No entrants have been drawn yet</p>
           <% end %>
 
-          <% if division.waitlisted_entrants.present? %>
+          <% if division.waitlisted_entrants.any? %>
             <h5>Wait List</h5>
             <ol>
-              <%= render partial: "entrant_for_results", collection: division.waitlisted_entrants, as: :entrant %>
+              <%= render partial: "entrant_for_results", collection: division.waitlisted_entrants.includes(:service_detail), as: :entrant %>
             </ol>
           <% end %>
 
-          <% if division.withdrawn_entrants.present? %>
+          <% if division.withdrawn_entrants.any? %>
             <h5>Withdrawn</h5>
             <ol>
-              <%= render partial: "entrant_for_results", collection: division.withdrawn_entrants, as: :entrant %>
+              <%= render partial: "entrant_for_results", collection: division.withdrawn_entrants.includes(:service_detail), as: :entrant %>
             </ol>
           <% end %>
         </div>

--- a/app/views/lotteries/manage_entrants.html.erb
+++ b/app/views/lotteries/manage_entrants.html.erb
@@ -5,22 +5,22 @@
 <%= render "lotteries/header", presenter: @presenter, breadcrumbs: ["Manage Entrants"] %>
 
 <article class="ost-article container">
-  <% if @presenter.lottery_draws.present? %>
+  <% if @presenter.lottery_draws.any? %>
     <% @presenter.ordered_divisions.each do |division| %>
       <div class="card">
         <h4 class="card-header fw-bold bg-primary text-white"><%= "#{division.name}" %></h4>
         <div class="card-body">
           <h5>Accepted</h5>
-          <%= render partial: "manage_entrants_table", locals: { entrants: division.accepted_entrants } %>
+          <%= render partial: "manage_entrants_table", locals: { entrants: division.accepted_entrants.includes(:service_detail) } %>
 
-          <% if division.waitlisted_entrants.present? %>
+          <% if division.waitlisted_entrants.any? %>
             <h5>Wait List</h5>
-            <%= render partial: "manage_entrants_table", locals: { entrants: division.waitlisted_entrants } %>
+            <%= render partial: "manage_entrants_table", locals: { entrants: division.waitlisted_entrants.includes(:service_detail) } %>
           <% end %>
 
-          <% if division.withdrawn_entrants.present? %>
+          <% if division.withdrawn_entrants.any? %>
             <h5>Withdrawn</h5>
-            <%= render partial: "manage_entrants_table", locals: { entrants: division.withdrawn_entrants } %>
+            <%= render partial: "manage_entrants_table", locals: { entrants: division.withdrawn_entrants.includes(:service_detail) } %>
           <% end %>
         </div>
       </div>

--- a/app/views/lotteries/setup.html.erb
+++ b/app/views/lotteries/setup.html.erb
@@ -165,7 +165,9 @@
 
       <div class="container">
         <% if @presenter.lottery_entrants_default_none.present? %>
-          <%= render partial: "lottery_entrants/lottery_entrant_admin", collection: @presenter.lottery_entrants_default_none, as: :record %>
+          <%= render partial: "lottery_entrants/lottery_entrant_admin",
+                     collection: @presenter.lottery_entrants_default_none,
+                     as: :record %>
         <% else %>
           <div class="card bg-light mt-2">
             <div class="card-body">


### PR DESCRIPTION
We are seeing a number of n+1 queries coming from lottery views. Most of these are caused by `division_ranking` or `service_detail` not being included in active record queries.

This PR optimizes these views to reduce n+1 queries.