### PR TITLE
Fix course group best efforts auto-pagination

### DIFF
--- a/app/views/course_group_best_efforts/index.turbo_stream.erb
+++ b/app/views/course_group_best_efforts/index.turbo_stream.erb
@@ -1,7 +1,6 @@
 <%= turbo_stream.append "best_effort_segments",
                         partial: "best_effort_segment",
-                        collection: @presenter.filtered_segments,
-                        locals: { organization: @presenter.organization, course_group: @presenter.course_group } %>
+                        collection: @presenter.filtered_segments %>
 
 <%= turbo_stream.replace "pager",
                          partial: "shared/pager",

--- a/app/views/course_group_finishers/_best_effort_segment.html.erb
+++ b/app/views/course_group_finishers/_best_effort_segment.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (best_effort_segment:) %>
+
 <tr>
   <td>
     <%= "#{best_effort_segment.overall_rank}/#{best_effort_segment.gender_rank}" %>

--- a/app/views/course_group_finishers/_best_efforts_list.html.erb
+++ b/app/views/course_group_finishers/_best_efforts_list.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (presenter:) %>
+
 <table class="table table-striped">
   <thead>
   <tr>
@@ -11,7 +13,7 @@
   </tr>
   </thead>
   <tbody>
-  <%= render partial: "best_effort_segment", collection: @presenter.course_group_best_efforts %>
+  <%= render partial: "best_effort_segment", collection: presenter.course_group_best_efforts %>
   </tbody>
 </table>
 

--- a/app/views/course_group_finishers/show.html.erb
+++ b/app/views/course_group_finishers/show.html.erb
@@ -27,6 +27,6 @@
 
 <article class="ost-article container">
   <% if @presenter.course_group_best_efforts.present? %>
-    <%= render partial: "best_efforts_list", best_efforts: @presenter.course_group_best_efforts %>
+    <%= render partial: "best_efforts_list", locals: { presenter: @presenter } %>
   <% end %>
 </article>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,6 +54,7 @@ RSpec.configure do |config|
   config.global_fixtures = [
     :aid_stations,
     :course_groups,
+    :course_group_courses,
     :courses,
     :credentials,
     :efforts,

--- a/spec/system/visit_course_group_best_efforts_spec.rb
+++ b/spec/system/visit_course_group_best_efforts_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Visit the course group best efforts page", js: true do
   let(:organization) { course_group.organization }
   # Expected count is the number of finished efforts + 1 for the header row
   let(:expected_count) { ::Effort.where(event: course_group_events).finished.count + 1 }
+  let(:half_of_expected) { expected_count / 2 }
 
   before { EffortSegment.set_all }
   after { EffortSegment.delete_all }
@@ -21,12 +22,17 @@ RSpec.describe "Visit the course group best efforts page", js: true do
   end
 
   scenario "Visitor visits the page and uses auto pagination" do
-    visit_page_with_pagination(20)
+    visit_page_with_pagination(half_of_expected)
+    scroll_to_bottom_of_page
     expect(page).not_to have_link("Show More")
     expect(page).to have_text("End of List")
   end
 
   def visit_page_with_pagination(per_page)
     visit organization_course_group_best_efforts_path(course_group.organization, course_group, per_page: per_page)
+  end
+
+  def scroll_to_bottom_of_page
+    execute_script('window.scrollTo(0, document.body.scrollHeight)')
   end
 end

--- a/spec/system/visit_course_group_best_efforts_spec.rb
+++ b/spec/system/visit_course_group_best_efforts_spec.rb
@@ -2,21 +2,31 @@
 
 require "rails_helper"
 
-RSpec.describe "Visit the course group best efforts page" do
+RSpec.describe "Visit the course group best efforts page", js: true do
   let(:course_group) { course_groups(:both_directions) }
   let(:course_group_events) { [events(:hardrock_2014), events(:hardrock_2015), events(:hardrock_2016)] }
-  let(:organization) { event_group.organization }
+  let(:organization) { course_group.organization }
+  # Expected count is the number of finished efforts + 1 for the header row
+  let(:expected_count) { ::Effort.where(event: course_group_events).finished.count + 1 }
 
-  before(:all) { EffortSegment.set_all }
-  after(:all) { EffortSegment.delete_all }
+  before { EffortSegment.set_all }
+  after { EffortSegment.delete_all }
 
-  scenario "Visitor visits the page and searches for a name" do
-    visit_page
+  scenario "Visitor visits the page" do
+    visit organization_course_group_best_efforts_path(course_group.organization, course_group)
 
     expect(page).to have_content(course_group.name)
+    expect(page).to have_selector("tr", count: expected_count)
+    expect(page).to have_text("End of List")
   end
 
-  def visit_page
-    visit organization_course_group_best_efforts_path(course_group.organization, course_group)
+  scenario "Visitor visits the page and uses auto pagination" do
+    visit_page_with_pagination(20)
+    expect(page).not_to have_link("Show More")
+    expect(page).to have_text("End of List")
+  end
+
+  def visit_page_with_pagination(per_page)
+    visit organization_course_group_best_efforts_path(course_group.organization, course_group, per_page: per_page)
   end
 end


### PR DESCRIPTION
This PR removes unknown locals that were being passed into the `course_group_best_efforts/_best_effort_segment` partial.

It also adds `course_group_courses` to the global fixture pool, making it possible to test the course group best efforts view.

Resolves #1360 