### PR TITLE
Remove deprecated `place` alias_attribute

### DIFF
--- a/app/models/best_effort_segment.rb
+++ b/app/models/best_effort_segment.rb
@@ -9,7 +9,6 @@ class BestEffortSegment < ::ApplicationRecord
   belongs_to :effort
   belongs_to :person
 
-  alias_attribute :place, :event_rank
   zonable_attribute :begin_time
 
   scope :for_courses, -> (courses) { where(course_id: courses) }

--- a/app/views/course_group_best_efforts/_best_effort_segment.html.erb
+++ b/app/views/course_group_best_efforts/_best_effort_segment.html.erb
@@ -9,6 +9,6 @@
   <td><%= best_effort_segment.flexible_geolocation %></td>
   <td><%= best_effort_segment.course_name %></td>
   <td class="text-center"><%= best_effort_segment.year_and_lap %></td>
-  <td class="text-center"><%= best_effort_segment.place %></td>
+  <td class="text-center"><%= best_effort_segment.event_rank %></td>
   <td class="text-end"><%= best_effort_segment.elapsed_time %></td>
 </tr>

--- a/app/views/course_group_finishers/_best_effort_segment.html.erb
+++ b/app/views/course_group_finishers/_best_effort_segment.html.erb
@@ -6,6 +6,6 @@
   </td>
   <td><%= best_effort_segment.course_name %></td>
   <td class="text-center"><%= link_to best_effort_segment.year_and_lap, best_effort_segment.effort %></td>
-  <td class="text-center"><%= best_effort_segment.place %></td>
+  <td class="text-center"><%= best_effort_segment.event_rank %></td>
   <td class="text-end"><%= best_effort_segment.elapsed_time %></td>
 </tr>


### PR DESCRIPTION
We are seeing a deprecation notice regarding the use of `alias_attribute` with a method that is not an attribute in the `BestEffortSegment` model.

This PR removes the alias and changes the only uses of the alias to use the original method name.