### PR TITLE
Service review toolbar

### DIFF
--- a/app/controllers/lotteries/entrant_service_details_controller.rb
+++ b/app/controllers/lotteries/entrant_service_details_controller.rb
@@ -41,9 +41,7 @@ class Lotteries::EntrantServiceDetailsController < ApplicationController
     completed_form = params.dig(:lotteries_entrant_service_detail, :completed_form)
 
     if completed_form.present?
-      if @service_detail.completed_form.attach(completed_form)
-        flash[:success] = "Completed service form was attached"
-      else
+      unless @service_detail.completed_form.attach(completed_form)
         flash[:danger] = "An error occurred while attaching service form: #{@service_detail.errors.full_messages}"
       end
 

--- a/app/models/concerns/lotteries/entrant_service_detail_validator.rb
+++ b/app/models/concerns/lotteries/entrant_service_detail_validator.rb
@@ -12,7 +12,7 @@ class Lotteries::EntrantServiceDetailValidator < ActiveModel::Validator
   delegate :errors, to: :service_detail, private: true
 
   def validate_accepted
-    return unless service_detail.accepted?
+    return unless service_detail.form_accepted_at?
 
     errors.add(:completed_date, "must be present") if service_detail.completed_date.blank?
     errors.add(:form_rejected_at, "may not be present") if service_detail.form_rejected_at.present?
@@ -20,7 +20,7 @@ class Lotteries::EntrantServiceDetailValidator < ActiveModel::Validator
   end
 
   def validate_rejected
-    return unless service_detail.rejected?
+    return unless service_detail.form_rejected_at?
 
     errors.add(:form_rejected_comments, "must be present") if service_detail.form_rejected_comments.blank?
     errors.add(:form_accepted_at, "may not be present") if service_detail.form_accepted_at.present?
@@ -29,7 +29,7 @@ class Lotteries::EntrantServiceDetailValidator < ActiveModel::Validator
   end
 
   def validate_under_review
-    return unless service_detail.under_review?
+    return if service_detail.form_accepted_at? || service_detail.form_rejected_at?
 
     errors.add(:form_accepted_comments, "may not be present") if service_detail.form_accepted_comments.present?
     errors.add(:form_rejected_comments, "may not be present") if service_detail.form_rejected_comments.present?

--- a/app/models/lotteries/entrant_service_detail.rb
+++ b/app/models/lotteries/entrant_service_detail.rb
@@ -29,8 +29,10 @@ class Lotteries::EntrantServiceDetail < ApplicationRecord
       "accepted"
     when rejected?
       "rejected"
-    else
+    when completed_form.attached?
       "under_review"
+    else
+      "not_received"
     end
   end
 end

--- a/app/models/lotteries/entrant_service_detail.rb
+++ b/app/models/lotteries/entrant_service_detail.rb
@@ -20,7 +20,7 @@ class Lotteries::EntrantServiceDetail < ApplicationRecord
   end
 
   def under_review?
-    !accepted? && !rejected?
+    !accepted? && !rejected? && completed_form.attached?
   end
 
   def status

--- a/app/models/lotteries/entrant_service_detail.rb
+++ b/app/models/lotteries/entrant_service_detail.rb
@@ -1,7 +1,7 @@
 class Lotteries::EntrantServiceDetail < ApplicationRecord
   self.table_name = "lotteries_entrant_service_details"
 
-  belongs_to :entrant, class_name: "LotteryEntrant", foreign_key: "lottery_entrant_id"
+  belongs_to :entrant, class_name: "LotteryEntrant", foreign_key: "lottery_entrant_id", touch: true
   has_one_attached :completed_form
 
   validates_with Lotteries::EntrantServiceDetailValidator

--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -24,6 +24,11 @@ class LotteryEntrant < ApplicationRecord
   scope :not_withdrawn, -> { where(withdrawn: [false, nil]) }
   scope :withdrawn, -> { where(withdrawn: true) }
 
+  scope :pending_completed_form_review, -> do
+    joins(service_detail: :completed_form_attachment)
+      .not_withdrawn
+      .where(lotteries_entrant_service_details: { form_accepted_at: nil, form_rejected_at: nil })
+  end
   scope :ordered, -> { joins(:division_ranking).order("lotteries_division_rankings.division_rank") }
   scope :ordered_for_export, -> { with_division_name.order("division_name, last_name") }
   scope :pre_selected, -> { where(pre_selected: true) }

--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -1,13 +1,9 @@
-# frozen_string_literal: true
-
 class LotteryEntrant < ApplicationRecord
   include StateCountrySyncable
   include Searchable
   include PersonalInfo
   include Delegable
   include CapitalizeAttributes
-
-  self.ignored_columns = %w[service_completed_date]
 
   belongs_to :person, optional: true
   belongs_to :division, class_name: "LotteryDivision", foreign_key: "lottery_division_id", touch: true
@@ -85,7 +81,7 @@ class LotteryEntrant < ApplicationRecord
 
   # @return [Boolean]
   def service_completed?
-    service_detail.present? && service_detail.completed_date?
+    service_detail.present? && service_detail.accepted?
   end
 
   # @return [String]

--- a/app/presenters/lotteries/entrant_service_detail_presenter.rb
+++ b/app/presenters/lotteries/entrant_service_detail_presenter.rb
@@ -1,4 +1,23 @@
 # frozen_string_literal: true
 
 class Lotteries::EntrantServiceDetailPresenter < SimpleDelegator
+  def next_entrant_for_review
+    return @next_entrant_for_review if defined?(@next_entrant_for_review)
+
+    @next_entrant_for_review = lottery.entrants
+      .pending_completed_form_review
+      .where("lottery_entrants.id > ?", lottery_entrant_id)
+      .order(id: :asc)
+      .first
+  end
+
+  def previous_entrant_for_review
+    return @previous_entrant_for_review if defined?(@previous_entrant_for_review)
+
+    @previous_entrant_for_review = lottery.entrants
+      .pending_completed_form_review
+      .where("lottery_entrants.id < ?", lottery_entrant_id)
+      .order(id: :desc)
+      .first
+  end
 end

--- a/app/presenters/lottery_presenter.rb
+++ b/app/presenters/lottery_presenter.rb
@@ -52,6 +52,12 @@ class LotteryPresenter < BasePresenter
     @pre_selected_entrant_count ||= lottery_entrants.pre_selected.count
   end
 
+  def first_service_detail_for_review
+    return @first_service_detail_for_review if defined?(@first_service_detail_for_review)
+
+    @first_service_detail_for_review = lottery_entrants.pending_completed_form_review.order(:id).first
+  end
+
   # @return [String, nil]
   def next_page_url
     view_context.url_for(request.params.merge(page: page + 1)) if records_from_context_count == per_page

--- a/app/views/credentials/_form.html.erb
+++ b/app/views/credentials/_form.html.erb
@@ -22,7 +22,7 @@
         <% if credential.persisted? %>
           <%= link_to "Clear", credential_path(credential), data: { turbo_method: :delete }, class: "btn btn-outline-danger" %>
         <% else %>
-          <%= link_to "Clear", "#", class: "btn btn-outline-danger", disabled: true %>
+          <%= link_to "Clear", "#", class: "btn btn-outline-danger disabled" %>
         <% end %>
       </div>
     </div>

--- a/app/views/event_groups/webhooks.html.erb
+++ b/app/views/event_groups/webhooks.html.erb
@@ -65,8 +65,7 @@
             <span class="d-grid" data-controller="tooltip" data-bs-original-title="<%= t('event_groups.webhooks.no_webhooks_available') %>">
               <%= link_to fa_icon("plus", text: "Add Subscription"),
                           "#",
-                          class: "btn btn-outline-success",
-                          disabled: true,
+                          class: "btn btn-outline-success disabled",
                           style: "pointer-events: none;"
               %>
             </span>

--- a/app/views/export_jobs/_actions_kebab.html.erb
+++ b/app/views/export_jobs/_actions_kebab.html.erb
@@ -8,8 +8,7 @@
     <%= link_to "Download", rails_blob_path(export_job.file, disposition: "attachment"), class: "dropdown-item" %>
   <% else %>
     <%= link_to "Nothing to download", "#",
-                class: "dropdown-item",
-                disabled: true %>
+                class: "dropdown-item disabled" %>
   <% end %>
   <%= link_to "Delete", export_job_path(export_job),
               class: "dropdown-item",

--- a/app/views/lotteries/_entrant_for_results.html.erb
+++ b/app/views/lotteries/_entrant_for_results.html.erb
@@ -1,5 +1,5 @@
 <li><%= "#{entrant.name} (#{entrant.flexible_geolocation})" %>
   <% if !entrant.withdrawn? && entrant.service_completed? %>
-    <span class="text-success px-2"><%= fa_icon("circle-check", text: "Service Form Received", type: :solid, class: "text-success") %></span>
+    <span class="text-success px-2"><%= fa_icon("circle-check", text: "Service Form Accepted", type: :solid, class: "text-success") %></span>
   <% end %>
 </li>

--- a/app/views/lotteries/entrant_service_details/_review_toolbar.html.erb
+++ b/app/views/lotteries/entrant_service_details/_review_toolbar.html.erb
@@ -1,0 +1,35 @@
+<%# locals: (presenter:) %>
+
+<aside class="ost-toolbar">
+  <div class="container">
+    <div class="row">
+      <div class="col">
+        <% if presenter.previous_entrant_for_review.present? %>
+          <%= link_to fa_icon("caret-left", text: "Previous"),
+                      organization_lottery_entrant_service_detail_path(presenter.organization, presenter.lottery, presenter.previous_entrant_for_review),
+                      class: "btn btn-outline-secondary" %>
+        <% else %>
+          <%= link_to fa_icon("caret-left", text: "Previous"),
+                      "#",
+                      class: "btn btn-outline-secondary disabled" %>
+        <% end %>
+        <%= link_to "Review",
+                    edit_organization_lottery_entrant_service_detail_path(presenter.organization, presenter.lottery, presenter.__getobj__),
+                    class: "btn btn-outline-secondary",
+                    data: {
+                      turbo_frame: "form_modal",
+                    }
+        %>
+        <% if presenter.next_entrant_for_review.present? %>
+          <%= link_to fa_icon("caret-right", text: "Next", right: true),
+                      organization_lottery_entrant_service_detail_path(presenter.organization, presenter.lottery, presenter.next_entrant_for_review),
+                      class: "btn btn-outline-secondary" %>
+        <% else %>
+          <%= link_to fa_icon("caret-right", text: "Next", right: true),
+                      "#",
+                      class: "btn btn-outline-secondary disabled" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</aside>

--- a/app/views/lotteries/entrant_service_details/_service_form_status_card.html.erb
+++ b/app/views/lotteries/entrant_service_details/_service_form_status_card.html.erb
@@ -22,9 +22,6 @@
           <td>Uploaded</td>
           <td><%= l(presenter.completed_form.created_at) %></td>
           <td><%= presenter.completed_form.filename %></td>
-          <% if current_user.authorized_for_lotteries?(presenter.lottery) %>
-            <td></td>
-          <% end %>
         </tr>
         <tr class="align-middle">
           <% if presenter.rejected? %>
@@ -42,17 +39,6 @@
             <td>Under review</td>
             <td></td>
             <td></td>
-          <% end %>
-          <% if current_user.authorized_for_lotteries?(presenter.lottery) %>
-            <td>
-              <%= link_to "Review",
-                          edit_organization_lottery_entrant_service_detail_path(presenter.organization, presenter.lottery, presenter.__getobj__),
-                          class: "btn btn-sm btn-outline-secondary",
-                          data: {
-                            turbo_frame: "form_modal",
-                          }
-              %>
-            </td>
           <% end %>
         </tr>
         </tbody>

--- a/app/views/lotteries/entrant_service_details/_upload_service_form_card.html.erb
+++ b/app/views/lotteries/entrant_service_details/_upload_service_form_card.html.erb
@@ -3,24 +3,26 @@
 <div class="card mt-4">
   <div class="card-header">
     <div class="row">
-      <div class="col">
-        <span class="fs-3 fw-bold">Upload Completed Service Form</span>
-        <% if presenter.completed_form.attached? %>
+      <% if presenter.completed_form.attached? %>
+        <div class="col">
+          <span class="fs-3 fw-bold">Completed Service Form</span>
           <span class="fs-5 text-muted ps-2"><%= fa_icon("circle-check", class: "text-success", text: "Attached") %></span>
-        <% end %>
-      </div>
-      <div class="col text-end">
-        <div class="d-flex justify-content-end gap-2">
-          <% if presenter.completed_form.attached? %>
+        </div>
+        <div class="col text-end">
+          <div class="d-flex justify-content-end gap-2">
             <%= link_to fa_icon("download", text: "Download"),
                         download_completed_form_organization_lottery_entrant_service_detail_path(presenter.organization, presenter.lottery, presenter.__getobj__),
                         target: "_blank",
                         rel: "noopener",
                         class: "btn btn-outline-success" %>
             <%= button_to_remove_completed_service_form(presenter) %>
-          <% end %>
+          </div>
         </div>
-      </div>
+      <% else %>
+        <div class="col">
+          <span class="fs-3 fw-bold">Upload Completed Service Form</span>
+        </div>
+      <% end %>
     </div>
   </div>
   <div class="card-body">
@@ -38,7 +40,7 @@
                         controller: "form-disable-submit",
                       }
               },
-              ) do |f| %>
+            ) do |f| %>
 
           <div class="mb-3 text-center">
             <div class="dropzone dropzone-default dz-clickable"

--- a/app/views/lotteries/entrant_service_details/show.html.erb
+++ b/app/views/lotteries/entrant_service_details/show.html.erb
@@ -27,6 +27,10 @@
   </div>
 </header>
 
+<% if current_user.authorized_for_lotteries?(@presenter.organization) %>
+  <%= render partial: "review_toolbar", locals: { presenter: @presenter } %>
+<% end %>
+
 <article class="ost-article container">
   <%= render partial: "service_form_status_card", locals: { presenter: @presenter } %>
   <%= render partial: "blank_service_form_card", locals: { presenter: @presenter } %>

--- a/app/views/lotteries/manage_entrants.html.erb
+++ b/app/views/lotteries/manage_entrants.html.erb
@@ -4,6 +4,20 @@
 
 <%= render "lotteries/header", presenter: @presenter, breadcrumbs: ["Manage Entrants"] %>
 
+<aside class="ost-toolbar">
+  <div class="container">
+    <div class="row">
+      <div class="col">
+        <% if @presenter.first_service_detail_for_review.present? %>
+          <%= link_to "Review service forms",
+                      organization_lottery_entrant_service_detail_path(@presenter.organization, @presenter.lottery, @presenter.first_service_detail_for_review),
+                      class: "btn btn-outline-secondary" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</aside>
+
 <article class="ost-article container">
   <% if @presenter.lottery_draws.any? %>
     <% @presenter.ordered_divisions.each do |division| %>

--- a/spec/factories/lotteries/entrant_service_detail.rb
+++ b/spec/factories/lotteries/entrant_service_detail.rb
@@ -12,5 +12,27 @@ FactoryBot.define do
       form_rejected_at { Time.zone.now }
       form_rejected_comments { "Form is not signed" }
     end
+
+    trait :with_completed_form do
+      transient do
+        file_params do
+          {
+            file: Rails.root.join("spec", "fixtures", "files", "service_form.pdf"),
+            filename: "service_form.pdf",
+            content_type: "application/pdf",
+          }
+        end
+      end
+
+      after(:build) do |service_detail, evaluator|
+        file_params = evaluator.file_params
+
+        service_detail.completed_form.attach(
+          io: File.open(file_params[:file]),
+          filename: file_params[:filename],
+          content_type: file_params[:content_type]
+        )
+      end
+    end
   end
 end

--- a/spec/factories/lottery_division.rb
+++ b/spec/factories/lottery_division.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :lottery_division do
     association :lottery
+    name { "Division A" }
+    maximum_entries { 10 }
+    maximum_wait_list { 10 }
   end
 end

--- a/spec/factories/lottery_entrant.rb
+++ b/spec/factories/lottery_entrant.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :lottery_entrant do
     association :division, factory: :lottery_division
+    first_name { FFaker::Name.first_name }
+    last_name { FFaker::Name.last_name }
+    gender { %w[male female].sample }
+    number_of_tickets { 1 }
   end
 end

--- a/spec/models/lotteries/entrant_service_detail_spec.rb
+++ b/spec/models/lotteries/entrant_service_detail_spec.rb
@@ -1,10 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Lotteries::EntrantServiceDetail do
+  let(:entrant) { lottery_entrants(:lottery_entrant_0001) }
+
   describe "validations" do
     subject do
       build_stubbed(
         :lotteries_entrant_service_detail,
+        entrant: entrant,
         form_accepted_at: form_accepted_at,
         form_accepted_comments: form_accepted_comments,
         form_rejected_at: form_rejected_at,
@@ -115,19 +118,29 @@ RSpec.describe Lotteries::EntrantServiceDetail do
   describe "#under_review?" do
     let(:result) { subject.under_review? }
 
-    context "when form_accepted_at is present" do
-      subject { build_stubbed(:lotteries_entrant_service_detail, :accepted) }
+    context "when completed form is not attached" do
+      subject { build(:lotteries_entrant_service_detail, entrant: entrant) }
       it { expect(result).to eq(false) }
     end
 
-    context "when form_rejected_at is present" do
-      subject { build_stubbed(:lotteries_entrant_service_detail, :rejected) }
-      it { expect(result).to eq(false) }
-    end
+    context "when completed form is attached" do
+      context "when form_accepted_at is present" do
+        subject { build(:lotteries_entrant_service_detail, :accepted, :with_completed_form, entrant: entrant) }
+        it { expect(result).to eq(false) }
+      end
 
-    context "when form_accepted_at and form_rejected_at are not present" do
-      subject { build_stubbed(:lotteries_entrant_service_detail) }
-      it { expect(result).to eq(true) }
+      context "when form_rejected_at is present" do
+        subject { build(:lotteries_entrant_service_detail, :rejected, :with_completed_form, entrant: entrant) }
+        it { expect(result).to eq(false) }
+      end
+
+      context "when form_accepted_at and form_rejected_at are not present" do
+        subject { build(:lotteries_entrant_service_detail, :with_completed_form, entrant: entrant) }
+        it do
+          expect(subject.completed_form.attached?).to eq(true)
+          expect(result).to eq(true)
+        end
+      end
     end
   end
 

--- a/spec/models/lotteries/entrant_service_detail_spec.rb
+++ b/spec/models/lotteries/entrant_service_detail_spec.rb
@@ -148,21 +148,27 @@ RSpec.describe Lotteries::EntrantServiceDetail do
     let(:result) { subject.status }
 
     context "when the form has been accepted" do
-      subject { build_stubbed(:lotteries_entrant_service_detail, :accepted) }
+      subject { build(:lotteries_entrant_service_detail, :accepted, :with_completed_form, entrant: entrant) }
 
       it { expect(result).to eq("accepted") }
     end
 
     context "when the form has been rejected" do
-      subject { build_stubbed(:lotteries_entrant_service_detail, :rejected) }
+      subject { build(:lotteries_entrant_service_detail, :rejected, :with_completed_form, entrant: entrant) }
 
       it { expect(result).to eq("rejected") }
     end
 
     context "when the form has not been accepted or rejected" do
-      subject { build_stubbed(:lotteries_entrant_service_detail) }
+      subject { build(:lotteries_entrant_service_detail, :with_completed_form, entrant: entrant) }
 
       it { expect(result).to eq("under_review") }
+    end
+
+    context "when no form is attached" do
+      subject { build(:lotteries_entrant_service_detail, entrant: entrant) }
+
+      it { expect(result).to eq("not_received") }
     end
   end
 end

--- a/spec/presenters/lotteries/entrant_service_detail_presenter_spec.rb
+++ b/spec/presenters/lotteries/entrant_service_detail_presenter_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Lotteries::EntrantServiceDetailPresenter do
+  subject { described_class.new(service_detail) }
+  let(:service_detail) { create(:lotteries_entrant_service_detail, :with_completed_form, entrant: entrant) }
+  let(:entrant) { lottery_entrants(:lottery_entrant_0005) }
+  let(:earlier_entrant) { lottery_entrants(:lottery_entrant_0002) }
+  let(:later_entrant) { lottery_entrants(:lottery_entrant_0008) }
+
+  describe "#next_entrant_for_review" do
+    let(:result) { subject.next_entrant_for_review }
+
+    context "when no other entrant needs review" do
+      it { expect(result).to be_nil }
+    end
+
+    context "when an entrant with a lower id needs review but none with a higher id needs review" do
+      before { create(:lotteries_entrant_service_detail, :with_completed_form, entrant: earlier_entrant) }
+      it { expect(result).to be_nil }
+    end
+
+    context "when an entrant with a higher id needs review" do
+      before { create(:lotteries_entrant_service_detail, :with_completed_form, entrant: later_entrant) }
+      it { expect(result).to eq(later_entrant) }
+    end
+  end
+
+  describe "#previous_entrant_for_review" do
+    let(:result) { subject.previous_entrant_for_review }
+
+    context "when no other entrant needs review" do
+      it { expect(result).to be_nil }
+    end
+
+    context "when an entrant with a higher id needs review but none with a lower id needs review" do
+      before { create(:lotteries_entrant_service_detail, :with_completed_form, entrant: later_entrant) }
+      it { expect(result).to be_nil }
+    end
+
+    context "when an entrant with a lower id needs review" do
+      before { create(:lotteries_entrant_service_detail, :with_completed_form, entrant: earlier_entrant) }
+      it { expect(result).to eq(earlier_entrant) }
+    end
+  end
+end

--- a/spec/presenters/lottery_entrant_presenter_spec.rb
+++ b/spec/presenters/lottery_entrant_presenter_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rails_helper"
 
 RSpec.describe LotteryEntrantPresenter do


### PR DESCRIPTION
This PR adds a Review toolbar to the Entrant Service Detail page, allowing a coordinator to quickly move from one service detail to the next or previous one needing review.

It also fixes logic in the validations and related methods for Lotteries::EntrantServiceDetail.