### PR TITLE
Course Average Time

### DIFF
--- a/app/presenters/organization_presenter.rb
+++ b/app/presenters/organization_presenter.rb
@@ -40,7 +40,7 @@ class OrganizationPresenter < BasePresenter
 
   def courses
     scoped_courses = CoursePolicy::Scope.new(current_user, Course).viewable
-    @courses ||= organization.courses.includes(:splits, :events).where(id: scoped_courses)
+    @courses ||= organization.courses.includes(:splits, :events).where(id: scoped_courses).order(:name)
   end
 
   def course_groups

--- a/app/views/courses/_courses_list.html.erb
+++ b/app/views/courses/_courses_list.html.erb
@@ -6,16 +6,18 @@
     <th>Name</th>
     <th>Splits</th>
     <th>Events</th>
-    <th>GPX</th>
+    <th class="text-center">GPX</th>
+    <th class="text-end">Average Finish Time</th>
   </tr>
   </thead>
   <tbody>
   <% courses.each do |course| %>
       <tr>
         <td><strong><%= link_to course.name, organization_course_path(course.organization, course) %></strong></td>
-        <td><%= pluralize(course.splits.size, 'split') %></td>
-        <td><%= pluralize(course.events.size, 'event') %></td>
-        <td><%= "#{course.gpx.filename} (#{(course.gpx.byte_size / 1.0.kilobytes).round(1)} KB)" if course.gpx.attached? %></td>
+        <td><%= pluralize(course.splits.size, "split") %></td>
+        <td><%= pluralize(course.events.size, "event") %></td>
+        <td class="text-center"><%= fa_icon("circle-check", class: "text-success") if course.gpx.attached? %></td>
+        <td class="text-end"><%= TimeConversion.seconds_to_hms(course.average_finish_seconds) %></td>
       </tr>
   <% end %>
   </tbody>


### PR DESCRIPTION
This PR adds an "Average Finish Time" column to the courses index, relying on an existing method `Course#average_finish_seconds` to do the computation. This does add an N+1 query to the courses index view, which is acceptable for now, because this view is not accessed very often and no organization has more than a handful of courses in any case.

This PR also orders courses alphabetically by name.

Resolves #1369 
Resolves #1370 
