### PR TITLE
Set deploy stack for Heroku CI to heroku-24

### DIFF
--- a/app.json
+++ b/app.json
@@ -31,5 +31,6 @@
         "test": "bin/rspec spec --tag ~@js"
       }
     }
-  }
+  },
+  "stack": "heroku-24"
 }


### PR DESCRIPTION
Testing to see if the app works with the heroku-24 stack. This applies only for Heroku CI and does not change the stack for the actual deployments. If CI continues to pass, we'll go ahead and update the stack for staging and then for production.