### PR TITLE
Fix ETL registration date problem

### DIFF
--- a/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
+++ b/lib/etl/transformers/async/ultrasignup_historical_facts_strategy.rb
@@ -46,10 +46,10 @@ module Etl::Transformers::Async
       self.base_proto_record = ProtoRecord.new(**struct.to_h)
 
       base_proto_record.transform_as(:historical_fact, organization: organization)
-      base_proto_record[:year] = Date.current.year
+      base_proto_record[:year] = struct[:Registration_Date].to_date.year
     end
 
-    def record_lottery_application(struct)
+    def record_lottery_application(_struct)
       proto_record = base_proto_record.deep_dup
       proto_record[:kind] = :lottery_application
       proto_record[:comments] = "Ultrasignup"


### PR DESCRIPTION
In the Ultrasignup historical facts transformer, we are currently setting the year of the registration based on `Date.current.year`. 

This PR pulls the year from the `Registration_Date` attribute instead.