### PR TITLE
Fix new organization view and add system specs

### DIFF
--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -2,7 +2,7 @@
   <% "OpenSplitTime: New Organization" %>
 <% end %>
 
-<%= render "shared/mode_widget", event_group: nil, organization: @organization %>
+<%= render "shared/mode_widget", event_group: nil %>
 
 <header class="ost-header">
   <div class="container">

--- a/spec/system/event_group_construction/create_organization_spec.rb
+++ b/spec/system/event_group_construction/create_organization_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "Create a new organization" do
+  let(:user) { users(:third_user) }
+  let(:admin) { users(:admin_user) }
+
+  scenario "The user is a visitor" do
+    visit_path
+
+    expect(page).to have_current_path(root_path)
+    expect(page).to have_text("You need to sign in or sign up before continuing")
+  end
+
+  scenario "The user is a non-admin user" do
+    login_as user, scope: :user
+    visit_path
+
+    verify_organization_creation
+  end
+
+  scenario "The user is an admin user" do
+    login_as admin, scope: :user
+    visit_path
+
+    verify_organization_creation
+  end
+
+  def visit_path
+    visit new_organization_path
+  end
+
+  def verify_organization_creation
+    expect(page).to have_content("New Organization")
+    fill_in "Name", with: "My Organization"
+    fill_in "Description", with: "This is my organization"
+
+    expect do
+      click_button "Continue"
+    end.to change { Organization.count }.by(1)
+
+    new_organization = Organization.last
+    expect(new_organization.name).to eq("My Organization")
+    expect(page).to have_current_path(new_organization_event_group_path(new_organization))
+  end
+end

--- a/spec/system/organization/visit_organizations_index_spec.rb
+++ b/spec/system/organization/visit_organizations_index_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Visit the organizations index" do
 
     verify_public_links_present
     verify_concealed_links_absent
+    verify_new_link_absent
   end
 
   scenario "The user is a non-admin user is neither owner nor steward of any concealed organization" do
@@ -33,6 +34,7 @@ RSpec.describe "Visit the organizations index" do
 
     verify_public_links_present
     verify_concealed_links_absent
+    verify_new_link_present_and_functional
   end
 
   scenario "The user is a non-admin user that created a concealed organization" do
@@ -42,6 +44,7 @@ RSpec.describe "Visit the organizations index" do
     verify_public_links_present
     verify_link_present(concealed_organization_1)
     verify_content_absent(concealed_organization_2)
+    verify_new_link_present_and_functional
   end
 
   scenario "The user is a non-admin user that is a steward of a concealed organization" do
@@ -51,6 +54,7 @@ RSpec.describe "Visit the organizations index" do
     verify_public_links_present
     verify_link_present(concealed_organization_2)
     verify_content_absent(concealed_organization_1)
+    verify_new_link_present_and_functional
   end
 
   scenario "The user is an admin user" do
@@ -59,6 +63,7 @@ RSpec.describe "Visit the organizations index" do
 
     verify_public_links_present
     concealed_organizations.each(&method(:verify_link_present))
+    verify_new_link_present_and_functional
   end
 
   def verify_public_links_present
@@ -68,5 +73,15 @@ RSpec.describe "Visit the organizations index" do
 
   def verify_concealed_links_absent
     concealed_organizations.each(&method(:verify_content_absent))
+  end
+
+  def verify_new_link_present_and_functional
+    expect(page).to have_link("Create a new organization")
+    click_link("Create a new organization")
+    expect(page).to have_current_path(new_organization_path)
+  end
+
+  def verify_new_link_absent
+    expect(page).not_to have_link("Create a new organization")
   end
 end


### PR DESCRIPTION
We are getting a new Sentry error when a user attempts to create a new organization: https://opensplittime.sentry.io/issues/6192346531

This is caused by an attempt to pass an unknown `organization` local to the `shared/mode_widget` view.

This PR removes the `organization` local from the partial render call. It also adds system specs that test the ability to click through and create a new organization.