### PR TITLE
Fix key not found error

### DIFF
--- a/app/views/import_jobs/new.html.erb
+++ b/app/views/import_jobs/new.html.erb
@@ -37,20 +37,23 @@
         <div><span class="fw-bold">Importing into: </span><span><%= "#{@import_job.parent_type.titleize} #{@import_job.parent_name}" %></span></div>
         <div><span class="fw-bold">Using format: </span><span class="font-monospace"><%= @import_job.format %></span></div>
       </div>
-      <div class="col-12 col-md mt-3 mt-md-0 text-center text-md-end">
-        <%= link_to fa_icon("file-csv", text: "Download CSV Template"),
-                    csv_templates_import_jobs_path(
-                      format: :csv,
-                      import_job_format: @import_job.format,
-                      parent_type: @import_job.parent_type,
-                      parent_id: @import_job.parent_id
-                    ),
-                    data: {
-                      controller: "tooltip",
-                      bs_title: "Click to download a CSV template for #{@import_job.format}",
-                    },
-                    class: "btn btn-outline-success" %>
-      </div>
+
+      <% if Etl::CsvTemplates::FIXED_HEADERS_BY_FORMAT.key?(@import_job.format) %>
+        <div class="col-12 col-md mt-3 mt-md-0 text-center text-md-end">
+          <%= link_to fa_icon("file-csv", text: "Download CSV Template"),
+                      csv_templates_import_jobs_path(
+                        format: :csv,
+                        import_job_format: @import_job.format,
+                        parent_type: @import_job.parent_type,
+                        parent_id: @import_job.parent_id
+                      ),
+                      data: {
+                        controller: "tooltip",
+                        bs_title: "Click to download a CSV template for #{@import_job.format}",
+                      },
+                      class: "btn btn-outline-success" %>
+        </div>
+      <% end %>
     </div>
   </div>
 

--- a/lib/etl/csv_templates.rb
+++ b/lib/etl/csv_templates.rb
@@ -33,8 +33,17 @@ module Etl
       event_entrants_with_elapsed_times: EFFORT_ATTRIBUTES,
       event_entrants_with_military_times: EFFORT_ATTRIBUTES,
       event_group_entrants: EFFORT_ATTRIBUTES,
+      historical_facts: [
+        *PERSON_ATTRIBUTES,
+        "Address",
+        "Kind",
+        "Quantity",
+        "Comments",
+        "Year",
+        "External ID",
+      ],
       lottery_entrants: PERSON_ATTRIBUTES,
-    }.freeze
+    }.with_indifferent_access.freeze
 
     def self.headers(format, parent)
       new(format, parent).headers


### PR DESCRIPTION
We are seeing a [new error in Sentry](https://opensplittime.sentry.io/issues/6194566355/?project=3805803), caused when a user requests a template when no template for that format exists.

This PR hides the button if the CSV template format is not available.

This PR also adds a CSV template for historical facts.