### PR TITLE
Prioritize matching by email, phone, and birthdate

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -10,8 +10,8 @@ module Searchable
     scope :gender_matches, -> (param) { where("#{table_name}.gender = ?", gender_int(param)) }
     scope :country_matches, -> (param) { where(arel_table["country_code"].matches(country_code_for(param).to_s)) }
     scope :state_matches, -> (param) { where(arel_table["state_code"].matches(state_code_for(param).to_s)) }
-    scope :email_matches, -> (param) { where(arel_table["email"].matches("%#{param}%")) }
-    scope :email_matches_or_nil, -> (param) { where(arel_table["email"].matches("%#{param}%")).or(where(email: nil)) }
+    scope :email_matches, -> (param) { where(arel_table["email"].matches(param)) }
+    scope :email_matches_or_nil, -> (param) { where(arel_table["email"].matches(param)).or(where(email: nil)) }
     scope :phone_matches, -> (param) { where(arel_table["phone"].matches("%#{param}%")) }
     scope :phone_matches_or_nil, -> (param) { where(arel_table["phone"].matches("%#{param}%")).or(where(phone: nil)) }
     scope :first_name_matches, -> (param) { where(arel_table["first_name"].matches("%#{param}%")) }

--- a/app/services/historical_fact_auto_reconciler.rb
+++ b/app/services/historical_fact_auto_reconciler.rb
@@ -19,7 +19,9 @@ class HistoricalFactAutoReconciler
       matching_person_id ||= person_id_from_related_facts(fact)
 
       matching_person = person_from_id(matching_person_id) ||
-        fact.definitive_matching_person ||
+        fact.definitive_matching_person_by_email ||
+        fact.definitive_matching_person_by_phone ||
+        fact.definitive_matching_person_by_birthdate ||
         fact.exact_matching_person
 
       person = if matching_person.present?
@@ -63,7 +65,7 @@ class HistoricalFactAutoReconciler
   def person_id_from_effort(fact)
     return unless fact.kind.in?(RESULT_KINDS)
 
-    key = [fact.first_name, fact.last_name, fact.comments.to_i]
+    key = [fact.first_name, fact.last_name, fact.year]
     effort = indexed_effort_structs[key]
 
     if effort.present?

--- a/spec/services/historical_fact_auto_reconciler_spec.rb
+++ b/spec/services/historical_fact_auto_reconciler_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe HistoricalFactAutoReconciler do
 
   describe "#reconcile" do
     context "for historical facts that match with a result in an organization effort" do
-      let!(:fact_1) { create(:historical_fact, organization: parent, first_name: effort_1.first_name, last_name: effort_1.last_name, gender: effort_1.gender, kind: :dnf, comments: "2016") }
-      let!(:fact_2) { create(:historical_fact, organization: parent, first_name: effort_2.first_name, last_name: effort_2.last_name, gender: effort_2.gender, kind: :finished, comments: "2016") }
+      let!(:fact_1) { create(:historical_fact, organization: parent, first_name: effort_1.first_name, last_name: effort_1.last_name, gender: effort_1.gender, kind: :dnf, year: 2016) }
+      let!(:fact_2) { create(:historical_fact, organization: parent, first_name: effort_2.first_name, last_name: effort_2.last_name, gender: effort_2.gender, kind: :finished, year: 2016) }
 
       it "assigns the fact to the person_id in the effort" do
         subject.reconcile

--- a/spec/support/concerns/matchable.rb
+++ b/spec/support/concerns/matchable.rb
@@ -72,7 +72,7 @@ RSpec.shared_examples_for "matchable" do
     end
   end
 
-  describe "#definitive_matching_person" do
+  describe "#definitive_matching_person_by_birthdate" do
     it "returns a record for which first and last names and gender and birthdate match" do
       subject_attributes =
         { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", email: "jane@jetson.com", phone: "3035551212" }
@@ -85,9 +85,21 @@ RSpec.shared_examples_for "matchable" do
         { first_name: "Jane", last_name: "Jetson", gender: "male", birthdate: "1967-07-01" },
         { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1999-07-01" },
       ]
-      verify_definitive_matching_person(subject_attributes, matching_attributes, differing_attributes)
+      verify_definitive_matching_person_by_birthdate(subject_attributes, matching_attributes, differing_attributes)
     end
 
+    it "returns nil if more than one record is turned up" do
+      subject_attributes = { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01" }
+      matching_attributes = nil
+      differing_attributes = [
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "NM" },
+        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO" },
+      ]
+      verify_definitive_matching_person_by_birthdate(subject_attributes, matching_attributes, differing_attributes)
+    end
+  end
+
+  describe "#definitive_matching_person_by_email" do
     it "returns a record for which last name and gender and email match" do
       subject_attributes =
         { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", email: "jane@jetson.com", phone: "3035551212" }
@@ -99,9 +111,11 @@ RSpec.shared_examples_for "matchable" do
         { first_name: "Jane", last_name: "Jetson", gender: "male", email: "jane@jetson.com" },
         { first_name: "Jane", last_name: "Jetson", gender: "female", email: "jane@gmail.com" },
       ]
-      verify_definitive_matching_person(subject_attributes, matching_attributes, differing_attributes)
+      verify_definitive_matching_person_by_email(subject_attributes, matching_attributes, differing_attributes)
     end
+  end
 
+  describe "#definitive_matching_person_by_phone" do
     it "returns a record for which last name and gender and phone match" do
       subject_attributes =
         { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", email: "jane@jetson.com", phone: "3035551212" }
@@ -113,27 +127,35 @@ RSpec.shared_examples_for "matchable" do
         { first_name: "Jane", last_name: "Jetson", gender: "male", phone: "3035551212" },
         { first_name: "Jane", last_name: "Jetson", gender: "female", phone: "8887776666" },
       ]
-      verify_definitive_matching_person(subject_attributes, matching_attributes, differing_attributes)
+      verify_definitive_matching_person_by_phone(subject_attributes, matching_attributes, differing_attributes)
     end
+  end
 
-    it "returns nil if more than one record is turned up" do
-      subject_attributes = { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01" }
-      matching_attributes = nil
-      differing_attributes = [
-        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "NM" },
-        { first_name: "Jane", last_name: "Jetson", gender: "female", birthdate: "1967-07-01", state_code: "CO" },
-      ]
-      verify_definitive_matching_person(subject_attributes, matching_attributes, differing_attributes)
-    end
+  def verify_definitive_matching_person_by_birthdate(subject_attributes, matching_attributes, differing_attributes)
+    subject = described_class.new(subject_attributes)
+    matching_person = matching_attributes ? create(:person, matching_attributes) : nil
+    differing_people = differing_attributes.map { |attribute_set| create(:person, attribute_set) }
+    person = subject.definitive_matching_person_by_birthdate
+    expect(person).to eq(matching_person)
+    differing_people.each { |differing_person| expect(person).not_to eq(differing_person) }
+  end
 
-    def verify_definitive_matching_person(subject_attributes, matching_attributes, differing_attributes)
-      subject = described_class.new(subject_attributes)
-      matching_person = matching_attributes ? create(:person, matching_attributes) : nil
-      differing_people = differing_attributes.map { |attribute_set| create(:person, attribute_set) }
-      person = subject.definitive_matching_person
-      expect(person).to eq(matching_person)
-      differing_people.each { |differing_person| expect(person).not_to eq(differing_person) }
-    end
+  def verify_definitive_matching_person_by_email(subject_attributes, matching_attributes, differing_attributes)
+    subject = described_class.new(subject_attributes)
+    matching_person = matching_attributes ? create(:person, matching_attributes) : nil
+    differing_people = differing_attributes.map { |attribute_set| create(:person, attribute_set) }
+    person = subject.definitive_matching_person_by_email
+    expect(person).to eq(matching_person)
+    differing_people.each { |differing_person| expect(person).not_to eq(differing_person) }
+  end
+
+  def verify_definitive_matching_person_by_phone(subject_attributes, matching_attributes, differing_attributes)
+    subject = described_class.new(subject_attributes)
+    matching_person = matching_attributes ? create(:person, matching_attributes) : nil
+    differing_people = differing_attributes.map { |attribute_set| create(:person, attribute_set) }
+    person = subject.definitive_matching_person_by_phone
+    expect(person).to eq(matching_person)
+    differing_people.each { |differing_person| expect(person).not_to eq(differing_person) }
   end
 
   describe "#exact_matching_person" do


### PR DESCRIPTION
The `Matchable#definitive_matching_person` method was not producing expected results.

This PR makes a few changes:

1. Separates the method into three new methods, which can be called in order of desired priority:
- `definitive_matching_person_by_email`
- `definitive_matching_person_by_phone`
- `definitive_matching_person_by_birthdate`

2. Fixes the logic for matching by effort. The existing logic looks at `comments` (where the year used to be stored), but it should look at the newer `year` attribute.

This PR also updates the historical facts auto reconciler to use the new `definitive_matching_person_by_` methods.