### PR TITLE
Include ticket count in lottery entrant export

### DIFF
--- a/app/views/lotteries/results/_all_entrants.csv.ruby
+++ b/app/views/lotteries/results/_all_entrants.csv.ruby
@@ -8,15 +8,17 @@ if records.present?
       "Gender",
       "Birthdate",
       "Email",
+      "Ticket count",
       "Status",
     ]
     records.each do |row|
       csv << [
         row.first_name,
         row.last_name,
-        row.gender,
+        row.gender.titleize,
         row.birthdate,
         row.email,
+        row.number_of_tickets,
         row.draw_status.titleize,
       ]
     end


### PR DESCRIPTION
This PR adds ticket count to the `all_entrants` lottery entrant export.