### PR TITLE
Historical fact auto reconciler fixes

### DIFF
--- a/app/models/concerns/matchable.rb
+++ b/app/models/concerns/matchable.rb
@@ -44,8 +44,7 @@ module Matchable
   # @return [Person, nil]
   def exact_matching_person # Suitable for automated matcher
     name_gender_age_match = potential_matches.first_name_matches_exact(first_name).age_matches(current_age)
-    exact_matches = name_gender_age_match.present? ? name_gender_age_match : potential_matches.state_matches(state_code)
-    exact_matches.one? ? exact_matches.first : nil # Return nil if more than one match
+    name_gender_age_match.one? ? name_gender_age_match.first : nil # Return nil if more than one match
   end
 
   # @return [Person, nil]

--- a/app/models/historical_fact.rb
+++ b/app/models/historical_fact.rb
@@ -74,7 +74,7 @@ class HistoricalFact < ApplicationRecord
   end
 
   def related_facts
-    organization.historical_facts.where(personal_info_hash: personal_info_hash)
+    organization.historical_facts.where(personal_info_hash: personal_info_hash).where.not(id: id)
   end
 
   def reconciled?

--- a/spec/models/historical_fact_spec.rb
+++ b/spec/models/historical_fact_spec.rb
@@ -122,5 +122,23 @@ RSpec.describe HistoricalFact, type: :model do
         end
       end
     end
+
+    describe "#related_facts" do
+      let(:result) { subject.related_facts }
+
+      context "when related facts exist" do
+        subject { historical_facts(:historical_fact_0001) }
+
+        it "returns all facts that have the same personal_info_hash" do
+          expect(result.count).to eq(4)
+          expect(result.map(&:personal_info_hash)).to all be_present
+          expect(result.map(&:personal_info_hash)).to all eq(subject.personal_info_hash)
+        end
+
+        it "does not include the subject" do
+          expect(result.pluck(:id)).not_to include(subject.id)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR makes two changes that may help with #1396:

1. Removes last name/gender/state matching from `exact_matching_person`
2. Excludes the subject historical fact from `related_facts`