### PR TITLE
Disallow double-click for lottery draw buttons

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -58,6 +58,9 @@ application.register("highlight", HighlightController)
 import InputmaskController from "./inputmask_controller"
 application.register("inputmask", InputmaskController)
 
+import LinkDisableController from "./link_disable_controller"
+application.register("link-disable", LinkDisableController)
+
 import LiveEntry__EffortTableController from "./live_entry/effort_table_controller"
 application.register("live-entry--effort-table", LiveEntry__EffortTableController)
 

--- a/app/javascript/controllers/link_disable_controller.js
+++ b/app/javascript/controllers/link_disable_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="link-disable"
+export default class extends Controller {
+  static values = { disableText: String };
+
+  disable(_event) {
+    this.element.classList.add("disabled");
+    this.element.style.pointerEvents = "none"; // Prevent further interaction
+    if (this.disableTextValue) {
+      this.element.innerText = this.disableTextValue; // Replace the text
+    }
+  }
+}

--- a/app/views/lottery_divisions/_draw_tickets_header.html.erb
+++ b/app/views/lottery_divisions/_draw_tickets_header.html.erb
@@ -15,7 +15,11 @@
                   disabled: lottery_division.full? || lottery_division.all_entrants_drawn?,
                   class: "btn btn-lg btn-success fw-bold w-100" %>
       <% if lottery_division.entrants.pre_selected.present? %>
-        <button class="btn btn-lg btn-success fw-bold dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button class="btn btn-lg btn-success fw-bold dropdown-toggle dropdown-toggle-split"
+                <%= "disabled" if lottery_division.full? || lottery_division.all_entrants_drawn? %>
+                data-bs-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false">
           <span class="sr-only">Toggle Dropdown</span>
         </button>
         <div class="dropdown-menu">

--- a/app/views/lottery_divisions/_draw_tickets_header.html.erb
+++ b/app/views/lottery_divisions/_draw_tickets_header.html.erb
@@ -7,7 +7,11 @@
   <div class="d-grid">
     <div class="btn-group">
       <%= link_to "Draw a Ticket", draw_organization_lottery_path(lottery_division.organization, lottery_division.lottery, division_id: lottery_division.id),
-                  data: { turbo_method: :post },
+                  data: {
+                    controller: "link-disable",
+                    action: "click->link-disable#disable",
+                    turbo_method: :post,
+                  },
                   disabled: lottery_division.full? || lottery_division.all_entrants_drawn?,
                   class: "btn btn-lg btn-success fw-bold w-100" %>
       <% if lottery_division.entrants.pre_selected.present? %>


### PR DESCRIPTION
This PR disables the draw buttons momentarily when clicked, preventing inadvertent double-clicks.

Resolves #1189