### PR TITLE
Generate lottery tickets directly in Postgres

### DIFF
--- a/app/models/lottery.rb
+++ b/app/models/lottery.rb
@@ -69,7 +69,7 @@ class Lottery < ApplicationRecord
 
     sql = LotteryTicketQuery.insert_lottery_tickets
     sanitized_sql = ActiveRecord::Base.sanitize_sql([sql, { lottery_id: id, beginning_reference_number: beginning_reference_number }])
-    ActiveRecord::Base.connection.execute(sanitized_sql, "Lottery Ticket Bulk Insert")
+    ActiveRecord::Base.connection.execute(sanitized_sql, "LotteryTicket Bulk Insert")
   end
 
   def start_time

--- a/app/queries/lottery_ticket_query.rb
+++ b/app/queries/lottery_ticket_query.rb
@@ -1,0 +1,38 @@
+class LotteryTicketQuery < BaseQuery
+  # This method returns a fixed string with no Ruby string injection. To use it, call:
+  # sanitized_sql = ActiveRecord::Base.sanitize_sql([sql, { lottery_id: lottery_id, beginning_reference_number: beginning_reference_number }])
+  # ActiveRecord::Base.connection.execute(sanitized_sql, "Lottery Ticket Bulk Insert")
+  def self.insert_lottery_tickets
+    <<~SQL.squish
+      with ticket_data as (
+                              select e.id                                    as lottery_entrant_id,
+                                     d.lottery_id                            as lottery_id,
+                                     generate_series(1, e.number_of_tickets) as ticket_number,
+                                     now()                                   as created_at,
+                                     now()                                   as updated_at
+                              from lottery_entrants e
+                                       join lottery_divisions d on e.lottery_division_id = d.id
+                                       join lotteries l on d.lottery_id = l.id
+                              where l.id = :lottery_id
+                              ),
+           shuffled_tickets as (
+                              select ticket_data.*,
+                                     random() as rand_val
+                              from ticket_data
+                              ),
+           ranked_tickets as (
+                              select st.*,
+                                     row_number() over (order by st.rand_val) + :beginning_reference_number - 1 as reference_number
+                              from shuffled_tickets st
+                              )
+      insert
+      into lottery_tickets (lottery_id, lottery_entrant_id, reference_number, created_at, updated_at)
+      select lottery_id,
+             lottery_entrant_id,
+             reference_number,
+             created_at,
+             updated_at
+      from ranked_tickets
+    SQL
+  end
+end

--- a/spec/models/lottery_spec.rb
+++ b/spec/models/lottery_spec.rb
@@ -44,20 +44,6 @@ RSpec.describe Lottery, type: :model do
     end
   end
 
-  describe "#generate_ticket_hashes" do
-    let(:result) { subject.generate_ticket_hashes }
-    let(:default_reference_number) { 10_000 }
-
-    it "returns an array the size of the aggregate sum of all tickets" do
-      expect(result.size).to eq(4)
-    end
-
-    it "returns hashes with expected information" do
-      expect(result.first[:lottery_id]).to eq(subject.id)
-      expect(result.first[:reference_number]).to eq(default_reference_number)
-    end
-  end
-
   describe "#delete_and_insert_tickets!" do
     let(:execute_method) { subject.delete_and_insert_tickets! }
 


### PR DESCRIPTION
This PR switches ticket-creation logic to the database, where it can happen at the rate of about 100,000 records per second.

Resolves #1403 