### PR TITLE
Pluck reference numbers instead of loading tickets

### DIFF
--- a/app/presenters/lottery_entrant_presenter.rb
+++ b/app/presenters/lottery_entrant_presenter.rb
@@ -53,6 +53,11 @@ class LotteryEntrantPresenter < SimpleDelegator
     user.admin? || user.steward_of?(organization) || belongs_to_user?(user)
   end
 
+  # @return [Array<Integer>]
+  def ticket_reference_numbers
+    @ticket_reference_numbers ||= tickets.pluck(:reference_number)
+  end
+
   private
 
   # @return [Boolean]

--- a/app/views/lottery_entrants/_lottery_entrant_with_tickets.html.erb
+++ b/app/views/lottery_entrants/_lottery_entrant_with_tickets.html.erb
@@ -52,9 +52,9 @@
         <% if presenter.lottery.preview? %>
           <div class="h5 ms-2 text-center">Tickets will appear here once the lottery is live</div>
         <% else %>
-          <% presenter.tickets.each do |ticket| %>
-            <div class="col-6 col-sm-3 col-md-2 text-center">
-              <h4><span class="badge bg-primary text-center font-monospace p-3"><%= "##{ticket.reference_number}" %></span></h4>
+          <% presenter.ticket_reference_numbers.each do |reference_number| %>
+            <div class="col-4 col-sm-3 col-md-2 col-xl-1 text-center">
+              <h4><span class="badge bg-primary text-center font-monospace fs-6 p-3"><%= "##{reference_number}" %></span></h4>
             </div>
           <% end %>
         <% end %>


### PR DESCRIPTION
When displaying tickets for an entrant, we are using only the reference number at this time. 

This PR optimizes the view by plucking reference numbers instead of loading entire tickets. This could make a significant performance difference when loading hundreds or thousands of tickets for an entrant.