### PR TITLE
Lottery setup | Entrants having mismatched tickets

### DIFF
--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -26,6 +26,13 @@ class LotteryEntrant < ApplicationRecord
   scope :not_withdrawn, -> { where(withdrawn: [false, nil]) }
   scope :withdrawn, -> { where(withdrawn: true) }
 
+  scope :having_mismatched_tickets, -> do
+    from(left_joins(:tickets)
+      .select("lottery_entrants.*, COUNT(lottery_tickets.id) AS generated_tickets_count")
+      .group("lottery_entrants.id")
+      .having("COUNT(lottery_tickets.id) != lottery_entrants.number_of_tickets"), :lottery_entrants)
+  end
+
   scope :pending_completed_form_review, -> do
     joins(service_detail: :completed_form_attachment)
       .not_withdrawn
@@ -36,7 +43,7 @@ class LotteryEntrant < ApplicationRecord
   scope :pre_selected, -> { where(pre_selected: true) }
   scope :with_division_name, -> { from(select("lottery_entrants.*, lottery_divisions.name as division_name").joins(:division), :lottery_entrants) }
   scope :with_policy_scope_attributes, lambda {
-    from(select("lottery_entrants.*, organizations.concealed, organizations.id as organization_id").joins(division: {lottery: :organization}), :lottery_entrants)
+    from(select("lottery_entrants.*, organizations.concealed, organizations.id as organization_id").joins(division: { lottery: :organization }), :lottery_entrants)
   }
 
   validates_presence_of :first_name, :last_name, :gender, :number_of_tickets

--- a/app/presenters/lottery_presenter.rb
+++ b/app/presenters/lottery_presenter.rb
@@ -19,6 +19,11 @@ class LotteryPresenter < BasePresenter
     @ordered_divisions ||= divisions.ordered_by_name
   end
 
+  # @return [ActiveRecord::Relation<LotteryEntrant>]
+  def mismatched_entrants
+    @mismatched_entrants ||= entrants.having_mismatched_tickets
+  end
+
   # @return [ActiveRecord::Relation<LotteryDraw>]
   def lottery_draws_ordered
     lottery_draws

--- a/app/views/lotteries/_setup_callouts.html.erb
+++ b/app/views/lotteries/_setup_callouts.html.erb
@@ -10,14 +10,45 @@
                  main_text: "Tickets have not been generated",
                  detail_paragraphs: "You will need to generate tickets before going live with your Lottery. Click the \"Generate tickets\" button above when your entrants and ticket counts are finalized.",
                } %>
-  <% elsif presenter.tickets.count != presenter.entrants.sum(:number_of_tickets) %>
+  <% elsif presenter.mismatched_entrants.any? %>
     <%= render partial: "shared/callout_with_link",
                locals: {
                  callout_color: "warning",
                  icon_color: "danger",
                  icon_name: "exclamation-triangle",
-                 main_text: "Generated tickets do not match the total ticket count",
-                 detail_paragraphs: "Your generated tickets do not match tickets allocated for your entrants. Click the \"Delete tickets\" button above and then re-generate tickets to correct this problem.",
+                 main_text: "One or more entrants have mismatched tickets",
+                 detail_paragraphs: [
+                   "Your generated tickets do not match tickets allocated for one or more of your entrants.",
+                   "If Tickets Generated is correct, edit the Entrant in the Entrant Lookup card below to change the number of Tickets Allocated.",
+                   "If Tickets Allocated is correct, click the \"Delete tickets\" button above and then re-generate tickets to correct this problem.",
+                 ]
                } %>
+    <div class="card mt-4">
+      <div class="card-header">
+        <%= fa_icon("exclamation-triangle", type: :regular, class: "text-danger", size: "2x") %>
+        <span class="h3 fw-bold mx-2">Mismatched Entrants</span>
+        <span class="h5 text-muted">Fix these before drawing tickets</span>
+      </div>
+      <div class="card-body">
+        <table class="table">
+          <thead>
+          <tr class="fw-bold">
+            <th>Name</th>
+            <th class="text-center">Tickets Allocated</th>
+            <th class="text-center">Tickets Generated</th>
+          </tr>
+          </thead>
+          <tbody>
+          <% presenter.mismatched_entrants.each do |entrant| %>
+          <tr>
+            <td><%= entrant.full_name %></td>
+            <td class="text-center"><%= entrant.number_of_tickets %></td>
+            <td class="text-center"><%= entrant.generated_tickets_count %></td>
+          </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
   <% end %>
 </div>

--- a/app/views/lotteries/_setup_divisions_card.html.erb
+++ b/app/views/lotteries/_setup_divisions_card.html.erb
@@ -36,7 +36,7 @@
           <td class="text-center"><%= presenter.entrants.sum(:number_of_tickets) %></td>
           <td class="text-center">
             <span class="ms-3"><%= presenter.tickets.count %></span>
-            <% if presenter.entrants.sum(:number_of_tickets) == presenter.tickets.count %>
+            <% if presenter.mismatched_entrants.none? %>
               <span><%= fa_icon(
                           "circle-check",
                           type: "regular",
@@ -53,7 +53,7 @@
                           class: "text-warning",
                           data: {
                             controller: "tooltip",
-                            bs_title: "Generated tickets and allocated tickets do not match",
+                            bs_title: "Generated tickets and allocated tickets for at least one Entrant in this Lottery do not match",
                           },
                         ) %></span>
             <% end %>

--- a/app/views/lottery_divisions/_lottery_division.html.erb
+++ b/app/views/lottery_divisions/_lottery_division.html.erb
@@ -9,7 +9,7 @@
   <td class="text-center"><%= division.entrants.sum(:number_of_tickets) %></td>
   <td class="text-center">
     <span class="ms-3"><%= division.tickets.count %></span>
-    <% if division.entrants.sum(:number_of_tickets) == division.tickets.count %>
+    <% if division.entrants.having_mismatched_tickets.none? %>
               <span><%= fa_icon(
                           "circle-check",
                           type: "regular",
@@ -26,7 +26,7 @@
                   class: "text-warning",
                   data: {
                     controller: "tooltip",
-                    bs_title: "Generated tickets and allocated tickets do not match",
+                    bs_title: "Generated tickets and allocated tickets for at least one Entrant in this Division do not match",
                   },
                 ) %></span>
     <% end %>


### PR DESCRIPTION
Currently, we are comparing the sum of `number_of_tickets` over a lottery or division against the actual tickets generated for that lottery or division to determine compliance. This is generally effective, but there are two problems:

1. There is no way for the user to know which entrants have mismatched ticket counts
2. If one entrant has to few tickets and another entrant has too many tickets, they will cancel out and the user will get no warning

This PR changes the logic to determine exactly which entrants are mismatched, and it lists those entrants for easy review.