### PR TITLE
Centralize lottery draw broadcast logic

### DIFF
--- a/app/models/lottery.rb
+++ b/app/models/lottery.rb
@@ -30,12 +30,7 @@ class Lottery < ApplicationRecord
   def create_draw_for_ticket!(ticket)
     return if ticket.nil? || ticket.drawn?
 
-    draw = draws.create!(ticket: ticket)
-
-    # Touch needs to happen after the draw is created, otherwise
-    # the division information will not be up to date when broadcast
-    ticket.entrant.division.touch
-    draw
+    draws.create!(ticket: ticket)
   end
 
   def delete_all_draws!

--- a/app/models/lottery_division.rb
+++ b/app/models/lottery_division.rb
@@ -2,7 +2,7 @@ class LotteryDivision < ApplicationRecord
   include Delegable
   include CapitalizeAttributes
 
-  belongs_to :lottery, touch: true
+  belongs_to :lottery
   has_many :entrants, class_name: "LotteryEntrant", dependent: :destroy
   has_many :tickets, through: :entrants
 

--- a/app/models/lottery_division.rb
+++ b/app/models/lottery_division.rb
@@ -17,8 +17,6 @@ class LotteryDivision < ApplicationRecord
     from(select("lottery_divisions.*, organizations.concealed, organizations.id as organization_id").joins(lottery: :organization), :lottery_divisions)
   }
 
-  after_touch :broadcast_lottery_draw_header
-
   delegate :organization, to: :lottery
 
   def accepted_entrants
@@ -56,18 +54,5 @@ class LotteryDivision < ApplicationRecord
 
   def withdrawn_entrants
     entrants.withdrawn
-  end
-
-  private
-
-  def broadcast_lottery_draw_header
-    broadcast_replace_to self, :lottery_draw_header,
-                         target: "draw_tickets_header_lottery_division_#{id}",
-                         partial: "lottery_divisions/draw_tickets_header",
-                         locals: { lottery_division: self }
-    broadcast_replace_to self, :lottery_header,
-                         target: "lottery_header_lottery_division_#{id}",
-                         partial: "lottery_divisions/tickets_progress_bars",
-                         locals: { lottery_division: self, show_pre_selected: false }
   end
 end

--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -6,7 +6,7 @@ class LotteryEntrant < ApplicationRecord
   include CapitalizeAttributes
 
   belongs_to :person, optional: true
-  belongs_to :division, class_name: "LotteryDivision", foreign_key: "lottery_division_id", touch: true
+  belongs_to :division, class_name: "LotteryDivision", foreign_key: "lottery_division_id"
   has_many :tickets, class_name: "LotteryTicket", dependent: :destroy
   has_many :historical_facts, ->(entrant) { where(organization: entrant.organization) }, through: :person
   has_one :lottery, through: :division
@@ -78,6 +78,7 @@ class LotteryEntrant < ApplicationRecord
   end
 
   def draw_ticket!
+    # In case the entrant is drawn by another process
     return if drawn?
 
     selected_ticket_index = rand(tickets.count)

--- a/app/views/lotteries/draw_tickets.html.erb
+++ b/app/views/lotteries/draw_tickets.html.erb
@@ -14,12 +14,11 @@
   <div class="row horizontal-scroll">
   <% if @presenter.lottery_tickets.present? %>
       <% @presenter.ordered_divisions.each do |division| %>
-        <%= turbo_stream_from division, :lottery_draws, class: "d-none" %>
-        <%= turbo_stream_from division, :lottery_draw_header, class: "d-none" %>
+        <%= turbo_stream_from division, :lottery_draws_admin, class: "d-none" %>
         <div class="col-12 col-md-6 col-lg-4 col-xl">
           <%= render partial: "lottery_divisions/draw_tickets_header", locals: { lottery_division: division } %>
           <hr/>
-          <div id="<%= dom_id(division, :lottery_draws) %>">
+          <div id="<%= dom_id(division, :lottery_draws_admin) %>">
             <%= render partial: "lottery_draws/lottery_draw_admin", collection: division.draws.with_entrant_and_ticket.most_recent_first, as: :lottery_draw %>
           </div>
           <hr/>

--- a/app/views/lotteries/draws/_created.turbo_stream.erb
+++ b/app/views/lotteries/draws/_created.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%# locals: (lottery_draw:, lottery_division:) -%>
+
+<%= turbo_stream.prepend dom_id(lottery_division.lottery, :lottery_draws),
+                         partial: "lottery_draws/lottery_draw",
+                         locals: { lottery_draw: lottery_draw } %>
+
+<%= turbo_stream.replace dom_id(lottery_division, :lottery_progress_bars),
+                         partial: "lottery_divisions/tickets_progress_bars",
+                         locals: { lottery_division: lottery_division, show_pre_selected: false } %>

--- a/app/views/lotteries/draws/_created_admin.turbo_stream.erb
+++ b/app/views/lotteries/draws/_created_admin.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%# locals: (lottery_draw:, lottery_division:) -%>
+
+<%= turbo_stream.prepend dom_id(lottery_division, :lottery_draws_admin),
+                         partial: "lottery_draws/lottery_draw_admin",
+                         locals: { lottery_draw: lottery_draw } %>
+
+<%= turbo_stream.replace dom_id(lottery_division, :lottery_progress_bars_admin),
+                         partial: "lottery_divisions/tickets_progress_bars",
+                         locals: { lottery_division: lottery_division, show_pre_selected: true } %>

--- a/app/views/lotteries/draws/_destroyed.turbo_stream.erb
+++ b/app/views/lotteries/draws/_destroyed.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%# locals: (lottery_draw:, lottery_division:) -%>
+
+<%= turbo_stream.remove dom_id(lottery_draw) %>
+
+<%= turbo_stream.replace dom_id(lottery_division, :lottery_progress_bars),
+                         partial: "lottery_divisions/tickets_progress_bars",
+                         locals: { lottery_division: lottery_division, show_pre_selected: false } %>

--- a/app/views/lotteries/draws/_destroyed_admin.turbo_stream.erb
+++ b/app/views/lotteries/draws/_destroyed_admin.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%# locals: (lottery_draw:, lottery_division:) -%>
+
+<%= turbo_stream.remove dom_id(lottery_draw) %>
+
+<%= turbo_stream.replace dom_id(lottery_division, :lottery_progress_bars_admin),
+                         partial: "lottery_divisions/tickets_progress_bars",
+                         locals: { lottery_division: lottery_division, show_pre_selected: true } %>

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -96,7 +96,6 @@
       <hr/>
       <div class="row">
         <% @presenter.ordered_divisions.each do |division| %>
-          <%= turbo_stream_from division, :lottery_header, class: "d-none" %>
           <div class="col-12 col-md-6 col-lg-4 col-xl pb-3">
             <h5 class="fw-bold"><%= division.name %></h5>
             <%= render partial: "lottery_divisions/tickets_progress_bars", locals: { lottery_division: division, show_pre_selected: false } %>
@@ -105,7 +104,7 @@
       </div>
       <hr/>
 
-      <div id="lottery_draws">
+      <div id="<%= dom_id(@presenter.lottery, :lottery_draws) %>">
         <%= render partial: "lottery_draws/lottery_draw", collection: @presenter.lottery_draws_ordered %>
       </div>
     <% else %>

--- a/app/views/lottery_divisions/_tickets_progress_bars.html.erb
+++ b/app/views/lottery_divisions/_tickets_progress_bars.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (lottery_division:, show_pre_selected:) %>
 
-<div id="<%= dom_id(lottery_division, :lottery_header) %>" class="card mt-3">
+<div id="<%= dom_id(lottery_division, :lottery_progress_bars_admin) %>" class="card mt-3">
   <div class="card-body">
     <div class="row">
       <div class="col-8">

--- a/spec/system/lotteries/draw_tickets_spec.rb
+++ b/spec/system/lotteries/draw_tickets_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe "draw tickets from the lottery draw_tickets page", js: true do
     perform_enqueued_jobs do
       expect do
         within(page.find("##{dom_id(division_with_draws, :draw_tickets_header)}")) { click_link("Draw a Ticket") }
-        within(page.find("##{dom_id(division_with_draws, :lottery_draws)}")) do
+        within(page.find("##{dom_id(division_with_draws, :lottery_draws_admin)}")) do
           expect(page).to have_selector("div.card", count: 3)
         end
       end.to change { division_with_draws.draws.count }.from(2).to(3)
 
       expect do
         within(page.find("##{dom_id(division_without_draws, :draw_tickets_header)}")) { click_link("Draw a Ticket") }
-        within(page.find("##{dom_id(division_without_draws, :lottery_draws)}")) do
+        within(page.find("##{dom_id(division_without_draws, :lottery_draws_admin)}")) do
           expect(page).to have_selector("div.card", count: 1)
         end
       end.to change { division_without_draws.draws.count }.from(0).to(1)
@@ -51,7 +51,7 @@ RSpec.describe "draw tickets from the lottery draw_tickets page", js: true do
           click_button("Toggle Dropdown")
           click_link("Draw Veola Cassin")
         end
-        within(page.find("##{dom_id(division_without_draws, :lottery_draws)}")) do
+        within(page.find("##{dom_id(division_without_draws, :lottery_draws_admin)}")) do
           expect(page).to have_selector("div.card", count: 1)
         end
       end.to change { division_without_draws.draws.count }.from(0).to(1)

--- a/spec/system/lotteries/monitor_lottery_draws_spec.rb
+++ b/spec/system/lotteries/monitor_lottery_draws_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "monitor lottery draws", js: true do
+  include ActionView::RecordIdentifier
   include ActiveJob::TestHelper
 
   let(:lottery) { lotteries(:lottery_with_tickets_and_draws) }
@@ -17,7 +18,7 @@ RSpec.describe "monitor lottery draws", js: true do
     visit_page
 
     perform_enqueued_jobs do
-      within("#lottery_draws") do
+      within(page.find("##{dom_id(lottery, :lottery_draws)}")) do
         expect(page).to have_selector("div.card", count: 7)
         sleep 1
         division.draw_ticket!
@@ -30,7 +31,7 @@ RSpec.describe "monitor lottery draws", js: true do
     visit_page
 
     perform_enqueued_jobs do
-      within("#lottery_draws") do
+      within(page.find("##{dom_id(lottery, :lottery_draws)}")) do
         expect(page).to have_selector("div.card", count: 7)
         sleep 1
         entrant.draw_ticket!


### PR DESCRIPTION
The lottery draw logic is currently divided between the LotteryDraw class (responsible for updating draws in both public and admin views) and the LotteryDivision class (responsible for updating progress bars in both public and admin views).

This PR centralizes that logic in the LotteryDraw class, which has the benefit of only running when a draw is created or destroyed, instead of running every time anything having to do with a division happens (e.g., when an entrant is created).

We still have a lot of expensive queries happening, particularly to build progress bars. Further optimization will happen in one or more future PRs.

This addresses a portion of #1413 