### PR TITLE
Update package.json and Procfile.dev for Rails 7.1 esbuild conventions

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: unset PORT && env RUBY_DEBUG_OPEN=true bin/rails server
 worker: bundle exec sidekiq
-js: yarn build --watch
+js: yarn build:watch
 css: yarn watch:css

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "node": "16.x"
   },
   "scripts": {
-    "build": "node esbuild.config.js",
+    "build": "esbuild app/javascript/application.js --bundle --sourcemap --outdir=app/assets/builds",
+    "build:watch": "esbuild app/javascript/application.js --bundle --sourcemap --outdir=app/assets/builds --watch",
     "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules",
     "build:css:prefix": "postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css",
     "build:css": "yarn build:css:compile && yarn build:css:prefix",


### PR DESCRIPTION
Fixes the broken JS watch after Rails 7.1 upgrade.