### PR TITLE
Cache lottery results view

### DIFF
--- a/app/models/lottery_division.rb
+++ b/app/models/lottery_division.rb
@@ -2,7 +2,7 @@ class LotteryDivision < ApplicationRecord
   include Delegable
   include CapitalizeAttributes
 
-  belongs_to :lottery
+  belongs_to :lottery, touch: true
   has_many :draws, class_name: "LotteryDraw", dependent: :destroy
   has_many :entrants, class_name: "LotteryEntrant", dependent: :destroy
   has_many :tickets, through: :entrants

--- a/app/models/lottery_draw.rb
+++ b/app/models/lottery_draw.rb
@@ -2,7 +2,7 @@ class LotteryDraw < ApplicationRecord
 
   self.ignored_columns = ["lottery_id"]
 
-  belongs_to :division, class_name: "LotteryDivision", foreign_key: :lottery_division_id
+  belongs_to :division, class_name: "LotteryDivision", foreign_key: :lottery_division_id, touch: true
   belongs_to :ticket, class_name: "LotteryTicket", foreign_key: :lottery_ticket_id
   has_one :lottery, through: :division
 

--- a/app/models/lottery_entrant.rb
+++ b/app/models/lottery_entrant.rb
@@ -6,7 +6,7 @@ class LotteryEntrant < ApplicationRecord
   include CapitalizeAttributes
 
   belongs_to :person, optional: true
-  belongs_to :division, class_name: "LotteryDivision", foreign_key: "lottery_division_id"
+  belongs_to :division, class_name: "LotteryDivision", foreign_key: "lottery_division_id", touch: true
   has_many :tickets, class_name: "LotteryTicket", dependent: :destroy
   has_many :historical_facts, ->(entrant) { where(organization: entrant.organization) }, through: :person
   has_one :lottery, through: :division

--- a/app/views/lotteries/_results.html.erb
+++ b/app/views/lotteries/_results.html.erb
@@ -3,33 +3,35 @@
 <% if presenter.viewable_results? %>
   <% if presenter.lottery_draws.exists? %>
     <% presenter.ordered_divisions.each do |division| %>
-      <div class="card">
-        <h4 class="card-header fw-bold bg-primary text-white"><%= "#{division.name}" %></h4>
-        <div class="card-body">
-          <h5>Accepted</h5>
-          <% if division.accepted_entrants.any? %>
-            <ol>
-              <%= render partial: "entrant_for_results", collection: division.accepted_entrants.includes(:service_detail), as: :entrant %>
-            </ol>
-          <% else %>
-            <p>No entrants have been drawn yet</p>
-          <% end %>
+      <% cache division do %>
+        <div class="card">
+          <h4 class="card-header fw-bold bg-primary text-white"><%= "#{division.name}" %></h4>
+          <div class="card-body">
+            <h5>Accepted</h5>
+            <% if division.accepted_entrants.any? %>
+              <ol>
+                <%= render partial: "entrant_for_results", collection: division.accepted_entrants.includes(:service_detail), as: :entrant %>
+              </ol>
+            <% else %>
+              <p>No entrants have been drawn yet</p>
+            <% end %>
 
-          <% if division.waitlisted_entrants.any? %>
-            <h5>Wait List</h5>
-            <ol>
-              <%= render partial: "entrant_for_results", collection: division.waitlisted_entrants.includes(:service_detail), as: :entrant %>
-            </ol>
-          <% end %>
+            <% if division.waitlisted_entrants.any? %>
+              <h5>Wait List</h5>
+              <ol>
+                <%= render partial: "entrant_for_results", collection: division.waitlisted_entrants.includes(:service_detail), as: :entrant %>
+              </ol>
+            <% end %>
 
-          <% if division.withdrawn_entrants.any? %>
-            <h5>Withdrawn</h5>
-            <ol>
-              <%= render partial: "entrant_for_results", collection: division.withdrawn_entrants.includes(:service_detail), as: :entrant %>
-            </ol>
-          <% end %>
+            <% if division.withdrawn_entrants.any? %>
+              <h5>Withdrawn</h5>
+              <ol>
+                <%= render partial: "entrant_for_results", collection: division.withdrawn_entrants.includes(:service_detail), as: :entrant %>
+              </ol>
+            <% end %>
+          </div>
         </div>
-      </div>
+      <% end %>
       <br/>
     <% end %>
   <% else %>

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -114,10 +114,11 @@
   <% when "results" %>
     <%= render partial: "service_form_callout", locals: { presenter: @presenter } %>
     <h4 class="mt-5">
-      <span class="fw-bold">Lottery Results</span><span class="px-1 h5 fw-light text-muted"><%= " Last updated #{time_ago_in_words(@presenter.lottery.updated_at)} ago" %></span>
+      <span class="fw-bold">Lottery Results</span>
+      <span class="px-1 h5 fw-light text-muted"><%= "Last updated #{time_ago_in_words(@presenter.lottery.updated_at)} ago" %></span>
     </h4>
     <hr/>
-    <%= render partial: "results", locals: { presenter: @presenter } %>
+    <%= render partial: "results", locals: { presenter: @presenter }, cached: true %>
 
   <% when "stats" %>
     <h4 class="mt-5"><strong>Lottery Stats</strong></h4>

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "esbuild app/javascript/application.js --bundle --sourcemap --outdir=app/assets/builds",
     "build:watch": "esbuild app/javascript/application.js --bundle --sourcemap --outdir=app/assets/builds --watch",
-    "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules",
+    "build:css:compile": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --quiet --quiet-deps",
     "build:css:prefix": "postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css",
     "build:css": "yarn build:css:compile && yarn build:css:prefix",
     "watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"yarn build:css\""


### PR DESCRIPTION
The lottery show view is by far the slowest view indicated by scoutapm at this time. There are many expensive calls that get made, particularly when building the results display style.

This PR caches each division in the results partial, which should greatly reduce load times.