### PR TITLE
Add unique finishers and total finishes columns to course groups index

### DIFF
--- a/app/views/organizations/_course_groups_list.html.erb
+++ b/app/views/organizations/_course_groups_list.html.erb
@@ -3,6 +3,8 @@
   <tr>
     <th>Name</th>
     <th>Courses</th>
+    <th class="text-center">Unique Finishers</th>
+    <th class="text-center">Total Finishes</th>
     <th></th>
   </tr>
   </thead>
@@ -13,6 +15,12 @@
         <%= link_to course_group.name, organization_course_group_path(course_group.organization, course_group) %>
       </td>
       <td><%= course_group.courses.pluck(:name).join(", ") %></td>
+      <td class="text-center">
+        <%= CourseGroupFinisher.for_course_groups(course_group).count %>
+      </td>
+      <td class="text-center">
+        <%= Effort.where(event: course_group.events).finished.count %>
+      </td>
       <td class="text-end">
         <%= link_to "All-time best",
                     organization_course_group_best_efforts_path(course_group.organization, course_group),


### PR DESCRIPTION
This PR adds a "Unique Finishers" column and a "Total Finishes" column to the course groups index view.

Resolves #1425 