### PR TITLE
Fix Rails 7.1 Decryption

### DIFF
--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -35,6 +35,9 @@ class Credential < ApplicationRecord
 
   scope :for_service, ->(service_identifier) { where(service_identifier: service_identifier) }
 
+  # This method is meant to be scoped to the credentials of a single user, e.g.
+  # user.credentials.fetch("runsignup", "api_key")
+
   # @param [String,Symbol] service_identifier
   # @param [String,Symbol] key
   # @return [String, nil]

--- a/app/views/user_settings/credentials.html.erb
+++ b/app/views/user_settings/credentials.html.erb
@@ -50,7 +50,11 @@
       <div id="credentials_list">
         <% @presenter.existing_user_services.each do |service| %>
           <%= render partial: "user_settings/credentials_service_card",
-                     locals: { service: service, user: @presenter.user } %>
+                     locals: {
+                       service: service,
+                       user: @presenter.user,
+                       initial_state_visible: false,
+                     } %>
         <% end %>
       </div>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,10 @@ module OpenSplitTime
       Rails.application.config.credentials.content_path = ::OstConfig.credentials_content_path
     end
 
+    # Make encrypted attributes from Rails 7.0 compatible with Rails 7.1
+    Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
+    Rails.application.config.active_record.encryption.support_sha1_for_non_deterministic_encryption = true
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/spec/fixtures/credentials.yml
+++ b/spec/fixtures/credentials.yml
@@ -1,25 +1,25 @@
 ---
 credential_0001:
-  id: 179223681
+  id: 962153798
   user_id: 3
   service_identifier: runsignup
   key: api_key
-  value: '1234'
+  value: '{"p":"YDUM0Q==","h":{"iv":"lFi7iv6CUmngdX9L","at":"01uqzSeZzCnndDdcdepgmA=="}}'
 credential_0002:
-  id: 658364642
-  user_id: 3
-  service_identifier: rattlesnake_ramble
-  key: email
-  value: user@example.com
-credential_0003:
-  id: 773744130
+  id: 962153799
   user_id: 3
   service_identifier: runsignup
   key: api_secret
-  value: '2345'
+  value: '{"p":"xJY/ZQ==","h":{"iv":"LUB+rLymjBxEna1U","at":"g69j+WJ20cUEwWkRhIRBEw=="}}'
+credential_0003:
+  id: 962153800
+  user_id: 3
+  service_identifier: rattlesnake_ramble
+  key: email
+  value: '{"p":"zSFLTSAadMoj+t/sOpx05g==","h":{"iv":"9gP7CNSGQsBCbDfS","at":"wb3J9CyiV67OE/bSfP2IGw=="}}'
 credential_0004:
-  id: 962153797
+  id: 962153801
   user_id: 3
   service_identifier: rattlesnake_ramble
   key: password
-  value: password
+  value: '{"p":"NYXqpkmMwC0=","h":{"iv":"6cs1dgwtsx3iAkB/","at":"Roh/IptWoIf2eLSDM3Ws+Q=="}}'

--- a/spec/fixtures/credentials.yml
+++ b/spec/fixtures/credentials.yml
@@ -1,25 +1,25 @@
 ---
 credential_0001:
-  id: 962153798
+  id: 179223681
   user_id: 3
   service_identifier: runsignup
   key: api_key
-  value: '{"p":"YDUM0Q==","h":{"iv":"lFi7iv6CUmngdX9L","at":"01uqzSeZzCnndDdcdepgmA=="}}'
+  value: '1234'
 credential_0002:
-  id: 962153799
-  user_id: 3
-  service_identifier: runsignup
-  key: api_secret
-  value: '{"p":"xJY/ZQ==","h":{"iv":"LUB+rLymjBxEna1U","at":"g69j+WJ20cUEwWkRhIRBEw=="}}'
-credential_0003:
-  id: 962153800
+  id: 658364642
   user_id: 3
   service_identifier: rattlesnake_ramble
   key: email
-  value: '{"p":"zSFLTSAadMoj+t/sOpx05g==","h":{"iv":"9gP7CNSGQsBCbDfS","at":"wb3J9CyiV67OE/bSfP2IGw=="}}'
+  value: user@example.com
+credential_0003:
+  id: 773744130
+  user_id: 3
+  service_identifier: runsignup
+  key: api_secret
+  value: '2345'
 credential_0004:
-  id: 962153801
+  id: 962153797
   user_id: 3
   service_identifier: rattlesnake_ramble
   key: password
-  value: '{"p":"NYXqpkmMwC0=","h":{"iv":"6cs1dgwtsx3iAkB/","at":"Roh/IptWoIf2eLSDM3Ws+Q=="}}'
+  value: password

--- a/spec/system/user_settings/credentials_spec.rb
+++ b/spec/system/user_settings/credentials_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "user settings preferences", type: :system, js: true do
+  let(:user) { users(:third_user) }
+
+  scenario "visitor attempts to reach the page" do
+    visit user_settings_credentials_path
+
+    expect(page).to have_current_path(root_path)
+  end
+
+  scenario "user visits the preferences page" do
+    login_as user, scope: :user
+    visit user_settings_credentials_path
+
+    expect(page).to have_text("Add Credentials")
+    within("#credentials_list") do
+      within(first(".card")) do
+        expect(page).to have_text("RunSignup")
+        expect(page).to have_button("Reveal")
+
+        expect(page).not_to have_text("api_key")
+        expect(page).not_to have_text("api_secret")
+
+        click_button("Reveal")
+
+        expect(page).to have_text("api_key")
+        expect(page).to have_text("api_secret")
+
+        click_button("Hide")
+
+        expect(page).not_to have_text("api_key")
+        expect(page).not_to have_text("api_secret")
+      end
+    end
+  end
+end

--- a/spec/system/user_settings/password_spec.rb
+++ b/spec/system/user_settings/password_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "user settings preferences", type: :system do
+  let(:user) { users(:third_user) }
+
+  scenario "visitor attempts to reach the page" do
+    visit user_settings_password_path
+
+    expect(page).to have_current_path(root_path)
+  end
+
+  scenario "user visits the preferences page" do
+    login_as user, scope: :user
+    visit user_settings_password_path
+
+    expect(page).to have_text("Change Email")
+    expect(page).to have_text("Change Password")
+    expect(page).to have_text("Deactivate Account")
+  end
+end

--- a/spec/system/user_settings/preferences_spec.rb
+++ b/spec/system/user_settings/preferences_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "user settings preferences", type: :system do
+  let(:user) { users(:third_user) }
+
+  scenario "visitor attempts to reach the page" do
+    visit user_settings_preferences_path
+
+    expect(page).to have_current_path(root_path)
+  end
+
+  scenario "user visits the preferences page" do
+    login_as user, scope: :user
+    visit user_settings_preferences_path
+
+    expect(page).to have_text("Preferences")
+    expect(page).to have_text("Personal Information")
+    expect(page).to have_text("Unit Preferences")
+  end
+end


### PR DESCRIPTION
We have records in the database that were encrypted using Rails 7.0, and now these records cannot be decrypted in Rails 7.1.

This PR contains changes to the configuration file that should fix this problem.