### PR TITLE
Allow event group friendly find in raw times API request

### DIFF
--- a/app/controllers/api/v1/raw_times_controller.rb
+++ b/app/controllers/api/v1/raw_times_controller.rb
@@ -21,7 +21,7 @@ module Api
       private
 
       def set_event_group
-        @event_group = EventGroupPolicy::Scope.new(current_user, EventGroup).viewable.find(params[:event_group_id])
+        @event_group = EventGroupPolicy::Scope.new(current_user, EventGroup).viewable.friendly.find(params[:event_group_id])
       end
 
       def authorize_event_group

--- a/app/views/docs/visitors/_api_query_1.html.erb
+++ b/app/views/docs/visitors/_api_query_1.html.erb
@@ -26,9 +26,24 @@
     <hr/>
     <code>$ curl -H "Authorization: bearer your.api.key" https://www.opensplittime.org/api/v1/event_groups</code>
     <hr/>
-    <p>Records are returned in batches of 25. Links are included to obtain additional batches.</p>
+    <p>Records are returned in batches of 25. Links are included in the response header to obtain additional batches.</p>
     <p>Remember that individual records are generally more useful and
       <strong>response times will generally be faster for individual record queries than for index queries</strong>.</p>
+  </div>
+</div>
+<br/>
+
+<div class="card">
+  <h4 class="card-header">Index Queries Scoped to a Parent Record</h4>
+  <div class="card-body">
+    <p>In addition to standard index queries, you may query for records scoped to an individual parent record. Currently, this feature is available
+      for Raw Times scoped to an event group.</p>
+    <p>Query for Raw Times by passing a GET request to the endpoint shown below and including your API key as a
+      bearer authorization in the request header:</p>
+    <hr/>
+    <code>$ curl -H "Authorization: bearer your.api.key" https://www.opensplittime.org/api/v1/event_groups/hardrock-100-2024/raw_times</code>
+    <hr/>
+    <p>Records are returned in batches of 25. Links are included in the response header to obtain additional batches.</p>
   </div>
 </div>
 <br/>

--- a/spec/controllers/api/v1/raw_times_controller_spec.rb
+++ b/spec/controllers/api/v1/raw_times_controller_spec.rb
@@ -18,26 +18,40 @@ RSpec.describe Api::V1::RawTimesController do
     let(:sort) { nil }
 
     via_login_and_jwt do
-      context "when an existing event group is provided" do
-        context "with no filter or sort" do
-          it "returns a 200 response" do
-            make_request
-            expect(response.status).to eq(200)
-          end
+      context "when an existing event group id is provided" do
+        it "returns a 200 response" do
+          make_request
+          expect(response.status).to eq(200)
+        end
 
-          it "returns the first page of raw_times in the event group" do
-            make_request
-            parsed_response = JSON.parse(response.body)
-            expect(parsed_response["data"].size).to eq(25)
-            expect(parsed_response["data"].map { |item| item["id"].to_i }).to all be_in(event_group.raw_times.ids)
-          end
+        it "returns the first page of raw_times in the event group" do
+          make_request
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response["data"].size).to eq(25)
+          expect(parsed_response["data"].map { |item| item["id"].to_i }).to all be_in(event_group.raw_times.ids)
+        end
 
-          it "includes a link to the next page and to the last page in the header" do
-            make_request
-            header = response.header
-            expect(header["Link"]).to include("rel=\"next\"")
-            expect(header["Link"]).to include("rel=\"last\"")
-          end
+        it "includes a link to the next page and to the last page in the header" do
+          make_request
+          header = response.header
+          expect(header["Link"]).to include("rel=\"next\"")
+          expect(header["Link"]).to include("rel=\"last\"")
+        end
+      end
+
+      context "when the event group slug is provided instead of id" do
+        let(:event_group_id) { event_group.slug }
+
+        it "returns a 200 response" do
+          make_request
+          expect(response.status).to eq(200)
+        end
+
+        it "returns the first page of raw_times in the event group" do
+          make_request
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response["data"].size).to eq(25)
+          expect(parsed_response["data"].map { |item| item["id"].to_i }).to all be_in(event_group.raw_times.ids)
         end
       end
     end


### PR DESCRIPTION
Currently, an event group must be referenced by its numeric ID to make a raw times API request.

This PR makes it possible to use either a human-readable slug or a numeric ID for this purpose.