### PR TITLE
Delete effort_segments before setting new ones

### DIFF
--- a/lib/tasks/effort_segments.rake
+++ b/lib/tasks/effort_segments.rake
@@ -14,6 +14,8 @@ namespace :effort_segments do
 
     efforts.find_each do |effort|
       progress_bar.increment!
+      # First delete existing effort_segments to remove any obsolete ones
+      effort.delete_effort_segments
       effort.set_effort_segments
     rescue ActiveRecordError => e
       puts "Could not set effort segments for effort #{effort.id}:"


### PR DESCRIPTION
Currently, we have a rake task that iterates over all Efforts and sets effort segments for each. But this does not remove any obsolete effort segments that are associated with incorrect splits.

This PR changes the rake task logic to remove all effort segments for an effort before creating new ones.

Related to #1484