### PR TITLE
Ignore ActionController::RoutingError in Scout error monitoring

### DIFF
--- a/config/scout_apm.yml
+++ b/config/scout_apm.yml
@@ -33,7 +33,7 @@ common: &defaults
   # - Valid Options: true, false
   monitor: true
   errors_enabled: true
-  errors_ignored_exceptions: [ActiveRecord::RecordNotFound]
+  errors_ignored_exceptions: [ActiveRecord::RecordNotFound, ActionController::RoutingError]
 
 production:
   <<: *defaults


### PR DESCRIPTION
We get too many `ActionController::RoutingError` errors resulting from bots. 

This PR ignores them for purposes of Scout error reporting.