### PR TITLE
Enable Rails 7.2 config framework defaults

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -32,7 +32,7 @@
 # backends that use the same database as Active Record as a queue, hence they
 # don't need this feature.
 #++
-# Rails.application.config.active_job.enqueue_after_transaction_commit = :default
+Rails.application.config.active_job.enqueue_after_transaction_commit = :default
 
 ###
 # Adds image/webp to the list of content types Active Storage considers as an image
@@ -40,7 +40,7 @@
 # This is possible due to broad browser support for WebP, but older browsers and email clients may still not support
 # WebP. Requires imagemagick/libvips built with WebP support.
 #++
-# Rails.application.config.active_storage.web_image_content_types = %w[image/png image/jpeg image/gif image/webp]
+Rails.application.config.active_storage.web_image_content_types = %w[image/png image/jpeg image/gif image/webp]
 
 ###
 # Enable validation of migration timestamps. When set, an ActiveRecord::InvalidMigrationTimestampError
@@ -51,7 +51,7 @@
 # Applications with existing timestamped migrations that do not adhere to the
 # expected format can disable validation by setting this config to `false`.
 #++
-# Rails.application.config.active_record.validate_migration_timestamps = true
+Rails.application.config.active_record.validate_migration_timestamps = true
 
 ###
 # Controls whether the PostgresqlAdapter should decode dates automatically with manual queries.
@@ -61,10 +61,10 @@
 #
 # This query used to return a `String`.
 #++
-# Rails.application.config.active_record.postgresql_adapter_decode_dates = true
+Rails.application.config.active_record.postgresql_adapter_decode_dates = true
 
 ###
 # Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are
 # deploying to a memory constrained environment you may want to set this to `false`.
 #++
-# Rails.application.config.yjit = true
+Rails.application.config.yjit = true


### PR DESCRIPTION
We have upgraded to Rails 7.2, but we are still using Rails 7.1 default framework configs.

This PR enables Rails 7.2 framework configs. In particular, this enables YJIT, which may consume additional memory, so we'll need to carefully monitor memory usage and roll back the YJIT config if necessary.