### PR TITLE
Add ActionController::InvalidAuthenticityToken to ignored exceptions

### DIFF
--- a/config/scout_apm.yml
+++ b/config/scout_apm.yml
@@ -33,7 +33,10 @@ common: &defaults
   # - Valid Options: true, false
   monitor: true
   errors_enabled: true
-  errors_ignored_exceptions: [ActiveRecord::RecordNotFound, ActionController::RoutingError]
+  errors_ignored_exceptions:
+    - ActiveRecord::RecordNotFound
+    - ActionController::RoutingError
+    - ActionController::InvalidAuthenticityToken
 
 production:
   <<: *defaults


### PR DESCRIPTION
We are seeing too many of these errors, mostly caused by bots.