### PR TITLE
Fix dom_id for lottery public progress bar updates

### DIFF
--- a/app/views/lottery_divisions/_tickets_progress_bars.html.erb
+++ b/app/views/lottery_divisions/_tickets_progress_bars.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (lottery_division:, show_pre_selected:) %>
 
-<div id="<%= dom_id(lottery_division, :lottery_progress_bars_admin) %>" class="card mt-3">
+<div id="<%= dom_id(lottery_division, :lottery_progress_bars) %>" class="card mt-3">
   <div class="card-body">
     <div class="row">
       <div class="col-8">


### PR DESCRIPTION
We had an incorrect `dom_id` for public-facing lottery progress bar updates.

This PR fixes that id.

Resolves #1528