### PR TITLE
Data migration to backfill lottery_division_id on lottery_tickets table

### DIFF
--- a/db/data/20251229145334_backfill_lottery_division_id_to_lottery_tickets.rb
+++ b/db/data/20251229145334_backfill_lottery_division_id_to_lottery_tickets.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class BackfillLotteryDivisionIdToLotteryTickets < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    execute <<~SQL.squish
+      UPDATE lottery_tickets lt
+      SET lottery_division_id = le.lottery_division_id
+      FROM lottery_entrants le
+      WHERE le.id = lt.lottery_entrant_id
+        AND lt.lottery_division_id IS NULL;
+    SQL
+  end
+
+  def down
+    LotteryTicket.update_all(lottery_division_id: nil)
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20251228215515)
+DataMigrate::Data.define(version: 20251229145334)


### PR DESCRIPTION
This is the data migration to backfill `lottery_division_id` on existing lottery tickets.

Relates to #1529