### PR TITLE
Run github actions on pull request instead of push

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,5 +1,6 @@
 name: Verify
-on: [ push ]
+on:
+  pull_request:
 
 jobs:
   linters:


### PR DESCRIPTION
Currently, github actions run only on push, which means that only pushes to the central repository will trigger actions to run. 

This PR allows for actions to be run when a PR is opened from a forked repository.