### PR TITLE
Streamline libvips installation in github workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -100,6 +100,9 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Install libvips
+        run: sudo apt-get install -y --no-install-recommends libvips42
+
       - name: Setup Node
         uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
Purportedly, `libvips` is included in the latest ubuntu release. So we should not need to install it via `apt`.