### PR TITLE
Further parallelize github workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -122,9 +122,9 @@ jobs:
           - name: unit and rack
             rspec_args: --tag ~js
           - name: browser1
-            rspec_args: --tag js spec/system/event_group_construction spec/system/*_spec.rb
+            rspec_args: --tag js spec/system/event_group_construction spec/system/devise spec/system/*_spec.rb
           - name: browser2
-            rspec_args: --tag js --exclude-pattern "spec/system/event_group_construction/**/*_spec.rb" --exclude-pattern "spec/system/*_spec.rb"
+            rspec_args: --tag js --exclude-pattern "spec/system/event_group_construction/**/*_spec.rb" --exclude-pattern "spec/system/devise/**/*_spec.rb" --exclude-pattern "spec/system/*_spec.rb"
     services:
       postgres:
         image: postgres:17


### PR DESCRIPTION
This PR further parallelizes the github workflow by splitting the run into three parts:
- Non-js (unit and rack)
- System specs in event_group_construction and /system root level
- All other system specs

It also adds a common build feature to avoid too much duplication of effort.