### PR TITLE
Remove ArgsValidator from six additional view models and added specs

### DIFF
--- a/app/view_models/aid_station_row.rb
+++ b/app/view_models/aid_station_row.rb
@@ -1,5 +1,6 @@
 class AidStationRow
   include ActionView::Helpers::TextHelper
+
   attr_reader :aid_station
 
   delegate :course, :organization, to: :event
@@ -11,19 +12,16 @@ class AidStationRow
   IN_BITKEY = SubSplit::IN_BITKEY
   OUT_BITKEY = SubSplit::OUT_BITKEY
 
-  def initialize(args)
-    ArgsValidator.validate(params: args,
-                           required: :aid_station,
-                           exclusive: [:aid_station, :event_framework, :split_times],
-                           class: self.class)
-    @aid_station = args[:aid_station]
-    @event_framework = args[:event_framework]
-    @split_times = args[:split_times] || []
+  def initialize(aid_station:, event_framework: nil, split_times: [])
+    @aid_station = aid_station
+    @event_framework = event_framework
+    @split_times = split_times
+    validate_setup
   end
 
   def category_effort_lap_keys
     @category_effort_lap_keys ||=
-      AID_EFFORT_CATEGORIES.map { |category| [category, method("row_#{category}_lap_keys").call] }.to_h
+      AID_EFFORT_CATEGORIES.index_with { |category| method("row_#{category}_lap_keys").call }
   end
 
   def category_sizes
@@ -32,7 +30,7 @@ class AidStationRow
 
   def category_table_titles
     @category_table_titles ||=
-      category_sizes.map { |category, count| [category, table_title(category, count)] }.to_h
+      category_sizes.to_h { |category, count| [category, table_title(category, count)] }
   end
 
   def split_name
@@ -67,17 +65,17 @@ class AidStationRow
   def row_stopped_here_lap_keys
     @row_stopped_here_lap_keys ||=
       efforts_stopped.select { |effort| effort.stopped_split_id == split_id }
-          .map { |effort| EffortLapKey.new(effort.id, effort.stopped_lap) }
+                     .map { |effort| EffortLapKey.new(effort.id, effort.stopped_lap) }
   end
 
   def row_dropped_here_lap_keys
     @row_dropped_here_lap_keys ||=
       efforts_dropped.select { |effort| effort.stopped_split_id == split_id }
-          .map { |effort| EffortLapKey.new(effort.id, effort.stopped_lap) }
+                     .map { |effort| EffortLapKey.new(effort.id, effort.stopped_lap) }
   end
 
   def row_missed_lap_keys
-    @row_recorded_later_lap_keys ||= efforts_started.flat_map { |effort| effort_lap_keys_missed(effort) }
+    @row_missed_lap_keys ||= efforts_started.flat_map { |effort| effort_lap_keys_missed(effort) }
   end
 
   def row_in_aid_lap_keys
@@ -92,18 +90,21 @@ class AidStationRow
     efforts_in_progress.flat_map { |effort| effort_lap_key_expected(effort) }
   end
 
-  def effort_lap_key_expected(effort) # Returns a single [effort_lap_key] or []
-    lap_split_keys.elements_after(latest_lap_split_key(effort))
-        .select { |lap_split_key| (lap_split_key.lap == latest_lap_split_key(effort).lap) && (lap_split_key.split_id == split_id) }
-        .map { |lap_split_key| EffortLapKey.new(effort.id, lap_split_key.lap) }
+  # Returns a single [effort_lap_key] or []
+  def effort_lap_key_expected(effort)
+    matching_keys = lap_split_keys.elements_after(latest_lap_split_key(effort)).select do |lap_split_key|
+      lap_split_key.lap == latest_lap_split_key(effort).lap && lap_split_key.split_id == split_id
+    end
+
+    matching_keys.map { |lap_split_key| EffortLapKey.new(effort.id, lap_split_key.lap) }
   end
 
   def effort_lap_keys_missed(effort)
     time_points_recorded = Set.new(time_points_recorded(effort))
     time_points_required(effort)
-        .reject { |time_point| time_points_recorded.include?(time_point) }
-        .map { |time_point| EffortLapKey.new(effort.id, time_point.lap) }
-        .uniq
+      .reject { |time_point| time_points_recorded.include?(time_point) }
+      .map { |time_point| EffortLapKey.new(effort.id, time_point.lap) }
+      .uniq
   end
 
   def time_points_recorded(effort)
@@ -112,7 +113,7 @@ class AidStationRow
 
   def time_points_required(effort)
     time_points.elements_before(latest_time_point(effort))
-        .select { |time_point| time_point.split_id == split_id }
+               .select { |time_point| time_point.split_id == split_id }
   end
 
   def latest_lap_split_key(effort)
@@ -150,5 +151,9 @@ class AidStationRow
     else
       "#{'was'.pluralize(count)} #{category.to_s.humanize(capitalize: false)}"
     end
+  end
+
+  def validate_setup
+    raise ArgumentError, "aid_station_row must include aid_station" unless aid_station
   end
 end

--- a/app/view_models/effort_times_row.rb
+++ b/app/view_models/effort_times_row.rb
@@ -2,23 +2,23 @@ class EffortTimesRow
   include TimeFormats
   include Rankable
 
-  EXPORT_ATTRIBUTES = [:overall_rank, :gender_rank, :bib_number, :first_name, :last_name, :gender, :age, :state_code, :country_code, :flexible_geolocation].freeze
+  EXPORT_ATTRIBUTES = [:overall_rank, :gender_rank, :bib_number, :first_name, :last_name, :gender, :age, :state_code,
+                       :country_code, :flexible_geolocation].freeze
 
   attr_reader :effort, :display_style
 
-  delegate :id, :first_name, :last_name, :full_name, :gender, :bib_number, :age, :city, :state_code, :country_code, :data_status,
-           :bad?, :questionable?, :good?, :confirmed?, :segment_time, :overall_rank, :gender_rank, :scheduled_start_offset,
-           :beyond_start?, :started?, :in_progress?, :stopped?, :dropped?, :finished?, :bio_historic, :flexible_geolocation, to: :effort
+  delegate :id, :first_name, :last_name, :full_name, :gender, :bib_number, :age, :city,
+           :state_code, :country_code, :data_status, :bad?, :questionable?, :good?, :confirmed?,
+           :segment_time, :overall_rank, :gender_rank, :scheduled_start_offset, :beyond_start?,
+           :started?, :in_progress?, :stopped?, :dropped?, :finished?, :bio_historic,
+           :flexible_geolocation, to: :effort
 
-  def initialize(args)
-    ArgsValidator.validate(params: args,
-                           required: [:effort, :lap_splits, :split_times],
-                           exclusive: [:effort, :lap_splits, :split_times, :display_style],
-                           class: self.class)
-    @effort = args[:effort]
-    @lap_splits = args[:lap_splits]
-    @split_times = args[:split_times]
-    @display_style = args[:display_style]
+  def initialize(effort:, lap_splits:, split_times:, display_style: nil)
+    @effort = effort
+    @lap_splits = lap_splits
+    @split_times = split_times
+    @display_style = display_style
+    validate_setup
   end
 
   def total_time_in_aid
@@ -128,5 +128,11 @@ class EffortTimesRow
 
   def multiple_laps?
     effort.laps_required != 1
+  end
+
+  def validate_setup
+    raise ArgumentError, "effort_times_row must include effort" unless effort
+    raise ArgumentError, "effort_times_row must include lap_splits" unless lap_splits
+    raise ArgumentError, "effort_times_row must include split_times" unless split_times
   end
 end

--- a/app/view_models/effort_with_lap_split_rows.rb
+++ b/app/view_models/effort_with_lap_split_rows.rb
@@ -5,8 +5,9 @@ class EffortWithLapSplitRows
     post_initialize(effort, options)
   end
 
-  def post_initialize(effort, options)
-    ArgsValidator.validate(subject: effort, params: options, class: self.class)
+  def post_initialize(effort, _options)
+    @effort = effort
+    validate_setup
     load_effort(effort)
   end
 
@@ -66,10 +67,14 @@ class EffortWithLapSplitRows
     effort.send(method)
   end
 
+  def respond_to_missing?(method, include_private = false)
+    effort.respond_to?(method, include_private) || super
+  end
+
   private
 
   def difference(first_time, last_time)
-    last_time && first_time && last_time - first_time
+    last_time && first_time && (last_time - first_time)
   end
 
   def rows_from_lap_splits(lap_splits, indexed_times, in_times_only: false)
@@ -90,7 +95,7 @@ class EffortWithLapSplitRows
 
   def prior_split_time(lap_split)
     prior_time_points = time_points.elements_before(lap_split.time_point_in).to_set
-    ordered_split_times.reverse.find { |st| prior_time_points.include?(st.time_point) }
+    ordered_split_times.rfind { |st| prior_time_points.include?(st.time_point) }
   end
 
   def ordered_split_times
@@ -121,11 +126,13 @@ class EffortWithLapSplitRows
     ordered_split_times.last&.lap || 1
   end
 
-  private
-
   def load_effort(effort)
     temp_effort = Effort.where(id: effort).ranking_subquery.includes(split_times: :split).first
     AssignSegmentTimes.perform(temp_effort.ordered_split_times, :absolute_time)
     @effort = temp_effort
+  end
+
+  def validate_setup
+    raise ArgumentError, "effort_with_lap_split_rows must include effort" unless effort
   end
 end

--- a/app/view_models/lap_split_row.rb
+++ b/app/view_models/lap_split_row.rb
@@ -9,16 +9,12 @@ class LapSplitRow
   # split_times should be an array having size == lap_split.time_points.size,
   # with nil values where no corresponding split_time exists
 
-  def initialize(args)
-    ArgsValidator.validate(params: args,
-                           required: [:lap_split, :split_times],
-                           exclusive: [:lap_split, :split_times, :show_laps, :in_times_only, :not_in_event],
-                           class: self.class)
-    @lap_split = args[:lap_split]
-    @split_times = args[:split_times]
-    @show_laps = args[:show_laps]
-    @in_times_only = args[:in_times_only]
-    @not_in_event = args[:not_in_event]
+  def initialize(lap_split:, split_times:, show_laps: nil, in_times_only: nil, not_in_event: nil)
+    @lap_split = lap_split
+    @split_times = split_times
+    @show_laps = show_laps
+    @in_times_only = in_times_only
+    @not_in_event = not_in_event
     validate_setup
   end
 
@@ -27,7 +23,8 @@ class LapSplitRow
   end
 
   def time_cluster
-    @time_cluster ||= TimeCluster.new(split_times_data: visible_split_times, finish: finish?, show_indicator_for_stop: show_indicator_for_stop?)
+    @time_cluster ||= TimeCluster.new(split_times_data: visible_split_times, finish: finish?,
+                                      show_indicator_for_stop: show_indicator_for_stop?)
   end
 
   def split_id
@@ -71,8 +68,12 @@ class LapSplitRow
   end
 
   def validate_setup
-    unless split_times.size == split.bitkeys.size
-      raise ArgumentError, "split_time objects must be provided for each sub_split (fill with an empty object if needed)"
-    end
+    raise ArgumentError, "lap_split_row must include lap_split" unless lap_split
+    raise ArgumentError, "lap_split_row must include split_times" unless split_times
+
+    return if split_times.size == split.bitkeys.size
+
+    raise ArgumentError,
+          "split_time objects must be provided for each sub_split (fill with an empty object if needed)"
   end
 end

--- a/app/view_models/live_progress_display.rb
+++ b/app/view_models/live_progress_display.rb
@@ -2,10 +2,8 @@ class LiveProgressDisplay < LiveEventFramework
   attr_reader :times_container, :past_due_threshold
 
   def post_initialize(args)
-    ArgsValidator.validate(params: args, required: :event,
-                           exclusive: [:event, :past_due_threshold, :times_container],
-                           class: self.class)
     @past_due_threshold = args[:past_due_threshold].presence.try(:to_i) || 30
+    validate_setup
   end
 
   def past_due_progress_rows
@@ -22,5 +20,9 @@ class LiveProgressDisplay < LiveEventFramework
     @progress_rows ||= event_efforts.select(&:in_progress?).map do |effort|
       EffortProgressSummary.new(effort: effort, event_framework: self)
     end
+  end
+
+  def validate_setup
+    raise ArgumentError, "live_progress_display must include event" unless event
   end
 end

--- a/app/view_models/place_detail_row.rb
+++ b/app/view_models/place_detail_row.rb
@@ -8,18 +8,15 @@ class PlaceDetailRow
   # split_times should be an array having size == lap_split.time_points.size,
   # with nil values where no corresponding split_time exists
 
-  def initialize(args)
-    ArgsValidator.validate(params: args,
-                           required: [:lap_split, :split_times],
-                           exclusive: [:lap_split, :split_times, :previous_lap_split, :show_laps,
-                                       :effort_name, :effort_ids_by_category],
-                           class: self.class)
-    @lap_split = args[:lap_split]
-    @split_times = args[:split_times] || []
-    @previous_lap_split = args[:previous_lap_split]
-    @show_laps = args[:show_laps]
-    @effort_name = args[:effort_name]
-    @effort_ids_by_category = args[:effort_ids_by_category]
+  def initialize(lap_split:, split_times: [], previous_lap_split: nil, show_laps: nil,
+                 effort_name: nil, effort_ids_by_category: nil)
+    @lap_split = lap_split
+    @split_times = split_times
+    @previous_lap_split = previous_lap_split
+    @show_laps = show_laps
+    @effort_name = effort_name
+    @effort_ids_by_category = effort_ids_by_category
+    validate_setup
   end
 
   def name
@@ -27,14 +24,15 @@ class PlaceDetailRow
   end
 
   def absolute_times_local
-    split_times.map { |st| st.absolute_time_local if st }
+    split_times.map { |st| st&.absolute_time_local }
   end
 
   def end_time_point
     split_times.last&.time_point
   end
 
-  def encountered_ids # Preserve duplicates to ensure accurate frequency testing
+  # Preserve duplicates to ensure accurate frequency testing
+  def encountered_ids
     (passed_segment_ids + passed_by_segment_ids + together_in_aid_ids)
   end
 
@@ -42,9 +40,7 @@ class PlaceDetailRow
     define_method("#{category}_ids") do
       effort_ids_by_category[category]
     end
-  end
 
-  CATEGORIES.each do |category|
     define_method("#{category}_table_title") do
       table_titles_by_category[category]
     end
@@ -59,14 +55,16 @@ class PlaceDetailRow
   end
 
   def table_titles_by_category
-    {passed_segment: "#{effort_name} passed #{persons(passed_segment_ids.size)} between" +
-      " #{split_base_name(previous_lap_split)} and #{split_base_name(lap_split)}",
-     passed_in_aid: "#{effort_name} passed #{persons(passed_in_aid_ids.size)} in aid at #{split_base_name(lap_split)}",
-     passed_by_segment: "#{effort_name} was passed by #{persons(passed_by_segment_ids.size)} between " +
-       "#{split_base_name(previous_lap_split)} and #{split_base_name(lap_split)}",
-     passed_by_in_aid: "#{effort_name} was passed by #{persons(passed_by_in_aid_ids.size)} while in aid at " +
-       split_base_name(lap_split).to_s,
-     together_in_aid: "#{effort_name} was in #{split_base_name(lap_split)} with #{persons(together_in_aid_ids.size)}"}
+    {
+      passed_segment: "#{effort_name} passed #{persons(passed_segment_ids.size)} between " \
+                      "#{split_base_name(previous_lap_split)} and #{split_base_name(lap_split)}",
+      passed_in_aid: "#{effort_name} passed #{persons(passed_in_aid_ids.size)} in aid at #{split_base_name(lap_split)}",
+      passed_by_segment: "#{effort_name} was passed by #{persons(passed_by_segment_ids.size)} between " \
+                         "#{split_base_name(previous_lap_split)} and #{split_base_name(lap_split)}",
+      passed_by_in_aid: "#{effort_name} was passed by #{persons(passed_by_in_aid_ids.size)} while in aid at " +
+        split_base_name(lap_split).to_s,
+      together_in_aid: "#{effort_name} was in #{split_base_name(lap_split)} with #{persons(together_in_aid_ids.size)}"
+    }
   end
 
   def show_laps?
@@ -83,5 +81,10 @@ class PlaceDetailRow
 
   def name_with_lap
     lap_split.name
+  end
+
+  def validate_setup
+    raise ArgumentError, "place_detail_row must include lap_split" unless lap_split
+    raise ArgumentError, "place_detail_row must include split_times" unless split_times
   end
 end

--- a/spec/view_models/aid_station_row_spec.rb
+++ b/spec/view_models/aid_station_row_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe AidStationRow do
+  subject(:row) { described_class.new(aid_station: aid_station, event_framework: event_framework, split_times: split_times) }
+
+  let(:event) { events(:hardrock_2015) }
+  let(:split) { event.splits.find_by(kind: :intermediate) }
+  let(:aid_station) { AidStation.new(event: event, split: split) }
+  let(:event_framework) { nil }
+  let(:split_times) { [] }
+
+  describe "#initialize" do
+    context "when initialized with an aid_station" do
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context "when initialized without an aid_station" do
+      let(:aid_station) { nil }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include aid_station/ }
+    end
+
+    context "when initialized with default split_times" do
+      let(:row) { described_class.new(aid_station: aid_station) }
+
+      it { expect { row }.not_to raise_error }
+    end
+  end
+
+  describe "#split_name" do
+    it "returns the split base_name" do
+      expect(subject.split_name).to eq(split.base_name)
+    end
+  end
+
+  describe "#parameterized_split_name" do
+    it "returns the parameterized base name" do
+      expect(subject.parameterized_split_name).to eq(split.parameterized_base_name)
+    end
+  end
+
+  describe "#category_sizes" do
+    let(:event_framework) { LiveEventFramework.new(event: event) }
+    let(:split_times) { event.split_times.where(split: split) }
+
+    it "returns a hash with category keys and integer values" do
+      result = subject.category_sizes
+      expect(result).to be_a(Hash)
+      expect(result.keys).to match_array(AidStationRow::AID_EFFORT_CATEGORIES)
+      expect(result.values).to all be_a(Integer)
+    end
+  end
+
+  describe "#category_table_titles" do
+    let(:event_framework) { LiveEventFramework.new(event: event) }
+    let(:split_times) { event.split_times.where(split: split) }
+
+    it "returns a hash with category keys and string values" do
+      result = subject.category_table_titles
+      expect(result).to be_a(Hash)
+      expect(result.keys).to match_array(AidStationRow::AID_EFFORT_CATEGORIES)
+      expect(result.values).to all be_a(String)
+    end
+  end
+end

--- a/spec/view_models/effort_times_row_spec.rb
+++ b/spec/view_models/effort_times_row_spec.rb
@@ -1,0 +1,153 @@
+require "rails_helper"
+
+RSpec.describe EffortTimesRow do
+  include BitkeyDefinitions
+
+  subject(:row) { described_class.new(effort: effort, lap_splits: lap_splits, split_times: split_times, display_style: display_style) }
+
+  let(:event) { events(:hardrock_2015) }
+  let(:effort) { Effort.where(id: event.efforts.order(:bib_number).first.id).ranking_subquery.finish_info_subquery.first }
+  let(:splits) { event.ordered_splits }
+  let(:lap_splits) { event.lap_splits_through(1) }
+  let(:split_times) { effort.ordered_split_times }
+  let(:display_style) { "elapsed" }
+
+  describe "#initialize" do
+    context "when initialized with all required arguments" do
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context "when initialized without effort" do
+      let(:effort) { nil }
+      let(:split_times) { [] }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include effort/ }
+    end
+
+    context "when initialized without lap_splits" do
+      let(:lap_splits) { nil }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include lap_splits/ }
+    end
+
+    context "when initialized without split_times" do
+      let(:split_times) { nil }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include split_times/ }
+    end
+  end
+
+  describe "#full_name" do
+    it "delegates to effort" do
+      expect(subject.full_name).to eq(effort.full_name)
+    end
+  end
+
+  describe "#bib_number" do
+    it "delegates to effort" do
+      expect(subject.bib_number).to eq(effort.bib_number)
+    end
+  end
+
+  describe "#time_clusters" do
+    it "returns an array of TimeCluster objects with size matching lap_splits" do
+      expect(subject.time_clusters.size).to eq(lap_splits.size)
+      expect(subject.time_clusters).to all be_a(TimeCluster)
+    end
+  end
+
+  describe "#total_time_in_aid" do
+    it "returns a numeric value" do
+      expect(subject.total_time_in_aid).to be_a(Numeric)
+    end
+  end
+
+  describe "#total_segment_time" do
+    it "returns a numeric value" do
+      expect(subject.total_segment_time).to be_a(Numeric)
+    end
+  end
+
+  describe "#show_elapsed_times?" do
+    context "when display_style is 'elapsed'" do
+      let(:display_style) { "elapsed" }
+
+      it { expect(subject.show_elapsed_times?).to be true }
+    end
+
+    context "when display_style is 'all'" do
+      let(:display_style) { "all" }
+
+      it { expect(subject.show_elapsed_times?).to be true }
+    end
+
+    context "when display_style is 'segment'" do
+      let(:display_style) { "segment" }
+
+      it { expect(subject.show_elapsed_times?).to be false }
+    end
+  end
+
+  describe "#show_absolute_times?" do
+    context "when display_style is 'ampm'" do
+      let(:display_style) { "ampm" }
+
+      it { expect(subject.show_absolute_times?).to be true }
+    end
+
+    context "when display_style is 'military'" do
+      let(:display_style) { "military" }
+
+      it { expect(subject.show_absolute_times?).to be true }
+    end
+
+    context "when display_style is 'elapsed'" do
+      let(:display_style) { "elapsed" }
+
+      it { expect(subject.show_absolute_times?).to be false }
+    end
+  end
+
+  describe "#show_segment_times?" do
+    context "when display_style is 'segment'" do
+      let(:display_style) { "segment" }
+
+      it { expect(subject.show_segment_times?).to be true }
+    end
+
+    context "when display_style is 'elapsed'" do
+      let(:display_style) { "elapsed" }
+
+      it { expect(subject.show_segment_times?).to be false }
+    end
+  end
+
+  describe "#show_pacer_flags?" do
+    context "when display_style is 'all'" do
+      let(:display_style) { "all" }
+
+      it { expect(subject.show_pacer_flags?).to be true }
+    end
+
+    context "when display_style is 'elapsed'" do
+      let(:display_style) { "elapsed" }
+
+      it { expect(subject.show_pacer_flags?).to be false }
+    end
+  end
+
+  describe "#elapsed_times" do
+    it "returns an array of arrays" do
+      expect(subject.elapsed_times).to be_a(Array)
+      expect(subject.elapsed_times.size).to eq(lap_splits.size)
+    end
+  end
+
+  describe "#segment_times" do
+    it "returns an array of two-element arrays" do
+      expect(subject.segment_times).to be_a(Array)
+      expect(subject.segment_times.size).to eq(lap_splits.size)
+      expect(subject.segment_times.first).to be_a(Array)
+    end
+  end
+end

--- a/spec/view_models/effort_with_lap_split_rows_spec.rb
+++ b/spec/view_models/effort_with_lap_split_rows_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe EffortWithLapSplitRows do
+  subject(:view_model) { described_class.new(effort) }
+
+  let(:event) { events(:hardrock_2015) }
+  let(:effort) { event.efforts.order(:bib_number).first }
+
+  describe "#initialize" do
+    context "when initialized with an effort" do
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context "when initialized without an effort" do
+      let(:effort) { nil }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include effort/ }
+    end
+  end
+
+  describe "#effort" do
+    it "returns an effort" do
+      expect(subject.effort).to be_a(Effort)
+    end
+  end
+
+  describe "#event" do
+    it "returns the effort's event" do
+      expect(subject.event).to eq(event)
+    end
+  end
+
+  describe "#lap_split_rows" do
+    it "returns an array of LapSplitRow objects" do
+      expect(subject.lap_split_rows).to all be_a(LapSplitRow)
+    end
+
+    it "returns rows matching the event splits" do
+      expect(subject.lap_split_rows.size).to eq(event.ordered_splits.size)
+    end
+  end
+
+  describe "#total_time_in_aid" do
+    it "returns a numeric value" do
+      expect(subject.total_time_in_aid).to be_a(Numeric)
+    end
+  end
+
+  describe "#not_analyzable?" do
+    context "when effort has two or more split_times" do
+      it "returns false" do
+        expect(subject.not_analyzable?).to be false
+      end
+    end
+  end
+
+  describe "#effort_start_time" do
+    it "returns the effort's actual start time" do
+      expect(subject.effort_start_time).to be_present
+    end
+  end
+
+  describe "#true_lap_time" do
+    it "returns a numeric value for lap 1" do
+      result = subject.true_lap_time(1)
+      expect(result).to be_a(Numeric)
+    end
+  end
+
+  describe "#method_missing" do
+    it "delegates unknown methods to effort" do
+      expect(subject.full_name).to eq(subject.effort.full_name)
+    end
+  end
+end

--- a/spec/view_models/lap_split_row_spec.rb
+++ b/spec/view_models/lap_split_row_spec.rb
@@ -1,9 +1,11 @@
+require "rails_helper"
 require "support/bitkey_definitions"
 
 RSpec.describe LapSplitRow, type: :model do
   include BitkeyDefinitions
 
-  subject(:lap_split_row) { LapSplitRow.new(lap_split: lap_split, split_times: split_times, show_laps: show_laps) }
+  subject(:lap_split_row) { described_class.new(lap_split: lap_split, split_times: split_times, show_laps: show_laps) }
+
   let(:show_laps) { false }
 
   let(:course) { Course.new(name: "Test Course 100") }
@@ -66,15 +68,6 @@ RSpec.describe LapSplitRow, type: :model do
 
   describe "#initialize" do
     context "when initialized with a lap_split and valid split_times for a split with in and out sub_splits" do
-      let(:lap_split) { lap_1_split_2 }
-      let(:split_times) { [split_time_data_2, split_time_data_3] }
-
-      it "does not raise an error" do
-        expect { subject }.not_to raise_error
-      end
-    end
-
-    context "when initialized with a lap_split and valid split_time_data objects for a split with in and out sub_splits" do
       let(:lap_split) { lap_1_split_2 }
       let(:split_times) { [split_time_data_2, split_time_data_3] }
 
@@ -345,7 +338,7 @@ RSpec.describe LapSplitRow, type: :model do
     let(:lap_split) { lap_2_split_2 }
     let(:split_times) { [split_time_data_2, split_time_data_3] }
 
-    context "if :show_laps is not provided" do
+    context "when show_laps is not provided" do
       let(:show_laps) { false }
 
       it "returns the split name" do
@@ -353,7 +346,7 @@ RSpec.describe LapSplitRow, type: :model do
       end
     end
 
-    context "if :show_laps is provided" do
+    context "when show_laps is provided" do
       let(:show_laps) { true }
 
       it "returns the split name with lap" do

--- a/spec/view_models/live_progress_display_spec.rb
+++ b/spec/view_models/live_progress_display_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe LiveProgressDisplay do
+  subject(:display) { described_class.new(event: event, past_due_threshold: past_due_threshold) }
+
+  let(:event) { events(:hardrock_2015) }
+  let(:past_due_threshold) { 30 }
+
+  describe "#initialize" do
+    context "when initialized with an event" do
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context "when initialized without an event" do
+      let(:event) { nil }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include event/ }
+    end
+  end
+
+  describe "#past_due_threshold" do
+    context "when a threshold is provided" do
+      let(:past_due_threshold) { 45 }
+
+      it "returns the provided threshold" do
+        expect(subject.past_due_threshold).to eq(45)
+      end
+    end
+
+    context "when no threshold is provided" do
+      let(:past_due_threshold) { nil }
+
+      it "defaults to 30" do
+        expect(subject.past_due_threshold).to eq(30)
+      end
+    end
+
+    context "when threshold is a string" do
+      let(:past_due_threshold) { "60" }
+
+      it "converts to integer" do
+        expect(subject.past_due_threshold).to eq(60)
+      end
+    end
+  end
+
+  describe "#past_due_progress_rows" do
+    it "returns an array" do
+      expect(subject.past_due_progress_rows).to be_a(Array)
+    end
+  end
+
+  describe "#efforts_past_due_count" do
+    it "returns a non-negative integer" do
+      expect(subject.efforts_past_due_count).to be >= 0
+    end
+  end
+end

--- a/spec/view_models/place_detail_row_spec.rb
+++ b/spec/view_models/place_detail_row_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe PlaceDetailRow do
+  subject(:row) do
+    described_class.new(
+      lap_split: lap_split,
+      split_times: split_times,
+      previous_lap_split: previous_lap_split,
+      show_laps: show_laps,
+      effort_name: effort_name,
+      effort_ids_by_category: effort_ids_by_category,
+    )
+  end
+
+  let(:course) { Course.new(name: "Test Course") }
+  let(:split_1) { Split.new(course: course, base_name: "Start", distance_from_start: 0, sub_split_bitmap: 1, vert_gain_from_start: 0, vert_loss_from_start: 0, kind: :start) }
+  let(:split_2) { Split.new(course: course, base_name: "Aid 1", distance_from_start: 10_000, sub_split_bitmap: 65, vert_gain_from_start: 500, vert_loss_from_start: 0, kind: :intermediate) }
+  let(:split_3) { Split.new(course: course, base_name: "Finish", distance_from_start: 20_000, sub_split_bitmap: 1, vert_gain_from_start: 500, vert_loss_from_start: 500, kind: :finish) }
+
+  let(:lap_1_split_1) { LapSplit.new(1, split_1) }
+  let(:lap_1_split_2) { LapSplit.new(1, split_2) }
+  let(:lap_2_split_2) { LapSplit.new(2, split_2) }
+
+  let(:lap_split) { lap_1_split_2 }
+  let(:split_times) { [nil, nil] }
+  let(:previous_lap_split) { lap_1_split_1 }
+  let(:show_laps) { false }
+  let(:effort_name) { "Jane Doe" }
+  let(:effort_ids_by_category) do
+    {
+      passed_segment: [1, 2],
+      passed_in_aid: [3],
+      passed_by_segment: [4],
+      passed_by_in_aid: [],
+      together_in_aid: [5, 6, 7],
+    }
+  end
+
+  describe "#initialize" do
+    context "when initialized with a lap_split" do
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context "when initialized without a lap_split" do
+      let(:lap_split) { nil }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include lap_split/ }
+    end
+  end
+
+  describe "#name" do
+    context "when show_laps is false" do
+      let(:show_laps) { false }
+
+      it "returns the name without lap" do
+        expect(subject.name).to eq(lap_split.name_without_lap)
+      end
+    end
+
+    context "when show_laps is true" do
+      let(:lap_split) { lap_2_split_2 }
+      let(:show_laps) { true }
+
+      it "returns the name with lap" do
+        expect(subject.name).to eq(lap_split.name)
+      end
+    end
+  end
+
+  describe "#encountered_ids" do
+    it "returns combined passed_segment, passed_by_segment, and together_in_aid ids" do
+      expect(subject.encountered_ids).to eq([1, 2, 4, 5, 6, 7])
+    end
+  end
+
+  describe "#passed_segment_ids" do
+    it "returns ids from the category hash" do
+      expect(subject.passed_segment_ids).to eq([1, 2])
+    end
+  end
+
+  describe "#together_in_aid_ids" do
+    it "returns ids from the category hash" do
+      expect(subject.together_in_aid_ids).to eq([5, 6, 7])
+    end
+  end
+
+  describe "#passed_segment_table_title" do
+    it "returns a descriptive string including the effort name and count" do
+      result = subject.passed_segment_table_title
+      expect(result).to include("Jane Doe")
+      expect(result).to include("passed")
+      expect(result).to include("2 people")
+    end
+  end
+end


### PR DESCRIPTION
Part 7 of #1639 
Resolves #1677

Removed ArgsValidator from the following classes:
- AidStationRow
- EffortTimesRow
- EffortWithLapSplitRows
- LapSplitRow
- LiveProgressDisplay
- PlaceDetailRow