### PR TITLE
Remove ArgsValidator from remaining view models

### DIFF
--- a/app/view_models/effort_analysis_row.rb
+++ b/app/view_models/effort_analysis_row.rb
@@ -8,19 +8,16 @@ class EffortAnalysisRow
   # split_times should be an array having size == split.sub_splits.size,
   # with nil values where no corresponding split_time exists
 
-  def initialize(args)
-    ArgsValidator.validate(params: args,
-                           required: [:lap_split, :split_times, :typical_split_times, :start_time],
-                           exclusive: [:lap_split, :split_times, :typical_split_times, :start_time, :show_laps,
-                                       :prior_lap_split, :prior_split_time],
-                           class: self.class)
-    @lap_split = args[:lap_split]
-    @split_times = args[:split_times]
-    @typical_split_times = args[:typical_split_times]
-    @prior_lap_split = args[:prior_lap_split]
-    @prior_split_time = args[:prior_split_time]
-    @start_time = args[:start_time]
-    @show_laps = args[:show_laps]
+  def initialize(lap_split:, split_times:, typical_split_times:, start_time:,
+                 show_laps: nil, prior_lap_split: nil, prior_split_time: nil)
+    @lap_split = lap_split
+    @split_times = split_times
+    @typical_split_times = typical_split_times
+    @prior_lap_split = prior_lap_split
+    @prior_split_time = prior_split_time
+    @start_time = start_time
+    @show_laps = show_laps
+    validate_setup
   end
 
   def name
@@ -44,7 +41,7 @@ class EffortAnalysisRow
   end
 
   def combined_time
-    segment_time && segment_time + (time_in_aid || 0)
+    segment_time && (segment_time + (time_in_aid || 0))
   end
 
   def segment_time_typical
@@ -56,7 +53,7 @@ class EffortAnalysisRow
   end
 
   def combined_time_typical
-    segment_time_typical && segment_time_typical + (time_in_aid_typical || 0)
+    segment_time_typical && (segment_time_typical + (time_in_aid_typical || 0))
   end
 
   def segment_time_over_under(round_to: 1.second)
@@ -112,5 +109,12 @@ class EffortAnalysisRow
 
   def name_with_lap
     lap_split.base_name
+  end
+
+  def validate_setup
+    raise ArgumentError, "effort_analysis_row must include lap_split" unless lap_split
+    raise ArgumentError, "effort_analysis_row must include split_times" unless split_times
+    raise ArgumentError, "effort_analysis_row must include typical_split_times" unless typical_split_times
+    raise ArgumentError, "effort_analysis_row must include start_time" unless start_time
   end
 end

--- a/app/view_models/time_cluster.rb
+++ b/app/view_models/time_cluster.rb
@@ -1,14 +1,11 @@
 class TimeCluster
   attr_reader :split_times_data
 
-  def initialize(args)
-    ArgsValidator.validate(params: args,
-                           required: [:split_times_data, :finish],
-                           exclusive: [:split_times_data, :finish, :show_indicator_for_stop],
-                           class: self.class)
-    @split_times_data = args[:split_times_data]
-    @finish = args[:finish]
-    @show_indicator_for_stop = args[:show_indicator_for_stop] || false
+  def initialize(split_times_data:, finish:, show_indicator_for_stop: false)
+    @split_times_data = split_times_data
+    @finish = finish
+    @show_indicator_for_stop = show_indicator_for_stop
+    validate_setup
   end
 
   def finish?
@@ -79,5 +76,10 @@ class TimeCluster
 
   def compacted_segment_times
     @compacted_segment_times ||= split_times_data.map(&:segment_time).compact
+  end
+
+  def validate_setup
+    raise ArgumentError, "time_cluster must include split_times_data" unless split_times_data
+    raise ArgumentError, "time_cluster must include finish" if @finish.nil?
   end
 end

--- a/spec/view_models/effort_analysis_row_spec.rb
+++ b/spec/view_models/effort_analysis_row_spec.rb
@@ -1,0 +1,220 @@
+require "rails_helper"
+require "support/bitkey_definitions"
+
+RSpec.describe EffortAnalysisRow do
+  include BitkeyDefinitions
+
+  subject(:row) do
+    described_class.new(
+      lap_split: lap_split,
+      split_times: split_times,
+      typical_split_times: typical_split_times,
+      start_time: start_time,
+      show_laps: show_laps,
+      prior_lap_split: prior_lap_split,
+      prior_split_time: prior_split_time,
+    )
+  end
+
+  let(:course) { Course.new(name: "Test Course") }
+  let(:split_start) do
+    Split.new(course: course, base_name: "Start", distance_from_start: 0,
+              sub_split_bitmap: 1, vert_gain_from_start: 0, vert_loss_from_start: 0, kind: :start)
+  end
+  let(:split_aid) do
+    Split.new(course: course, base_name: "Aid 1", distance_from_start: 10_000,
+              sub_split_bitmap: 65, vert_gain_from_start: 500, vert_loss_from_start: 0, kind: :intermediate)
+  end
+  let(:split_finish) do
+    Split.new(course: course, base_name: "Finish", distance_from_start: 20_000,
+              sub_split_bitmap: 1, vert_gain_from_start: 500, vert_loss_from_start: 500, kind: :finish)
+  end
+
+  let(:lap_split_start) { LapSplit.new(1, split_start) }
+  let(:lap_split_aid) { LapSplit.new(1, split_aid) }
+  let(:lap_split_finish) { LapSplit.new(1, split_finish) }
+
+  let(:start_time) { Time.zone.parse("2015-07-01 06:00:00") }
+  let(:show_laps) { false }
+  let(:prior_lap_split) { lap_split_start }
+  let(:prior_split_time) { nil }
+
+  let(:split_time_in) do
+    SplitTimeData.new(
+      effort_id: 1, lap: 1, split_id: split_aid.id, bitkey: in_bitkey,
+      time_from_start: 4000, segment_time: 4000, data_status_numeric: 2,
+    )
+  end
+  let(:split_time_out) do
+    SplitTimeData.new(
+      effort_id: 1, lap: 1, split_id: split_aid.id, bitkey: out_bitkey,
+      time_from_start: 4200, segment_time: 200, data_status_numeric: 2,
+    )
+  end
+  let(:typical_in) do
+    SplitTimeData.new(
+      effort_id: nil, lap: 1, split_id: split_aid.id, bitkey: in_bitkey,
+      time_from_start: 3800, segment_time: 3800, data_status_numeric: 2,
+    )
+  end
+  let(:typical_out) do
+    SplitTimeData.new(
+      effort_id: nil, lap: 1, split_id: split_aid.id, bitkey: out_bitkey,
+      time_from_start: 3900, segment_time: 100, data_status_numeric: 2,
+    )
+  end
+
+  let(:lap_split) { lap_split_aid }
+  let(:split_times) { [split_time_in, split_time_out] }
+  let(:typical_split_times) { [typical_in, typical_out] }
+
+  describe "#initialize" do
+    context "when initialized with all required arguments" do
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context "when initialized without lap_split" do
+      let(:lap_split) { nil }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include lap_split/ }
+    end
+
+    context "when initialized without split_times" do
+      let(:split_times) { nil }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include split_times/ }
+    end
+
+    context "when initialized without typical_split_times" do
+      let(:typical_split_times) { nil }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include typical_split_times/ }
+    end
+
+    context "when initialized without start_time" do
+      let(:start_time) { nil }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include start_time/ }
+    end
+  end
+
+  describe "#name" do
+    context "when show_laps is false" do
+      let(:show_laps) { false }
+
+      it "returns the base name without lap" do
+        expect(subject.name).to eq(lap_split.base_name_without_lap)
+      end
+    end
+
+    context "when show_laps is true" do
+      let(:show_laps) { true }
+
+      it "returns the base name with lap" do
+        expect(subject.name).to eq(lap_split.base_name)
+      end
+    end
+  end
+
+  describe "#time_cluster" do
+    it "returns a TimeCluster" do
+      expect(subject.time_cluster).to be_a(TimeCluster)
+    end
+  end
+
+  describe "#typical_time_cluster" do
+    it "returns a TimeCluster" do
+      expect(subject.typical_time_cluster).to be_a(TimeCluster)
+    end
+  end
+
+  describe "#segment_time" do
+    it "returns the segment time from the time cluster" do
+      expect(subject.segment_time).to eq(4000)
+    end
+  end
+
+  describe "#time_in_aid" do
+    it "returns the time in aid from the time cluster" do
+      expect(subject.time_in_aid).to eq(200)
+    end
+  end
+
+  describe "#combined_time" do
+    it "returns segment_time plus time_in_aid" do
+      expect(subject.combined_time).to eq(4200)
+    end
+  end
+
+  describe "#segment_time_typical" do
+    it "returns the typical segment time" do
+      expect(subject.segment_time_typical).to eq(3800)
+    end
+  end
+
+  describe "#time_in_aid_typical" do
+    it "returns the typical time in aid" do
+      expect(subject.time_in_aid_typical).to eq(100)
+    end
+  end
+
+  describe "#combined_time_typical" do
+    it "returns typical segment_time plus typical time_in_aid" do
+      expect(subject.combined_time_typical).to eq(3900)
+    end
+  end
+
+  describe "#segment_time_over_under" do
+    it "returns the difference between actual and typical segment times" do
+      expect(subject.segment_time_over_under).to eq(200)
+    end
+
+    context "when segment_time is nil" do
+      let(:split_times) { [SplitTimeData.new, SplitTimeData.new] }
+
+      it "returns nil" do
+        expect(subject.segment_time_over_under).to be_nil
+      end
+    end
+  end
+
+  describe "#time_in_aid_over_under" do
+    it "returns the difference between actual and typical time in aid" do
+      expect(subject.time_in_aid_over_under).to eq(100)
+    end
+  end
+
+  describe "#split_id" do
+    it "returns the split id" do
+      expect(subject.split_id).to eq(split_aid.id)
+    end
+  end
+
+  describe "#intermediate?" do
+    context "when the split is intermediate" do
+      let(:lap_split) { lap_split_aid }
+
+      it { expect(subject.intermediate?).to be true }
+    end
+
+    context "when the split is finish" do
+      let(:lap_split) { lap_split_finish }
+
+      it { expect(subject.intermediate?).to be false }
+    end
+  end
+
+  describe "#finish?" do
+    context "when the split is finish" do
+      let(:lap_split) { lap_split_finish }
+
+      it { expect(subject.finish?).to be true }
+    end
+
+    context "when the split is intermediate" do
+      let(:lap_split) { lap_split_aid }
+
+      it { expect(subject.finish?).to be false }
+    end
+  end
+end

--- a/spec/view_models/time_cluster_spec.rb
+++ b/spec/view_models/time_cluster_spec.rb
@@ -1,0 +1,215 @@
+require "rails_helper"
+require "support/bitkey_definitions"
+
+RSpec.describe TimeCluster do
+  include BitkeyDefinitions
+
+  subject(:cluster) { described_class.new(split_times_data: split_times_data, finish: finish, show_indicator_for_stop: show_indicator_for_stop) }
+
+  let(:finish) { false }
+  let(:show_indicator_for_stop) { false }
+
+  let(:split_time_data_blank) { SplitTimeData.new }
+  let(:split_time_data_1) do
+    SplitTimeData.new(
+      effort_id: 1, lap: 1, split_id: 10, bitkey: in_bitkey,
+      time_from_start: 4000, segment_time: 4000,
+      stopped_here: false, pacer: false, data_status_numeric: 2, id: 101,
+    )
+  end
+  let(:split_time_data_2) do
+    SplitTimeData.new(
+      effort_id: 1, lap: 1, split_id: 10, bitkey: out_bitkey,
+      time_from_start: 4100, segment_time: 100,
+      stopped_here: false, pacer: true, data_status_numeric: 2, id: 102,
+    )
+  end
+  let(:split_time_data_stopped) do
+    SplitTimeData.new(
+      effort_id: 1, lap: 1, split_id: 10, bitkey: in_bitkey,
+      time_from_start: 5000, segment_time: 5000,
+      stopped_here: true, pacer: false, data_status_numeric: 2, id: 103,
+    )
+  end
+
+  describe "#initialize" do
+    context "when initialized with all required arguments" do
+      let(:split_times_data) { [split_time_data_1, split_time_data_2] }
+
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context "when initialized without split_times_data" do
+      let(:split_times_data) { nil }
+
+      it { expect { subject }.to raise_error ArgumentError, /must include split_times_data/ }
+    end
+
+    context "when finish is not provided" do
+      subject(:cluster) { described_class.new(split_times_data: [split_time_data_1]) }
+
+      it { expect { subject }.to raise_error ArgumentError }
+    end
+  end
+
+  describe "#finish?" do
+    let(:split_times_data) { [split_time_data_1] }
+
+    context "when finish is true" do
+      let(:finish) { true }
+
+      it { expect(subject.finish?).to be true }
+    end
+
+    context "when finish is false" do
+      let(:finish) { false }
+
+      it { expect(subject.finish?).to be false }
+    end
+  end
+
+  describe "#segment_time" do
+    context "when split_times_data has two populated objects" do
+      let(:split_times_data) { [split_time_data_1, split_time_data_2] }
+
+      it "returns the segment_time of the first object" do
+        expect(subject.segment_time).to eq(4000)
+      end
+    end
+
+    context "when split_times_data has one populated and one blank object" do
+      let(:split_times_data) { [split_time_data_1, split_time_data_blank] }
+
+      it "returns the segment_time of the populated object" do
+        expect(subject.segment_time).to eq(4000)
+      end
+    end
+
+    context "when split_times_data has all blank objects" do
+      let(:split_times_data) { [split_time_data_blank, split_time_data_blank] }
+
+      it "returns nil" do
+        expect(subject.segment_time).to be_nil
+      end
+    end
+  end
+
+  describe "#time_in_aid" do
+    context "when split_times_data has two populated objects" do
+      let(:split_times_data) { [split_time_data_1, split_time_data_2] }
+
+      it "returns the segment_time of the last object" do
+        expect(subject.time_in_aid).to eq(100)
+      end
+    end
+
+    context "when split_times_data has a single object" do
+      let(:split_times_data) { [split_time_data_1] }
+
+      it "returns nil" do
+        expect(subject.time_in_aid).to be_nil
+      end
+    end
+  end
+
+  describe "#times_from_start" do
+    context "when split_times_data has two populated objects" do
+      let(:split_times_data) { [split_time_data_1, split_time_data_2] }
+
+      it "returns an array of times" do
+        expect(subject.times_from_start).to eq([4000, 4100])
+      end
+    end
+
+    context "when split_times_data has one populated and one blank object" do
+      let(:split_times_data) { [split_time_data_1, split_time_data_blank] }
+
+      it "returns an array with a time and nil" do
+        expect(subject.times_from_start).to eq([4000, nil])
+      end
+    end
+  end
+
+  describe "#time_data_statuses" do
+    let(:split_times_data) { [split_time_data_1, split_time_data_2] }
+
+    it "returns an array of data statuses" do
+      expect(subject.time_data_statuses).to eq(%w[good good])
+    end
+  end
+
+  describe "#pacer_flags" do
+    let(:split_times_data) { [split_time_data_1, split_time_data_2] }
+
+    it "returns an array of pacer flags" do
+      expect(subject.pacer_flags).to eq([false, true])
+    end
+  end
+
+  describe "#stopped_here_flags" do
+    let(:split_times_data) { [split_time_data_1, split_time_data_2] }
+
+    it "returns an array of stopped_here flags" do
+      expect(subject.stopped_here_flags).to eq([false, false])
+    end
+  end
+
+  describe "#stopped_here?" do
+    context "when no split_times are stopped" do
+      let(:split_times_data) { [split_time_data_1, split_time_data_2] }
+
+      it { expect(subject.stopped_here?).to be false }
+    end
+
+    context "when a split_time is stopped" do
+      let(:split_times_data) { [split_time_data_stopped] }
+
+      it { expect(subject.stopped_here?).to be true }
+    end
+  end
+
+  describe "#show_stop_indicator?" do
+    context "when stopped_here and show_indicator_for_stop are both true" do
+      let(:split_times_data) { [split_time_data_stopped] }
+      let(:show_indicator_for_stop) { true }
+
+      it { expect(subject.show_stop_indicator?).to be true }
+    end
+
+    context "when stopped_here is true but show_indicator_for_stop is false" do
+      let(:split_times_data) { [split_time_data_stopped] }
+      let(:show_indicator_for_stop) { false }
+
+      it { expect(subject.show_stop_indicator?).to be false }
+    end
+
+    context "when not stopped_here" do
+      let(:split_times_data) { [split_time_data_1] }
+      let(:show_indicator_for_stop) { true }
+
+      it { expect(subject.show_stop_indicator?).to be false }
+    end
+  end
+
+  describe "#aid_time_recordable?" do
+    context "when split_times_data has multiple objects" do
+      let(:split_times_data) { [split_time_data_1, split_time_data_2] }
+
+      it { expect(subject.aid_time_recordable?).to be true }
+    end
+
+    context "when split_times_data has a single object" do
+      let(:split_times_data) { [split_time_data_1] }
+
+      it { expect(subject.aid_time_recordable?).to be false }
+    end
+  end
+
+  describe "#split_time_ids" do
+    let(:split_times_data) { [split_time_data_1, split_time_data_2] }
+
+    it "returns an array of ids" do
+      expect(subject.split_time_ids).to eq([101, 102])
+    end
+  end
+end


### PR DESCRIPTION
Step 8 of #1639
Resolves #1678

## Summary
- Replace `ArgsValidator` with Ruby keyword arguments in `effort_analysis_row.rb` and `time_cluster.rb`
- Add `validate_setup` method (as last private method) in each class for argument validation
- Add comprehensive specs for both `EffortAnalysisRow` (23 examples) and `TimeCluster` (23 examples)
- Fix pre-existing `Lint/AmbiguousOperatorPrecedence` offenses in `effort_analysis_row.rb`

## Test plan
- [x] All 46 new spec examples pass
- [x] Zero rubocop offenses on all changed files
- [x] Existing callers (`EffortAnalysisView`, `LapSplitRow`, `EffortTimesRow`) already use keyword args — no caller changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)