### PR TITLE
Remove ArgsValidator from model classes

### DIFF
--- a/app/models/data_entry_node.rb
+++ b/app/models/data_entry_node.rb
@@ -1,18 +1,25 @@
 class DataEntryNode
   include Locatable
 
-  DISTANCE_THRESHOLD = Split::DISTANCE_THRESHOLD # Distance (in meters) below which split locations are deemed equivalent
+  # Distance (in meters) below which split locations are deemed equivalent
+  DISTANCE_THRESHOLD = Split::DISTANCE_THRESHOLD
   NODE_ATTRIBUTES = [:split_name, :parameterized_split_name, :sub_split_kind, :label,
                      :latitude, :longitude, :min_distance_from_start].freeze
 
   attr_reader(*NODE_ATTRIBUTES)
 
-  def initialize(args)
-    ArgsValidator.validate(params: args, exclusive: NODE_ATTRIBUTES)
-    NODE_ATTRIBUTES.each { |attribute| instance_variable_set("@#{attribute}", args[attribute]) }
+  def initialize(split_name: nil, parameterized_split_name: nil, sub_split_kind: nil,
+                 label: nil, latitude: nil, longitude: nil, min_distance_from_start: nil)
+    @split_name = split_name
+    @parameterized_split_name = parameterized_split_name
+    @sub_split_kind = sub_split_kind
+    @label = label
+    @latitude = latitude
+    @longitude = longitude
+    @min_distance_from_start = min_distance_from_start
   end
 
   def to_h
-    NODE_ATTRIBUTES.map { |attribute| [attribute, send(attribute)] }.to_h
+    NODE_ATTRIBUTES.index_with { |attribute| send(attribute) }
   end
 end

--- a/app/models/projected_effort.rb
+++ b/app/models/projected_effort.rb
@@ -1,13 +1,10 @@
 class ProjectedEffort
-  def initialize(args)
-    ArgsValidator.validate(params: args,
-                           required: [:event, :start_time, :baseline_split_time, :projected_time_points],
-                           exclusive: [:event, :start_time, :baseline_split_time, :projected_time_points],
-                           class: self)
-    @event = args[:event]
-    @start_time = args[:start_time]
-    @baseline_split_time = args[:baseline_split_time]
-    @projected_time_points = args[:projected_time_points]
+  def initialize(event:, start_time:, baseline_split_time:, projected_time_points:)
+    @event = event
+    @start_time = start_time
+    @baseline_split_time = baseline_split_time
+    @projected_time_points = projected_time_points
+    validate_setup
   end
 
   def ordered_split_times
@@ -54,6 +51,13 @@ class ProjectedEffort
   end
 
   def add_to_baseline(seconds)
-    seconds && baseline_time + seconds
+    seconds && (baseline_time + seconds)
+  end
+
+  def validate_setup
+    raise ArgumentError, "projected_effort must include event" unless event
+    raise ArgumentError, "projected_effort must include start_time" unless start_time
+    raise ArgumentError, "projected_effort must include baseline_split_time" unless baseline_split_time
+    raise ArgumentError, "projected_effort must include projected_time_points" unless projected_time_points
   end
 end

--- a/app/models/segment.rb
+++ b/app/models/segment.rb
@@ -4,21 +4,12 @@ class Segment
   delegate :course, to: :begin_split
   delegate :events, :earliest_event_date, :most_recent_event_date, to: :end_split
 
-  def initialize(args)
-    ArgsValidator.validate(params: args,
-                           required_alternatives: [[:begin_point, :end_point], [:begin_sub_split, :end_sub_split]],
-                           exclusive: [:begin_point, :end_point, :begin_sub_split, :end_sub_split,
-                                       :begin_split, :end_split, :order_control, :begin_lap_split, :end_lap_split],
-                           deprecated: {begin_sub_split: :begin_point, end_sub_split: :end_point,
-                                        begin_split: :begin_lap_split, end_split: :end_lap_split},
-                           class: self.class)
-    @begin_point = args[:begin_point] || assumed_time_point(args[:begin_sub_split])
-    @end_point = args[:end_point] || assumed_time_point(args[:end_sub_split])
-    @arg_begin_split = args[:begin_split]
-    @arg_end_split = args[:end_split]
-    @arg_begin_lap_split = args[:begin_lap_split]
-    @arg_end_lap_split = args[:end_lap_split]
-    @order_control = args[:order_control].nil? ? true : args[:order_control]
+  def initialize(begin_point:, end_point:, begin_lap_split: nil, end_lap_split: nil, order_control: true)
+    @begin_point = begin_point
+    @end_point = end_point
+    @arg_begin_lap_split = begin_lap_split
+    @arg_end_lap_split = end_lap_split
+    @order_control = order_control
     validate_setup
   end
 
@@ -61,7 +52,7 @@ class Segment
   end
 
   def splits
-    @splits ||= [arg_begin_split, arg_end_split].compact.presence || Split.find(split_ids).to_a
+    @splits ||= Split.find(split_ids).to_a
   end
 
   def begin_lap
@@ -87,12 +78,10 @@ class Segment
       "Time in #{begin_split.base_name} Lap #{begin_lap}"
     elsif zero_segment?
       "#{begin_split.name(begin_bitkey)} Lap #{begin_lap}"
+    elsif begin_lap == end_lap
+      "#{begin_split.base_name} to #{end_split.base_name} Lap #{begin_lap}"
     else
-      if begin_lap == end_lap
-        "#{begin_split.base_name} to #{end_split.base_name} Lap #{begin_lap}"
-      else
-        "#{begin_split.base_name} Lap #{begin_lap} to #{end_split.base_name} Lap #{end_lap}"
-      end
+      "#{begin_split.base_name} Lap #{begin_lap} to #{end_split.base_name} Lap #{end_lap}"
     end
   end
 
@@ -143,21 +132,14 @@ class Segment
   def special_limits_type
     if zero_start?
       :zero_start
-    elsif in_aid?
-      :in_aid
-    elsif between_laps?
+    elsif in_aid? || between_laps?
       :in_aid
     end
   end
 
   private
 
-  attr_reader :arg_begin_split, :arg_end_split, :arg_begin_lap_split, :arg_end_lap_split, :order_control
-
-  def assumed_time_point(sub_split)
-    assumed_lap = 1
-    TimePoint.new(assumed_lap, sub_split.split_id, sub_split.bitkey)
-  end
+  attr_reader :arg_begin_lap_split, :arg_end_lap_split, :order_control
 
   def discovered_lap_split(time_point)
     LapSplit.new(time_point.lap, splits.find { |split| split.id == time_point.split_id })
@@ -175,62 +157,46 @@ class Segment
     begin_point == end_point
   end
 
-  def validate_setup
-    if splits_inconsistent?
-      raise ArgumentError,
-            "Segment splits must be on same course"
-    end
-    if lap_splits_inconsistent?
-      raise ArgumentError,
-            "Segment lap_splits must be on same course"
-    end
-    if order_control && in_aid_bitkeys_reversed?
-      raise ArgumentError,
-            "Segment bitkeys within the same split are out of order; " +
-            "begin_split: #{begin_split.name(begin_bitkey)} Lap #{begin_lap}, " +
-            "end_split: #{end_split.name(end_bitkey)} Lap #{end_lap}"
-    end
-    if order_control && splits_reversed_on_lap?
-      raise ArgumentError,
-            "Segment splits on the same lap are out of order; " +
-            "begin_split: #{begin_split.name(begin_bitkey)} Lap #{begin_lap}, " +
-            "end_split: #{end_split.name(end_bitkey)} Lap #{end_lap}"
-    end
-    if order_control && laps_reversed?
-      raise ArgumentError,
-            "Segment laps are out of order; " +
-            "begin_split: #{begin_split.name(begin_bitkey)} Lap #{begin_lap}, " +
-            "end_split: #{end_split.name(end_bitkey)} Lap #{end_lap}"
-    end
-    if arg_begin_split && (arg_begin_split.id != begin_id)
-      raise ArgumentError,
-            "Segment begin_point (id #{begin_id}) does not reconcile with begin split (id #{begin_split.id})"
-    end
-    if arg_end_split && (arg_end_split.id != end_id)
-      raise ArgumentError,
-            "Segment begin_point (id #{end_id}) does not reconcile with begin split (id #{end_split.id})"
-    end
-  end
-
-  def splits_inconsistent?
-    arg_begin_split && arg_end_split && (arg_begin_split.course_id != arg_end_split.course_id)
-  end
-
-  def lap_splits_inconsistent?
-    arg_begin_lap_split && arg_end_lap_split && (arg_begin_lap_split.course_id != arg_end_lap_split.course_id)
-  end
-
   def in_aid_bitkeys_reversed?
     in_aid? && (begin_bitkey > end_bitkey)
   end
 
   def splits_reversed_on_lap?
     (begin_lap == end_lap) &&
-      ((arg_begin_split && arg_end_split) || (arg_begin_lap_split && arg_end_lap_split)) &&
+      arg_begin_lap_split && arg_end_lap_split &&
       (begin_split.distance_from_start > end_split.distance_from_start)
   end
 
   def laps_reversed?
     begin_lap > end_lap
+  end
+
+  def lap_splits_inconsistent?
+    arg_begin_lap_split && arg_end_lap_split && (arg_begin_lap_split.course_id != arg_end_lap_split.course_id)
+  end
+
+  def validate_setup
+    if lap_splits_inconsistent?
+      raise ArgumentError,
+            "Segment lap_splits must be on same course"
+    end
+    if order_control && in_aid_bitkeys_reversed?
+      raise ArgumentError,
+            "Segment bitkeys within the same split are out of order; " \
+            "begin_split: #{begin_split.name(begin_bitkey)} Lap #{begin_lap}, " \
+            "end_split: #{end_split.name(end_bitkey)} Lap #{end_lap}"
+    end
+    if order_control && splits_reversed_on_lap?
+      raise ArgumentError,
+            "Segment splits on the same lap are out of order; " \
+            "begin_split: #{begin_split.name(begin_bitkey)} Lap #{begin_lap}, " \
+            "end_split: #{end_split.name(end_bitkey)} Lap #{end_lap}"
+    end
+    return unless order_control && laps_reversed?
+
+    raise ArgumentError,
+          "Segment laps are out of order; " \
+          "begin_split: #{begin_split.name(begin_bitkey)} Lap #{begin_lap}, " \
+          "end_split: #{end_split.name(end_bitkey)} Lap #{end_lap}"
   end
 end

--- a/app/models/segment_time_calculator.rb
+++ b/app/models/segment_time_calculator.rb
@@ -1,20 +1,17 @@
 class SegmentTimeCalculator
   DISTANCE_FACTOR = 0.6 # Multiply distance in meters by this factor to approximate normal travel time on foot
-  UP_VERT_GAIN_FACTOR = 4.0 # Multiply positive vert_gain in meters by this factor to approximate normal travel time on foot
+  # Multiply positive vert_gain in meters by this factor to approximate normal travel time on foot
+  UP_VERT_GAIN_FACTOR = 4.0
   STATS_CALC_THRESHOLD = 4
 
-  def self.typical_time(args)
-    new(args).typical_time
+  def self.typical_time(segment:, calc_model:, effort_ids: nil)
+    new(segment: segment, calc_model: calc_model, effort_ids: effort_ids).typical_time
   end
 
-  def initialize(args)
-    ArgsValidator.validate(params: args,
-                           required: [:segment, :calc_model],
-                           exclusive: [:segment, :effort_ids, :calc_model],
-                           class: self.class)
-    @segment = args[:segment]
-    @effort_ids = args[:effort_ids]
-    @calc_model = args[:calc_model]
+  def initialize(segment:, calc_model:, effort_ids: nil)
+    @segment = segment
+    @effort_ids = effort_ids
+    @calc_model = calc_model
     validate_setup
   end
 
@@ -47,10 +44,11 @@ class SegmentTimeCalculator
 
   def validate_setup
     if calc_model == :focused && effort_ids.nil?
-      raise ArgumentError, "SegmentTimeCalculator cannot be initialized with calc_model: :focused unless effort_ids are provided"
+      raise ArgumentError,
+            "SegmentTimeCalculator cannot be initialized with calc_model: :focused unless effort_ids are provided"
     end
-    if calc_model && SegmentTimesContainer::VALID_CALC_MODELS.exclude?(calc_model)
-      raise ArgumentError, "calc_model #{calc_model} is not recognized"
-    end
+    return unless calc_model && SegmentTimesContainer::VALID_CALC_MODELS.exclude?(calc_model)
+
+    raise ArgumentError, "calc_model #{calc_model} is not recognized"
   end
 end

--- a/app/models/segment_times_container.rb
+++ b/app/models/segment_times_container.rb
@@ -3,27 +3,26 @@ class SegmentTimesContainer
 
   attr_reader :calc_model
 
-  def initialize(args = {})
-    ArgsValidator.validate(params: args,
-                           exclusive: [:effort_ids, :efforts, :calc_model],
-                           class: self.class)
-    @effort_ids = args[:effort_ids] || (args[:efforts] && args[:efforts].map(&:id))
-    @calc_model = args[:calc_model] || :terrain
+  def initialize(effort_ids: nil, efforts: nil, calc_model: :terrain)
+    @effort_ids = effort_ids || efforts&.map(&:id)
+    @calc_model = calc_model
     @segment_times = {}
     @limits_hashes = {}
     validate_setup
   end
 
   def segment_time(segment)
-    return @segment_times[segment] if @segment_times.has_key?(segment)
+    return @segment_times[segment] if @segment_times.key?(segment)
 
-    @segment_times[segment] = SegmentTimeCalculator.typical_time(segment: segment, effort_ids: effort_ids, calc_model: calc_model)
+    @segment_times[segment] =
+      SegmentTimeCalculator.typical_time(segment: segment, effort_ids: effort_ids, calc_model: calc_model)
   end
 
   def limits(segment)
-    return @limits_hashes[segment] if @limits_hashes.has_key?(segment)
+    return @limits_hashes[segment] if @limits_hashes.key?(segment)
 
-    @limits_hashes[segment] = segment_time(segment) ? DataStatus.limits(segment_time(segment), limits_type(segment)) : {}
+    @limits_hashes[segment] =
+      segment_time(segment) ? DataStatus.limits(segment_time(segment), limits_type(segment)) : {}
   end
 
   def data_status(segment, seconds)
@@ -40,10 +39,11 @@ class SegmentTimesContainer
 
   def validate_setup
     if calc_model == :focused && effort_ids.nil?
-      raise ArgumentError, "SegmentTimesContainer cannot be initialized with calc_model: :focused unless effort_ids are provided"
+      raise ArgumentError,
+            "SegmentTimesContainer cannot be initialized with calc_model: :focused unless effort_ids are provided"
     end
-    if calc_model && VALID_CALC_MODELS.exclude?(calc_model)
-      raise ArgumentError, "calc_model #{calc_model} is not recognized"
-    end
+    return unless calc_model && VALID_CALC_MODELS.exclude?(calc_model)
+
+    raise ArgumentError, "calc_model #{calc_model} is not recognized"
   end
 end

--- a/spec/factories/segment.rb
+++ b/spec/factories/segment.rb
@@ -11,14 +11,14 @@ FactoryBot.define do
       order_control { true }
     end
 
-    initialize_with { new(args) }
+    initialize_with { new(**args) }
 
     args do
-      {begin_point: TimePoint.new(begin_lap, begin_split.id, SubSplit.bitkey(begin_in_out.to_s)),
-       end_point: TimePoint.new(end_lap, end_split.id, SubSplit.bitkey(end_in_out.to_s)),
-       begin_lap_split: LapSplit.new(begin_lap, begin_split),
-       end_lap_split: LapSplit.new(end_lap, end_split),
-       order_control: order_control}
+      { begin_point: TimePoint.new(begin_lap, begin_split.id, SubSplit.bitkey(begin_in_out.to_s)),
+        end_point: TimePoint.new(end_lap, end_split.id, SubSplit.bitkey(end_in_out.to_s)),
+        begin_lap_split: LapSplit.new(begin_lap, begin_split),
+        end_lap_split: LapSplit.new(end_lap, end_split),
+        order_control: order_control }
     end
   end
 end

--- a/spec/models/data_entry_node_spec.rb
+++ b/spec/models/data_entry_node_spec.rb
@@ -1,19 +1,19 @@
+require "rails_helper"
 require "support/concerns/locatable"
 
 RSpec.describe DataEntryNode do
-  it_behaves_like "locatable"
-
-  subject { DataEntryNode.new(attributes) }
+  subject { described_class.new(**attributes) }
 
   let(:attributes) do
-    {split_name: "Split Name",
-     parameterized_split_name: "split-name",
-     sub_split_kind: "in",
-     label: "label",
-     latitude: 40,
-     longitude: -105,
-     min_distance_from_start: 0}
+    { split_name: "Split Name",
+      parameterized_split_name: "split-name",
+      sub_split_kind: "in",
+      label: "label",
+      latitude: 40,
+      longitude: -105,
+      min_distance_from_start: 0 }
   end
+  it_behaves_like "locatable"
 
   describe "#to_h" do
     it "returns all attributes in a Hash" do

--- a/spec/models/segment_spec.rb
+++ b/spec/models/segment_spec.rb
@@ -89,20 +89,20 @@ RSpec.describe Segment, type: :model do
     it "initializes when given a begin_point and end_point in an args hash" do
       begin_point = LapSplit.new(lap_1, aid_1).time_point_in
       end_point = LapSplit.new(lap_1, aid_1).time_point_out
-      expect { Segment.new(begin_point: begin_point, end_point: end_point) }
-          .not_to raise_error
+      expect { described_class.new(begin_point: begin_point, end_point: end_point) }
+        .not_to raise_error
     end
 
     it "raises an error if missing begin_point" do
       end_point = LapSplit.new(lap_1, aid_1).time_point_out
-      expect { Segment.new(end_point: end_point) }
-          .to raise_error(/must include one of begin_point and end_point or begin_sub_split and end_sub_split/)
+      expect { described_class.new(end_point: end_point) }
+        .to raise_error(ArgumentError, /missing keyword/)
     end
 
     it "raises an error if missing end_point" do
       begin_point = LapSplit.new(lap_1, aid_1).time_point_in
-      expect { Segment.new(begin_point: begin_point) }
-          .to raise_error(/must include one of begin_point and end_point or begin_sub_split and end_sub_split/)
+      expect { described_class.new(begin_point: begin_point) }
+        .to raise_error(ArgumentError, /missing keyword/)
     end
 
     it "raises an error when splits on the same lap are out of order" do
@@ -360,9 +360,7 @@ RSpec.describe Segment, type: :model do
 
   def validate_attribute(attribute, segment, expected)
     course = build_stubbed(:course)
-    allow(course).to receive(:distance).and_return(finish.distance_from_start)
-    allow(course).to receive(:vert_gain).and_return(finish.vert_gain_from_start)
-    allow(course).to receive(:vert_loss).and_return(finish.vert_loss_from_start)
+    allow(course).to receive_messages(distance: finish.distance_from_start, vert_gain: finish.vert_gain_from_start, vert_loss: finish.vert_loss_from_start)
     allow(segment.end_lap_split).to receive(:course).and_return(course)
     allow(segment.begin_lap_split).to receive(:course).and_return(course)
     expect(segment.send(attribute)).to eq(expected)

--- a/spec/models/segment_time_calculator_spec.rb
+++ b/spec/models/segment_time_calculator_spec.rb
@@ -38,28 +38,28 @@ RSpec.describe SegmentTimeCalculator do
 
   describe "#initialize" do
     it "initializes with an args hash that contains only a calc_model and a segment" do
-      expect { SegmentTimeCalculator.new(segment: lap_1_zero_start, calc_model: :terrain) }
-          .not_to raise_error
+      expect { described_class.new(segment: lap_1_zero_start, calc_model: :terrain) }
+        .not_to raise_error
     end
 
     it "raises an ArgumentError if initialized without a calc_model" do
-      expect { SegmentTimeCalculator.new(segment: lap_1_zero_start) }
-          .to raise_error(/must include calc_model/)
+      expect { described_class.new(segment: lap_1_zero_start) }
+        .to raise_error(ArgumentError, /missing keyword/)
     end
 
     it "raises an ArgumentError if initialized without a segment" do
-      expect { SegmentTimeCalculator.new(calc_model: :terrain) }
-          .to raise_error(/must include segment/)
+      expect { described_class.new(calc_model: :terrain) }
+        .to raise_error(ArgumentError, /missing keyword/)
     end
 
     it "raises an ArgumentError if initialized with calc_model: :focused but without effort_ids" do
-      expect { SegmentTimeCalculator.new(segment: lap_1_zero_start, calc_model: :focused) }
-          .to raise_error(/cannot be initialized/)
+      expect { described_class.new(segment: lap_1_zero_start, calc_model: :focused) }
+        .to raise_error(/cannot be initialized/)
     end
 
     it "raises an ArgumentError if initialized with an unrecognized calc_model" do
-      expect { SegmentTimeCalculator.new(segment: lap_1_zero_start, calc_model: :random) }
-          .to raise_error(/calc_model random is not recognized/)
+      expect { described_class.new(segment: lap_1_zero_start, calc_model: :random) }
+        .to raise_error(/calc_model random is not recognized/)
     end
   end
 
@@ -69,7 +69,7 @@ RSpec.describe SegmentTimeCalculator do
 
     it "calculates a segment time in seconds using the specified calc_model" do
       segment = lap_1_start_to_lap_1_aid_1
-      expected = 10_000 * distance_factor + 1000 * vert_gain_factor
+      expected = (10_000 * distance_factor) + (1000 * vert_gain_factor)
       validate_typical_time_terrain(segment, expected)
     end
 
@@ -87,33 +87,31 @@ RSpec.describe SegmentTimeCalculator do
 
     it "returns typical time between splits for a segment that begins and ends with different intermediate splits" do
       segment = lap_1_aid_2_to_lap_1_aid_3
-      expected = 20_000 * distance_factor + 2000 * vert_gain_factor
+      expected = (20_000 * distance_factor) + (2000 * vert_gain_factor)
       validate_typical_time_terrain(segment, expected)
     end
 
     it "returns typical time between splits for a segment made up of a complete lap" do
       segment = lap_1_start_to_lap_1_finish
-      expected = 70_000 * distance_factor + 7_000 * vert_gain_factor
+      expected = (70_000 * distance_factor) + (7_000 * vert_gain_factor)
       validate_typical_time_terrain(segment, expected)
     end
 
     it "returns typical time between splits for a segment that spans different laps" do
       segment = lap_1_start_to_lap_2_aid_1
-      expected = 80_000 * distance_factor + 8000 * vert_gain_factor
+      expected = (80_000 * distance_factor) + (8000 * vert_gain_factor)
       validate_typical_time_terrain(segment, expected)
     end
 
     it "returns typical time between splits for a segment made up of multiple complete laps" do
       segment = lap_1_start_to_lap_3_finish
-      expected = 210_000 * distance_factor + 21_000 * vert_gain_factor
+      expected = (210_000 * distance_factor) + (21_000 * vert_gain_factor)
       validate_typical_time_terrain(segment, expected)
     end
 
     def validate_typical_time_terrain(segment, expected)
       course = build_stubbed(:course)
-      allow(course).to receive(:distance).and_return(finish.distance_from_start)
-      allow(course).to receive(:vert_gain).and_return(finish.vert_gain_from_start)
-      allow(course).to receive(:vert_loss).and_return(finish.vert_loss_from_start)
+      allow(course).to receive_messages(distance: finish.distance_from_start, vert_gain: finish.vert_gain_from_start, vert_loss: finish.vert_loss_from_start)
       allow(segment.end_lap_split).to receive(:course).and_return(course)
       allow(segment.begin_lap_split).to receive(:course).and_return(course)
       calculator = SegmentTimeCalculator.new(segment: segment, calc_model: :terrain)
@@ -148,7 +146,7 @@ RSpec.describe SegmentTimeCalculator do
 
     def typical_time_stats(segment, time_result, count_result)
       calculator = SegmentTimeCalculator.new(segment: segment, calc_model: :stats)
-      allow(SplitTimeQuery).to receive(:typical_segment_time).and_return({"effort_count" => count_result, "average" => time_result}.with_indifferent_access)
+      allow(SplitTimeQuery).to receive(:typical_segment_time).and_return({ "effort_count" => count_result, "average" => time_result }.with_indifferent_access)
       calculator.typical_time
     end
   end
@@ -192,7 +190,7 @@ RSpec.describe SegmentTimeCalculator do
 
     def typical_time_focused(segment, time_result, count_result, effort_ids)
       calculator = SegmentTimeCalculator.new(segment: segment, calc_model: :focused, effort_ids: effort_ids)
-      allow(SplitTimeQuery).to receive(:typical_segment_time).and_return({"effort_count" => count_result, "average" => time_result}.with_indifferent_access)
+      allow(SplitTimeQuery).to receive(:typical_segment_time).and_return({ "effort_count" => count_result, "average" => time_result }.with_indifferent_access)
       calculator.typical_time
     end
   end

--- a/spec/models/segment_times_container_spec.rb
+++ b/spec/models/segment_times_container_spec.rb
@@ -28,24 +28,24 @@ RSpec.describe SegmentTimesContainer do
 
   describe "#initialize" do
     it "initializes with no arguments" do
-      expect { SegmentTimesContainer.new }.not_to raise_error
+      expect { described_class.new }.not_to raise_error
     end
 
     it "initializes with an args hash that contains only efforts" do
       efforts = build_stubbed_list(:effort, 4)
-      expect { SegmentTimesContainer.new(efforts: efforts) }.not_to raise_error
+      expect { described_class.new(efforts: efforts) }.not_to raise_error
     end
 
-    it "raises an ArgumentError if initialized with an args hash that contains an unknown parameter" do
-      expect { SegmentTimesContainer.new(random_param: 123) }.to raise_error(/may not include random_param/)
+    it "raises an ArgumentError if initialized with an unknown parameter" do
+      expect { described_class.new(random_param: 123) }.to raise_error(ArgumentError, /unknown keyword/)
     end
 
     it "raises an ArgumentError if initialized with calc_model: :focused but without effort_ids" do
-      expect { SegmentTimesContainer.new(calc_model: :focused) }.to raise_error(/cannot be initialized/)
+      expect { described_class.new(calc_model: :focused) }.to raise_error(/cannot be initialized/)
     end
 
     it "raises an ArgumentError if initialized with an unrecognized calc_model" do
-      expect { SegmentTimesContainer.new(calc_model: :random) }.to raise_error(/calc_model random is not recognized/)
+      expect { described_class.new(calc_model: :random) }.to raise_error(/calc_model random is not recognized/)
     end
   end
 
@@ -53,35 +53,35 @@ RSpec.describe SegmentTimesContainer do
     it "sends the correct message to SegmentTimeCalculator for a zero_start segment" do
       segment = lap_1_zero_start
       calc_model = :terrain
-      expected = {segment: segment, effort_ids: nil, calc_model: calc_model}
+      expected = { segment: segment, effort_ids: nil, calc_model: calc_model }
       validate_segment_time(segment, calc_model, expected)
     end
 
     it "sends the correct message to SegmentTimeCalculator for a segment on the same lap" do
       segment = lap_1_aid_1_to_lap_1_finish
       calc_model = :terrain
-      expected = {segment: segment, effort_ids: nil, calc_model: calc_model}
+      expected = { segment: segment, effort_ids: nil, calc_model: calc_model }
       validate_segment_time(segment, calc_model, expected)
     end
 
     it "sends the correct message to SegmentTimeCalculator for a segment between laps" do
       segment = lap_1_start_to_lap_2_finish
       calc_model = :terrain
-      expected = {segment: segment, effort_ids: nil, calc_model: calc_model}
+      expected = { segment: segment, effort_ids: nil, calc_model: calc_model }
       validate_segment_time(segment, calc_model, expected)
     end
 
     it "sends the correct message to SegmentTimeCalculator for a reversed segment" do
       segment = lap_2_finish_to_lap_1_start
       calc_model = :terrain
-      expected = {segment: segment, effort_ids: nil, calc_model: calc_model}
+      expected = { segment: segment, effort_ids: nil, calc_model: calc_model }
       validate_segment_time(segment, calc_model, expected)
     end
 
     it "sends the correct message using calc_model: :stats" do
       segment = lap_1_aid_1_to_lap_1_finish
       calc_model = :stats
-      expected = {segment: segment, effort_ids: nil, calc_model: calc_model}
+      expected = { segment: segment, effort_ids: nil, calc_model: calc_model }
       validate_segment_time(segment, calc_model, expected)
     end
 
@@ -89,7 +89,7 @@ RSpec.describe SegmentTimesContainer do
       segment = lap_1_aid_1_to_lap_1_finish
       calc_model = :focused
       effort_ids = [1, 2, 3]
-      expected = {segment: segment, effort_ids: effort_ids, calc_model: calc_model}
+      expected = { segment: segment, effort_ids: effort_ids, calc_model: calc_model }
       validate_segment_time(segment, calc_model, expected, effort_ids)
     end
 
@@ -138,7 +138,7 @@ RSpec.describe SegmentTimesContainer do
 
     it "returns an empty hash if segment_time is not present" do
       segment = lap_1_start_to_lap_2_finish
-      container = SegmentTimesContainer.new(calc_model: :terrain)
+      container = described_class.new(calc_model: :terrain)
       allow(container).to receive(:segment_time).and_return(nil)
       expect(container.limits(segment)).to eq({})
     end
@@ -156,21 +156,21 @@ RSpec.describe SegmentTimesContainer do
     it "sends the correct message to DataStatus for a zero_start segment" do
       segment = lap_1_zero_start
       time = 0
-      limits = {low_bad: 0, low_questionable: 0, high_questionable: 0, high_bad: 0}
+      limits = { low_bad: 0, low_questionable: 0, high_questionable: 0, high_bad: 0 }
       validate_data_status(segment, time, limits, :terrain)
     end
 
     it "sends the correct message to DataStatus for an inter-lap segment" do
       segment = lap_1_start_to_lap_2_finish
       time = 50_000
-      limits = {low_bad: 30_000, low_questionable: 35_000, high_questionable: 60_000, high_bad: 80_000}
+      limits = { low_bad: 30_000, low_questionable: 35_000, high_questionable: 60_000, high_bad: 80_000 }
       validate_data_status(segment, time, limits, :terrain)
     end
 
     it "returns nil if limits is not present" do
       segment = lap_1_start_to_lap_2_finish
       time = 0
-      container = SegmentTimesContainer.new(calc_model: :terrain)
+      container = described_class.new(calc_model: :terrain)
       allow(container).to receive(:limits).and_return({})
       expect(container.data_status(segment, time)).to eq(nil)
     end


### PR DESCRIPTION
## Summary
- Replace `ArgsValidator` with Ruby keyword arguments in `DataEntryNode`, `ProjectedEffort`, `Segment`, `SegmentTimeCalculator`, and `SegmentTimesContainer`
- Remove deprecated `Segment` constructor params (`begin_sub_split`, `end_sub_split`, `begin_split`, `end_split`) and related validation code
- Update specs and segment factory for keyword args; fix all rubocop offenses

Closes #1679

## Test plan
- [x] All 89 specs pass across the 5 model spec files
- [x] Rubocop passes with no offenses on all changed files
- [ ] Verify no regressions in integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)