### PR TITLE
Remove ArgsValidator from presenter classes and add specs

### DIFF
--- a/app/presenters/effort_with_times_presenter.rb
+++ b/app/presenters/effort_with_times_presenter.rb
@@ -1,16 +1,16 @@
 class EffortWithTimesPresenter < EffortWithLapSplitRows
-  DEFAULT_DISPLAY_STYLE = "military_time"
-  VALID_DISPLAY_STYLES = %w(military_time elapsed_time absolute_time_local).freeze
+  DEFAULT_DISPLAY_STYLE = "military_time".freeze
+  VALID_DISPLAY_STYLES = %w[military_time elapsed_time absolute_time_local].freeze
   INPUTMASK_TYPES_BY_DISPLAY_STYLE = {
-      military_time: "military",
-      elapsed_time: "elapsed",
-      absolute_time_local: "datetime_us",
-  }
+    military_time: "military",
+    elapsed_time: "elapsed",
+    absolute_time_local: "datetime_us",
+  }.freeze
 
   def post_initialize(effort, args)
-    ArgsValidator.validate(subject: effort, params: args, required: [:params], exclusive: [:params], class: self.class)
     @effort = effort
     @params = args[:params] || {}
+    validate_setup
   end
 
   def autofocus_for_time_point?(time_point)
@@ -47,7 +47,7 @@ class EffortWithTimesPresenter < EffortWithLapSplitRows
     if suppress_form?
       "Elapsed times cannot be calculated. No start time is present."
     elsif elapsed_times?
-      "All times are elapsed since #{I18n.localize(actual_start_time_local, format: :full_day_military_and_zone)}"
+      "All times are elapsed since #{I18n.l(actual_start_time_local, format: :full_day_military_and_zone)}"
     else
       "All times are in #{home_time_zone}"
     end
@@ -73,7 +73,7 @@ class EffortWithTimesPresenter < EffortWithLapSplitRows
     field_value = field_value(time_point)
     return nil unless field_value
 
-    I18n.localize(field_value, format: :datetime_input)
+    I18n.l(field_value, format: :datetime_input)
   end
 
   def field_value(time_point)

--- a/app/presenters/effort_with_times_row_presenter.rb
+++ b/app/presenters/effort_with_times_row_presenter.rb
@@ -3,9 +3,9 @@ class EffortWithTimesRowPresenter < EffortWithLapSplitRows
 
   delegate :id, :event, :event_name, :split_times, :to_param, to: :effort
 
-  def post_initialize(effort, args)
-    ArgsValidator.validate(subject: effort, params: args, class: self.class)
+  def post_initialize(effort, _args)
     @effort = effort
+    validate_setup
   end
 
   def effort_times_row
@@ -36,6 +36,6 @@ class EffortWithTimesRowPresenter < EffortWithLapSplitRows
   end
 
   def event_presenter
-    @event_presenter ||= EventSpreadDisplay.new(event: event, params: {display_style: "all"})
+    @event_presenter ||= EventSpreadDisplay.new(event: event, params: { display_style: "all" })
   end
 end

--- a/app/presenters/event_with_efforts_presenter.rb
+++ b/app/presenters/event_with_efforts_presenter.rb
@@ -1,26 +1,23 @@
 class EventWithEffortsPresenter < BasePresenter
   include PagyPresenter
 
-  DEFAULT_ORDER_CRITERIA = { overall_rank: :asc, bib_number: :asc }
+  DEFAULT_ORDER_CRITERIA = { overall_rank: :asc, bib_number: :asc }.freeze
 
   attr_reader :event
 
   delegate :course_groups, to: :course
   delegate :id, :name, :course, :course_id, :simple?, :beacon_url, :home_time_zone, :finish_split,
            :start_split, :multiple_laps?, :to_param, :created_by, :new_record?, :event_group,
-           :ordered_events_within_group, :scheduled_start_time_local, :efforts_count, :notice_text, :notice_text?, to: :event
+           :ordered_events_within_group, :scheduled_start_time_local, :efforts_count,
+           :notice_text, :notice_text?, to: :event
   delegate :available_live, :available_live?, :concealed, :concealed?, :organization, :monitor_pacers?,
            :multiple_events?, to: :event_group
 
-  def initialize(args)
-    @event = args[:event]
-    @params = args[:params] || {}
-    @current_user = args[:current_user]
-    post_initialize(args)
-  end
-
-  def post_initialize(args)
-    ArgsValidator.validate(params: args, required: [:event, :params], exclusive: [:event, :params, :current_user], class: self.class)
+  def initialize(event:, params:, current_user: nil)
+    @event = event
+    @params = params
+    @current_user = current_user
+    validate_setup
   end
 
   def ranked_effort_rows
@@ -34,8 +31,8 @@ class EventWithEffortsPresenter < BasePresenter
     return @filtered_ranked_efforts if defined?(@filtered_ranked_efforts)
 
     scope = ranked_efforts
-      .where(filter_hash)
-      .search(search_text)
+            .where(filter_hash)
+            .search(search_text)
 
     @pagy, @filtered_ranked_efforts = pagy_from_scope(scope, limit: per_page, page: page)
     @filtered_ranked_efforts
@@ -92,5 +89,9 @@ class EventWithEffortsPresenter < BasePresenter
 
   def person_ids
     @person_ids ||= filtered_ranked_efforts.map(&:person_id).compact
+  end
+
+  def validate_setup
+    raise ArgumentError, "event_with_efforts_presenter must include event" unless event
   end
 end

--- a/spec/presenters/effort_with_times_presenter_spec.rb
+++ b/spec/presenters/effort_with_times_presenter_spec.rb
@@ -1,23 +1,24 @@
 require "rails_helper"
 
 RSpec.describe EffortWithTimesPresenter do
-  subject { EffortWithTimesPresenter.new(effort, params: params) }
+  subject { described_class.new(effort, params: params) }
+
   let(:effort) { build_stubbed(:effort) }
   let(:params) { ActionController::Parameters.new(params_hash) }
   let(:params_hash) { {} }
 
   describe "#initialize" do
-    context "given an effort and params object" do
+    context "when given an effort and params object" do
       it "initializes" do
         expect { subject }.not_to raise_error
       end
     end
 
-    context "if effort argument is not given" do
+    context "without an effort argument" do
       let(:effort) { nil }
 
       it "raises an error" do
-        expect { subject }.to raise_error(/must include a subject/)
+        expect { subject }.to raise_error(ArgumentError, /must include effort/)
       end
     end
   end
@@ -55,7 +56,7 @@ RSpec.describe EffortWithTimesPresenter do
 
   describe "#table_header" do
     context "when params[:display_style] == military_time" do
-      let(:params_hash) { {display_style: "military_time"} }
+      let(:params_hash) { { display_style: "military_time" } }
 
       it "returns a header indicating military times" do
         expect(subject.table_header).to eq("Military Times")
@@ -63,7 +64,7 @@ RSpec.describe EffortWithTimesPresenter do
     end
 
     context "when params[:display_style] == elapsed_time" do
-      let(:params_hash) { {display_style: "elapsed_time"} }
+      let(:params_hash) { { display_style: "elapsed_time" } }
 
       it "returns a header indicating elapsed times" do
         expect(subject.table_header).to eq("Elapsed Times")
@@ -73,7 +74,7 @@ RSpec.describe EffortWithTimesPresenter do
 
   describe "#working_field" do
     context "when params[:display_style] == elapsed_time" do
-      let(:params_hash) { {display_style: "military_time"} }
+      let(:params_hash) { { display_style: "military_time" } }
 
       it "returns :military_time" do
         expect(subject.working_field).to eq(:military_time)
@@ -81,7 +82,7 @@ RSpec.describe EffortWithTimesPresenter do
     end
 
     context "when params[:display_style] != military_time" do
-      let(:params_hash) { {display_style: ""} }
+      let(:params_hash) { { display_style: "" } }
 
       it "returns :military_time" do
         expect(subject.working_field).to eq(:military_time)

--- a/spec/presenters/effort_with_times_row_presenter_spec.rb
+++ b/spec/presenters/effort_with_times_row_presenter_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe EffortWithTimesRowPresenter do
+  subject { described_class.new(effort) }
+
+  let(:effort) { build_stubbed(:effort) }
+
+  describe "#initialize" do
+    context "when given an effort" do
+      it "initializes" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "without an effort argument" do
+      let(:effort) { nil }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(ArgumentError, /must include effort/)
+      end
+    end
+  end
+
+  describe "#effort_times_row_id" do
+    it "returns the effort id" do
+      expect(subject.effort_times_row_id).to eq(effort.id)
+    end
+  end
+end

--- a/spec/presenters/event_with_efforts_presenter_spec.rb
+++ b/spec/presenters/event_with_efforts_presenter_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
 RSpec.describe EventWithEffortsPresenter do
+  subject { described_class.new(event: event, params: prepared_params) }
+
   before { FactoryBot.reload }
 
-  subject { EventWithEffortsPresenter.new(event: event, params: prepared_params) }
   let(:event) { Event.new }
   let(:prepared_params) { create(:prepared_params) }
 
@@ -13,19 +14,19 @@ RSpec.describe EventWithEffortsPresenter do
     end
 
     it "raises an error if event argument is not given" do
-      expect { EventWithEffortsPresenter.new(params: prepared_params, random_param: 123) }
-          .to raise_error(/must include event/)
+      expect { described_class.new(params: prepared_params) }
+        .to raise_error(ArgumentError, /missing keyword/)
     end
 
-    it "raises an error if any argument other than event and params is given" do
-      expect { EventWithEffortsPresenter.new(event: event, params: prepared_params, random_param: 123) }
-          .to raise_error(/may not include random_param/)
+    it "raises an error if any unknown argument is given" do
+      expect { described_class.new(event: event, params: prepared_params, random_param: 123) }
+        .to raise_error(ArgumentError, /unknown keyword/)
     end
   end
 
   describe "#sort_hash" do
     it "returns a hash containing sort data" do
-      expect(subject.sort_hash).to eq({"name" => :asc, "age" => :desc})
+      expect(subject.sort_hash).to eq({ "name" => :asc, "age" => :desc })
     end
   end
 
@@ -43,7 +44,7 @@ RSpec.describe EventWithEffortsPresenter do
 
   describe "#filter_hash" do
     it "returns a hash containing filter requirements" do
-      expect(subject.filter_hash).to eq({"state_code" => %w[NM NY BC], "gender" => [1]})
+      expect(subject.filter_hash).to eq({ "state_code" => %w[NM NY BC], "gender" => [1] })
     end
   end
 end


### PR DESCRIPTION
Step 9 of #1639
Closes #1697

Replace ArgsValidator with validate_setup in EffortWithTimesPresenter and EffortWithTimesRowPresenter, and with keyword arguments in EventWithEffortsPresenter. Add spec for EffortWithTimesRowPresenter. Fix all rubocop offenses.