### PR TITLE
Use latest version of artifact github actions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -106,7 +106,7 @@ jobs:
           yarn build:css
 
       - name: Upload assets
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: built-assets
           path: app/assets/builds/
@@ -172,7 +172,7 @@ jobs:
         run: sudo apt-get install -y --no-install-recommends libvips42
 
       - name: Download assets
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: built-assets
           path: app/assets/builds/
@@ -217,7 +217,7 @@ jobs:
 
       - name: Save capybara screenshots as artifact
         if: failure() && contains(matrix.name, 'browser')
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: capybara-failure-screenshots-${{ matrix.name }}
           path: tmp/capybara/*.png

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20251229145334)
+DataMigrate::Data.define(version: 2025_12_29_145334)


### PR DESCRIPTION
We're seeing node deprecation warnings coming from the older version of the artifact actions, so we're bumping them:
- `upload-artifact@v5` -> `upload-artifact@v7`
- `download-artifact@v5` -> `download-artifact@v8`