### PR TITLE
Point docs/_config.yml at docs.opensplittime.org

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,8 +1,8 @@
 # Site settings
 title: OpenSplitTime Documentation
 description: Documentation for OpenSplitTime, the free, open-source ultrarunning event management system
-url: "https://splittime.github.io" # Production URL
-baseurl: "/OpenSplitTime" # Subpath for GitHub Pages
+url: "docs.opensplittime.org" # Production URL
+baseurl: "" # Subpath not needed; github.io figures it out
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
We've switched the docs site over to `docs.opensplittime.org`, so now we need to point `docs/_config.yml` there.

Relates to #1647