### PR TITLE
Use port 2525 and https for email in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,11 +14,11 @@ Rails.application.configure do
   config.eager_load = true
 
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default_url_options = { host: "opensplittime.org", protocol: "http" }
+  config.action_mailer.default_url_options = { host: "opensplittime.org", protocol: "https" }
 
   config.action_mailer.smtp_settings = {
     address: "smtp.sendgrid.net",
-    port: "587",
+    port: "2525",
     authentication: :plain,
     user_name: "apikey",
     password: ::OstConfig.sendgrid_api_key,


### PR DESCRIPTION
These changes are needed to use OST running on digital ocean servers.