### PR TITLE
Fix syntax error in `config/scout_apm.yml`

### DIFF
--- a/config/scout_apm.yml
+++ b/config/scout_apm.yml
@@ -28,7 +28,7 @@ common: &defaults
 
   # name: Application name in APM Web UI
   # - Default: the application names comes from the Rails or Sinatra class name
-   name: <%= ::OstConfig.scout_apm_app_name %>
+  name: <%= ::OstConfig.scout_apm_app_name %>
 
   # monitor: Enable Scout APM or not
   # - Default: none


### PR DESCRIPTION
An extra space was causing the scout config file not to load