### PR TITLE
Disable search engine indexing of pages with personal information

### DIFF
--- a/app/views/event_groups/index.html.erb
+++ b/app/views/event_groups/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :robots_meta, "nofollow" %>
 <% content_for :title do %>
   <% if params[:search].present? %>
     <% "OpenSplitTime: Search events - #{params[:search]}" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title><%= content_for?(:title) ? yield(:title) : "OpenSplitTime" %></title>
   <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "OpenSplitTime" %>">
+  <%= tag.meta(name: "robots", content: yield(:robots_meta)) if content_for?(:robots_meta) %>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
   <%= render "layouts/google_maps_api_js" %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :robots_meta, "nofollow" %>
 <% content_for :title do %>
   <% "OpenSplitTime: List organizations" %>
 <% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :robots_meta, "noindex" %>
 <% content_for :title do %>
   <% "OpenSplitTime: Organization - #{@presenter.name}" %>
 <% end %>

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for :robots_meta, "nofollow" %>
 <% content_for :title do %>
     <% if params[:search].present? %>
         <% "OpenSplitTime: Search people - #{params[:search]}" %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :robots_meta, "noindex" %>
 <% content_for :title do %>
   <% "OpenSplitTime: Show person - #{@presenter.full_name}" %>
 <% end %>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,8 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
+Allow: /people/$
+Allow: /event_groups/$
+Allow: /organizations/$
+Disallow: /people/
+Disallow: /event_groups/
+Disallow: /organizations/
+Disallow: /api/


### PR DESCRIPTION
## Summary
- Updates `robots.txt` to block crawlers from detail pages under `/people/`, `/event_groups/`, `/organizations/`, and `/api/` while allowing listing pages
- Adds `nofollow` meta tags to listing pages so crawlers don't follow links to detail pages
- Adds `noindex` meta tags to detail pages (`people/show`, `organizations/show`) as a stronger guarantee they won't appear in search results
- Adds a `content_for :robots_meta` mechanism in the application layout for per-page meta tag control

Closes #1768

## Test plan
- [x] Visit `/robots.txt` and confirm the rules are present
- [x] View source on `/people` — confirm `<meta name="robots" content="nofollow">`
- [x] View source on `/people/:id` — confirm `<meta name="robots" content="noindex">`
- [x] View source on `/` (home) — confirm no robots meta tag is present
- [x] Repeat for `/event_groups` and `/organizations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)