### PR TITLE
Ignore CookieOverflow errors in ScoutAPM

### DIFF
--- a/config/scout_apm.yml
+++ b/config/scout_apm.yml
@@ -39,6 +39,7 @@ common: &defaults
     - ActiveRecord::RecordNotFound
     - ActionController::RoutingError
     - ActionController::InvalidAuthenticityToken
+    - ActionDispatch::Cookies::CookieOverflow
 
 production:
   <<: *defaults


### PR DESCRIPTION
## Summary
- Add `ActionDispatch::Cookies::CookieOverflow` to the ScoutAPM ignored exceptions list to reduce noise in error tracking.

## Test plan
- [ ] Verify ScoutAPM no longer reports CookieOverflow errors in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)