### PR TITLE
Find event group by slug in raceresult webhook

### DIFF
--- a/app/services/interactors/webhooks/process_raceresult_webhook.rb
+++ b/app/services/interactors/webhooks/process_raceresult_webhook.rb
@@ -1,93 +1,99 @@
-module Interactors::Webhooks
-  class ProcessRaceresultWebhook
-    include Interactors::Errors
+module Interactors
+  module Webhooks
+    class ProcessRaceresultWebhook
+      include Interactors::Errors
 
-    class ParsingError < StandardError; end
+      class ParsingError < StandardError; end
 
-    # The raw data is expected to be in the format: JSON_DATA;EVENT_GROUP_NAME
-    def self.call(raw)
-      new(raw).call
-    end
+      # The raw data is expected to be in the format: JSON_DATA;EVENT_GROUP_NAME
+      def self.call(raw)
+        new(raw).call
+      end
 
-    def initialize(raw)
-      @raw = raw
-      @errors = []
-    end
+      def initialize(raw)
+        @raw = raw
+        @errors = []
+      end
 
-    def call
-      parse_raw
-      find_event_group
-      process_data
-      build_raw_time
-      save_raw_time
-      submit_raw_time
+      def call
+        parse_raw
+        find_event_group
+        process_data
+        build_raw_time
+        save_raw_time
+        submit_raw_time
 
-      Interactors::Response.new(errors, "", [raw_time])
-    rescue ParsingError => e
-      errors << raceresult_parsing_error(e.message)
-      Interactors::Response.new(errors, "", [])
-    end
+        Interactors::Response.new(errors, "", [raw_time])
+      rescue ParsingError => e
+        errors << raceresult_parsing_error(e.message)
+        Interactors::Response.new(errors, "", [])
+      end
 
-    private
+      private
 
-    attr_reader :raw
-    attr_accessor :raw_attributes, :processed_attributes, :raw_time, :event_group_name, :event_group, :errors
+      attr_reader :raw
+      attr_accessor :raw_attributes, :processed_attributes, :raw_time, :event_group_name, :event_group, :errors
 
-    def parse_raw
-      parts = raw.split(';')
-      raise ParsingError, "Invalid format: expected JSON;EVENT_GROUP_NAME" if parts.size != 2
-      raise ParsingError, "JSON data cannot be blank" if parts.first.blank?
-      self.raw_attributes = JSON.parse(parts.first)  # Automatically raises JSON::ParserError if invalid
-      raise ParsingError, "JSON data cannot be empty" if raw_attributes.blank?
-      self.event_group_name = parts.last.to_s.strip
-      raise ParsingError, "Event group name cannot be blank" if event_group_name.blank?
-    end
+      def parse_raw
+        parts = raw.split(";")
+        raise ParsingError, "Invalid format: expected JSON;EVENT_GROUP_NAME" if parts.size != 2
 
-    def find_event_group
-      self.event_group = EventGroup.find_by(name: event_group_name)
-      raise ParsingError, "Event group not found: #{event_group_name}" unless event_group
-    end
+        raise ParsingError, "JSON data cannot be blank" if parts.first.blank?
 
-    def process_data
-      self.processed_attributes = {
-        bib: raw_attributes["Bib"],
-        utc_time: raw_attributes.dig("Passing", "UTCTime"),
-        device_id: raw_attributes.dig("Passing", "DeviceID"),
-        timing_point: raw_attributes["TimingPoint"],
-        id: raw_attributes["ID"]
-      }
-      raise ParsingError, "Missing required field: Bib" if processed_attributes[:bib].blank?
-      raise ParsingError, "Missing required field: TimingPoint" if processed_attributes[:timing_point].blank?
-      raise ParsingError, "Missing required field: Passing.UTCTime" if processed_attributes[:utc_time].blank?
-      raise ParsingError, "Missing required field: ID" if processed_attributes[:id].blank?
-    end
+        self.raw_attributes = JSON.parse(parts.first) # Automatically raises JSON::ParserError if invalid
 
-    def build_raw_time
-      self.raw_time = RawTime.new(
-        event_group: event_group,
-        bib_number: processed_attributes[:bib],
-        split_name: processed_attributes[:timing_point],
-        entered_time: processed_attributes[:utc_time],
-        bitkey: SubSplit::IN_BITKEY,
-        source: "raceresult_webhook",
-        created_by: nil
-      )
-    end
+        raise ParsingError, "JSON data cannot be empty" if raw_attributes.blank?
 
-    def save_raw_time
-      raw_time.save!
-    end
+        self.event_group_name = parts.last.to_s.strip
+        raise ParsingError, "Event group name cannot be blank" if event_group_name.blank?
+      end
 
-    def submit_raw_time
-      raw_time_rows = RowifyRawTimes.build(event_group: event_group, raw_times: [raw_time])
+      def find_event_group
+        self.event_group = EventGroup.find_by(slug: event_group_name.parameterize)
+        raise ParsingError, "Event group not found: #{event_group_name}" unless event_group
+      end
 
-      Interactors::SubmitRawTimeRows.perform!(
-        raw_time_rows: raw_time_rows,
-        event_group: event_group,
-        force_submit: false,
-        mark_as_reviewed: false,
-        current_user_id: nil
-      )
+      def process_data
+        self.processed_attributes = {
+          bib: raw_attributes["Bib"],
+          utc_time: raw_attributes.dig("Passing", "UTCTime"),
+          device_id: raw_attributes.dig("Passing", "DeviceID"),
+          timing_point: raw_attributes["TimingPoint"],
+          id: raw_attributes["ID"]
+        }
+        raise ParsingError, "Missing required field: Bib" if processed_attributes[:bib].blank?
+        raise ParsingError, "Missing required field: TimingPoint" if processed_attributes[:timing_point].blank?
+        raise ParsingError, "Missing required field: Passing.UTCTime" if processed_attributes[:utc_time].blank?
+        raise ParsingError, "Missing required field: ID" if processed_attributes[:id].blank?
+      end
+
+      def build_raw_time
+        self.raw_time = RawTime.new(
+          event_group: event_group,
+          bib_number: processed_attributes[:bib],
+          split_name: processed_attributes[:timing_point],
+          entered_time: processed_attributes[:utc_time],
+          bitkey: SubSplit::IN_BITKEY,
+          source: "raceresult_webhook",
+          created_by: nil
+        )
+      end
+
+      def save_raw_time
+        raw_time.save!
+      end
+
+      def submit_raw_time
+        raw_time_rows = RowifyRawTimes.build(event_group: event_group, raw_times: [raw_time])
+
+        Interactors::SubmitRawTimeRows.perform!(
+          raw_time_rows: raw_time_rows,
+          event_group: event_group,
+          force_submit: false,
+          mark_as_reviewed: false,
+          current_user_id: nil
+        )
+      end
     end
   end
 end

--- a/spec/services/interactors/webhooks/process_raceresult_webhook_spec.rb
+++ b/spec/services/interactors/webhooks/process_raceresult_webhook_spec.rb
@@ -1,0 +1,161 @@
+require "rails_helper"
+
+RSpec.describe Interactors::Webhooks::ProcessRaceresultWebhook do
+  include BitkeyDefinitions
+
+  let(:raw) { "#{json_data};#{event_group.name}" }
+  let(:event_group) { event_groups(:hardrock_2014) }
+
+  let(:json_data) do
+    {
+      "Bib" => bib,
+      "TimingPoint" => timing_point,
+      "ID" => id,
+      "Passing" => {
+        "UTCTime" => utc_time,
+        "DeviceID" => device_id
+      }
+    }.to_json
+  end
+
+  let(:bib) { "101" }
+  let(:timing_point) { "Aid 1" }
+  let(:id) { 12_345 }
+  let(:utc_time) { "2014-07-11T10:45:00Z" }
+  let(:device_id) { "device_1" }
+
+  describe ".call" do
+    let(:result) { described_class.call(raw) }
+
+    context "when given valid data" do
+      before do
+        allow(RowifyRawTimes).to receive(:build).and_return([])
+        allow(Interactors::SubmitRawTimeRows).to receive(:perform!)
+      end
+
+      it "returns a successful response with a raw_time" do
+        expect(result.errors).to be_empty
+        expect(result.resources.size).to eq(1)
+      end
+
+      it "creates a RawTime record" do
+        expect { result }.to change(RawTime, :count).by(1)
+      end
+
+      it "creates a RawTime with the correct attributes" do
+        result
+        raw_time = RawTime.last
+
+        expect(raw_time.event_group).to eq(event_group)
+        expect(raw_time.bib_number).to eq("101")
+        expect(raw_time.split_name).to eq("Aid 1")
+        expect(raw_time.entered_time).to eq("2014-07-11T10:45:00Z")
+        expect(raw_time.bitkey).to eq(SubSplit::IN_BITKEY)
+        expect(raw_time.source).to eq("raceresult_webhook")
+      end
+
+      it "submits the raw time" do
+        result
+
+        expect(RowifyRawTimes).to have_received(:build)
+        expect(Interactors::SubmitRawTimeRows).to have_received(:perform!)
+      end
+
+      context "when the event group is identified by slug" do
+        let(:raw) { "#{json_data};#{event_group.slug}" }
+
+        it "finds the event group" do
+          expect(result.errors).to be_empty
+          expect(result.resources.size).to eq(1)
+        end
+      end
+    end
+
+    context "when the raw data format is invalid" do
+      it "returns an error when there is no semicolon separator" do
+        result = described_class.call("just_some_data")
+
+        expect(result.errors).to be_present
+        expect(result.resources).to be_empty
+      end
+
+      it "returns an error when there are too many semicolons" do
+        result = described_class.call("a;b;c")
+
+        expect(result.errors).to be_present
+        expect(result.resources).to be_empty
+      end
+    end
+
+    context "when the JSON is invalid" do
+      let(:raw) { "not_json;#{event_group.name}" }
+
+      it "raises a JSON::ParserError" do
+        expect { result }.to raise_error(JSON::ParserError)
+      end
+    end
+
+    context "when the JSON is empty" do
+      let(:raw) { "{};#{event_group.name}" }
+
+      it "returns an error" do
+        expect(result.errors).to be_present
+        expect(result.resources).to be_empty
+      end
+    end
+
+    context "when the event group name is blank" do
+      let(:raw) { "#{json_data}; " }
+
+      it "returns an error" do
+        expect(result.errors).to be_present
+        expect(result.resources).to be_empty
+      end
+    end
+
+    context "when the event group is not found" do
+      let(:raw) { "#{json_data};Nonexistent Group" }
+
+      it "returns an error" do
+        expect(result.errors).to be_present
+        expect(result.resources).to be_empty
+      end
+    end
+
+    context "when Bib is missing" do
+      let(:bib) { nil }
+
+      it "returns an error" do
+        expect(result.errors).to be_present
+        expect(result.resources).to be_empty
+      end
+    end
+
+    context "when TimingPoint is missing" do
+      let(:timing_point) { nil }
+
+      it "returns an error" do
+        expect(result.errors).to be_present
+        expect(result.resources).to be_empty
+      end
+    end
+
+    context "when Passing.UTCTime is missing" do
+      let(:utc_time) { nil }
+
+      it "returns an error" do
+        expect(result.errors).to be_present
+        expect(result.resources).to be_empty
+      end
+    end
+
+    context "when ID is missing" do
+      let(:id) { nil }
+
+      it "returns an error" do
+        expect(result.errors).to be_present
+        expect(result.resources).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Parameterize the incoming event group name and look up by slug instead of by name, so both `"Hardrock 2014"` and `"hardrock-2014"` resolve correctly
- Add spec for `ProcessRaceresultWebhook` covering happy path, slug lookup, parsing errors, and missing fields
- Fix RuboCop offenses in the service file (nested module style, string literals, guard clause spacing)

## Test plan
- [x] All 15 examples pass in `process_raceresult_webhook_spec.rb`
- [ ] Verify webhook processing works end-to-end with a real or simulated raceresult payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)