### PR TITLE
Add Analytics::MailgunEvent STI subclass

### DIFF
--- a/app/models/analytics/mailgun_event.rb
+++ b/app/models/analytics/mailgun_event.rb
@@ -1,0 +1,7 @@
+module ::Analytics
+  class MailgunEvent < EmailEvent
+    alias_attribute :mailgun_event_id, :provider_event_id
+    alias_attribute :mailgun_message_id, :provider_message_id
+    alias_attribute :recipient, :email
+  end
+end

--- a/spec/models/analytics/mailgun_event_spec.rb
+++ b/spec/models/analytics/mailgun_event_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe ::Analytics::MailgunEvent do
+  it "inherits from EmailEvent" do
+    expect(described_class.superclass).to eq(Analytics::EmailEvent)
+  end
+
+  it "sets type automatically via STI" do
+    event = described_class.new
+    expect(event.type).to eq("Analytics::MailgunEvent")
+  end
+
+  it "aliases mailgun_event_id to provider_event_id" do
+    event = described_class.new(mailgun_event_id: "abc123")
+    expect(event.provider_event_id).to eq("abc123")
+  end
+
+  it "aliases mailgun_message_id to provider_message_id" do
+    event = described_class.new(mailgun_message_id: "msg456")
+    expect(event.provider_message_id).to eq("msg456")
+  end
+
+  it "aliases recipient to email" do
+    event = described_class.new(recipient: "user@example.com")
+    expect(event.email).to eq("user@example.com")
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Analytics::MailgunEvent` inheriting from `Analytics::EmailEvent` via STI
- Maps Mailgun webhook field names to generic columns via `alias_attribute`:
  - `mailgun_event_id` → `provider_event_id`
  - `mailgun_message_id` → `provider_message_id`
  - `recipient` → `email`
- Part of email provider migration per #1763

## Test plan
- [x] Model specs pass (5 examples, 0 failures)
- [x] Rubocop passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)