### PR TITLE
Improve Madmin email events index display

### DIFF
--- a/app/madmin/resources/analytics/email_event_resource.rb
+++ b/app/madmin/resources/analytics/email_event_resource.rb
@@ -2,32 +2,27 @@ module Analytics
   class EmailEventResource < Madmin::Resource
     # Attributes
     attribute :id, form: false
-    attribute :email
-    attribute :timestamp
-    attribute :smtp_id
-    attribute :event
-    attribute :category
-    attribute :provider_event_id
-    attribute :provider_message_id
-    attribute :reason
-    attribute :status
-    attribute :ip
-    attribute :response
-    attribute :event_type
-    attribute :useragent
-    attribute :type
-    attribute :created_at, form: false
-    attribute :updated_at, form: false
+    attribute :type, index: true
+    attribute :email, index: true
+    attribute :event, index: true
+    attribute :timestamp, index: true
+    attribute :status, index: true
+    attribute :reason, index: true
+    attribute :response, index: false
+    attribute :ip, index: false
+    attribute :useragent, index: false
+    attribute :smtp_id, index: false
+    attribute :category, index: false
+    attribute :event_type, index: false
+    attribute :provider_event_id, index: false
+    attribute :provider_message_id, index: false
+    attribute :created_at, form: false, index: false
+    attribute :updated_at, form: false, index: false
 
     # Associations
 
-    # Uncomment this to customize the display name of records in the admin area.
-    # def self.display_name(record)
-    #   record.name
-    # end
-
     def self.default_sort_column
-      "timestamp"
+      "created_at"
     end
 
     def self.default_sort_direction

--- a/app/madmin/resources/analytics/email_event_resource.rb
+++ b/app/madmin/resources/analytics/email_event_resource.rb
@@ -16,7 +16,7 @@ module Analytics
     attribute :event_type, index: false
     attribute :provider_event_id, index: false
     attribute :provider_message_id, index: false
-    attribute :created_at, form: false, index: false
+    attribute :created_at, form: false, index: true
     attribute :updated_at, form: false, index: false
 
     # Associations

--- a/app/madmin/resources/analytics/email_event_resource.rb
+++ b/app/madmin/resources/analytics/email_event_resource.rb
@@ -2,12 +2,12 @@ module Analytics
   class EmailEventResource < Madmin::Resource
     # Attributes
     attribute :id, form: false
-    attribute :type, index: true
     attribute :email, index: true
     attribute :event, index: true
     attribute :timestamp, index: true
     attribute :status, index: true
     attribute :reason, index: true
+    attribute :type, index: true
     attribute :response, index: false
     attribute :ip, index: false
     attribute :useragent, index: false


### PR DESCRIPTION
## Summary
- Show useful columns on the index: type, email, event, timestamp, status, reason
- Hide detail-only columns from index: response, IP, user-agent, smtp_id, provider IDs, timestamps
- Sort by `created_at desc` for reliable ordering

## Test plan
- [ ] Verify `/madmin/analytics/email_events` shows a readable index with recent events at the top
- [ ] Verify clicking into a record shows all fields on the detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)