### PR TITLE
Honor hide_age on person and effort displays

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -296,6 +296,16 @@ class Effort < ApplicationRecord
     @current_age_approximate ||= age && (((Time.current - calculated_start_time) / 1.year) + age).round
   end
 
+  def bio_historic
+    return [gender&.titlecase].compact.join(", ") if person&.hide_age?
+
+    super
+  end
+
+  def display_age
+    person&.hide_age? ? nil : age
+  end
+
   def unreconciled?
     person_id.nil?
   end

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -297,7 +297,7 @@ class Effort < ApplicationRecord
   end
 
   def bio_historic
-    return [gender&.titlecase].compact.join(", ") if person&.hide_age?
+    return gender&.titlecase if person&.hide_age?
 
     super
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -85,6 +85,12 @@ class Person < ApplicationRecord
     Person.where(id: id).with_age_and_effort_count.order(:id).first&.current_age_from_efforts
   end
 
+  def current_age
+    return nil if hide_age?
+
+    super
+  end
+
   def unclaimed?
     claimant.nil?
   end

--- a/app/parameters/person_parameters.rb
+++ b/app/parameters/person_parameters.rb
@@ -1,6 +1,7 @@
 class PersonParameters < BaseParameters
   def self.permitted
-    [:id, :slug, :city, :state_code, :country_code, :first_name, :last_name, :gender, :email, :phone, :birthdate, :concealed, :photo]
+    [:id, :slug, :city, :state_code, :country_code, :first_name, :last_name, :gender, :email, :phone, :birthdate,
+     :concealed, :hide_age, :photo]
   end
 
   def self.permitted_query

--- a/app/serializers/api/v1/effort_serializer.rb
+++ b/app/serializers/api/v1/effort_serializer.rb
@@ -9,8 +9,7 @@ module Api
                             :emergency_contact,
                             :emergency_phone].freeze
 
-      attributes :age,
-                 :beacon_url,
+      attributes :beacon_url,
                  :bib_number,
                  :city,
                  :country_code,
@@ -26,6 +25,14 @@ module Api
                  :report_url,
                  :scheduled_start_time,
                  :state_code
+
+      attribute :age do |effort, params|
+        if effort.person&.hide_age? && !params[:current_user]&.authorized_to_edit?(effort)
+          nil
+        else
+          effort.age
+        end
+      end
 
       PRIVATE_ATTRIBUTES.each do |att|
         attribute att, if: proc { |effort, params|

--- a/app/serializers/api/v1/person_serializer.rb
+++ b/app/serializers/api/v1/person_serializer.rb
@@ -12,10 +12,17 @@ module Api
                  :last_name,
                  :full_name,
                  :gender,
-                 :current_age,
                  :city,
                  :state_code,
                  :country_code
+
+      attribute :current_age do |person, params|
+        if person.hide_age? && !params[:current_user]&.authorized_to_edit?(person)
+          nil
+        else
+          person.current_age_from_birthdate || person.current_age_approximate
+        end
+      end
 
       PRIVATE_ATTRIBUTES.each do |att|
         attribute att, if: proc { |effort, params|

--- a/app/views/efforts/_efforts_list_person.html.erb
+++ b/app/views/efforts/_efforts_list_person.html.erb
@@ -19,7 +19,7 @@
     <tr>
       <td><strong><%= link_to effort.event.name, effort_path(effort) %></strong></td>
       <td><%= effort.state_and_country %></td>
-      <td><%= effort.age %></td>
+      <td><%= effort.display_age %></td>
       <td><%= l(effort.event.scheduled_start_time.to_date, format: :full_with_weekday) %></td>
       <td class="text-end"><%= text_with_status_indicator(effort.finish_status, effort.data_status, data_type: :effort_time_data) %></td>
       <% if current_user&.admin? %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -25,6 +25,10 @@
         <%= f.label :birthdate, class: "mb-1" %>
         <%= f.datepicker_field :birthdate %>
       </div>
+      <div class="col-md-4 mb-3 align-self-end">
+        <%= f.label :hide_age, "Hide my age on public pages", class: "me-2" %>
+        <%= f.check_box :hide_age %>
+      </div>
     </div>
 
     <div class="row">

--- a/spec/models/effort_spec.rb
+++ b/spec/models/effort_spec.rb
@@ -552,4 +552,49 @@ RSpec.describe Effort, type: :model do
       end
     end
   end
+
+  describe "hide_age behavior" do
+    let(:effort) { build_stubbed(:effort, age: 45, gender: "female", person: person) }
+
+    context "when person is nil" do
+      let(:person) { nil }
+
+      it "returns the effort's age via display_age" do
+        expect(effort.display_age).to eq(45)
+      end
+
+      it "includes age in bio_historic" do
+        expect(effort.bio_historic).to eq("Female, 45")
+      end
+    end
+
+    context "when the linked person has hide_age set" do
+      let(:person) { build_stubbed(:person, hide_age: true) }
+
+      it "returns nil from display_age" do
+        expect(effort.display_age).to be_nil
+      end
+
+      it "omits age from bio_historic" do
+        expect(effort.bio_historic).to eq("Female")
+      end
+
+      it "leaves the raw age attribute untouched for internal uses" do
+        expect(effort.age).to eq(45)
+        expect(effort.template_age).to eq(45)
+      end
+    end
+
+    context "when the linked person has hide_age false" do
+      let(:person) { build_stubbed(:person, hide_age: false) }
+
+      it "returns the effort's age via display_age" do
+        expect(effort.display_age).to eq(45)
+      end
+
+      it "includes age in bio_historic" do
+        expect(effort.bio_historic).to eq("Female, 45")
+      end
+    end
+  end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Person, type: :model do
 
   describe "#initialize" do
     it "saves a generic factory-created record to the database" do
-      expect { create(:person) }.to change { Person.count }.by(1)
+      expect { create(:person) }.to change(described_class, :count).by(1)
     end
 
     it "is valid when created with a first_name, a last_name, and a gender" do
@@ -46,7 +46,7 @@ RSpec.describe Person, type: :model do
     it "rejects invalid email" do
       bad_emails = %w[johnny@appleseed appleseed.com johnny@.com johnny]
       bad_emails.each do |email|
-        person = Person.new(email: email)
+        person = described_class.new(email: email)
         expect(person).not_to be_valid
         expect(person.errors[:email]).to include("is invalid")
       end
@@ -61,7 +61,7 @@ RSpec.describe Person, type: :model do
       bad_birthdates = { "1880-01-01" => "can't be before 1900",
                          1.day.from_now => "can't be today or in the future" }
       bad_birthdates.each do |birthdate, error_message|
-        person = Person.new(birthdate: birthdate)
+        person = described_class.new(birthdate: birthdate)
         expect(person).not_to be_valid
         expect(person.errors[:birthdate]).to include(error_message)
       end
@@ -88,6 +88,30 @@ RSpec.describe Person, type: :model do
       good_phone_numbers.each do |phone|
         person = build_stubbed(:person, phone: phone)
         expect(person).to be_valid
+      end
+    end
+  end
+
+  describe "#current_age" do
+    let(:person) { build_stubbed(:person, birthdate: 40.years.ago.to_date, hide_age: hide_age) }
+
+    context "when hide_age is false" do
+      let(:hide_age) { false }
+
+      it "returns the age derived from birthdate" do
+        expect(person.current_age).to eq(40)
+      end
+    end
+
+    context "when hide_age is true" do
+      let(:hide_age) { true }
+
+      it "returns nil" do
+        expect(person.current_age).to be_nil
+      end
+
+      it "still exposes the raw age via current_age_from_birthdate" do
+        expect(person.current_age_from_birthdate).to eq(40)
       end
     end
   end

--- a/spec/serializers/api/v1/effort_serializer_spec.rb
+++ b/spec/serializers/api/v1/effort_serializer_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::EffortSerializer do
+  subject(:attributes) { described_class.new(effort, params: { current_user: current_user }).serializable_hash[:data][:attributes] }
+
+  let(:effort) { build_stubbed(:effort, age: 45, person: person) }
+
+  context "when the linked person has hide_age false" do
+    let(:person) { build_stubbed(:person, hide_age: false) }
+    let(:current_user) { nil }
+
+    it "exposes age" do
+      expect(attributes[:age]).to eq(45)
+    end
+  end
+
+  context "when the effort has no linked person" do
+    let(:person) { nil }
+    let(:current_user) { nil }
+
+    it "exposes age" do
+      expect(attributes[:age]).to eq(45)
+    end
+  end
+
+  context "when the linked person has hide_age true" do
+    let(:person) { build_stubbed(:person, hide_age: true) }
+
+    context "with no current_user" do
+      let(:current_user) { nil }
+
+      it "returns nil for age" do
+        expect(attributes[:age]).to be_nil
+      end
+    end
+
+    context "with a non-admin current_user" do
+      let(:current_user) { build_stubbed(:user) }
+
+      it "returns nil for age" do
+        expect(attributes[:age]).to be_nil
+      end
+    end
+
+    context "with an admin current_user" do
+      let(:current_user) { build_stubbed(:admin) }
+
+      it "exposes the real age" do
+        expect(attributes[:age]).to eq(45)
+      end
+    end
+  end
+end

--- a/spec/serializers/api/v1/person_serializer_spec.rb
+++ b/spec/serializers/api/v1/person_serializer_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::PersonSerializer do
+  subject(:attributes) { described_class.new(person, params: { current_user: current_user }).serializable_hash[:data][:attributes] }
+
+  let(:person) { build_stubbed(:person, birthdate: 40.years.ago.to_date, hide_age: hide_age) }
+
+  context "when hide_age is false" do
+    let(:hide_age) { false }
+    let(:current_user) { nil }
+
+    it "exposes currentAge" do
+      expect(attributes[:currentAge]).to eq(40)
+    end
+  end
+
+  context "when hide_age is true" do
+    let(:hide_age) { true }
+
+    context "with no current_user" do
+      let(:current_user) { nil }
+
+      it "returns nil for currentAge" do
+        expect(attributes[:currentAge]).to be_nil
+      end
+    end
+
+    context "with a non-admin current_user" do
+      let(:current_user) { build_stubbed(:user) }
+
+      it "returns nil for currentAge" do
+        expect(attributes[:currentAge]).to be_nil
+      end
+    end
+
+    context "with an admin current_user" do
+      let(:current_user) { build_stubbed(:admin) }
+
+      it "exposes the real currentAge" do
+        expect(attributes[:currentAge]).to eq(40)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #1843. Part of #1841.

## Summary
- `Person#current_age` returns nil when `hide_age?`.
- `Effort#bio_historic` drops the age segment, and `Effort#display_age` exposes the same gated value for views that render the age column directly.
- Person and Effort API serializers return nil for `currentAge` / `age` unless the viewer `authorized_to_edit?` the record (admins / stewards / owners).
- Person edit form has a "Hide my age on public pages" checkbox; `:hide_age` permitted through the params whitelist. The person edit page is reachable by admins and by the claimant (`PersonPolicy#edit?`).
- Raw `age` column on efforts left untouched so age-category award logic (`Results::Compute#template_age`) keeps working.

## Public surfaces audited
All public HTML surfaces displaying age/bio go through either `Person#current_age` or `Effort#bio_historic` (finish_history, spread, podium, course/course_group best efforts, people list, effort history) and are handled by the two model overrides. Lottery entrant pages already suppressed age via `LotteryEntrant#current_age_approximate => nil`. All CSV exports (`_ultrasignup`, `_itra`, `_finishers`, `_spread`, lottery `export_entrants`) require controller-level authorization and are intentionally left alone.

## Test plan
- [x] `bundle exec rspec spec/models/person_spec.rb spec/models/effort_spec.rb spec/models/effort_row_spec.rb spec/serializers/api/v1/`
- [x] New model specs cover `Person#current_age`, `Effort#bio_historic`, `Effort#display_age`, and that the raw `age` attribute is preserved for internal consumers like `template_age`.
- [x] New serializer specs cover `PersonSerializer` and `EffortSerializer` with `hide_age` off, `hide_age` on + anonymous viewer, `hide_age` on + non-admin viewer, and `hide_age` on + admin viewer.
- [x] Rubocop clean on touched files
- [ ] Manual QA after merge: toggle hide_age from the person edit form, verify the person show page, effort history, people index, and `/api/v1/people/:id.json` all suppress age for anonymous viewers while admins still see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)