### PR TITLE
Bust event caches when a person toggles hide_age

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -47,6 +47,8 @@ class Person < ApplicationRecord
   validates :user_id, uniqueness: true, allow_blank: true
   validates_with BirthdateValidator
 
+  after_update_commit :touch_related_events, if: :saved_change_to_hide_age?
+
   # This method needs to extract ids and run a new search to remain compatible
   # with the scope `.with_age_and_effort_count`.
   def self.search(param)
@@ -104,6 +106,13 @@ class Person < ApplicationRecord
   end
 
   private
+
+  # Invalidate cached public views (e.g. events/spread) that key on event.
+  # Touch events directly rather than efforts because Effort#after_touch
+  # triggers an expensive performance-data recalc we don't need here.
+  def touch_related_events
+    Event.where(id: efforts.select(:event_id)).touch_all
+  end
 
   def generate_new_topic_resource?
     true

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -115,4 +115,29 @@ RSpec.describe Person, type: :model do
       end
     end
   end
+
+  describe "cache busting when hide_age changes" do
+    let(:person) { create(:person, hide_age: false) }
+    let(:effort) { efforts(:hardrock_2014_finished_first) }
+
+    before do
+      effort.update_columns(person_id: person.id)
+    end
+
+    it "touches the event when hide_age changes so public caches invalidate" do
+      original = effort.event.updated_at
+      travel 1.second do
+        person.update!(hide_age: true)
+      end
+      expect(effort.event.reload.updated_at).to be > original
+    end
+
+    it "does not touch the event when unrelated attributes change" do
+      original = effort.event.updated_at
+      travel 1.second do
+        person.update!(city: "Boulder")
+      end
+      expect(effort.event.reload.updated_at).to eq(original)
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to #1843 / #1841.

## Summary
When a person toggles `hide_age`, the cached `events/spread` fragment (keyed on the event) doesn't regenerate, so anonymous visitors keep seeing stale age data. This adds an `after_update_commit` on Person that touches each related event when `hide_age` changes, invalidating the cache.

## Why touch events directly, not cascade through efforts
`Effort#belongs_to :event, touch: true` does cascade, but `Effort#after_touch` triggers `Results::SetEffortPerformanceData` — an expensive recalc we don't need for a visibility toggle. The only cached public surface is keyed on `event`, so we touch events directly in one query.

## Test plan
- [x] `bundle exec rspec spec/models/person_spec.rb`
- [x] Unit tests cover: event gets touched when `hide_age` changes; event is NOT touched when an unrelated attribute changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)