### PR TITLE
Document hide_age option in privacy policy and docs

### DIFF
--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -28,6 +28,11 @@
       <div class="col-md-4 mb-3 align-self-end">
         <%= f.label :hide_age, "Hide my age on public pages", class: "me-2" %>
         <%= f.check_box :hide_age %>
+        <div class="form-text">
+          Suppresses age on your public profile, effort history, and in API responses.
+          Your birthdate is still stored and used for age-group scoring, so if an event
+          places you in an age category (e.g. "M40-49"), that category is still visible.
+        </div>
       </div>
     </div>
 

--- a/app/views/visitors/privacy_policy.html.erb
+++ b/app/views/visitors/privacy_policy.html.erb
@@ -4,7 +4,7 @@
 <article class="ost-article container">
   <h1>Privacy Policy</h1>
 
-  <p>Effective date: March 26, 2026</p>
+  <p>Effective date: April 12, 2026</p>
 
   <p>OpenSplitTime Company ("us", "we", or "our") operates the https://www.opensplittime.org website and the OST
     Remote mobile application (the "Service").</p>
@@ -110,6 +110,25 @@
       settings.
     </li>
     <li><strong>Security Cookies.</strong> We use Security Cookies for security purposes.</li>
+  </ul>
+
+  <h2>Controlling What Appears Publicly</h2>
+
+  <p>Most information we collect about event participation is published on public pages (person
+    profiles, event results, finish history, podiums, and similar views) and is indexed by search
+    engines. This is core to how our Service works. You have the following controls over what
+    appears publicly:</p>
+
+  <ul>
+    <li><strong>Hide my age.</strong> If you have claimed your person record, you can check
+      "Hide my age on public pages" on the profile edit page. When enabled, your age is omitted
+      from your public profile, effort history, bio lines throughout the Service, and API
+      responses. Your birthdate is still stored and used internally (for example, for age-group
+      scoring). If an event places you in an age-group category (e.g. "M40-49"), that category
+      is still visible on public results pages even when your age is hidden.</li>
+    <li><strong>Contact private fields.</strong> Email address, phone number, birthdate, and
+      emergency contact information are never shown on public pages and are only exposed through
+      our API to administrators and event organizers authorized to edit your record.</li>
   </ul>
 
   <h2>Use of Data</h2>

--- a/app/views/visitors/privacy_policy.html.erb
+++ b/app/views/visitors/privacy_policy.html.erb
@@ -127,8 +127,8 @@
       scoring). If an event places you in an age-group category (e.g. "M40-49"), that category
       is still visible on public results pages even when your age is hidden.</li>
     <li><strong>Contact private fields.</strong> Email address, phone number, birthdate, and
-      emergency contact information are never shown on public pages and are only exposed through
-      our API to administrators and event organizers authorized to edit your record.</li>
+      emergency contact information are never shown on public pages and are only exposed
+      to administrators and event organizers and their teams.</li>
   </ul>
 
   <h2>Use of Data</h2>

--- a/docs/user-info/profile-privacy.md
+++ b/docs/user-info/profile-privacy.md
@@ -1,0 +1,42 @@
+---
+title: Profile Privacy
+parent: User Information
+nav_order: 2
+---
+
+# Profile Privacy
+
+OpenSplitTime publishes most event participation data on public pages and through its API. This page describes the controls you have over what appears publicly.
+
+## Hiding your age
+
+If you have claimed your person record, you can suppress your age on public pages:
+
+1. Sign in and go to your profile.
+2. Click **Edit**.
+3. Check **Hide my age on public pages** and save.
+
+When enabled, your age is omitted from:
+
+- Your public person profile and bio line
+- Your effort history and event results pages
+- The `currentAge` and `age` fields in API responses
+
+Your birthdate is still stored and is used internally for age-group scoring.
+
+### What remains visible
+
+- **Age-group categories.** If an event places you in an age-group category (for example `M40-49`), that category is still visible on public results pages. Hiding your age does not move you out of your age group or remove you from age-group awards.
+- **Other profile fields.** Your name, gender, location, and event history remain public unless the event itself is concealed.
+
+### Who can still see your age
+
+Administrators and event organizers authorized to edit your person record still see your real age in the admin UI and through the API. This is intentional — race directors need that information to run their events.
+
+## Hiding private contact information
+
+Email address, phone number, birthdate, and emergency contact information are never shown on public pages. They are only exposed through the API to administrators and event organizers authorized to edit your record.
+
+## Claiming your person record
+
+To use any of these controls, you need to claim your person record first. From your person page, click **Claim this profile** if you see it there. Once claimed, you can edit your own profile directly.


### PR DESCRIPTION
Closes #1844. Part of #1841.

## Summary
- New "Controlling What Appears Publicly" section in the privacy policy describing the hide-age toggle and the age-group caveat.
- Inline help text next to the checkbox on the person edit form, including the age-group caveat.
- New `docs/user-info/profile-privacy.md` explaining the feature end-to-end: how to claim, how to toggle, what remains visible (age-group categories like "M40-49"), and who can still see the real age.
- Bumped the privacy policy effective date.

## Age-group caveat
Age groups are derived from birthdate at event time and rendered on podium / results pages. Hiding age does not move a person out of their category or remove them from age-group awards, and "M40-49" (or similar) is still publicly visible. This is called out both in the privacy policy and the user docs.

## Test plan
- [ ] Manual: view /privacy_policy and confirm the new section renders.
- [ ] Manual: view the person edit form and confirm the help text sits next to the checkbox.
- [ ] Manual: docs build picks up the new profile-privacy page under User Information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)