### PR TITLE
Roll back blanket noindex/nofollow from #1771

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -15,7 +15,7 @@ class Effort < ApplicationRecord
   include LapsRequiredMethods
   include GuaranteedFindable
   include DelegatedConcealable
-  include Delegablae
+  include Delegable
   include DataStatusMethods
   include CapitalizeAttributes
   include Auditable

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -15,7 +15,7 @@ class Effort < ApplicationRecord
   include LapsRequiredMethods
   include GuaranteedFindable
   include DelegatedConcealable
-  include Delegable
+  include Delegablae
   include DataStatusMethods
   include CapitalizeAttributes
   include Auditable

--- a/app/views/event_groups/index.html.erb
+++ b/app/views/event_groups/index.html.erb
@@ -1,4 +1,3 @@
-<% content_for :robots_meta, "nofollow" %>
 <% content_for :title do %>
   <% if params[:search].present? %>
     <% "OpenSplitTime: Search events - #{params[:search]}" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title><%= content_for?(:title) ? yield(:title) : "OpenSplitTime" %></title>
   <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "OpenSplitTime" %>">
-  <%= tag.meta(name: "robots", content: yield(:robots_meta)) if content_for?(:robots_meta) %>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
   <%= render "layouts/google_maps_api_js" %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,4 +1,3 @@
-<% content_for :robots_meta, "nofollow" %>
 <% content_for :title do %>
   <% "OpenSplitTime: List organizations" %>
 <% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,4 +1,3 @@
-<% content_for :robots_meta, "noindex" %>
 <% content_for :title do %>
   <% "OpenSplitTime: Organization - #{@presenter.name}" %>
 <% end %>

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -1,4 +1,3 @@
-<% content_for :robots_meta, "nofollow" %>
 <% content_for :title do %>
     <% if params[:search].present? %>
         <% "OpenSplitTime: Search people - #{params[:search]}" %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :robots_meta, "noindex" %>
+<% content_for :robots_meta, "noindex" if @person.hide_age? %>
 <% content_for :title do %>
   <% "OpenSplitTime: Show person - #{@presenter.full_name}" %>
 <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,4 +1,3 @@
-<% content_for :robots_meta, "noindex" if @person.hide_age? %>
 <% content_for :title do %>
   <% "OpenSplitTime: Show person - #{@presenter.full_name}" %>
 <% end %>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+# This file is managed by Cloudflare. Rules configured here may be
+# overridden or supplemented by the rules Cloudflare serves in front
+# of the origin. Make changes in the Cloudflare dashboard when possible.
 #
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,5 @@
-User-agent: *
-Allow: /people/$
-Allow: /event_groups/$
-Allow: /organizations/$
-Disallow: /people/
-Disallow: /event_groups/
-Disallow: /organizations/
-Disallow: /api/
+# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+#
+# To ban all spiders from the entire site uncomment the next two lines:
+# User-agent: *
+# Disallow: /


### PR DESCRIPTION
Closes #1846. Part of #1841.

## Summary
With the per-person `hide_age` opt-in shipped in #1843, the blanket search-engine suppression from #1771 is no longer necessary. Restores normal indexing of public pages:

- `public/robots.txt` back to the default, with a note that the file is managed by Cloudflare
- Remove `nofollow` from `people/index`, `event_groups/index`, `organizations/index`
- Remove the blanket `noindex` from `organizations/show` and `people/show`
- Remove the unused `robots_meta` layout helper

`hide_age` suppresses the age field on the person page, which is the actual user concern — no per-page `noindex` needed.

## Sequencing note
Prerequisite sub-issues (#1842 migration, #1843 behavior, #1844 docs) are merged. #1845 (backfill for users who already asked) should complete before or alongside this PR.

## Test plan
- [x] Manual: `GET /robots.txt` returns the default (no Disallow entries).
- [ ] Manual: View source on `/people`, `/event_groups`, `/organizations`, an organization show page, and a person show page — no `<meta name="robots">` tag.
- [ ] After deploy: watch Search Console for re-indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)