### PR TITLE
Upgrade Bootstrap from 5.2.3 to 5.3.8

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,5 +1,6 @@
 @import "./fa6_text";
 @import "./variables";
+@import "bootstrap/scss/variables-dark";
 @import "./mixins";
 @import "./fix_bootstrap_5_links";
 

--- a/app/assets/stylesheets/utilities/_buttons.scss
+++ b/app/assets/stylesheets/utilities/_buttons.scss
@@ -29,7 +29,7 @@
 }
 
 .btn-input-group {
-    @include button-outline-variant($input-group-addon-border-color);
+    @include button-outline-variant($gray-400);
 }
 
 .dropdown-toggle {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -49,6 +49,7 @@ $breadcrumb-active-color: $black;
 
 // Navbar Overrides
 $navbar-brand-padding-y: 0;
+$navbar-dark-color: $white;
 $navbar-toggler-padding-y: 0.125rem;
 $navbar-toggler-padding-x: 0.5rem;
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -49,7 +49,6 @@ $breadcrumb-active-color: $black;
 
 // Navbar Overrides
 $navbar-brand-padding-y: 0;
-$navbar-dark-color: $white;
 $navbar-toggler-padding-y: 0.125rem;
 $navbar-toggler-padding-x: 0.5rem;
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -19,7 +19,7 @@
           <%= f.password_field :password, autofocus: true, class: "form-control" %>
           <%= f.label :password, t(".new_password") %>
 
-          <small class="form-text text-muted"><%= t("devise.shared.minimum_password_length") %></small>
+          <small class="form-text text-body-secondary"><%= t("devise.shared.minimum_password_length") %></small>
         </div>
 
         <div class="form-floating mb-3">

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -24,7 +24,7 @@
   <div class="form-floating mb-3 required">
     <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
     <%= f.label :password %>
-    <small class="form-text text-muted"><%= t("devise.shared.minimum_password_length") %></small>
+    <small class="form-text text-body-secondary"><%= t("devise.shared.minimum_password_length") %></small>
   </div>
 
   <div class="form-floating mb-3 required">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -36,19 +36,19 @@
         <div class="form-floating mb-3">
           <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
           <%= f.label :new_password %>
-          <small class="form-text text-muted"><%= t(".leave_blank_if_you_don_t_want_to_change_it") %></small>
+          <small class="form-text text-body-secondary"><%= t(".leave_blank_if_you_don_t_want_to_change_it") %></small>
         </div>
 
         <div class="form-floating mb-3">
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %>
           <%= f.label :new_password_confirmation %>
-          <small class="form-text text-muted"><%= t(".leave_blank_if_you_don_t_want_to_change_it") %></small>
+          <small class="form-text text-body-secondary"><%= t(".leave_blank_if_you_don_t_want_to_change_it") %></small>
         </div>
 
         <div class="form-floating mb-3">
           <%= f.password_field :current_password, autocomplete: "current-password", class: "form-control" %>
           <%= f.label :current_password, class: "required" %>
-          <small class="form-text text-muted"><%= t(".we_need_your_current_password_to_confirm_your_changes") %></small>
+          <small class="form-text text-body-secondary"><%= t(".we_need_your_current_password_to_confirm_your_changes") %></small>
         </div>
         <hr>
 

--- a/app/views/event_groups/_raceresult_webhook_card.html.erb
+++ b/app/views/event_groups/_raceresult_webhook_card.html.erb
@@ -11,10 +11,10 @@
         Read the <%= link_to "full documentation", docs_url("raceresult-integration"), target: "_blank", rel: "noopener" %>
         for a detailed explanation of how to set up this integration.</p>
       <% if presenter.webhook_token? %>
-        <p class="text-muted"><%= t("event_groups.setup.webhook_token_active_detail") %></p>
+        <p class="text-body-secondary"><%= t("event_groups.setup.webhook_token_active_detail") %></p>
         <%= render "shared/copyable_field", label: "Webhook URL", value: webhooks_raceresult_url(token: presenter.webhook_token, event_group_name: presenter.event_group.slug), field_id: "webhook_url" %>
       <% else %>
-        <p class="text-muted mb-0"><%= t("event_groups.setup.webhook_token_inactive_detail") %></p>
+        <p class="text-body-secondary mb-0"><%= t("event_groups.setup.webhook_token_inactive_detail") %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/event_groups/manage_entrant_photos.html.erb
+++ b/app/views/event_groups/manage_entrant_photos.html.erb
@@ -25,7 +25,7 @@
            data-dropzone-accepted-files="image/*"
            data-action="dropzone:success->form-disable-submit#enableSubmitButton">
         <%= f.file_field :entrant_photos, multiple: true, direct_upload: true, data: { "dropzone-target" => "input" } %>
-        <div class="dropzone-msg dz-message needsclick text-muted">
+        <div class="dropzone-msg dz-message needsclick text-body-secondary">
           <h3 class="dropzone-msg-title">Drag here to upload or click here to browse</h3>
           <span class="dropzone-msg-desc text-sm">1 MB file size maximum. Allowed file types png, jpg.</span>
         </div>
@@ -76,7 +76,7 @@
       <div class="row my-3">
         <div class="col">
           <h4 class="fw-bold">Already assigned
-            <span class="fw-light text-muted small"><%= @presenter.event_group.efforts.photo_assigned.count %></span>
+            <span class="fw-light text-body-secondary small"><%= @presenter.event_group.efforts.photo_assigned.count %></span>
           </h4>
         </div>
         <div class="col">
@@ -114,7 +114,7 @@
       <div class="row my-3">
         <div class="col">
           <h4 class="fw-bold">Not yet assigned
-            <span class="fw-light text-muted small"><%= @presenter.event_group.efforts.no_photo_assigned.count %></span>
+            <span class="fw-light text-body-secondary small"><%= @presenter.event_group.efforts.no_photo_assigned.count %></span>
           </h4>
         </div>
       </div>

--- a/app/views/event_groups/setup_summary.html.erb
+++ b/app/views/event_groups/setup_summary.html.erb
@@ -16,10 +16,10 @@
       <% @presenter.events.each do |event| %>
         <div class="row mx-3 py-3 border-bottom">
           <div class="col-12">
-            <span class="h4"><%= event.guaranteed_short_name %></span><span class="h5 text-muted ms-2"><%= pluralize(event.efforts.count, "entrant") %></span>
+            <span class="h4"><%= event.guaranteed_short_name %></span><span class="h5 text-body-secondary ms-2"><%= pluralize(event.efforts.count, "entrant") %></span>
           </div>
           <div class="col-12">
-            <span class="h5"><%= "Course: #{event.course.name}" %></span><span class="h5 text-muted ms-2"><%= pluralize(event.course.splits.count, "split") %></span>
+            <span class="h5"><%= "Course: #{event.course.name}" %></span><span class="h5 text-body-secondary ms-2"><%= pluralize(event.course.splits.count, "split") %></span>
           </div>
         </div>
       <% end %>
@@ -28,7 +28,7 @@
 
   <div class="card my-3">
     <div class="card-header">
-      <span class="h4">Entrants</span><span class="h4 text-muted ms-2"><%= pluralize(@presenter.event_group.efforts.count, "entrant") %></span>
+      <span class="h4">Entrants</span><span class="h4 text-body-secondary ms-2"><%= pluralize(@presenter.event_group.efforts.count, "entrant") %></span>
     </div>
     <div class="card-body">
       <table class="table table-sm">

--- a/app/views/events/_course_gpx_form.html.erb
+++ b/app/views/events/_course_gpx_form.html.erb
@@ -27,7 +27,7 @@
                data-dropzone-accepted-files=".gpx"
                data-action="dropzone:success->form-disable-submit#enableSubmitButton">
             <%= f.file_field :gpx, direct_upload: true, data: { "dropzone-target" => "input" } %>
-            <div class="dropzone-msg dz-message needsclick text-muted">
+            <div class="dropzone-msg dz-message needsclick text-body-secondary">
               <h3 class="dropzone-msg-title">Drag here to upload or click here to browse</h3>
               <span class="dropzone-msg-desc text-sm">1 MB file size maximum. File must be a gpx file.</span>
             </div>

--- a/app/views/events/_event_overview_card.html.erb
+++ b/app/views/events/_event_overview_card.html.erb
@@ -5,7 +5,7 @@
     <div class="row">
       <div class="col-md-6">
         <span class="h2 fw-bold"><%= event.short_name %></span>
-        <span class="h4 text-muted ms-2"><%= " #{pluralize(event.efforts.count, 'entrant')}" %></span>
+        <span class="h4 text-body-secondary ms-2"><%= " #{pluralize(event.efforts.count, 'entrant')}" %></span>
       </div>
       <div class="col text-md-end my-2 my-md-0">
         <% if grouping_button == "join" %>
@@ -24,7 +24,7 @@
       <h5><%= fa_icon("calendar", text: l(event.scheduled_start_time_local, format: :full_day_time_and_zone)) %></h5>
       <div class="col-md-6">
         <span class="h5 me-2"><%= fa_icon("map-marked-alt") %> <%= event.course.name %></span>
-        <span class="h6 text-muted"><%= " #{pluralize(event.course.splits.count, 'split')}" %></span>
+        <span class="h6 text-body-secondary"><%= " #{pluralize(event.course.splits.count, 'split')}" %></span>
         <span class="ms-2"><%= link_to_event_setup_course(event) %></span>
       </div>
     </div>

--- a/app/views/export_jobs/_export_job.html.erb
+++ b/app/views/export_jobs/_export_job.html.erb
@@ -11,7 +11,7 @@
               <span class="mx-2"><%= badge_with_text("New", color: "success") %></span>
             <% end %>
           </h5>
-          <h6 class="fs-6 text-muted"><%= "Created #{time_ago_in_words(export_job.created_at)} ago" %></h6>
+          <h6 class="fs-6 text-body-secondary"><%= "Created #{time_ago_in_words(export_job.created_at)} ago" %></h6>
         </div>
         <div class="col text-end">
           <%= render "export_jobs/actions_kebab", export_job: export_job %>

--- a/app/views/import_jobs/_form.html.erb
+++ b/app/views/import_jobs/_form.html.erb
@@ -15,7 +15,7 @@
                data-dropzone-accepted-files=".csv"
                data-action="dropzone:success->form-disable-submit#enableSubmitButton">
             <%= f.file_field :files, direct_upload: true, data: { "dropzone-target" => "input" } %>
-            <div class="dropzone-msg dz-message needsclick text-muted">
+            <div class="dropzone-msg dz-message needsclick text-body-secondary">
               <h3 class="dropzone-msg-title">Drag here to upload or click here to browse</h3>
               <span class="dropzone-msg-desc text-sm">1 MB file size maximum. File must be a csv file.</span>
             </div>

--- a/app/views/layouts/_nav_links_for_auth.html.erb
+++ b/app/views/layouts/_nav_links_for_auth.html.erb
@@ -6,7 +6,7 @@
         <%= current_user.email %><%= " (admin)" if current_user.admin? %>
         <span class="caret"></span>
       </a>
-      <div class="dropdown-menu dropdown-menu-dark" aria-labelledby="nav-dropdown-auth">
+      <div class="dropdown-menu" data-bs-theme="dark" aria-labelledby="nav-dropdown-auth">
         <%= link_to "Settings", user_settings_preferences_path, class: "dropdown-item" %>
         <% if current_user&.admin? %>
           <div class="dropdown-divider"></div>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -14,7 +14,7 @@
     </aside>
   <% end %>
 
-  <nav class="navbar navbar-dark bg-dark navbar-expand-md">
+  <nav class="navbar bg-dark navbar-expand-md" data-bs-theme="dark">
     <div class="container-fluid mx-1">
       <%= link_to "OpenSplitTime", root_path, class: "navbar-brand", id: "logo" %>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarMain" aria-controls="navbarsExample04" aria-expanded="false" aria-label="Toggle navigation">

--- a/app/views/lotteries/_setup_callouts.html.erb
+++ b/app/views/lotteries/_setup_callouts.html.erb
@@ -27,7 +27,7 @@
       <div class="card-header">
         <%= fa_icon("exclamation-triangle", type: :regular, class: "text-danger", size: "2x") %>
         <span class="h3 fw-bold mx-2">Mismatched Entrants</span>
-        <span class="h5 text-muted">Fix these before drawing tickets</span>
+        <span class="h5 text-body-secondary">Fix these before drawing tickets</span>
       </div>
       <div class="card-body">
         <table class="table">

--- a/app/views/lotteries/_setup_divisions_card.html.erb
+++ b/app/views/lotteries/_setup_divisions_card.html.erb
@@ -6,7 +6,7 @@
       <div class="row">
         <div class="col">
           <span class="h3 fw-bold me-2">Divisions</span>
-          <span class="h5 text-muted"><%= pluralize(presenter.divisions.size, "division") %></span>
+          <span class="h5 text-body-secondary"><%= pluralize(presenter.divisions.size, "division") %></span>
         </div>
       </div>
     </div>

--- a/app/views/lotteries/_setup_entrant_lookup_card.html.erb
+++ b/app/views/lotteries/_setup_entrant_lookup_card.html.erb
@@ -6,7 +6,7 @@
       <div class="row">
         <div class="col">
           <span class="h3 fw-bold me-2">Entrant Lookup</span>
-          <span class="h5 text-muted"><%= pluralize_with_delimiter(presenter.lottery.entrants.count, "entrant") %></span>
+          <span class="h5 text-body-secondary"><%= pluralize_with_delimiter(presenter.lottery.entrants.count, "entrant") %></span>
         </div>
       </div>
     </div>

--- a/app/views/lotteries/_setup_pre_selected_entrants_card.html.erb
+++ b/app/views/lotteries/_setup_pre_selected_entrants_card.html.erb
@@ -12,7 +12,7 @@
         <div class="col">
           <div>
             <span class="h3 fw-bold me-2">Pre-Selected Entrants</span>
-            <span class="h5 text-muted"><%= pluralize_with_delimiter(presenter.pre_selected_entrant_count, "entrant") %></span>
+            <span class="h5 text-body-secondary"><%= pluralize_with_delimiter(presenter.pre_selected_entrant_count, "entrant") %></span>
           </div>
         </div>
         <div class="col-4 col-md-2 text-end d-grid">

--- a/app/views/lotteries/_setup_service_form_card.html.erb
+++ b/app/views/lotteries/_setup_service_form_card.html.erb
@@ -7,7 +7,7 @@
         <div class="col">
           <span class="fs-3 fw-bold">Service Form</span>
           <% if presenter.service_form.attached? %>
-            <span class="fs-5 text-muted ps-2"><%= fa_icon("circle-check", class: "text-success", text: "Attached") %></span>
+            <span class="fs-5 text-body-secondary ps-2"><%= fa_icon("circle-check", class: "text-success", text: "Attached") %></span>
           <% end %>
         </div>
         <div class="col text-end">
@@ -51,7 +51,7 @@
                    data-dropzone-accepted-files=".pdf"
                    data-action="dropzone:success->form-disable-submit#enableSubmitButton">
                 <%= f.file_field :service_form, direct_upload: true, data: { "dropzone-target" => "input" } %>
-                <div class="dropzone-msg dz-message needsclick text-muted">
+                <div class="dropzone-msg dz-message needsclick text-body-secondary">
                   <h3 class="dropzone-msg-title">Drag here to upload or click here to browse</h3>
                   <span class="dropzone-msg-desc text-sm">2 MB file size maximum. File must be a pdf file.</span>
                 </div>

--- a/app/views/lotteries/entrant_service_details/_upload_service_form_card.html.erb
+++ b/app/views/lotteries/entrant_service_details/_upload_service_form_card.html.erb
@@ -6,7 +6,7 @@
       <% if presenter.completed_form.attached? %>
         <div class="col">
           <span class="fs-3 fw-bold">Completed Service Form</span>
-          <span class="fs-5 text-muted ps-2"><%= fa_icon("circle-check", class: "text-success", text: "Attached") %></span>
+          <span class="fs-5 text-body-secondary ps-2"><%= fa_icon("circle-check", class: "text-success", text: "Attached") %></span>
         </div>
         <div class="col text-end">
           <div class="d-flex justify-content-end gap-2">
@@ -49,7 +49,7 @@
                  data-dropzone-accepted-files="image/*,.pdf"
                  data-action="dropzone:success->form-disable-submit#enableSubmitButton">
               <%= f.file_field :completed_form, direct_upload: true, data: { "dropzone-target" => "input" } %>
-              <div class="dropzone-msg dz-message needsclick text-muted">
+              <div class="dropzone-msg dz-message needsclick text-body-secondary">
                 <h3 class="dropzone-msg-title">Drag here to upload or click here to browse</h3>
                 <span class="dropzone-msg-desc text-sm">5 MB file size maximum. File must be a pdf, jpeg, or png file.</span>
               </div>

--- a/app/views/lotteries/show.html.erb
+++ b/app/views/lotteries/show.html.erb
@@ -66,7 +66,7 @@
   <% when "entrants" %>
     <%= render partial: "service_form_callout", locals: { presenter: @presenter } %>
     <h4 class="mt-5">
-      <span class="fw-bold"><%= "Lottery Entrants" %></span><span class="px-1 h5 fw-light text-muted"><%= " #{pluralize_with_delimiter(@presenter.lottery_entrants.count, 'total entrant')}" %></span>
+      <span class="fw-bold"><%= "Lottery Entrants" %></span><span class="px-1 h5 fw-light text-body-secondary"><%= " #{pluralize_with_delimiter(@presenter.lottery_entrants.count, 'total entrant')}" %></span>
     </h4>
     <hr>
     <aside class="ost-toolbar">
@@ -82,7 +82,7 @@
     <%= render partial: "entrant_list", locals: { presenter: @presenter } %>
 
   <% when "draws" %>
-    <h4 class="mt-5"><span class="fw-bold">Lottery Draws</span><span class="px-1 h5 fw-light text-muted">(Most recent at the top)</span></h4>
+    <h4 class="mt-5"><span class="fw-bold">Lottery Draws</span><span class="px-1 h5 fw-light text-body-secondary">(Most recent at the top)</span></h4>
     <hr>
     <% if @presenter.viewable_results? %>
       <% if @presenter.lottery.live? %>
@@ -115,7 +115,7 @@
     <%= render partial: "service_form_callout", locals: { presenter: @presenter } %>
     <h4 class="mt-5">
       <span class="fw-bold">Lottery Results</span>
-      <span class="px-1 h5 fw-light text-muted"><%= "Last updated #{time_ago_in_words(@presenter.lottery.updated_at)} ago" %></span>
+      <span class="px-1 h5 fw-light text-body-secondary"><%= "Last updated #{time_ago_in_words(@presenter.lottery.updated_at)} ago" %></span>
     </h4>
     <hr>
     <%= render partial: "results", locals: { presenter: @presenter }, cached: true %>

--- a/app/views/lottery_entrants/_name_and_geolocation_with_icon.html.erb
+++ b/app/views/lottery_entrants/_name_and_geolocation_with_icon.html.erb
@@ -25,7 +25,7 @@
   <div class="col">
     <div class="d-flex flex-column h-100">
       <span class="fs-5 fw-bold"><%= record.name %></span>
-      <span class="text-muted"><%= record.flexible_geolocation %></span>
+      <span class="text-body-secondary"><%= record.flexible_geolocation %></span>
     </div>
   </div>
 </div>

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -25,7 +25,7 @@
              data-action="dropzone:success->form-disable-submit#enableSubmitButton">
           <%= f.file_field :banner, direct_upload: true, data: { "dropzone-target" => "input" } %>
 
-          <div class="dropzone-msg dz-message needsclick text-muted">
+          <div class="dropzone-msg dz-message needsclick text-body-secondary">
             <h3 class="dropzone-msg-title">Drag a banner here or click to upload</h3>
             <span class="dropzone-msg-desc text-sm">1 MB file size maximum. Must be JPEG or PNG.</span>
           </div>

--- a/app/views/subscriptions/_subscriptions_count.html.erb
+++ b/app/views/subscriptions/_subscriptions_count.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (subscribable:, current_user:) %>
 
-<span id="<%= dom_id(subscribable, :subscriptions_count) %>" class="h5 text-muted">
+<span id="<%= dom_id(subscribable, :subscriptions_count) %>" class="h5 text-body-secondary">
   <%= pluralize_with_delimiter(subscribable.subscriptions.for_user(current_user).count, "subscription") %>
 </span>

--- a/app/views/user_settings/password.html.erb
+++ b/app/views/user_settings/password.html.erb
@@ -38,7 +38,7 @@
         <div class="mb-3">
           <%= f.label :old_password %>
           <%= f.password_field :current_password, autocomplete: "off", class: "form-control", placeholder: "Current Password" %>
-          <p class="form-text text-muted"><small>We need your current password to confirm your changes</small></p>
+          <p class="form-text text-body-secondary"><small>We need your current password to confirm your changes</small></p>
         </div>
 
         <div class="mb-3">

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@rails/activestorage": "^8.1.200",
     "@rails/request.js": "^0.0.13",
     "autoprefixer": "^10.4.14",
-    "bootstrap": "5.2.3",
+    "bootstrap": "5.3.8",
     "bootstrap-icons": "^1.10.5",
     "chart.js": "^3.8.0",
     "chartkick": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,10 +343,10 @@ bootstrap-icons@^1.10.5:
   resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz#0aad3f5b55b67402990e729ce3883416f9cef6c5"
   integrity sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==
 
-bootstrap@5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.3.tgz#54739f4414de121b9785c5da3c87b37ff008322b"
-  integrity sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==
+bootstrap@5.3.8:
+  version "5.3.8"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.8.tgz#6401a10057a22752d21f4e19055508980656aeed"
+  integrity sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==
 
 brace-expansion@^5.0.2:
   version "5.0.5"


### PR DESCRIPTION
## Summary
- Bumps Bootstrap to 5.3.8 and migrates deprecated classes (`text-muted` → `text-body-secondary`, `navbar-dark`/`dropdown-menu-dark` → `data-bs-theme="dark"`)
- Imports `bootstrap/scss/variables-dark` so our custom variables are available in both light and dark theme scopes
- Works around 5.3 turning `$input-group-addon-border-color` into a CSS variable (passing a literal `$gray-400` to `button-outline-variant` instead)
- Does **not** implement a dark-mode toggle — that's future work

Closes #1800.

## Test plan
- [x] `yarn install` clean
- [x] `yarn build:css` compiles with no Sass errors
- [x] `bundle exec erb_lint` clean on changed files
- [x] Rails boots
- [ ] Manual QA: top navbar renders with full-white links, user dropdown renders dark, "muted" text locations still render as secondary gray, forms/modals/breadcrumbs/tables have no visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)