### PR TITLE
Add obscure_name column to people

### DIFF
--- a/db/migrate/20260414040218_add_obscure_name_to_people.rb
+++ b/db/migrate/20260414040218_add_obscure_name_to_people.rb
@@ -1,0 +1,5 @@
+class AddObscureNameToPeople < ActiveRecord::Migration[8.1]
+  def change
+    add_column :people, :obscure_name, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_170833) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_14_040218) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -531,6 +531,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_170833) do
     t.integer "gender", null: false
     t.boolean "hide_age", default: false, null: false
     t.string "last_name", limit: 64, null: false
+    t.boolean "obscure_name", default: false, null: false
     t.string "phone"
     t.string "slug", null: false
     t.string "state_code"


### PR DESCRIPTION
## Summary
- Adds `obscure_name:boolean` column to `people` (null: false, default: false), mirroring the `hide_age` migration from #1842.

Closes #1859. Part of #1858.

## Test plan
- [x] `bin/rails db:migrate` succeeds
- [x] `bin/rails db:rollback` succeeds
- [x] `schema.rb` diff shows only the new column

🤖 Generated with [Claude Code](https://claude.com/claude-code)