### PR TITLE
Document obscure_name option in privacy policy and docs

### DIFF
--- a/app/views/visitors/privacy_policy.html.erb
+++ b/app/views/visitors/privacy_policy.html.erb
@@ -126,6 +126,13 @@
       responses. Your birthdate is still stored and used internally (for example, for age-group
       scoring). If an event places you in an age-group category (e.g. "M40-49"), that category
       is still visible on public results pages even when your age is hidden.</li>
+    <li><strong>Show only my initials.</strong> If you have claimed your person record, you can
+      check "Show only my initials on public pages" on the profile edit page. When enabled, your
+      full name is replaced with initials (for example, "Mark Oveson" becomes "M. O.") on your
+      public profile, the people index, effort history and results listings, CSV exports, and
+      API responses. Your first and last name are still stored for record-keeping and result
+      attribution, and remain visible to administrators and event organizers authorized to edit
+      your record.</li>
     <li><strong>Contact private fields.</strong> Email address, phone number, birthdate, and
       emergency contact information are never shown on public pages and are only exposed
       to administrators and event organizers and their teams.</li>

--- a/docs/user-info/profile-privacy.md
+++ b/docs/user-info/profile-privacy.md
@@ -33,6 +33,27 @@ Your birthdate is still stored and is used internally for age-group scoring.
 
 Administrators and event organizers authorized to edit your person record still see your real age in the admin UI and through the API. This is intentional — race directors need that information to run their events.
 
+## Showing only your initials
+
+If you have claimed your person record, you can replace your full name with initials on public pages:
+
+1. Sign in and go to your profile.
+2. Click **Edit**.
+3. Check **Show only my initials on public pages** and save.
+
+When enabled, your name is displayed as initials (for example, "Mark Oveson" becomes "M. O.") on:
+
+- Your public person profile and the people index
+- Effort history and event results listings
+- CSV exports of event results
+- `firstName` and `lastName` fields in API responses
+
+Your first and last name are still stored in the database so that results remain correctly attributed to you. Only the display is obscured.
+
+### Who can still see your full name
+
+Administrators and event organizers authorized to edit your person record still see your real name in the admin UI and through the API. Race directors need that information to run their events.
+
 ## Hiding private contact information
 
 Email address, phone number, birthdate, and emergency contact information are never shown on public pages. They are only exposed through the API to administrators and event organizers authorized to edit your record.


### PR DESCRIPTION
Closes #1861.

## Summary
- Adds a "Show only my initials" bullet to the Controlling What Appears Publicly section of the privacy policy, noting names are still stored for record-keeping and result attribution.
- Adds a parallel "Showing only your initials" section to `docs/user-info/profile-privacy.md`, mirroring the existing hide_age documentation.
- The person edit form already has adequate inline help text near the checkbox (added in #1858), so no form changes were needed.

## Test plan
- [x] Render `/privacy_policy` and verify the new bullet appears under "Controlling What Appears Publicly".
- [x] Verify the profile-privacy doc renders on the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)