### PR TITLE
Obscure slugs for people and efforts with obscure_name set

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -117,10 +117,10 @@ class Effort < ApplicationRecord
 
   def slug_candidates
     [
-      [:event_name, :full_name],
-      [:event_name, :full_name, :state_and_country],
-      [:event_name, :full_name, :state_and_country, Time.zone.today.to_s],
-      [:event_name, :full_name, :state_and_country, Time.zone.today.to_s, Time.current.strftime("%H:%M:%S")]
+      [:event_name, :name_for_slug],
+      [:event_name, :name_for_slug, :state_and_country],
+      [:event_name, :name_for_slug, :state_and_country, Time.zone.today.to_s],
+      [:event_name, :name_for_slug, :state_and_country, Time.zone.today.to_s, Time.current.strftime("%H:%M:%S")]
     ]
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -48,6 +48,7 @@ class Person < ApplicationRecord
   validates_with BirthdateValidator
 
   after_update_commit :touch_related_events, if: :visibility_flags_changed?
+  after_update_commit :regenerate_slugs_for_obscure_name, if: :saved_change_to_obscure_name?
 
   # This method needs to extract ids and run a new search to remain compatible
   # with the scope `.with_age_and_effort_count`.
@@ -75,12 +76,15 @@ class Person < ApplicationRecord
   end
 
   def slug_candidates
-    [:full_name, [:full_name, :state_and_country], [:full_name, :state_and_country, Time.zone.today.to_s],
-     [:full_name, :state_and_country, Time.zone.today.to_s, Time.current.strftime("%H:%M:%S")]]
+    [:name_for_slug,
+     [:name_for_slug, :state_and_country],
+     [:name_for_slug, :state_and_country, Time.zone.today.to_s],
+     [:name_for_slug, :state_and_country, Time.zone.today.to_s, Time.current.strftime("%H:%M:%S")]]
   end
 
   def should_generate_new_friendly_id?
-    slug.blank? || first_name_changed? || last_name_changed? || state_code_changed? || country_code_changed?
+    slug.blank? || first_name_changed? || last_name_changed? || state_code_changed? ||
+      country_code_changed? || obscure_name_changed?
   end
 
   def current_age_approximate
@@ -116,6 +120,22 @@ class Person < ApplicationRecord
 
   def visibility_flags_changed?
     saved_change_to_hide_age? || saved_change_to_obscure_name?
+  end
+
+  # When obscure_name toggles, the slug built from full_name becomes
+  # privacy-sensitive (enabling) or outdated (disabling). Regenerate the
+  # person's slug and all linked effort slugs. When enabling, also purge
+  # friendly_id history so the previous revealing slug no longer resolves.
+  def regenerate_slugs_for_obscure_name
+    slugs.delete_all if obscure_name?
+    self.slug = nil
+    save!
+
+    efforts.find_each do |effort|
+      effort.slugs.delete_all if obscure_name?
+      effort.slug = nil
+      effort.save!
+    end
   end
 
   def generate_new_topic_resource?

--- a/lib/personal_info.rb
+++ b/lib/personal_info.rb
@@ -88,6 +88,10 @@ module PersonalInfo
     "#{first_name&.first}. #{last_name&.first}."
   end
 
+  def name_for_slug
+    obscure_name_applied? ? initials : full_name
+  end
+
   def personal_info
     [full_name, bio, flexible_geolocation].compact_blank.join(" – ")
   end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -162,6 +162,49 @@ RSpec.describe Person, type: :model do
     end
   end
 
+  describe "slug generation" do
+    let(:effort) { efforts(:hardrock_2014_finished_first) }
+
+    it "uses the full name when obscure_name is false" do
+      person = create(:person, first_name: "Mark", last_name: "Oveson", obscure_name: false)
+      expect(person.slug).to start_with("mark-oveson")
+    end
+
+    it "uses initials when obscure_name is true on create" do
+      person = create(:person, first_name: "Mark", last_name: "Oveson", obscure_name: true)
+      expect(person.slug).not_to include("mark")
+      expect(person.slug).not_to include("oveson")
+      expect(person.slug).to start_with("m-o")
+    end
+
+    it "regenerates the slug and purges history when obscure_name is toggled on" do
+      person = create(:person, first_name: "Mark", last_name: "Oveson", obscure_name: false)
+      effort.update!(person_id: person.id, first_name: "Mark", last_name: "Oveson", slug: nil)
+      original_person_slug = person.slug
+      original_effort_slug = effort.reload.slug
+      expect(original_effort_slug).to include("oveson")
+
+      person.update!(obscure_name: true)
+
+      expect(person.reload.slug).to start_with("m-o")
+      expect(person.slug).not_to include("oveson")
+      expect(described_class.friendly.exists?(original_person_slug)).to be(false)
+
+      expect(effort.reload.slug).not_to include("oveson")
+      expect(Effort.friendly.exists?(original_effort_slug)).to be(false)
+    end
+
+    it "regenerates the slug when obscure_name is toggled off, keeping history" do
+      person = create(:person, first_name: "Mark", last_name: "Oveson", obscure_name: true)
+      obscured_slug = person.slug
+
+      person.update!(obscure_name: false)
+
+      expect(person.reload.slug).to start_with("mark-oveson")
+      expect(described_class.friendly.find(obscured_slug)).to eq(person)
+    end
+  end
+
   describe "cache busting when visibility flags change" do
     let(:person) { create(:person, hide_age: false, obscure_name: false) }
     let(:effort) { efforts(:hardrock_2014_finished_first) }

--- a/spec/system/effort_show/visit_spec.rb
+++ b/spec/system/effort_show/visit_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "visit an effort show page", :js do
     before { effort.person.update!(obscure_name: true) }
 
     scenario "A visitor sees initials in the effort header" do
-      visit effort_path(effort)
+      visit effort_path(effort.reload)
       expect(page).to have_content("F. F.")
       expect(page).not_to have_content("Finished First")
     end


### PR DESCRIPTION
Follow-up to #1858. The `obscure_name` opt-in hid names in views, serializers, and exports, but the friendly_id slug on `Person` and `Effort` was still built from `full_name` — so URLs like `/people/mark-oveson` continued to leak the name users asked us to hide.

## Summary
- Adds `PersonalInfo#name_for_slug` — returns initials when `obscure_name_applied?` is true, else the full name.
- `Person#slug_candidates` and `Effort#slug_candidates` now use `:name_for_slug` in place of `:full_name`.
- `should_generate_new_friendly_id?` on Person now fires on `obscure_name` changes.
- New `after_update_commit` on Person regenerates the person's slug and cascades to all linked efforts when the flag toggles. When the flag is turned **on**, friendly_id history rows are purged for both the person and its efforts so the old revealing slug no longer resolves. When turned **off**, history is preserved so the obscured slug still redirects.

## Test plan
- [x] `bundle exec rspec spec/models/person_spec.rb`
- [x] `bundle exec rubocop` on touched files
- [ ] Manual: toggle obscure_name on a claimed person; verify the person and effort URLs use initials and that the old name-based URL 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)