### PR TITLE
Scope raw-time matching to the same effort

### DIFF
--- a/app/services/interactors/match_time_records_to_split_times.rb
+++ b/app/services/interactors/match_time_records_to_split_times.rb
@@ -45,7 +45,9 @@ module Interactors
     end
 
     def matching_record(split_time, time_record)
-      (split_time.split_id == time_record.split_id) &&
+      time_record.effort_id.present? &&
+        (split_time.effort_id == time_record.effort_id) &&
+        (split_time.split_id == time_record.split_id) &&
         (split_time.bitkey == time_record.bitkey) &&
         time_record.matchable_bib_number.present? &&
         (split_time.bib_number == time_record.matchable_bib_number) &&

--- a/spec/services/interactors/match_time_records_to_split_times_spec.rb
+++ b/spec/services/interactors/match_time_records_to_split_times_spec.rb
@@ -127,5 +127,31 @@ RSpec.describe Interactors::MatchTimeRecordsToSplitTimes do
         expect(response.resources[:unmatched].size).to eq(1)
       end
     end
+
+    context "when the candidate pool contains a matching split_time belonging to a different effort" do
+      let(:other_event_group) { create(:event_group) }
+      let(:other_event) do
+        create(:event, event_group: other_event_group, course: event.course,
+                       scheduled_start_time: event.scheduled_start_time)
+      end
+      let(:other_effort) do
+        create(:effort, event: other_event, bib_number: effort.bib_number,
+                        scheduled_start_time: effort.scheduled_start_time)
+      end
+      let!(:other_split_time) do
+        create(:split_time, effort: other_effort, lap: 1, split: split_1, bitkey: in_bitkey,
+                            absolute_time: split_time_1.absolute_time)
+      end
+      let(:split_times) do
+        SplitTime.where(id: [split_time_2.id, other_split_time.id]).with_time_record_matchers
+      end
+
+      it "does not match a split_time that belongs to a different effort" do
+        expect(response).to be_successful
+        expect(response.resources[:matched].map(&:id)).to contain_exactly(raw_time_2.id)
+        expect(response.resources[:unmatched].map(&:id)).to contain_exactly(raw_time_1.id)
+        expect(response.resources[:matched].map(&:split_time_id)).not_to include(other_split_time.id)
+      end
+    end
   end
 end

--- a/spec/services/interactors/match_time_records_to_split_times_spec.rb
+++ b/spec/services/interactors/match_time_records_to_split_times_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Interactors::MatchTimeRecordsToSplitTimes do
       end
     end
 
-    context "when the candidate pool contains a matching split_time belonging to a different effort" do
+    context "when the candidate pool contains a matching split_time belonging to an effort in a different event_group" do
       let(:other_event_group) { create(:event_group) }
       let(:other_event) do
         create(:event, event_group: other_event_group, course: event.course,
@@ -146,7 +146,7 @@ RSpec.describe Interactors::MatchTimeRecordsToSplitTimes do
         SplitTime.where(id: [split_time_2.id, other_split_time.id]).with_time_record_matchers
       end
 
-      it "does not match a split_time that belongs to a different effort" do
+      it "does not match a split_time that belongs to an effort in a different event_group" do
         expect(response).to be_successful
         expect(response.resources[:matched].map(&:id)).to contain_exactly(raw_time_2.id)
         expect(response.resources[:unmatched].map(&:id)).to contain_exactly(raw_time_1.id)


### PR DESCRIPTION
## Summary
- Fixes #1876
- `MatchTimeRecordsToSplitTimes#matching_record` previously matched on `split_id`, `bitkey`, `bib_number`, time, and pacer/stopped flags only. The candidate `split_times` are pre-scoped by `effort_id` at the call site, but any split_time within that pool whose other attributes coincided could still be matched to a raw_time belonging to a *different* effort — particularly in scenarios with shared courses, reused bibs across events, or historical data corruption. This can cross event-group boundaries and produces the FK violations reported in ScoutAPM error group 98108.
- Now requires `split_time.effort_id == time_record.effort_id` (and that `time_record.effort_id` is present) so a raw time can only match a split time on its own effort.

## Test plan
- [x] Added regression spec: candidate pool contains a same-bib/same-split/same-time split_time on a different effort in a different event_group; matcher must skip it.
- [x] Verified the new spec fails on master and passes with this change.
- [x] Existing matcher specs still pass (29 examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)