### PR TITLE
Skip int32-overflowing segments in EffortSegmentQuery.set

### DIFF
--- a/app/queries/effort_segment_query.rb
+++ b/app/queries/effort_segment_query.rb
@@ -61,7 +61,13 @@ class EffortSegmentQuery < BaseQuery
               (select course_id, begin_split_id, begin_bitkey, end_split_id, end_bitkey,
                       effort_id, lap, begin_time, end_time, elapsed_seconds::integer,
                       begin_split_kind, end_split_kind
-               from sub_split_segments)
+               from sub_split_segments
+               /* Skip segments whose elapsed_seconds would overflow a 32-bit integer
+                  (~68 years). No legitimate race produces such values, but a single
+                  imported split_time with a malformed absolute_time can, and would
+                  otherwise crash the entire ingestion job. */
+               where elapsed_seconds is null
+                  or elapsed_seconds between -2147483648 and 2147483647)
       on conflict (begin_split_id, begin_bitkey, end_split_id, end_bitkey, effort_id, lap) do update
           set begin_time      = EXCLUDED.begin_time,
               end_time        = EXCLUDED.end_time,

--- a/spec/models/effort_segment_spec.rb
+++ b/spec/models/effort_segment_spec.rb
@@ -74,5 +74,24 @@ RSpec.describe EffortSegment do
         described_class.set_for_split_time(split_time_1)
       end.not_to(change { effort_2.effort_segments.count })
     end
+
+    context "when a split_time has a pathological absolute_time that would overflow int32 elapsed_seconds" do
+      before do
+        # Force a ~100 year elapsed_seconds, well beyond 32-bit int range (~68 years).
+        split_time_1.update_columns(absolute_time: effort_1.split_times.first.absolute_time + 100.years)
+        split_time_1.send(:sync_elapsed_seconds)
+      end
+
+      it "skips the overflowing segments rather than raising RangeError" do
+        expect { described_class.set_for_effort(effort_1) }.not_to raise_error
+        # Segments not involving the poisoned split_time should still be created.
+        expect(effort_1.effort_segments.count).to be > 0
+        expect(effort_1.effort_segments.pluck(:elapsed_seconds).max).to be <= 2_147_483_647
+        # Segments involving the poisoned split_time (as end_split) should have been filtered out.
+        expect(effort_1.effort_segments.where(end_split_id: split_time_1.split_id,
+                                              end_bitkey: split_time_1.bitkey,
+                                              lap: split_time_1.lap)).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Fixes #1878
- `ProcessImportedRawTimesJob` was crashing with `PG::NumericValueOutOfRange` (ScoutAPM error group 98034) whenever a single imported split_time had a malformed `absolute_time` that pushed the computed `elapsed_seconds` difference past 32-bit int range. The `elapsed_seconds::integer` cast in the `INSERT ... SELECT` would fail and abort the whole job, poisoning all downstream ingestion for that effort group.
- Add a `WHERE` filter so overflowing rows are silently skipped. Legitimate race data never comes close to 2,147,483,647 seconds (~68 years) — every overflow we see is bad input. Widening the column to bigint would only preserve the garbage value, and the table rewrite risk wasn't warranted.

## Test plan
- [x] Added regression spec that poisons a fixture split_time with `absolute_time + 100.years` and verifies `set_for_effort` no longer raises. Confirmed the spec fails on master and passes with the filter.
- [x] Existing 9 examples in `effort_segment_spec` still pass (NULL `elapsed_seconds` rows are preserved via `elapsed_seconds is null or between ...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)