### PR TITLE
Guard Course#average_finish_seconds against missing splits

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -46,9 +46,9 @@ class Course < ApplicationRecord
 
   # @return [Integer, nil]
   def average_finish_seconds
-    starting_split_id = start_split.id
-    finish_split_id = finish_split.id
-    segments = EffortSegment.where(begin_split_id: starting_split_id, end_split_id: finish_split_id)
+    return nil unless start_split && finish_split
+
+    segments = EffortSegment.where(begin_split_id: start_split.id, end_split_id: finish_split.id)
     return nil if segments.empty?
 
     segments.average(:elapsed_seconds).to_i

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -65,12 +65,24 @@ RSpec.describe Course, type: :model do
 
   describe "#average_finish_seconds" do
     let(:result) { course.average_finish_seconds }
-    let(:course) { courses(:hardrock_ccw) }
 
-    before { EffortSegment.set_all }
+    context "with a complete course that has finished efforts" do
+      let(:course) { courses(:hardrock_ccw) }
 
-    it "returns the average finish time in seconds for the course" do
-      expect(result).to eq(139039)
+      before { EffortSegment.set_all }
+
+      it "returns the average finish time in seconds for the course" do
+        expect(result).to eq(139039)
+      end
+    end
+
+    context "when the course is missing start or finish splits" do
+      let(:course) { create(:course) }
+
+      it "returns nil without raising" do
+        expect { result }.not_to raise_error
+        expect(result).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- Fixes #1875
- `Course#average_finish_seconds` called `.id` on `start_split` and `finish_split`, both of which return `nil` for courses missing a start or finish split. Because `courses#index` renders every course through this method (via the `_courses_list` partial), a single incomplete course would 500 the whole page (ScoutAPM error group 98116).
- Return `nil` early when either split is missing — matches the declared `@return [Integer, nil]` contract and the sibling methods (`distance`, `vert_gain`, `vert_loss`) that already use safe navigation.

## Additional cleanup
- The pre-commit hook flagged 5 pre-existing rubocop offenses on `course.rb`. Addressed them: modernized validation syntax, `unless … present?` → `if … blank?`, and a couple of multiline formatting fixes.
- Dropped the explicit `validates :organization, presence: true` — `belongs_to` auto-validates presence in Rails 5+, and the cop flagged it as redundant. The spec was updated from `"can't be blank"` to `"must exist"` to match the Rails-default message.
- Added an inline `# rubocop:disable Rails/UniqueValidationWithoutIndex` on the `:name` uniqueness validation. `courses.name` has no unique DB index; adding one is a separate migration out of scope for a bug fix PR.

## Test plan
- [x] Added regression spec for the nil-split case (verified it fails on master and passes with the fix).
- [x] Existing 31 examples in `course_spec` still pass.
- [x] Rubocop clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)