### PR TITLE
Guard last_reported_location against nil final_distance

### DIFF
--- a/app/helpers/efforts_helper.rb
+++ b/app/helpers/efforts_helper.rb
@@ -10,11 +10,10 @@ module EffortsHelper
   end
 
   def last_reported_location(effort_row)
-    if effort_row.started?
-      "#{effort_row.final_lap_split_name} (#{pdu('singular')} #{d(effort_row.final_distance)})"
-    else
-      "--"
-    end
+    return "--" unless effort_row.started?
+    return effort_row.final_lap_split_name.to_s if effort_row.final_distance.nil?
+
+    "#{effort_row.final_lap_split_name} (#{pdu('singular')} #{d(effort_row.final_distance)})"
   end
 
   def last_reported_time_of_day(effort_row)

--- a/spec/helpers/efforts_helper_spec.rb
+++ b/spec/helpers/efforts_helper_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe EffortsHelper do
+  describe "#last_reported_location" do
+    # EffortRow is a SimpleDelegator, so instance_double can't verify delegator-forwarded methods.
+    let(:effort_row) do
+      double("EffortRow", # rubocop:disable RSpec/VerifiedDoubles
+             started?: started,
+             final_lap_split_name: "Aid 3",
+             final_distance: final_distance)
+    end
+    let(:started) { true }
+
+    context "when the effort has not started" do
+      let(:started) { false }
+      let(:final_distance) { nil }
+
+      it "returns the placeholder" do
+        expect(helper.last_reported_location(effort_row)).to eq("--")
+      end
+    end
+
+    context "when the effort has started but final_distance is nil" do
+      let(:final_distance) { nil }
+
+      it "returns the split name only, without raising" do
+        expect { helper.last_reported_location(effort_row) }.not_to raise_error
+        expect(helper.last_reported_location(effort_row)).to eq("Aid 3")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fixes #1872
- `EffortsHelper#last_reported_location` assumed every started effort has a computable `final_distance` and passed it straight to the distance formatter. When `final_distance` was `nil`, the chain hit `numericize` on `nil` and crashed the entire `events#summary` page (ScoutAPM error group 95904).
- When `final_distance` is `nil` for a started effort, fall back to the split name alone rather than raising. One effort with incomplete distance metadata no longer takes down the page for every other row.

## Test plan
- [x] Added a new `spec/helpers/efforts_helper_spec.rb` covering the not-started case and the started-but-nil-distance case (confirmed to fail on master, pass with the fix).
- [x] Rubocop clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)