### PR TITLE
Reject unsupported record types in event imports

### DIFF
--- a/lib/etl/errors.rb
+++ b/lib/etl/errors.rb
@@ -171,6 +171,13 @@ module Etl
         detail: { row_index: row_index, messages: ["Transform failed: #{error_text}"] } }
     end
 
+    def unsupported_record_type_error(parent_class, record_type, suggested_parent: nil)
+      messages = ["#{parent_class} imports do not accept #{record_type} records."]
+      messages << "Use the #{suggested_parent} import endpoint instead." if suggested_parent.present?
+      { title: "Record type not supported for this parent",
+        detail: { messages: messages } }
+    end
+
     def value_not_permitted_error(option, permitted_values, provided_value)
       {
         title: "Argument value is not permitted",

--- a/lib/etl/loaders/upsert_strategy.rb
+++ b/lib/etl/loaders/upsert_strategy.rb
@@ -1,9 +1,16 @@
 module Etl
   module Loaders
     class UpsertStrategy < BaseLoader
+      # Maps record_type -> parent class name that DOES accept it, used to tell the API client
+      # where to send the payload when they've hit the wrong endpoint.
+      SUGGESTED_PARENT_FOR_RECORD_TYPE = {
+        raw_time: "event_group",
+      }.freeze
+
       def post_initialize(options)
         @unique_key = options[:unique_key]&.map { |attribute| attribute.to_s.underscore.to_sym }
         @parent = options[:parent]
+        validate_parent_accepts_record_types
       end
 
       def custom_load
@@ -77,6 +84,21 @@ module Etl
 
       def unique_key_valid?(unique_key, unique_attributes)
         unique_key.present? && unique_key.size == unique_attributes.size && unique_attributes.values.none?(&:nil?)
+      end
+
+      def validate_parent_accepts_record_types
+        return unless parent
+
+        proto_records.map(&:record_type).compact.uniq.each do |record_type|
+          plural_model_class = record_type.to_s.pluralize
+          next if parent.respond_to?(plural_model_class)
+
+          errors << unsupported_record_type_error(
+            parent.class.name,
+            record_type,
+            suggested_parent: SUGGESTED_PARENT_FOR_RECORD_TYPE[record_type],
+          )
+        end
       end
     end
   end

--- a/spec/controllers/api/v1/events_controller_spec.rb
+++ b/spec/controllers/api/v1/events_controller_spec.rb
@@ -461,6 +461,29 @@ RSpec.describe Api::V1::EventsController do
           end
         end
       end
+
+      context "when payload contains raw_time records (which belong to event_group, not event)" do
+        let(:request_params) { { id: event.id, data_format: "jsonapi_batch", data: data } }
+        let(:data) do
+          [
+            { type: "raw_time",
+              attributes: { bib_number: "101", split_name: "Aid 1", sub_split_kind: "in",
+                            entered_time: "08:00:00", source: "ost-test" } },
+          ]
+        end
+
+        it "rejects the request with a 422 and a descriptive error" do
+          allow(ProcessImportedRawTimesJob).to receive(:perform_later)
+          expect { make_request }.not_to change(RawTime, :count)
+          expect(response.status).to eq(422)
+          error_titles = parsed_response["errors"].pluck("title")
+          expect(error_titles).to include("Record type not supported for this parent")
+          messages = parsed_response["errors"].flat_map { |err| err["detail"]["messages"] }
+          expect(messages).to include(a_string_matching(/Event imports do not accept raw_time records/))
+          expect(messages).to include(a_string_matching(/event_group import endpoint/))
+          expect(ProcessImportedRawTimesJob).not_to have_received(:perform_later)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Fixes #1874
- `/api/v1/events/:id/import` was crashing with `NoMethodError: undefined method 'raw_times' for an instance of Event` when a client POSTed raw_time records (ScoutAPM error group 98362). `Etl::Loaders::UpsertStrategy#fetch_record` called `parent.send(plural_model_class).new` without checking that the association exists on the parent, and `Event` deliberately has no `raw_times` association (raw times belong to `EventGroup`).
- Chose rejection over routing: raw-time ingestion goes through a separate pipeline (`ProcessImportedRawTimesJob` with matching/rowification) that's driven by `Etl::EventGroupImportProcess`. Surfacing it on the event endpoint would mean duplicating that whole flow. Clients hitting the event endpoint with raw_times should use `/api/v1/event_groups/:id/import` instead — the error message says so.

## Changes
- `lib/etl/loaders/upsert_strategy.rb` — new `validate_parent_accepts_record_types` step in `post_initialize`. Iterates distinct record types in the batch, checks `parent.respond_to?(plural_model_class)`, and appends a JSON:API error for any mismatch. `BaseLoader#load_records` already short-circuits when `errors.present?`, so the transaction is never entered.
- `lib/etl/errors.rb` — `unsupported_record_type_error(parent_class, record_type, suggested_parent:)` helper. When a suggested parent is provided (currently just `raw_time` → `event_group`), it's appended to the message.
- `spec/controllers/api/v1/events_controller_spec.rb` — request spec covering an event import with a `raw_time` payload. Asserts 422, the error title, the "use the event_group import endpoint" guidance, that no `RawTime` was persisted, and that `ProcessImportedRawTimesJob` was not enqueued.

## Test plan
- [x] Added regression spec; verified it fails on master and passes with the fix.
- [x] All 164 existing `Api::V1::{Events,EventGroups}Controller` specs still pass.
- [x] Rubocop clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)