### PR TITLE
Fix duplicate event group webhook token and created_by

### DIFF
--- a/app/controllers/duplicate_event_groups_controller.rb
+++ b/app/controllers/duplicate_event_groups_controller.rb
@@ -5,12 +5,13 @@ class DuplicateEventGroupsController < ApplicationController
 
   def new
     authorize @existing_event_group, policy_class: DuplicateEventGroupPolicy
-    @duplicate_event_group = DuplicateEventGroup.new(existing_id: @existing_event_group.id, new_start_date: Date.today)
+    @duplicate_event_group = DuplicateEventGroup.new(existing_id: @existing_event_group.id,
+                                                     new_start_date: Time.zone.today)
   end
 
   def create
     authorize @existing_event_group, policy_class: DuplicateEventGroupPolicy
-    @duplicate_event_group = DuplicateEventGroup.create(permitted_params)
+    @duplicate_event_group = DuplicateEventGroup.create(permitted_params.merge(created_by: current_user.id))
 
     if @duplicate_event_group.valid?
       redirect_to setup_event_group_path(@duplicate_event_group.new_event_group)

--- a/app/models/duplicate_event_group.rb
+++ b/app/models/duplicate_event_group.rb
@@ -32,13 +32,22 @@ class DuplicateEventGroup
 
   def duplicate_event_group
     self.new_event_group = existing_event_group.dup
-    new_event_group.assign_attributes(name: new_name, concealed: true, available_live: false,
-                                      webhook_token: nil, created_by: created_by)
+    new_event_group.assign_attributes(
+      name: new_name,
+      concealed: true,
+      available_live: false,
+      webhook_token: nil,
+      created_by: created_by,
+    )
     existing_event_group.events.each do |existing_event|
       new_event = existing_event.dup
-      new_event.assign_attributes(scheduled_start_time: existing_event.scheduled_start_time + offset,
-                                  historical_name: nil, beacon_url: nil, efforts_count: 0,
-                                  created_by: created_by)
+      new_event.assign_attributes(
+        scheduled_start_time: existing_event.scheduled_start_time + offset,
+        historical_name: nil,
+        beacon_url: nil,
+        efforts_count: 0,
+        created_by: created_by,
+      )
       new_event_group.events << new_event
     end
   end

--- a/app/models/duplicate_event_group.rb
+++ b/app/models/duplicate_event_group.rb
@@ -5,6 +5,7 @@ class DuplicateEventGroup
   attribute :existing_id, :integer
   attribute :new_name, :string
   attribute :new_start_date, :date
+  attribute :created_by, :integer
   attr_reader :new_event_group
 
   validates :existing_event_group, :new_name, :new_start_date, presence: true
@@ -31,11 +32,13 @@ class DuplicateEventGroup
 
   def duplicate_event_group
     self.new_event_group = existing_event_group.dup
-    new_event_group.assign_attributes(name: new_name, concealed: true, available_live: false)
+    new_event_group.assign_attributes(name: new_name, concealed: true, available_live: false,
+                                      webhook_token: nil, created_by: created_by)
     existing_event_group.events.each do |existing_event|
       new_event = existing_event.dup
       new_event.assign_attributes(scheduled_start_time: existing_event.scheduled_start_time + offset,
-                                  historical_name: nil, beacon_url: nil, efforts_count: 0)
+                                  historical_name: nil, beacon_url: nil, efforts_count: 0,
+                                  created_by: created_by)
       new_event_group.events << new_event
     end
   end

--- a/spec/models/duplicate_event_group_spec.rb
+++ b/spec/models/duplicate_event_group_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe DuplicateEventGroup, type: :model do
+  let(:event_group) { event_groups(:sum) }
+  let(:user) { users(:admin_user) }
+  let(:new_name) { "SUM Duplicate" }
+  let(:new_start_date) { "2025-06-01" }
+
+  describe "#create" do
+    subject do
+      described_class.create(existing_id: event_group.id, new_name: new_name,
+                             new_start_date: new_start_date, created_by: user.id)
+    end
+
+    context "with valid params" do
+      it "creates a new event group" do
+        expect { subject }.to change(EventGroup, :count).by(1)
+      end
+
+      it "creates events matching the original" do
+        expect { subject }.to change(Event, :count).by(event_group.events.count)
+      end
+
+      it "sets the new name" do
+        expect(subject.new_event_group.name).to eq(new_name)
+      end
+
+      it "sets concealed to true" do
+        expect(subject.new_event_group.concealed).to be true
+      end
+
+      it "sets created_by to the provided user" do
+        expect(subject.new_event_group.created_by).to eq(user.id)
+      end
+
+      it "sets created_by on duplicated events" do
+        subject.new_event_group.events.each do |event|
+          expect(event.created_by).to eq(user.id)
+        end
+      end
+    end
+
+    context "when the source event group has a webhook token" do
+      before { event_group.update_column(:webhook_token, SecureRandom.base58(24)) }
+
+      it "does not copy the webhook token from the source" do
+        expect(subject.new_event_group.webhook_token).not_to eq(event_group.reload.webhook_token)
+      end
+
+      it "creates successfully without a unique constraint violation" do
+        expect { subject }.to change(EventGroup, :count).by(1)
+      end
+    end
+
+    context "with a blank name" do
+      let(:new_name) { "" }
+
+      it "does not create an event group" do
+        expect { subject }.not_to change(EventGroup, :count)
+      end
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context "with a blank date" do
+      let(:new_start_date) { nil }
+
+      it "does not create an event group" do
+        expect { subject }.not_to change(EventGroup, :count)
+      end
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context "with a duplicate name" do
+      let(:new_name) { event_group.name }
+
+      it "does not create an event group" do
+        expect { subject }.not_to change(EventGroup, :count)
+      end
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/duplicate_event_group_spec.rb
+++ b/spec/models/duplicate_event_group_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DuplicateEventGroup, type: :model do
     end
 
     context "when the source event group has a webhook token" do
-      before { event_group.update_column(:webhook_token, SecureRandom.base58(24)) }
+      before { event_group.regenerate_webhook_token }
 
       it "does not copy the webhook token from the source" do
         expect(subject.new_event_group.webhook_token).not_to eq(event_group.reload.webhook_token)

--- a/spec/system/event_groups/duplicate_event_group_flow_spec.rb
+++ b/spec/system/event_groups/duplicate_event_group_flow_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "create a duplicate event group using the duplicate event group p
     end
 
     scenario "The source event group has a webhook token" do
-      event_group.update_column(:webhook_token, SecureRandom.base58(24))
+      event_group.regenerate_webhook_token
       login_as admin, scope: :user
 
       visit new_duplicate_path

--- a/spec/system/event_groups/duplicate_event_group_flow_spec.rb
+++ b/spec/system/event_groups/duplicate_event_group_flow_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe "create a duplicate event group using the duplicate event group p
       verify_visit_and_duplication
     end
 
+    scenario "The source event group has a webhook token" do
+      event_group.update_column(:webhook_token, SecureRandom.base58(24))
+      login_as admin, scope: :user
+
+      visit new_duplicate_path
+      verify_visit_and_duplication
+    end
+
     scenario "The name has been taken" do
       login_as admin, scope: :user
 


### PR DESCRIPTION
## Summary

- Clear `webhook_token` on the duplicated event group so `has_secure_token` generates a fresh one, fixing `PG::UniqueViolation` on the unique index
- Set `created_by` to the current user on both the duplicated event group and its events, instead of copying the original creator

Fixes #1896

## Test plan

- [ ] Duplicate an event group in staging — no more unique constraint error
- [ ] Verify the new event group has a different webhook token than the original
- [ ] Verify `created_by` on the new event group and events is the current user
- [x] `bundle exec rspec spec/system/event_groups/duplicate_event_group_flow_spec.rb` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)