### PR TITLE
Fix shift event start time argument error

### DIFF
--- a/app/jobs/event_update_start_time_job.rb
+++ b/app/jobs/event_update_start_time_job.rb
@@ -2,11 +2,10 @@ class EventUpdateStartTimeJob < ApplicationJob
   queue_as :default
 
   def perform(event, new_start_time:, current_user:)
-    options = { new_start_time: new_start_time, current_user: current_user }
     validate_setup(event)
-    set_current_user(options)
+    set_current_user(current_user: current_user)
 
-    result = Interactors::ShiftEventStartTime.perform!(event, options)
+    result = Interactors::ShiftEventStartTime.perform!(event, new_start_time: new_start_time)
 
     Rails.logger.debug result.message_with_error_report # TODO: use ActionCable to send this message to the session
     result

--- a/spec/jobs/event_update_start_time_job_spec.rb
+++ b/spec/jobs/event_update_start_time_job_spec.rb
@@ -17,11 +17,18 @@ RSpec.describe EventUpdateStartTimeJob do
     expect { job }.to change(described_class.queue_adapter.enqueued_jobs, :size).by(1)
   end
 
-  it "calls Interactors::ShiftEventStartTime with the correct arguments" do
+  it "calls Interactors::ShiftEventStartTime with keyword arguments" do
     result = Interactors::Response.new(errors: [])
-    allow(Interactors::ShiftEventStartTime).to receive(:perform!).with(event, { new_start_time: "2017-10-01 08:00:00" }).and_return(result)
+    allow(Interactors::ShiftEventStartTime).to receive(:perform!)
+      .with(event, new_start_time: "2017-10-01 08:00:00").and_return(result)
     perform_enqueued_jobs { job }
-    expect(Interactors::ShiftEventStartTime).to have_received(:perform!).with(event, { new_start_time: "2017-10-01 08:00:00" })
+    expect(Interactors::ShiftEventStartTime).to have_received(:perform!)
+      .with(event, new_start_time: "2017-10-01 08:00:00")
+  end
+
+  it "shifts the event start time without error" do
+    perform_enqueued_jobs { job }
+    expect(event.reload.scheduled_start_time_local.to_s).to include("2017-10-01")
   end
 
   describe "validation" do


### PR DESCRIPTION
## Summary

- Pass `new_start_time:` as a keyword argument to `ShiftEventStartTime.perform!` instead of a positional hash
- Ruby 4.0 no longer auto-converts hashes to keyword arguments, causing `wrong number of arguments (given 2, expected 1; required keyword: new_start_time)`

Fixes #1897

## Test plan

- [ ] Shift an event's start time in staging — no more argument error
- [ ] `bundle exec rspec spec/jobs/event_update_start_time_job_spec.rb` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)