### PR TITLE
Deduplicate follower_ids in notification records

### DIFF
--- a/app/jobs/notify_participation_job.rb
+++ b/app/jobs/notify_participation_job.rb
@@ -14,7 +14,7 @@ class NotifyParticipationJob < ApplicationJob
     notification = Notification.new(
       kind: :participation,
       effort: effort,
-      follower_ids: person.followers.ids,
+      follower_ids: person.followers.distinct.ids,
       subject: response.resources[:subject],
       notice_text: response.resources[:notice_text],
       topic_resource_key: topic_resource_key

--- a/app/jobs/notify_progress_job.rb
+++ b/app/jobs/notify_progress_job.rb
@@ -44,7 +44,7 @@ class NotifyProgressJob < ApplicationJob
   end
 
   def followers
-    @followers ||= effort.followers
+    @followers ||= effort.followers.distinct
   end
 
   def effort_not_notifiable?

--- a/spec/jobs/notify_progress_job_spec.rb
+++ b/spec/jobs/notify_progress_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NotifyProgressJob do
 
   let(:effort_id) { effort.id }
   let(:event) { events(:rufa_2017_24h) }
-  let(:effort) { efforts(:rufa_2017_24h_progress_lap6) } # rubocop:disable Naming/VariableNumber
+  let(:effort) { efforts(:rufa_2017_24h_progress_lap6) }
   let(:splits) { event.splits }
 
   describe "#perform" do
@@ -40,6 +40,18 @@ RSpec.describe NotifyProgressJob do
           expect(notification.bitkey).to eq(notification_split_times.last.bitkey)
           expect(notification.topic_resource_key).to eq(effort.topic_resource_key)
           expect(notification.subject).to eq("Update for Progress Lap6 at RUFA 2017 (24H) from OpenSplitTime")
+        end
+
+        it "stores distinct follower_ids when a user has multiple subscriptions" do
+          user = users(:admin_user)
+          Subscription.create!(user: user, subscribable: effort, protocol: :email,
+                               endpoint: user.email, resource_key: "arn:aws:sns:us-west-2:123:test-email")
+          Subscription.create!(user: user, subscribable: effort, protocol: :sms,
+                               endpoint: user.phone, resource_key: "arn:aws:sns:us-west-2:123:test-sms")
+
+          perform_notification
+          notification = Notification.last
+          expect(notification.follower_ids).to eq([user.id])
         end
       end
 


### PR DESCRIPTION
## Summary

- Add `.distinct` to `followers` queries in `NotifyProgressJob` and `NotifyParticipationJob`
- When a user subscribes via both email and SMS, they appeared twice in `follower_ids` because the `has_many :followers, through: :subscriptions` association returns one row per subscription

## Test plan

- [x] Spec reproducing the duplicate: `bundle exec rspec spec/jobs/notify_progress_job_spec.rb -e "stores distinct follower_ids"`
- [x] Full suite: `bundle exec rspec spec/jobs/notify_progress_job_spec.rb spec/jobs/notify_participation_job_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)