### PR TITLE
Show flash confirmation when SMS consent changes

### DIFF
--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -31,20 +31,16 @@ class UserSettingsController < ApplicationController
   def update
     sms_was_opted_in = current_user.sms_opted_in?
     updated = current_user.update(settings_update_params)
-    message = if updated && current_user.unconfirmed_email.present?
-                "You have requested that your email address be changed. " \
-                  "Please check your email to confirm your new address."
-              elsif updated && !sms_was_opted_in && current_user.sms_opted_in?
-                t("sms.consent.opted_in")
-              elsif updated && sms_was_opted_in && !current_user.sms_opted_in?
-                t("sms.consent.opted_out")
-              elsif updated
-                nil
-              else
-                current_user.errors.full_messages.join("; ")
-              end
 
-    redirect_to request.referrer, notice: message
+    if updated
+      messages = []
+      messages << t("user_settings.update.email_change_requested") if current_user.unconfirmed_email.present?
+      messages << t("sms.consent.opted_in") if !sms_was_opted_in && current_user.sms_opted_in?
+      messages << t("sms.consent.opted_out") if sms_was_opted_in && !current_user.sms_opted_in?
+      redirect_to request.referrer, notice: messages.join(" ").presence
+    else
+      redirect_to request.referrer, notice: current_user.errors.full_messages.join("; ")
+    end
   end
 
   private

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -29,10 +29,15 @@ class UserSettingsController < ApplicationController
   end
 
   def update
+    sms_was_opted_in = current_user.sms_opted_in?
     updated = current_user.update(settings_update_params)
     message = if updated && current_user.unconfirmed_email.present?
                 "You have requested that your email address be changed. " \
                   "Please check your email to confirm your new address."
+              elsif updated && !sms_was_opted_in && current_user.sms_opted_in?
+                t("sms.consent.opted_in")
+              elsif updated && sms_was_opted_in && !current_user.sms_opted_in?
+                t("sms.consent.opted_out")
               elsif updated
                 nil
               else

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -108,6 +108,8 @@ en:
       hint: "US or Canada mobile number only"
 
   user_settings:
+    update:
+      email_change_requested: "You have requested that your email address be changed. Please check your email to confirm your new address."
     credentials:
       credentials_callout:
         detail_paragraph_1: "Credentials are used to connect your OpenSplitTime resource (such as an Event Group or an Event) with an external service, like Runsignup. This makes it easy to sync data from the external service into OpenSplitTime."

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -102,6 +102,8 @@ en:
       checkbox_label: "I agree to receive SMS text messages from OpenSplitTime"
       view_terms: "View full SMS terms"
       enabled_since: "SMS enabled since %{date}"
+      opted_in: "You have opted in to receive SMS text message updates from OpenSplitTime. Reply STOP to cancel. Reply HELP for help. Msg & data rates may apply."
+      opted_out: "You have opted out of SMS text message updates."
     phone:
       hint: "US or Canada mobile number only"
 


### PR DESCRIPTION
## Summary

- Display a confirmation flash message when the user opts in or out of SMS on the preferences page
- Opt-in message: "You have opted in to receive SMS text message updates from OpenSplitTime. Reply STOP to cancel. Reply HELP for help. Msg & data rates may apply."
- Opt-out message: "You have opted out of SMS text message updates."
- This is the "opt-in confirmation message" required by TCR for the 10DLC campaign submission

## Test plan

- [ ] Log in, go to preferences, enter phone, check consent, save — see opt-in flash
- [ ] Uncheck consent, save — see opt-out flash
- [ ] Save without changing consent — no SMS-related flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)