### PR TITLE
Handle credential decryption failures gracefully

### DIFF
--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -5,30 +5,37 @@ class Credential < ApplicationRecord
 
   encrypts :value
 
+  def value
+    super
+  rescue ActiveRecord::Encryption::Errors::Decryption
+    nil
+  end
+
   validates :service_identifier, :key, :value, presence: true
   validates :key,
             if: :key?,
             uniqueness: {
               scope: [:user, :service_identifier],
-              message: ->(record, _) do
-                "Duplicate key #{record.key} for user #{record.user_id} and service_identifier #{record.service_identifier}"
+              message: lambda do |record, _|
+                "Duplicate key #{record.key} for user #{record.user_id} " \
+                  "and service_identifier #{record.service_identifier}"
               end
             }
   validates :service_identifier,
             if: :service_identifier?,
             inclusion: {
               in: Connectors::Service::IDENTIFIERS,
-              message: ->(record, _) do
+              message: lambda do |record, _|
                 "Invalid service_identifier #{record.service_identifier}"
               end
             }
   validates :key,
             if: :key?,
             inclusion: {
-              in: ->(record) do
+              in: lambda do |record|
                 Connectors::Service::BY_IDENTIFIER[record.service_identifier]&.credential_keys || []
               end,
-              message: ->(record, _) do
+              message: lambda do |record, _|
                 "Invalid key #{record.key} for service_identifier #{record.service_identifier}"
               end
             }
@@ -43,7 +50,10 @@ class Credential < ApplicationRecord
   # @return [String, nil]
   def self.fetch(service_identifier, key)
     records = where(service_identifier: service_identifier, key: key).limit(2).to_a
-    raise ActiveRecord::RecordNotUnique, "Multiple records found for service_identifier #{service_identifier} and key #{key}" if records.many?
+    if records.many?
+      raise ActiveRecord::RecordNotUnique,
+            "Multiple records found for service_identifier #{service_identifier} and key #{key}"
+    end
 
     records.first&.value
   end

--- a/spec/models/credential_spec.rb
+++ b/spec/models/credential_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Credential do
   subject { described_class.new(user: user, service_identifier: service_identifier, key: key, value: value) }
+
   let(:user) { users(:third_user) }
   let(:service_identifier) { "runsignup" }
   let(:key) { "api_key" }
@@ -11,7 +12,7 @@ RSpec.describe Credential do
     before { subject.validate }
 
     context "when no conflicting credentials exist" do
-      before { Credential.delete_all }
+      before { described_class.delete_all }
 
       context "when all attributes are valid" do
         it { expect(subject).to be_valid }
@@ -60,6 +61,40 @@ RSpec.describe Credential do
     end
   end
 
+  describe "#value when decryption fails" do
+    let(:credential) { user.credentials.for_service("runsignup").find_by(key: "api_key") }
+
+    before do
+      # Write invalid ciphertext directly to simulate an encryption key mismatch
+      described_class.connection.execute(
+        "UPDATE credentials SET value = 'corrupted-ciphertext' WHERE id = #{credential.id}"
+      )
+      credential.reload
+    end
+
+    it "returns nil instead of raising" do
+      expect(credential.value).to be_nil
+    end
+  end
+
+  describe ".fetch when decryption fails" do
+    let(:result) { user.credentials.fetch(service_identifier, key) }
+    let(:user) { users(:third_user) }
+    let(:service_identifier) { "runsignup" }
+    let(:key) { "api_key" }
+
+    before do
+      credential = user.credentials.for_service(service_identifier).find_by(key: key)
+      described_class.connection.execute(
+        "UPDATE credentials SET value = 'corrupted-ciphertext' WHERE id = #{credential.id}"
+      )
+    end
+
+    it "returns nil instead of raising" do
+      expect(result).to be_nil
+    end
+  end
+
   describe ".fetch" do
     let(:result) { user.credentials.fetch(service_identifier, key) }
     let(:user) { users(:third_user) }
@@ -74,7 +109,7 @@ RSpec.describe Credential do
     end
 
     context "when multiple records exist" do
-      let(:result) { Credential.fetch(service_identifier, key) }
+      let(:result) { described_class.fetch(service_identifier, key) }
       before { described_class.create(user: other_user, service_identifier: service_identifier, key: key, value: "5678") }
 
       it "raises an error" do


### PR DESCRIPTION
## Summary

- Override `Credential#value` to rescue `ActiveRecord::Encryption::Errors::Decryption` and return `nil`
- The credentials page now renders instead of crashing when records were encrypted with a different key (e.g., after restoring a database dump or rotating encryption keys)
- Unreadable credentials appear as blank fields, allowing the user to re-enter them

Fixes #1889

## Test plan

- [ ] Spec reproducing the crash: `bundle exec rspec spec/models/credential_spec.rb -e "decryption fails"`
- [ ] Full suite: `bundle exec rspec spec/models/credential_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)