### PR TITLE
Add 3-state subscription buttons with async pending refresh

### DIFF
--- a/app/helpers/toggle_helper.rb
+++ b/app/helpers/toggle_helper.rb
@@ -144,7 +144,7 @@ module ToggleHelper
     unsubscribe_alert = args[:unsubscribe_alert]
     existing_subscription = subscribable.subscriptions.find_by(user: current_user, protocol: protocol)
 
-    if existing_subscription
+    if existing_subscription&.confirmed?
       url = polymorphic_path([subscribable, existing_subscription])
       html_options = { method: :delete,
                        class: "#{protocol}-sub btn btn-lg btn-primary",
@@ -152,6 +152,18 @@ module ToggleHelper
                          turbo_confirm: unsubscribe_alert,
                          turbo_submits_with: fa_icon("spinner", class: "fa-spin", text: protocol),
                        } }
+      button_to(url, html_options) { fa_icon(icon_name, text: protocol) }
+    elsif existing_subscription&.pending?
+      RefreshPendingSubscriptionJob.perform_later(existing_subscription.id)
+      url = polymorphic_path([subscribable, existing_subscription])
+      html_options = { method: :delete,
+                       class: "#{protocol}-sub btn btn-lg btn-outline-primary",
+                       data: {
+                         turbo_confirm: unsubscribe_alert,
+                         turbo_submits_with: fa_icon("spinner", class: "fa-spin", text: protocol),
+                       } }
+      pending_text = "#{protocol} #{t('subscriptions.toggle.pending_suffix')}"
+      button_to(url, html_options) { fa_icon(icon_name, text: pending_text) }
     else
       url = polymorphic_path([subscribable, :subscriptions], subscription: { protocol: protocol })
       html_options = { method: :post,
@@ -160,9 +172,8 @@ module ToggleHelper
                          turbo_confirm: subscribe_alert,
                          turbo_submits_with: fa_icon("spinner", class: "fa-spin", text: protocol),
                        } }
+      button_to(url, html_options) { fa_icon(icon_name, text: protocol) }
     end
-
-    button_to(url, html_options) { fa_icon(icon_name, text: protocol) }
   end
 
   def link_to_sms_opt_in(icon:)

--- a/app/helpers/toggle_helper.rb
+++ b/app/helpers/toggle_helper.rb
@@ -146,34 +146,32 @@ module ToggleHelper
 
     if existing_subscription&.confirmed?
       url = polymorphic_path([subscribable, existing_subscription])
-      html_options = { method: :delete,
-                       class: "#{protocol}-sub btn btn-lg btn-primary",
-                       data: {
-                         turbo_confirm: unsubscribe_alert,
-                         turbo_submits_with: fa_icon("spinner", class: "fa-spin", text: protocol),
-                       } }
-      button_to(url, html_options) { fa_icon(icon_name, text: protocol) }
+      button_class = "btn-primary"
+      confirm_text = unsubscribe_alert
+      method = :delete
+      label = protocol
     elsif existing_subscription&.pending?
       RefreshPendingSubscriptionJob.perform_later(existing_subscription.id)
       url = polymorphic_path([subscribable, existing_subscription])
-      html_options = { method: :delete,
-                       class: "#{protocol}-sub btn btn-lg btn-outline-primary",
-                       data: {
-                         turbo_confirm: unsubscribe_alert,
-                         turbo_submits_with: fa_icon("spinner", class: "fa-spin", text: protocol),
-                       } }
-      pending_text = "#{protocol} #{t('subscriptions.toggle.pending_suffix')}"
-      button_to(url, html_options) { fa_icon(icon_name, text: pending_text) }
+      button_class = "btn-outline-primary"
+      confirm_text = unsubscribe_alert
+      method = :delete
+      label = "#{protocol} #{t('subscriptions.toggle.pending_suffix')}"
     else
       url = polymorphic_path([subscribable, :subscriptions], subscription: { protocol: protocol })
-      html_options = { method: :post,
-                       class: "#{protocol}-sub btn btn-lg btn-outline-secondary",
-                       data: {
-                         turbo_confirm: subscribe_alert,
-                         turbo_submits_with: fa_icon("spinner", class: "fa-spin", text: protocol),
-                       } }
-      button_to(url, html_options) { fa_icon(icon_name, text: protocol) }
+      button_class = "btn-outline-secondary"
+      confirm_text = subscribe_alert
+      method = :post
+      label = protocol
     end
+
+    html_options = { method: method,
+                     class: "#{protocol}-sub btn btn-lg #{button_class}",
+                     data: {
+                       turbo_confirm: confirm_text,
+                       turbo_submits_with: fa_icon("spinner", class: "fa-spin", text: protocol),
+                     } }
+    button_to(url, html_options) { fa_icon(icon_name, text: label) }
   end
 
   def link_to_sms_opt_in(icon:)

--- a/app/jobs/refresh_pending_subscription_job.rb
+++ b/app/jobs/refresh_pending_subscription_job.rb
@@ -1,0 +1,14 @@
+class RefreshPendingSubscriptionJob < ApplicationJob
+  queue_as :default
+
+  def perform(subscription_id)
+    subscription = Subscription.find_by(id: subscription_id)
+    return unless subscription&.pending?
+
+    subscription.save
+
+    return unless subscription.confirmed?
+
+    Turbo::StreamsChannel.broadcast_refresh_to(subscription.subscribable)
+  end
+end

--- a/app/views/subscriptions/_subscription_button.html.erb
+++ b/app/views/subscriptions/_subscription_button.html.erb
@@ -1,5 +1,6 @@
 <%# locals: (subscribable:, protocol:) -%>
 
+<%= turbo_stream_from subscribable %>
 <%= content_tag :span, id: dom_id(subscribable, protocol), class: "mx-1" do %>
   <%= link_to_subscription(subscribable, protocol) %>
 <% end %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -95,6 +95,7 @@ en:
       sign_in_required: "You must be signed in to subscribe to notifications."
       effort_update_type: "live progress"
       person_update_type: "future event sign-up"
+      pending_suffix: "(pending)"
 
   sms:
     consent:

--- a/spec/jobs/refresh_pending_subscription_job_spec.rb
+++ b/spec/jobs/refresh_pending_subscription_job_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe RefreshPendingSubscriptionJob do
+  subject(:job) { described_class.new }
+
+  let(:subscription) { subscriptions(:subscription_0003) }
+  let(:effort) { subscription.subscribable }
+
+  describe "#perform" do
+    context "when the subscription is pending and becomes confirmed after save" do
+      before do
+        effort.update_column(:topic_resource_key, "arn:aws:sns:us-west-2:123:test-topic")
+        subscription.update_columns(resource_key: "pending:#{SecureRandom.uuid}", endpoint: "user@example.com")
+        allow(SnsSubscriptionManager).to receive(:locate)
+          .and_return(SnsSubscriptionManager::Response.new(subscription_arn: "arn:aws:sns:us-west-2:123:confirmed"))
+      end
+
+      it "updates the resource_key to confirmed" do
+        job.perform(subscription.id)
+        expect(subscription.reload.resource_key).to include("arn:aws:sns")
+      end
+
+      it "broadcasts a Turbo Stream refresh" do
+        expect(Turbo::StreamsChannel).to receive(:broadcast_refresh_to).with(effort)
+        job.perform(subscription.id)
+      end
+    end
+
+    context "when the subscription is pending but remains pending after save" do
+      before do
+        effort.update_column(:topic_resource_key, "arn:aws:sns:us-west-2:123:test-topic")
+        subscription.update_columns(resource_key: "pending:#{SecureRandom.uuid}", endpoint: "user@example.com")
+        allow(SnsSubscriptionManager).to receive(:locate)
+          .and_return(SnsSubscriptionManager::Response.new(error_message: "not confirmed yet"))
+      end
+
+      it "does not broadcast" do
+        expect(Turbo::StreamsChannel).not_to receive(:broadcast_refresh_to)
+        job.perform(subscription.id)
+      end
+    end
+
+    context "when the subscription is already confirmed" do
+      it "does not attempt to save or broadcast" do
+        expect(Turbo::StreamsChannel).not_to receive(:broadcast_refresh_to)
+        expect_any_instance_of(Subscription).not_to receive(:save) # rubocop:disable RSpec/AnyInstance
+        job.perform(subscription.id)
+      end
+    end
+
+    context "when the subscription does not exist" do
+      it "returns without error" do
+        expect { job.perform(-1) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Subscription buttons now show three visual states: not subscribed (outline), pending (outline-primary + "(pending)"), and confirmed (solid primary)
- When a pending subscription button renders, `RefreshPendingSubscriptionJob` is enqueued to check SNS for confirmation
- If confirmed, the job triggers a Turbo Stream page refresh so the button updates without manual reload
- Added `turbo_stream_from` to the subscription button partial to receive async updates

Fixes #1895

## Test plan

- [ ] Subscribe to email notifications on an effort — button shows "email (pending)" in outline-primary
- [ ] Confirm via SNS email link, revisit page — button transitions to solid primary "email"
- [ ] Unsubscribe still works from both pending and confirmed states
- [ ] `bundle exec rspec spec/jobs/refresh_pending_subscription_job_spec.rb` — 5 examples, 0 failures
- [ ] `bundle exec rspec spec/system/subscriptions/` — 16 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)