### PR TITLE
Add Turbo Stream subscription to event group setup page

### DIFF
--- a/app/views/event_groups/setup.html.erb
+++ b/app/views/event_groups/setup.html.erb
@@ -2,6 +2,7 @@
   <% "OpenSplitTime: Setup Event Group - #{@presenter.event_group.name}" %>
 <% end %>
 
+<%= turbo_stream_from @presenter.event_group %>
 <%= render "shared/mode_widget", event_group: @presenter.event_group %>
 <%= render "setup_header", presenter: @presenter, breadcrumbs: [] %>
 


### PR DESCRIPTION
## Summary

The setup page was missing `turbo_stream_from`, so it couldn't receive Turbo Stream broadcasts. This meant the async flash from `EventUpdateStartTimeJob` (implemented in #1905 / #1900) was sent but never displayed — the user only saw "Shifting start time..." and it never updated.

One-line fix: add `turbo_stream_from @presenter.event_group` to `setup.html.erb`.

## Test plan

- [ ] Go to event group setup, shift an event's start time
- [ ] See "Shifting start time..." flash on redirect
- [ ] Flash updates to the result message when the job completes
- [ ] Page refreshes to show updated start time

🤖 Generated with [Claude Code](https://claude.com/claude-code)