### PR TITLE
Fix start time shift flash being wiped by page refresh

### DIFF
--- a/app/jobs/event_update_start_time_job.rb
+++ b/app/jobs/event_update_start_time_job.rb
@@ -9,9 +9,11 @@ class EventUpdateStartTimeJob < ApplicationJob
 
     result = Interactors::ShiftEventStartTime.perform!(event, new_start_time: new_start_time)
 
-    message = "#{result.message} Refresh the page to see changes."
-    level = result.successful? ? :success : :danger
-    broadcast_flash(event.event_group, message: message, level: level)
+    if result.successful?
+      broadcast_flash(event.event_group, message: "#{result.message} Refresh the page to see changes.")
+    else
+      broadcast_flash(event.event_group, message: result.message, level: :danger)
+    end
     result
   end
 

--- a/app/jobs/event_update_start_time_job.rb
+++ b/app/jobs/event_update_start_time_job.rb
@@ -9,8 +9,9 @@ class EventUpdateStartTimeJob < ApplicationJob
 
     result = Interactors::ShiftEventStartTime.perform!(event, new_start_time: new_start_time)
 
-    broadcast_flash(event.event_group, message: result.message)
-    Turbo::StreamsChannel.broadcast_refresh_to(event.event_group)
+    message = "#{result.message} Refresh the page to see changes."
+    level = result.successful? ? :success : :danger
+    broadcast_flash(event.event_group, message: message, level: level)
     result
   end
 

--- a/spec/jobs/event_update_start_time_job_spec.rb
+++ b/spec/jobs/event_update_start_time_job_spec.rb
@@ -40,14 +40,8 @@ RSpec.describe EventUpdateStartTimeJob do
       event_group,
       target: "flash",
       partial: "layouts/broadcast_flash",
-      locals: hash_including(level: :success, message: anything)
+      locals: hash_including(level: :success, message: /Refresh the page to see changes/)
     )
-
-    perform_enqueued_jobs { job }
-  end
-
-  it "broadcasts a refresh on completion" do
-    expect(Turbo::StreamsChannel).to receive(:broadcast_refresh_to).with(event_group)
 
     perform_enqueued_jobs { job }
   end


### PR DESCRIPTION
## Summary

- Remove `broadcast_refresh_to` from `EventUpdateStartTimeJob` — the page morph was wiping the flash message before the user could read it
- Append "Refresh the page to see changes." to the flash message instead
- Set flash level to `:danger` on error, `:success` on success

Follow-up to #1905 / #1900.

## Test plan

- [ ] Shift an event's start time from the setup page
- [ ] See "Shifting start time..." flash on redirect
- [ ] Flash updates to result message with "Refresh the page to see changes."
- [ ] Flash stays visible until dismissed or page refresh
- [ ] `bundle exec rspec spec/jobs/event_update_start_time_job_spec.rb` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)