### PR TITLE
Add auto-draw all tickets for lottery divisions

### DIFF
--- a/app/controllers/lotteries_controller.rb
+++ b/app/controllers/lotteries_controller.rb
@@ -75,7 +75,8 @@ class LotteriesController < ApplicationController
       Lotteries::SyncCalculationsJob.perform_later(@lottery, current_user: current_user)
       redirect_to setup_organization_lottery_path(@organization, @lottery), notice: "Sync in progress"
     else
-      redirect_to setup_organization_lottery_path(@organization, @lottery), alert: "Lottery does not have a calculations_class"
+      redirect_to setup_organization_lottery_path(@organization, @lottery),
+                  alert: "Lottery does not have a calculations_class"
     end
   end
 
@@ -103,39 +104,44 @@ class LotteriesController < ApplicationController
         case export_format
         when :all_entrants
           entrants = @lottery.entrants.includes(:division_ranking)
-          filename = "#{@lottery.name}-export-all-entrants-#{Time.now.strftime('%Y-%m-%d')}.csv"
-          csv_stream = render_to_string(partial: "lotteries/results/all_entrants", formats: :csv, locals: { records: entrants })
+          filename = "#{@lottery.name}-export-all-entrants-#{Time.zone.now.strftime('%Y-%m-%d')}.csv"
+          csv_stream = render_to_string(partial: "lotteries/results/all_entrants", formats: :csv,
+                                        locals: { records: entrants })
 
           send_data(csv_stream, type: "text/csv", filename: filename)
         when :in_divisions
-          filename = "#{@lottery.name}-export-in-divisions-#{Time.now.strftime('%Y-%m-%d')}.csv"
-          csv_stream = render_to_string(partial: "lotteries/results/in_divisions", formats: :csv, locals: { lottery: @lottery })
+          filename = "#{@lottery.name}-export-in-divisions-#{Time.zone.now.strftime('%Y-%m-%d')}.csv"
+          csv_stream = render_to_string(partial: "lotteries/results/in_divisions", formats: :csv,
+                                        locals: { lottery: @lottery })
 
           send_data(csv_stream, type: "text/csv", filename: filename)
         when :ultrasignup
           entrants = @lottery.divisions.flat_map(&:accepted_entrants)
-          filename = "#{@lottery.name}-export-for-ultrasignup-#{Time.now.strftime('%Y-%m-%d')}.csv"
-          csv_stream = render_to_string(partial: "lotteries/results/ultrasignup", formats: :csv, locals: { records: entrants })
+          filename = "#{@lottery.name}-export-for-ultrasignup-#{Time.zone.now.strftime('%Y-%m-%d')}.csv"
+          csv_stream = render_to_string(partial: "lotteries/results/ultrasignup", formats: :csv,
+                                        locals: { records: entrants })
 
           send_data(csv_stream, type: "text/csv", filename: filename)
         when :ultrasignup_with_waitlist
           # Get accepted and waitlisted entrants in true draw order (by division_rank)
           entrants = @lottery.entrants
-            .includes(:division_ranking)
-            .where(lotteries_division_rankings: { draw_status: [:accepted, :waitlisted] })
-            .ordered
-          filename = "#{@lottery.name}-export-for-ultrasignup-with-waitlist-#{Time.now.strftime('%Y-%m-%d')}.csv"
-          csv_stream = render_to_string(partial: "lotteries/results/ultrasignup_with_waitlist", formats: :csv, locals: { records: entrants })
+                             .includes(:division_ranking)
+                             .where(lotteries_division_rankings: { draw_status: [:accepted, :waitlisted] })
+                             .ordered
+          filename = "#{@lottery.name}-export-for-ultrasignup-with-waitlist-#{Time.zone.now.strftime('%Y-%m-%d')}.csv"
+          csv_stream = render_to_string(partial: "lotteries/results/ultrasignup_with_waitlist", formats: :csv,
+                                        locals: { records: entrants })
 
           send_data(csv_stream, type: "text/csv", filename: filename)
         else
           entrants = @lottery.entrants.ordered_for_export.where(prepared_params[:filter])
           builder = ::CsvBuilder.new(::LotteryEntrant, entrants)
           filename = if prepared_params[:filter] == { "id" => "0" }
-            "lottery-entrants-template.csv"
-          else
-            "#{prepared_params[:filter].to_param}-#{builder.model_class_name}-#{Time.now.strftime('%Y-%m-%d')}.csv"
-          end
+                       "lottery-entrants-template.csv"
+                     else
+                       filter_param = prepared_params[:filter].to_param
+                       "#{filter_param}-#{builder.model_class_name}-#{Time.zone.now.strftime('%Y-%m-%d')}.csv"
+                     end
 
           send_data(builder.full_string, type: "text/csv", filename: filename)
         end
@@ -155,6 +161,15 @@ class LotteriesController < ApplicationController
     end
   end
 
+  # POST /organizations/:organization_id/lotteries/:id/draw_all
+  def draw_all
+    division = @lottery.divisions.find(params[:division_id])
+    Lotteries::DrawAllTicketsJob.perform_later(division)
+
+    redirect_to draw_tickets_organization_lottery_path(@organization, @lottery),
+                notice: "Drawing all remaining tickets for #{division.name}..."
+  end
+
   # DELETE /organizations/:organization_id/lotteries/:id/delete_draws
   def delete_draws
     if @lottery.delete_all_draws! && @lottery.entrants.update_all(withdrawn: false)
@@ -170,8 +185,8 @@ class LotteriesController < ApplicationController
   def delete_entrants
     begin
       if @lottery.delete_all_draws! &&
-        @lottery.tickets.delete_all &&
-        @lottery.divisions.each { |division| division.entrants.delete_all }
+         @lottery.tickets.delete_all &&
+         @lottery.divisions.each { |division| division.entrants.delete_all }
         flash[:success] = "Deleted all lottery entrants, tickets, and draws"
       else
         flash[:danger] = "Unable to delete all lottery entrants, tickets, and draws"

--- a/app/controllers/strong_confirm_controller.rb
+++ b/app/controllers/strong_confirm_controller.rb
@@ -6,6 +6,6 @@ class StrongConfirmController < ApplicationController
       required_pattern: params[:required_pattern],
       method: params[:method],
       button_text: params[:button_text],
-    }.compact
+    }
   end
 end

--- a/app/controllers/strong_confirm_controller.rb
+++ b/app/controllers/strong_confirm_controller.rb
@@ -4,8 +4,8 @@ class StrongConfirmController < ApplicationController
       path_on_confirm: params[:on_confirm],
       message: params[:message],
       required_pattern: params[:required_pattern],
-      method: params[:method] || :delete,
-      button_text: params[:button_text] || "Permanently Delete",
+      method: params[:method],
+      button_text: params[:button_text],
     }
   end
 end

--- a/app/controllers/strong_confirm_controller.rb
+++ b/app/controllers/strong_confirm_controller.rb
@@ -6,6 +6,6 @@ class StrongConfirmController < ApplicationController
       required_pattern: params[:required_pattern],
       method: params[:method],
       button_text: params[:button_text],
-    }
+    }.compact
   end
 end

--- a/app/controllers/strong_confirm_controller.rb
+++ b/app/controllers/strong_confirm_controller.rb
@@ -3,7 +3,9 @@ class StrongConfirmController < ApplicationController
     render "show", locals: {
       path_on_confirm: params[:on_confirm],
       message: params[:message],
-      required_pattern: params[:required_pattern]
+      required_pattern: params[:required_pattern],
+      method: params[:method] || :delete,
+      button_text: params[:button_text] || "Permanently Delete",
     }
   end
 end

--- a/app/helpers/strong_confirm_helper.rb
+++ b/app/helpers/strong_confirm_helper.rb
@@ -6,7 +6,7 @@ module StrongConfirmHelper
       required_pattern: options[:required_pattern],
       method: options[:method],
       button_text: options[:button_text],
-    }
+    }.compact
 
     link_to name, strong_confirm_path(params),
             class: options[:class],

--- a/app/helpers/strong_confirm_helper.rb
+++ b/app/helpers/strong_confirm_helper.rb
@@ -4,9 +4,9 @@ module StrongConfirmHelper
       on_confirm: path_on_confirm,
       message: options[:message],
       required_pattern: options[:required_pattern],
-      method: options[:method],
-      button_text: options[:button_text],
-    }.compact
+      method: options[:method] || :delete,
+      button_text: options[:button_text] || "Permanently Delete",
+    }
 
     link_to name, strong_confirm_path(params),
             class: options[:class],

--- a/app/helpers/strong_confirm_helper.rb
+++ b/app/helpers/strong_confirm_helper.rb
@@ -4,10 +4,13 @@ module StrongConfirmHelper
       on_confirm: path_on_confirm,
       message: options[:message],
       required_pattern: options[:required_pattern],
+      method: options[:method] || :delete,
+      button_text: options[:button_text] || "Permanently Delete",
     }
 
     link_to name, strong_confirm_path(params),
             class: options[:class],
+            disabled: options[:disabled],
             data: { turbo_frame: "form_modal" }.merge(options[:data] || {})
   end
 

--- a/app/helpers/strong_confirm_helper.rb
+++ b/app/helpers/strong_confirm_helper.rb
@@ -4,8 +4,8 @@ module StrongConfirmHelper
       on_confirm: path_on_confirm,
       message: options[:message],
       required_pattern: options[:required_pattern],
-      method: options[:method] || :delete,
-      button_text: options[:button_text] || "Permanently Delete",
+      method: options[:method],
+      button_text: options[:button_text],
     }
 
     link_to name, strong_confirm_path(params),

--- a/app/javascript/controllers/confirm_controller.js
+++ b/app/javascript/controllers/confirm_controller.js
@@ -20,6 +20,6 @@ export default class extends Controller {
 
   onClickDelete() {
     this.deleteButtonTarget.classList.add("disabled", "saving")
-    this.deleteButtonTarget.value = "Deleting ..."
+    this.deleteButtonTarget.value = "Processing..."
   }
 }

--- a/app/jobs/lotteries/draw_all_tickets_job.rb
+++ b/app/jobs/lotteries/draw_all_tickets_job.rb
@@ -1,0 +1,33 @@
+module Lotteries
+  class DrawAllTicketsJob < ApplicationJob
+    queue_as :default
+
+    def perform(division)
+      loop do
+        break if division.full? || division.all_entrants_drawn?
+
+        result = division.draw_ticket!
+        break if result.nil?
+      end
+
+      broadcast_completion_flash(division)
+    end
+
+    private
+
+    def broadcast_completion_flash(division)
+      message = if division.full?
+                  "All accepted and waitlisted slots have been filled for #{division.name}."
+                else
+                  "No more eligible entrants to draw for #{division.name}."
+                end
+
+      Turbo::StreamsChannel.broadcast_replace_to(
+        division, :lottery_draws_admin,
+        target: "flash",
+        partial: "layouts/broadcast_flash",
+        locals: { level: :success, message: message }
+      )
+    end
+  end
+end

--- a/app/policies/lottery_policy.rb
+++ b/app/policies/lottery_policy.rb
@@ -67,6 +67,10 @@ class LotteryPolicy < ApplicationPolicy
     new?
   end
 
+  def draw_all?
+    new?
+  end
+
   def delete_draws?
     new?
   end

--- a/app/views/lottery_divisions/_draw_tickets_header.html.erb
+++ b/app/views/lottery_divisions/_draw_tickets_header.html.erb
@@ -14,15 +14,15 @@
                   },
                   disabled: lottery_division.full? || lottery_division.all_entrants_drawn?,
                   class: "btn btn-lg btn-success fw-bold w-100" %>
-      <% if lottery_division.entrants.pre_selected.present? %>
-        <button class="btn btn-lg btn-success fw-bold dropdown-toggle dropdown-toggle-split"
-                <%= "disabled" if lottery_division.full? || lottery_division.all_entrants_drawn? %>
-                data-bs-toggle="dropdown"
-                aria-haspopup="true"
-                aria-expanded="false">
-          <span class="sr-only">Toggle Dropdown</span>
-        </button>
-        <div class="dropdown-menu">
+      <button class="btn btn-lg btn-success fw-bold dropdown-toggle dropdown-toggle-split"
+              <%= "disabled" if lottery_division.full? || lottery_division.all_entrants_drawn? %>
+              data-bs-toggle="dropdown"
+              aria-haspopup="true"
+              aria-expanded="false">
+        <span class="sr-only">Toggle Dropdown</span>
+      </button>
+      <div class="dropdown-menu">
+        <% if lottery_division.entrants.pre_selected.present? %>
           <a class="dropdown-item disabled" href="#">Pre-Selected Entrants</a>
           <div class="dropdown-divider"></div>
           <% lottery_division.entrants.pre_selected.each do |entrant| %>
@@ -31,8 +31,17 @@
                         disabled: entrant.drawn?,
                         class: "dropdown-item" %>
           <% end %>
-        </div>
-      <% end %>
+          <div class="dropdown-divider"></div>
+        <% end %>
+        <%= link_to_strong_confirm "Draw All Tickets",
+                                   draw_all_organization_lottery_path(lottery_division.organization, lottery_division.lottery, division_id: lottery_division.id),
+                                   class: "dropdown-item",
+                                   disabled: lottery_division.full? || lottery_division.all_entrants_drawn?,
+                                   message: "This will draw all remaining entrants for the #{lottery_division.name} division, filling accepted and waitlisted slots.",
+                                   required_pattern: lottery_division.name.upcase,
+                                   method: :post,
+                                   button_text: "Draw All Tickets" %>
+      </div>
     </div>
   </div>
 

--- a/app/views/strong_confirm/_form.html.erb
+++ b/app/views/strong_confirm/_form.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (message:, path_on_confirm:, required_pattern:, method:, button_text:) -%>
+<%# locals: (message:, path_on_confirm:, required_pattern:, method: :delete, button_text: "Permanently Delete") -%>
 
 <div data-controller="confirm" data-confirm-required-pattern-value="<%= required_pattern %>">
   <div class="modal-header">

--- a/app/views/strong_confirm/_form.html.erb
+++ b/app/views/strong_confirm/_form.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (message:, path_on_confirm:, required_pattern:) -%>
+<%# locals: (message:, path_on_confirm:, required_pattern:, method: :delete, button_text: "Permanently Delete") -%>
 
 <div data-controller="confirm" data-confirm-required-pattern-value="<%= required_pattern %>">
   <div class="modal-header">
@@ -10,7 +10,7 @@
     <% message.split("\n").each do |fragment| %>
       <p><%= fragment %></p>
     <% end %>
-    <p>To proceed, please type <strong><%= required_pattern %></strong> below and click the Delete button.</p>
+    <p>To proceed, please type <strong><%= required_pattern %></strong> below and click the button.</p>
   </div>
   <div class="modal-footer">
     <div class="container p-0 d-block justify-content-center">
@@ -24,12 +24,12 @@
                            action: "keyup->confirm#compare",
                            "confirm-target": "pattern",
                          } %>
-      <%= button_to "Permanently Delete",
+      <%= button_to button_text,
                     path_on_confirm,
                     tabindex: -1,
                     class: "btn btn-danger fw-bold disabled w-100",
                     form: { class: "mt-2" },
-                    method: :delete,
+                    method: method,
                     data: {
                       "confirm-target" => "deleteButton",
                       action: "click->confirm#onClickDelete",

--- a/app/views/strong_confirm/_form.html.erb
+++ b/app/views/strong_confirm/_form.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (message:, path_on_confirm:, required_pattern:, method: :delete, button_text: "Permanently Delete") -%>
+<%# locals: (message:, path_on_confirm:, required_pattern:, method:, button_text:) -%>
 
 <div data-controller="confirm" data-confirm-required-pattern-value="<%= required_pattern %>">
   <div class="modal-header">

--- a/app/views/strong_confirm/show.html.erb
+++ b/app/views/strong_confirm/show.html.erb
@@ -1,5 +1,5 @@
-<%# locals: (message:, path_on_confirm:, required_pattern:) -%>
+<%# locals: (message:, path_on_confirm:, required_pattern:, method: :delete, button_text: "Permanently Delete") -%>
 
 <%= turbo_frame_tag "form_modal" do %>
-  <%= render "form", message: message, path_on_confirm: path_on_confirm, required_pattern: required_pattern %>
+  <%= render "form", message: message, path_on_confirm: path_on_confirm, required_pattern: required_pattern, method: method, button_text: button_text %>
 <% end %>

--- a/app/views/strong_confirm/show.html.erb
+++ b/app/views/strong_confirm/show.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (message:, path_on_confirm:, required_pattern:, method: :delete, button_text: "Permanently Delete") -%>
+<%# locals: (message:, path_on_confirm:, required_pattern:, method:, button_text:) -%>
 
 <%= turbo_frame_tag "form_modal" do %>
   <%= render "form", message: message, path_on_confirm: path_on_confirm, required_pattern: required_pattern, method: method, button_text: button_text %>

--- a/app/views/strong_confirm/show.html.erb
+++ b/app/views/strong_confirm/show.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (message:, path_on_confirm:, required_pattern:, method:, button_text:) -%>
+<%# locals: (message:, path_on_confirm:, required_pattern:, method: :delete, button_text: "Permanently Delete") -%>
 
 <%= turbo_frame_tag "form_modal" do %>
   <%= render "form", message: message, path_on_confirm: path_on_confirm, required_pattern: required_pattern, method: method, button_text: button_text %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,6 +240,7 @@ Rails.application.routes.draw do
       member { get :manage_entrants }
       member { post :sync_calculations }
       member { post :draw }
+      member { post :draw_all }
       member { post :generate_entrants }
       member { post :generate_tickets }
       member { patch :attach_service_form }

--- a/spec/jobs/lotteries/draw_all_tickets_job_spec.rb
+++ b/spec/jobs/lotteries/draw_all_tickets_job_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe Lotteries::DrawAllTicketsJob do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later(division) }
+
+  let(:lottery) { division.lottery }
+
+  after do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
+  it "queues the job" do
+    division = LotteryDivision.find_by(name: "Elses")
+    expect { described_class.perform_later(division) }.to change(described_class.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  context "when the division has eligible entrants" do
+    let(:division) { LotteryDivision.find_by(name: "Elses") }
+
+    before { lottery.delete_and_insert_tickets! }
+
+    it "draws tickets until the division is full or all entrants are drawn" do
+      expect { perform_enqueued_jobs { job } }.to(change { division.draws.count })
+      expect(division.full? || division.all_entrants_drawn?).to eq(true)
+    end
+  end
+
+  context "when the division is already full" do
+    let(:division) { LotteryDivision.find_by(name: "Never Ever Evers") }
+
+    it "does not create any new draws" do
+      expect { perform_enqueued_jobs { job } }.not_to(change(LotteryDraw, :count))
+    end
+  end
+
+  context "when all entrants have already been drawn" do
+    let(:division) { LotteryDivision.find_by(name: "Elses") }
+
+    before do
+      lottery.delete_and_insert_tickets!
+      division.entrants.not_drawn.count.times { division.draw_ticket! }
+    end
+
+    it "does not create any draws" do
+      expect { perform_enqueued_jobs { job } }.not_to(change(LotteryDraw, :count))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a "Draw All Tickets" option to the existing dropdown on the draw_tickets page for each lottery division
- Uses the strong confirm pattern (generalized to support POST and custom button text) requiring the user to type the division name in uppercase
- A background job (`DrawAllTicketsJob`) draws tickets in a loop until the division is full or no eligible entrants remain, with real-time turbo stream updates for each draw
- Broadcasts a completion flash message indicating whether all slots were filled or no more eligible entrants remain

Closes #1542

## Test plan
- [x] Verify "Draw All Tickets" appears in the dropdown for each division on the draw_tickets page
- [x] Verify clicking it opens the strong confirm modal requiring the division name in uppercase
- [x] Verify typing the correct name enables the "Draw All Tickets" button
- [x] Verify confirming draws all remaining tickets with real-time card updates
- [x] Verify the initial flash message is replaced with a completion message when the job finishes
- [x] Verify the dropdown button is disabled when the division is full or all entrants are drawn
- [x] Verify existing "Permanently Delete" strong confirm modals still work correctly on the setup page
- [x] Run `bundle exec rspec spec/jobs/lotteries/draw_all_tickets_job_spec.rb` (4 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)