### PR TITLE
Update SMS compliance language for 10DLC campaign approval

### DIFF
--- a/app/services/participation_notifier.rb
+++ b/app/services/participation_notifier.rb
@@ -1,6 +1,7 @@
 class ParticipationNotifier < BaseNotifier
-  VERBS = {unstarted: "will be participating", in_progress: "is in progress", stopped: "recently participated"}.freeze
-  RESULTS_DESCRIPTORS = {unstarted: "Watch for results", in_progress: "Follow along", stopped: "See full results"}.freeze
+  VERBS = { unstarted: "will be participating", in_progress: "is in progress", stopped: "recently participated" }.freeze
+  RESULTS_DESCRIPTORS = { unstarted: "Watch for results", in_progress: "Follow along",
+                          stopped: "See full results" }.freeze
 
   def post_initialize(args)
     @effort = args[:effort]
@@ -18,11 +19,11 @@ class ParticipationNotifier < BaseNotifier
 
   def message
     <<~MESSAGE
-      Your friend #{person.full_name} #{verb} at #{event.name}!
+      OpenSplitTime: Your friend #{person.full_name} #{verb} at #{event.name}!
       #{results_descriptor} here: #{::OstConfig.base_uri}/efforts/#{effort.id}
       #{live_update_message}
       Thank you for using OpenSplitTime!
-      You are receiving this message because you signed up on OpenSplitTime and asked to follow #{person.first_name}. 
+      You are receiving this message because you signed up on OpenSplitTime and asked to follow #{person.first_name}.
       To change your preferences, go to #{::OstConfig.base_uri}/people/#{person.id}, then log in and click to unfollow.
     MESSAGE
   end

--- a/app/services/progress_notifier.rb
+++ b/app/services/progress_notifier.rb
@@ -13,9 +13,9 @@ class ProgressNotifier < BaseNotifier
 
   def message
     <<~MESSAGE
-      #{effort_data[:full_name]} made progress at #{effort_data[:event_name]}:
+      OpenSplitTime: #{effort_data[:full_name]} made progress at #{effort_data[:event_name]}:
       #{times_text}
-      Results on OpenSplitTime: #{shortened_url}
+      Results: #{shortened_url}
     MESSAGE
   end
 
@@ -36,10 +36,10 @@ class ProgressNotifier < BaseNotifier
   end
 
   def follower_update_body_text(split_time_data)
-    "#{split_time_data[:split_name]} " +
-      "(Mile #{(split_time_data[:split_distance] / UnitConversions::METERS_PER_MILE).round(1)}), " +
-      "#{split_time_data[:absolute_time_local]} " +
-      "(+#{split_time_data[:elapsed_time]})" +
+    "#{split_time_data[:split_name]} " \
+    "(Mile #{(split_time_data[:split_distance] / UnitConversions::METERS_PER_MILE).round(1)}), " \
+    "#{split_time_data[:absolute_time_local]} " \
+    "(+#{split_time_data[:elapsed_time]})" +
       (split_time_data[:stopped_here] ? " and stopped there" : "").to_s
   end
 end

--- a/app/views/user_settings/preferences.html.erb
+++ b/app/views/user_settings/preferences.html.erb
@@ -44,7 +44,10 @@
             <div class="mb-3 p-3 bg-light border rounded">
               <p class="small mb-2">
                 <%= t("sms.consent.disclosure") %>
+              </p>
+              <p class="small mb-2">
                 <%= link_to t("sms.consent.view_terms"), sms_info_path %>.
+                See our <%= link_to "Privacy Policy", privacy_policy_path(anchor: "sms") %>.
               </p>
               <div class="form-check">
                 <%= f.check_box :sms_consent, class: "form-check-input", checked: current_user.sms_opted_in?,

--- a/app/views/visitors/privacy_policy.html.erb
+++ b/app/views/visitors/privacy_policy.html.erb
@@ -4,7 +4,7 @@
 <article class="ost-article container">
   <h1>Privacy Policy</h1>
 
-  <p>Effective date: April 12, 2026</p>
+  <p>Effective date: April 17, 2026</p>
 
   <p>OpenSplitTime Company ("us", "we", or "our") operates the https://www.opensplittime.org website and the OST
     Remote mobile application (the "Service").</p>
@@ -19,7 +19,7 @@
     information in accordance with this policy. Unless otherwise defined in this Privacy Policy, terms used in this
     Privacy Policy have the same meanings as in our Terms and Conditions.</p>
 
-  <h2>Information Collection And Use</h2>
+  <h2 id="information-collection">Information Collection And Use</h2>
 
   <p>We collect several different types of information for various purposes to provide and improve our Service to
     you.</p>
@@ -112,7 +112,7 @@
     <li><strong>Security Cookies.</strong> We use Security Cookies for security purposes.</li>
   </ul>
 
-  <h2>Controlling What Appears Publicly</h2>
+  <h2 id="controlling-public">Controlling What Appears Publicly</h2>
 
   <p>Most information we collect about event participation is published on public pages (person
     profiles, event results, finish history, podiums, and similar views) and is indexed by search
@@ -138,7 +138,7 @@
       to administrators and event organizers and their teams.</li>
   </ul>
 
-  <h2>Use of Data</h2>
+  <h2 id="use-of-data">Use of Data</h2>
 
   <p>OpenSplitTime Company uses the collected data for various purposes:</p>
   <ul>
@@ -151,9 +151,9 @@
     <li>To detect, prevent and address technical issues</li>
   </ul>
 
-  <h2>SMS Text Messages</h2>
-  <p>If you choose to opt in to SMS text messages, OpenSplitTime Company will use your phone number to send you live
-    progress updates for race participants you subscribe to follow.</p>
+  <h2 id="sms">SMS Text Messages</h2>
+  <p>If you choose to opt in to SMS text messages, OpenSplitTime Company will use your phone number to send you automated
+    live progress updates for race participants you subscribe to follow.</p>
   <ul>
     <li>Messages are sent by OpenSplitTime Company.</li>
     <li>Message types may include live progress updates, participation confirmations, and event status changes.</li>
@@ -163,11 +163,11 @@
       option on your Preferences page.</li>
     <li>Reply <strong>HELP</strong> for help, or email
       <a href="mailto:mark@opensplittime.org">mark@opensplittime.org</a>.</li>
-    <li>We do not share SMS opt-in data or phone numbers with third parties for marketing purposes.</li>
+    <li>No mobile information will be shared with third parties or affiliates for marketing or promotional purposes.</li>
   </ul>
   <p>For full SMS terms and conditions, see our <%= link_to "SMS Info", sms_info_path %> page.</p>
 
-  <h2>Transfer Of Data</h2>
+  <h2 id="transfer-of-data">Transfer Of Data</h2>
   <p>Your information, including Personal Data, may be transferred to — and maintained on — computers located outside of
     your state, province, country or other governmental jurisdiction where the data protection laws may differ than
     those from your jurisdiction.</p>
@@ -180,7 +180,7 @@
     or a country unless there are adequate controls in place including the security of your data and other personal
     information.</p>
 
-  <h2>Disclosure Of Data</h2>
+  <h2 id="disclosure-of-data">Disclosure Of Data</h2>
 
   <h3>Legal Requirements</h3>
   <p>OpenSplitTime Company may disclose your Personal Data in the good faith belief that such action is necessary
@@ -193,19 +193,19 @@
     <li>To protect against legal liability</li>
   </ul>
 
-  <h2>Security Of Data</h2>
+  <h2 id="security-of-data">Security Of Data</h2>
   <p>The security of your data is important to us, but remember that no method of transmission over the Internet, or
     method of electronic storage is 100% secure. While we strive to use commercially acceptable means to protect your
     Personal Data, we cannot guarantee its absolute security.</p>
 
-  <h2>Deletion Of Data</h2>
+  <h2 id="deletion-of-data">Deletion Of Data</h2>
   <p>You may delete your account at any time. Deletion of your account will remove all personal information about you
   that is stored under your account, including information received from third-party authorization providers such as
   Facebook.</p>
   <p>To delete your account, log in and then click your email address in the upper right corner of the page. Choose
   "Edit My Profile," click "Delete my account," and then confirm that you want to delete your account.</p>
 
-  <h2>Service Providers</h2>
+  <h2 id="service-providers">Service Providers</h2>
   <p>We may employ third party companies and individuals to facilitate our Service ("Service Providers"), to provide the
     Service on our behalf, to perform Service-related services or to assist us in analyzing how our Service is used.</p>
   <p>These third parties have access to your Personal Data only to perform these tasks on our behalf and are obligated
@@ -225,14 +225,14 @@
     </li>
   </ul>
 
-  <h2>Links To Other Sites</h2>
+  <h2 id="links-to-other-sites">Links To Other Sites</h2>
   <p>Our Service may contain links to other sites that are not operated by us. If you click on a third party link, you
     will be directed to that third party's site. We strongly advise you to review the Privacy Policy of every site you
     visit.</p>
   <p>We have no control over and assume no responsibility for the content, privacy policies or practices of any third
     party sites or services.</p>
 
-  <h2>Changes To This Privacy Policy</h2>
+  <h2 id="changes">Changes To This Privacy Policy</h2>
   <p>We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy
     Policy on this page.</p>
   <p>We will let you know via email and/or a prominent notice on our Service, prior to the change becoming effective and
@@ -240,7 +240,7 @@
   <p>You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are
     effective when they are posted on this page.</p>
 
-  <h2>Contact Us</h2>
+  <h2 id="contact-us">Contact Us</h2>
   <p>If you have any questions about this Privacy Policy, please contact us:</p>
   <ul>
     <li>By email: mark@opensplittime.org</li>

--- a/app/views/visitors/sms_info.html.erb
+++ b/app/views/visitors/sms_info.html.erb
@@ -28,16 +28,15 @@
   </ol>
 
   <h2>SMS Terms and Conditions</h2>
+  <p>Before receiving any text messages, you must check a consent box on your
+    <%= link_to "Preferences", user_settings_preferences_path %> page agreeing to the following:</p>
+  <blockquote class="p-3 bg-light border rounded">
+    <p class="mb-0"><%= t("sms.consent.disclosure") %></p>
+  </blockquote>
+  <p class="mt-3">Additionally:</p>
   <ul>
-    <li>By opting in, you consent to receive SMS text messages from OpenSplitTime regarding live race progress updates
-      for participants you choose to follow.</li>
-    <li>Message frequency varies based on the events and participants you subscribe to.</li>
-    <li>Message and data rates may apply.</li>
-    <li>Reply <strong>STOP</strong> to any message to cancel and stop receiving all text messages from
-      OpenSplitTime.</li>
+    <li>Reply <strong>STOP</strong> to any message to cancel and stop receiving all text messages from OpenSplitTime.</li>
     <li>Reply <strong>HELP</strong> for help, or contact us at the email address below.</li>
-    <li>We do not share SMS opt-in data or phone numbers with third parties for marketing purposes.</li>
-    <li>Consent is not a condition of purchasing any goods or services.</li>
   </ul>
 
   <h2>How to Opt Out</h2>
@@ -50,6 +49,6 @@
   <h2>More Information</h2>
   <p>For questions or support, email
     <a href="mailto:mark@opensplittime.org">mark@opensplittime.org</a>.</p>
-  <p>See our <%= link_to "Privacy Policy", privacy_policy_path %> and
+  <p>See our <%= link_to "Privacy Policy", privacy_policy_path(anchor: "sms") %> and
     <%= link_to "Terms of Service", terms_path %> for additional details.</p>
 </article>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -99,8 +99,8 @@ en:
 
   sms:
     consent:
-      disclosure: "By checking the box below, you agree to receive SMS text messages from OpenSplitTime with live race progress updates for participants you choose to follow. Message frequency varies. Msg & data rates may apply. Reply STOP to cancel or HELP for help. US and Canada numbers only."
-      checkbox_label: "I agree to receive SMS text messages from OpenSplitTime"
+      disclosure: "By checking the box below, you provide your express written consent to receive automated SMS text messages from OpenSplitTime with live race progress updates and related information for participants you choose to follow. Message frequency varies. Msg & data rates may apply. Reply STOP to cancel or HELP for help. Consent is not required as a condition to use OpenSplitTime for any service or transaction. No mobile information will be shared with third parties or affiliates for marketing or promotional purposes. Opt-in data will not be shared with unauthorized third parties."
+      checkbox_label: "I consent to receive automated SMS text messages from OpenSplitTime"
       view_terms: "View full SMS terms"
       enabled_since: "SMS enabled since %{date}"
       opted_in: "You have opted in to receive SMS text message updates from OpenSplitTime. Reply STOP to cancel. Reply HELP for help. Msg & data rates may apply."

--- a/spec/services/participation_notifier_spec.rb
+++ b/spec/services/participation_notifier_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe ParticipationNotifier do
-  subject { ParticipationNotifier.new(topic_arn: topic_arn, effort: effort, sns_client: sns_client) }
+  subject { described_class.new(topic_arn: topic_arn, effort: effort, sns_client: sns_client) }
+
   let(:topic_arn) { "arn:aws:sns:us-west-2:998989370925:d-follow_rufa-2017-12h-progress-lap2" }
   let(:effort) { efforts(:rufa_2017_12h_progress_lap2) }
   let(:sns_client) { Aws::SNS::Client.new(stub_responses: true) }
@@ -26,64 +27,64 @@ RSpec.describe ParticipationNotifier do
     context "when the SNS client returns a successful response" do
       before { sns_client.stub_data(:publish) }
 
-      context "for an effort in progress" do
+      context "when the effort is in progress" do
         let(:effort) { efforts(:rufa_2017_12h_progress_lap2) }
 
         it "sends a message to an SNS client containing the expected information" do
-          stubbed_response = OpenStruct.new(successful?: true)
+          stubbed_response = Struct.new(:successful?).new(true)
           expected_subject = "#{effort.full_name} is in progress at #{effort.event.name}"
           expected_message = <<~MESSAGE
-            Your friend #{effort.full_name} is in progress at #{effort.event.name}!
+            OpenSplitTime: Your friend #{effort.full_name} is in progress at #{effort.event.name}!
             Follow along here: #{::OstConfig.base_uri}/efforts/#{effort.id}
             Click the link and sign in to receive live updates for #{effort.first_name}.
             Thank you for using OpenSplitTime!
-            You are receiving this message because you signed up on OpenSplitTime and asked to follow #{effort.first_name}. 
+            You are receiving this message because you signed up on OpenSplitTime and asked to follow #{effort.first_name}.
             To change your preferences, go to #{::OstConfig.base_uri}/people/#{effort.person.id}, then log in and click to unfollow.
           MESSAGE
-          expect(sns_client).to receive(:publish)
-              .with(topic_arn: topic_arn, subject: expected_subject, message: expected_message)
-              .and_return(stubbed_response)
+          expect(sns_client).to receive(:publish) # rubocop:disable RSpec/StubbedMock
+            .with(topic_arn: topic_arn, subject: expected_subject, message: expected_message)
+            .and_return(stubbed_response)
           subject.publish
         end
 
-        context "for an unstarted effort" do
+        context "when the effort is unstarted" do
           let(:effort) { efforts(:rufa_2017_12h_not_started) }
 
           it "sends a message to an SNS client containing the expected information" do
-            stubbed_response = OpenStruct.new(successful?: true)
+            stubbed_response = Struct.new(:successful?).new(true)
             expected_subject = "#{effort.full_name} will be participating at #{effort.event.name}"
             expected_message = <<~MESSAGE
-              Your friend #{effort.full_name} will be participating at #{effort.event.name}!
+              OpenSplitTime: Your friend #{effort.full_name} will be participating at #{effort.event.name}!
               Watch for results here: #{::OstConfig.base_uri}/efforts/#{effort.id}
               Click the link and sign in to receive live updates for #{effort.first_name}.
               Thank you for using OpenSplitTime!
-              You are receiving this message because you signed up on OpenSplitTime and asked to follow #{effort.first_name}. 
+              You are receiving this message because you signed up on OpenSplitTime and asked to follow #{effort.first_name}.
               To change your preferences, go to #{::OstConfig.base_uri}/people/#{effort.person.id}, then log in and click to unfollow.
             MESSAGE
-            expect(sns_client).to receive(:publish)
-                .with(topic_arn: topic_arn, subject: expected_subject, message: expected_message)
-                .and_return(stubbed_response)
+            expect(sns_client).to receive(:publish) # rubocop:disable RSpec/StubbedMock
+              .with(topic_arn: topic_arn, subject: expected_subject, message: expected_message)
+              .and_return(stubbed_response)
             subject.publish
           end
         end
 
-        context "for a finished effort" do
+        context "when the effort is finished" do
           let(:effort) { efforts(:rufa_2017_12h_finished_first) }
 
           it "sends a message to an SNS client containing the expected information" do
-            stubbed_response = OpenStruct.new(successful?: true)
+            stubbed_response = Struct.new(:successful?).new(true)
             expected_subject = "#{effort.full_name} recently participated at #{effort.event.name}"
             expected_message = <<~MESSAGE
-              Your friend #{effort.full_name} recently participated at #{effort.event.name}!
+              OpenSplitTime: Your friend #{effort.full_name} recently participated at #{effort.event.name}!
               See full results here: #{::OstConfig.base_uri}/efforts/#{effort.id}
 
               Thank you for using OpenSplitTime!
-              You are receiving this message because you signed up on OpenSplitTime and asked to follow #{effort.first_name}. 
+              You are receiving this message because you signed up on OpenSplitTime and asked to follow #{effort.first_name}.
               To change your preferences, go to #{::OstConfig.base_uri}/people/#{effort.person.id}, then log in and click to unfollow.
             MESSAGE
-            expect(sns_client).to receive(:publish)
-                .with(topic_arn: topic_arn, subject: expected_subject, message: expected_message)
-                .and_return(stubbed_response)
+            expect(sns_client).to receive(:publish) # rubocop:disable RSpec/StubbedMock
+              .with(topic_arn: topic_arn, subject: expected_subject, message: expected_message)
+              .and_return(stubbed_response)
             subject.publish
           end
         end

--- a/spec/services/progress_notifier_spec.rb
+++ b/spec/services/progress_notifier_spec.rb
@@ -1,13 +1,16 @@
+require "rails_helper"
+
 RSpec.describe ProgressNotifier do
-  subject { ProgressNotifier.new(topic_arn: topic_arn, effort_data: effort_data, sns_client: sns_client) }
+  subject { described_class.new(topic_arn: topic_arn, effort_data: effort_data, sns_client: sns_client) }
+
   let(:topic_arn) { "arn:aws:sns:us-west-2:998989370925:d-follow_joe-lastname-1" }
   let(:effort_data) do
-    {full_name: "Joe LastName 1",
-     event_name: "Test Event 1",
-     split_times_data: [{split_name: "Split 1 In", split_distance: 10_000, absolute_time_local: "Fri 11:40AM", elapsed_time: "01:40:00", pacer: nil, stopped_here: false},
-                        {split_name: "Split 1 Out", split_distance: 10_000, absolute_time_local: "Fri 11:50AM", elapsed_time: "01:50:00", pacer: nil, stopped_here: true}],
-     effort_id: 101,
-     effort_slug: "joe-lastname-1-at-test-event-1"}
+    { full_name: "Joe LastName 1",
+      event_name: "Test Event 1",
+      split_times_data: [{ split_name: "Split 1 In", split_distance: 10_000, absolute_time_local: "Fri 11:40AM", elapsed_time: "01:40:00", pacer: nil, stopped_here: false },
+                         { split_name: "Split 1 Out", split_distance: 10_000, absolute_time_local: "Fri 11:50AM", elapsed_time: "01:50:00", pacer: nil, stopped_here: true }],
+      effort_id: 101,
+      effort_slug: "joe-lastname-1-at-test-event-1" }
   end
   let(:sns_client) { Aws::SNS::Client.new(stub_responses: true) }
 
@@ -21,22 +24,24 @@ RSpec.describe ProgressNotifier do
     let(:expected_subject) { "Update for Joe LastName 1 at Test Event 1 from OpenSplitTime" }
     let(:expected_message) do
       <<~MESSAGE
-        Joe LastName 1 made progress at Test Event 1:
+        OpenSplitTime: Joe LastName 1 made progress at Test Event 1:
         Split 1 In (Mile 6.2), Fri 11:40AM (+01:40:00)
         Split 1 Out (Mile 6.2), Fri 11:50AM (+01:50:00) and stopped there
-        Results on OpenSplitTime: #{expected_shortened_url}
+        Results: #{expected_shortened_url}
       MESSAGE
     end
     let(:expected_shortened_url) { "#{::OstConfig.shortened_uri}/s/#{expected_key}" }
     let(:expected_key) { Shortener::ShortenedUrl.find_by(url: effort_path).unique_key }
     let(:effort_path) { subject.send(:effort_path) }
-    let(:stubbed_response) { OpenStruct.new(successful?: true) }
+    let(:stubbed_response) { Struct.new(:successful?).new(true) }
 
     before { Shortener::ShortenedUrl.generate!(effort_path) }
 
     it "sends a message to an SNS client containing the expected information" do
       sns_client.stub_data(:publish)
-      expect(sns_client).to receive(:publish).with(topic_arn: topic_arn, subject: expected_subject, message: expected_message).and_return(stubbed_response)
+      expect(sns_client).to receive(:publish) # rubocop:disable RSpec/StubbedMock
+        .with(topic_arn: topic_arn, subject: expected_subject, message: expected_message)
+        .and_return(stubbed_response)
       subject.publish
     end
   end


### PR DESCRIPTION
## Summary

- Use TCR-required "express written consent" and "automated SMS" language in consent disclosure
- Add privacy policy link (anchored to #sms) in the consent area on preferences page
- Use exact third-party sharing statement: "No mobile information will be shared with third parties or affiliates for marketing or promotional purposes"
- Prefix all user-facing SMS messages with "OpenSplitTime: " per AWS sample message requirement
- Add anchor IDs to all privacy policy headings for deep linking
- Pull consent disclosure on `/sms_info` from I18n locale string (single source of truth)
- Fix pre-existing rubocop offenses in notifier specs

## Test plan

- [x] Visit `/sms_info` — consent disclosure renders from locale string in a blockquote
- [x] Log in, visit preferences — consent area shows disclosure, SMS terms link, and Privacy Policy link (anchored to #sms)
- [x] Click Privacy Policy link — scrolls to SMS section
- [x] Visit `/privacy_policy#sms` directly — jumps to SMS heading
- [x] `bundle exec rspec spec/services/progress_notifier_spec.rb spec/services/participation_notifier_spec.rb` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)