### PR TITLE
Move SMS phone and consent to dedicated User Settings tab

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -32,7 +32,7 @@ class SubscriptionsController < ApplicationController
                         else
                           t("subscriptions.create.sms_not_opted_in")
                         end
-      redirect_to user_settings_preferences_path
+      redirect_to user_settings_sms_messaging_path
     elsif @subscription.save
       flash.now[:success] = t("subscriptions.create.success",
                               protocol: protocol,

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -18,6 +18,11 @@ class UserSettingsController < ApplicationController
     @presenter = UserSettings::CredentialsPresenter.new(current_user)
   end
 
+  # GET /user_settings/sms_messaging
+  def sms_messaging
+    flash.keep
+  end
+
   # GET /user_settings/credentials_new_service
   def credentials_new_service
     respond_to do |format|

--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -38,11 +38,10 @@ class UserSettingsController < ApplicationController
     updated = current_user.update(settings_update_params)
 
     if updated
-      messages = []
-      messages << t("user_settings.update.email_change_requested") if current_user.unconfirmed_email.present?
-      messages << t("sms.consent.opted_in") if !sms_was_opted_in && current_user.sms_opted_in?
-      messages << t("sms.consent.opted_out") if sms_was_opted_in && !current_user.sms_opted_in?
-      redirect_to request.referrer, notice: messages.join(" ").presence
+      flash[:notice] = t("user_settings.update.email_change_requested") if current_user.unconfirmed_email.present?
+      flash[:info] = t("sms.consent.opted_in") if !sms_was_opted_in && current_user.sms_opted_in?
+      flash[:info] = t("sms.consent.opted_out") if sms_was_opted_in && !current_user.sms_opted_in?
+      redirect_to request.referrer
     else
       redirect_to request.referrer, notice: current_user.errors.full_messages.join("; ")
     end

--- a/app/helpers/toggle_helper.rb
+++ b/app/helpers/toggle_helper.rb
@@ -175,7 +175,7 @@ module ToggleHelper
   end
 
   def link_to_sms_opt_in(icon:)
-    link_to(user_settings_preferences_path, class: "btn btn-lg btn-outline-secondary") do
+    link_to(user_settings_sms_messaging_path, class: "btn btn-lg btn-outline-secondary") do
       fa_icon(icon, text: t("subscriptions.toggle.enable_sms"))
     end
   end

--- a/app/policies/user_settings_policy.rb
+++ b/app/policies/user_settings_policy.rb
@@ -20,6 +20,10 @@ class UserSettingsPolicy < ApplicationPolicy
     credentials?
   end
 
+  def sms_messaging?
+    user.present?
+  end
+
   def update?
     preferences?
   end

--- a/app/views/user_settings/_sidebar.html.erb
+++ b/app/views/user_settings/_sidebar.html.erb
@@ -9,6 +9,9 @@
           <%= render "shared/sidebar_item", title: "Password", icon: "user-shield", link: user_settings_password_path %>
         </li>
       <% end %>
+      <li class="nav-item border-sidebar w-100 mb-3 <%= action_name == "sms_messaging" ? "active" : nil %>">
+        <%= render "shared/sidebar_item", title: "SMS Messaging", icon: "mobile-alt", link: user_settings_sms_messaging_path %>
+      </li>
       <li class="nav-item border-sidebar w-100 mb-3 <%= action_name == "credentials" ? "active" : nil %>">
         <%= render "shared/sidebar_item", title: "Credentials", icon: "key", link: user_settings_credentials_path %>
       </li>

--- a/app/views/user_settings/preferences.html.erb
+++ b/app/views/user_settings/preferences.html.erb
@@ -23,7 +23,7 @@
           <h4>Personal Information</h4>
         </div>
         <div class="card-body">
-          <%= form_with(model: current_user, url: user_settings_update_path, html: { method: :put, data: { controller: "form-disable-submit phone-consent" } }) do |f| %>
+          <%= form_with(model: current_user, url: user_settings_update_path, html: { method: :put, data: { controller: "form-disable-submit" } }) do |f| %>
             <div class="mb-3">
               <%= f.label :first_name, class: "mb-1 required" %>
               <%= f.text_field :first_name, class: "form-control", placeholder: "First name" %>
@@ -32,34 +32,6 @@
             <div class="mb-3">
               <%= f.label :last_name, class: "mb-1 required" %>
               <%= f.text_field :last_name, class: "form-control", placeholder: "Last name" %>
-            </div>
-
-            <div class="mb-3">
-              <%= f.label "Phone", class: "mb-1" %>
-              <%= f.text_field :phone, class: "form-control", placeholder: "XXX-XXX-XXXX",
-                                       data: { phone_consent_target: "phone", action: "input->phone-consent#toggle" } %>
-              <div class="form-text"><%= t("sms.phone.hint") %></div>
-            </div>
-
-            <div class="mb-3 p-3 bg-light border rounded">
-              <p class="small mb-2">
-                <%= t("sms.consent.disclosure") %>
-              </p>
-              <p class="small mb-2">
-                <%= link_to t("sms.consent.view_terms"), sms_info_path %>.
-                See our <%= link_to "Privacy Policy", privacy_policy_path(anchor: "sms") %>.
-              </p>
-              <div class="form-check">
-                <%= f.check_box :sms_consent, class: "form-check-input", checked: current_user.sms_opted_in?,
-                                              data: { phone_consent_target: "consent" } %>
-                <%= f.label :sms_consent, t("sms.consent.checkbox_label"), class: "form-check-label" %>
-              </div>
-              <% if current_user.sms_opted_in? %>
-                <p class="small text-success mt-2 mb-0">
-                  <i class="fas fa-check-circle"></i>
-                  <%= t("sms.consent.enabled_since", date: l(current_user.phone_confirmed_at.to_date, format: :long)) %>
-                </p>
-              <% end %>
             </div>
 
             <div class="mb-3">

--- a/app/views/user_settings/sms_messaging.html.erb
+++ b/app/views/user_settings/sms_messaging.html.erb
@@ -1,0 +1,73 @@
+<% content_for :title do %>
+  <% "OpenSplitTime: SMS Messaging" %>
+<% end %>
+
+<%= render "header", title: "SMS Messaging" %>
+
+<article class="ost-article container">
+  <div class="row flex-nowrap">
+    <%= render "sidebar" %>
+    <div class="col px-md-4 py-3">
+      <% if current_user.errors.any? %>
+        <div id="error_explanation">
+          <ul>
+            <% current_user.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="card mb-5">
+        <div class="card-header">
+          <h4>SMS Messaging</h4>
+        </div>
+        <div class="card-body">
+          <p>
+            SMS text message notifications are strictly optional. You can use every feature of OpenSplitTime
+            &mdash; including following participants and receiving email updates &mdash; without providing a phone number
+            or consenting to SMS.
+          </p>
+          <p>
+            For full program details, see the
+            <%= link_to "SMS information page", sms_info_path %>.
+          </p>
+
+          <%= form_with(model: current_user, url: user_settings_update_path, html: { method: :put, data: { controller: "form-disable-submit phone-consent" } }) do |f| %>
+            <div class="mb-3">
+              <%= f.label :phone, "Phone", class: "mb-1" %>
+              <%= f.text_field :phone, class: "form-control", placeholder: "XXX-XXX-XXXX",
+                                       data: { phone_consent_target: "phone", action: "input->phone-consent#toggle" } %>
+              <div class="form-text"><%= t("sms.phone.hint") %></div>
+            </div>
+
+            <div class="mb-3 p-3 bg-light border rounded">
+              <p class="small mb-2">
+                <%= t("sms.consent.disclosure") %>
+              </p>
+              <p class="small mb-2">
+                <%= link_to t("sms.consent.view_terms"), sms_info_path %>.
+                See our <%= link_to "Privacy Policy", privacy_policy_path(anchor: "sms") %>.
+              </p>
+              <div class="form-check">
+                <%= f.check_box :sms_consent, class: "form-check-input", checked: current_user.sms_opted_in?,
+                                              data: { phone_consent_target: "consent" } %>
+                <%= f.label :sms_consent, t("sms.consent.checkbox_label"), class: "form-check-label" %>
+              </div>
+              <% if current_user.sms_opted_in? %>
+                <p class="small text-success mt-2 mb-0">
+                  <i class="fas fa-check-circle"></i>
+                  <%= t("sms.consent.enabled_since", date: l(current_user.phone_confirmed_at.to_date, format: :long)) %>
+                </p>
+              <% end %>
+            </div>
+
+            <div class="mb-3">
+              <%= f.submit "Save Changes", class: "btn btn-primary", data: { turbo: false } %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</article>

--- a/app/views/visitors/sms_info.html.erb
+++ b/app/views/visitors/sms_info.html.erb
@@ -19,7 +19,7 @@
   <h2>How to Opt In</h2>
   <ol>
     <li>Create an account and sign in to OpenSplitTime.</li>
-    <li>Go to your <%= link_to "Preferences", user_settings_preferences_path %> page.</li>
+    <li>Go to your <%= link_to "SMS Messaging settings", user_settings_sms_messaging_path %> page.</li>
     <li>Enter your mobile phone number.</li>
     <li>Read the SMS disclosure and check the consent box agreeing to receive text messages.</li>
     <li>Click "Save Changes."</li>
@@ -29,7 +29,7 @@
 
   <h2>SMS Terms and Conditions</h2>
   <p>Before receiving any text messages, you must check a consent box on your
-    <%= link_to "Preferences", user_settings_preferences_path %> page agreeing to the following:</p>
+    <%= link_to "SMS Messaging settings", user_settings_sms_messaging_path %> page agreeing to the following:</p>
   <blockquote class="p-3 bg-light border rounded">
     <p class="mb-0"><%= t("sms.consent.disclosure") %></p>
   </blockquote>
@@ -43,7 +43,7 @@
   <p>You can stop receiving SMS messages at any time by:</p>
   <ul>
     <li>Replying <strong>STOP</strong> to any message from OpenSplitTime, or</li>
-    <li>Unchecking the SMS consent box on your <%= link_to "Preferences", user_settings_preferences_path %> page.</li>
+    <li>Unchecking the SMS consent box on your <%= link_to "SMS Messaging settings", user_settings_sms_messaging_path %> page.</li>
   </ul>
 
   <h2>More Information</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
     get :password
     get :credentials
     get :credentials_new_service
+    get :sms_messaging
     put :update
   end
 

--- a/spec/system/devise/user_settings_preferences_spec.rb
+++ b/spec/system/devise/user_settings_preferences_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "visit the user settings preferences page and make changes", type: :system, js: true do
+RSpec.describe "visit the user settings preferences page and make changes", :js, type: :system do
   let(:user) { users(:third_user) }
 
   scenario "The user is a visitor" do
@@ -19,7 +19,6 @@ RSpec.describe "visit the user settings preferences page and make changes", type
 
     fill_in "First name", with: "John"
     fill_in "Last name", with: "Doe"
-    fill_in "user_phone", with: "555-555-5555"
 
     click_button "Save Changes"
 
@@ -29,7 +28,6 @@ RSpec.describe "visit the user settings preferences page and make changes", type
     user.reload
     expect(user.first_name).to eq("John")
     expect(user.last_name).to eq("Doe")
-    expect(user.phone).to eq("+15555555555")
   end
 
   def visit_page

--- a/spec/system/user_settings/sms_messaging_spec.rb
+++ b/spec/system/user_settings/sms_messaging_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "user settings sms messaging", type: :system do
+  let(:user) { users(:third_user) }
+
+  scenario "visitor attempts to reach the page" do
+    visit user_settings_sms_messaging_path
+
+    expect(page).to have_current_path(root_path)
+  end
+
+  scenario "user visits the SMS Messaging page" do
+    login_as user, scope: :user
+    visit user_settings_sms_messaging_path
+
+    expect(page).to have_text("SMS Messaging")
+    expect(page).to have_text("strictly optional")
+    expect(page).to have_field("Phone")
+    expect(page).to have_field("user_sms_consent")
+  end
+end


### PR DESCRIPTION
## Summary

- Splits the phone field and SMS consent checkbox out of the Preferences page into their own "SMS Messaging" tab in User Settings, alongside Password and Credentials
- Preferences now contains only the name fields in Personal Information, plus Unit Preferences
- The new tab has its own form scoped to phone + consent with its own submit button, so the consent checkbox no longer shares a submit with required profile fields (first_name, last_name)
- Updates `/sms_info`, the "Enable SMS" opt-in button, and the subscriptions-controller redirect to point at the new tab
- Intro copy on the new tab states SMS is strictly optional

This unbundles SMS consent from required profile fields, directly addressing TCR's "freely given and cannot be bundled as a required condition of service" concern, and reflects the fact that phone is only used for SMS.

Closes #1923. Part of parent issue #1921 and umbrella #1216.

## Test plan

- [ ] Log in as a user with no phone — visit `/user_settings/sms_messaging` and confirm the new tab renders, phone field is empty, consent checkbox is unchecked
- [ ] Enter a valid US/Canada phone, check the consent box, Save Changes — confirm "SMS enabled since …" row appears
- [ ] Visit `/user_settings/preferences` — confirm phone and SMS consent are gone; only name fields and Unit Preferences remain
- [ ] Click the sidebar "SMS Messaging" item from other tabs — confirm navigation + active state
- [ ] Visit `/sms_info` — confirm the links now point to "SMS Messaging settings"
- [ ] On an effort page while logged in as an admin without SMS consent, click "Enable SMS" — confirm redirect to the new SMS Messaging tab
- [ ] Try to POST a new SMS subscription while not opted in (admin) — confirm redirect goes to SMS Messaging tab with the "not opted in" flash
- [ ] `bundle exec rspec spec/system/user_settings/ spec/system/devise/user_settings_preferences_spec.rb spec/system/subscriptions/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)