### PR TITLE
Tighten SMS consent disclosure text to match ProgressNotifier output

### DIFF
--- a/app/views/visitors/privacy_policy.html.erb
+++ b/app/views/visitors/privacy_policy.html.erb
@@ -156,11 +156,12 @@
     live progress updates for race participants you subscribe to follow.</p>
   <ul>
     <li>Messages are sent by OpenSplitTime Company.</li>
-    <li>Message types may include live progress updates, participation confirmations, and event status changes.</li>
+    <li>Messages contain live progress updates only: the participant's name, event, aid station, distance, time of day,
+      elapsed time, and a link to view full results.</li>
     <li>Message frequency varies based on the events and participants you follow.</li>
     <li>Message and data rates may apply.</li>
     <li>You may opt out at any time by replying <strong>STOP</strong> to any message, or by unchecking the SMS consent
-      option on your Preferences page.</li>
+      option on your <%= link_to "SMS Messaging settings", user_settings_sms_messaging_path %> page.</li>
     <li>Reply <strong>HELP</strong> for help, or email
       <a href="mailto:mark@opensplittime.org">mark@opensplittime.org</a>.</li>
     <li>No mobile information will be shared with third parties or affiliates for marketing or promotional purposes.</li>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -99,7 +99,7 @@ en:
 
   sms:
     consent:
-      disclosure: "By checking the box below, you provide your express written consent to receive automated SMS text messages from OpenSplitTime with live race progress updates and related information for participants you choose to follow. Message frequency varies. Msg & data rates may apply. Reply STOP to cancel or HELP for help. Consent is not required as a condition to use OpenSplitTime for any service or transaction. No mobile information will be shared with third parties or affiliates for marketing or promotional purposes. Opt-in data will not be shared with unauthorized third parties."
+      disclosure: "By checking the box below, you provide your express written consent to receive automated SMS text messages from OpenSplitTime with live race progress updates for participants you choose to follow. Each message reports the participant's name, event, aid station, distance, time of day, and elapsed time, plus a link to view full results. Message frequency varies. Msg & data rates may apply. Reply STOP to cancel or HELP for help. Consent is not required as a condition to use OpenSplitTime for any service or transaction. No mobile information will be shared with third parties or affiliates for marketing or promotional purposes. Opt-in data will not be shared with unauthorized third parties."
       checkbox_label: "I consent to receive automated SMS text messages from OpenSplitTime"
       view_terms: "View full SMS terms"
       enabled_since: "SMS enabled since %{date}"

--- a/spec/system/user_settings/sms_messaging_spec.rb
+++ b/spec/system/user_settings/sms_messaging_spec.rb
@@ -18,4 +18,13 @@ RSpec.describe "user settings sms messaging", type: :system do
     expect(page).to have_field("Phone")
     expect(page).to have_field("user_sms_consent")
   end
+
+  scenario "disclosure enumerates message contents and omits the old catch-all phrase" do
+    login_as user, scope: :user
+    visit user_settings_sms_messaging_path
+
+    expect(page).to have_text("name, event, aid station, distance, time of day, and elapsed time")
+    expect(page).to have_text("link to view full results")
+    expect(page).to have_no_text("related information")
+  end
 end


### PR DESCRIPTION
## Summary

- Replaces the vague "and related information" phrase in `sms.consent.disclosure` with an explicit enumeration of the fields each SMS contains: participant's name, event, aid station, distance, time of day, elapsed time, and a link to view full results
- Aligns the Privacy Policy SMS section with the same narrow scope (removes "participation confirmations, and event status changes" — neither is sent)
- Updates the Privacy Policy's stale "Preferences page" reference to point at the new SMS Messaging settings page (moved in #1925)
- Adds a spec covering the new disclosure enumeration and the absence of the old catch-all phrase

This directly addresses finding (C) in parent issue #1921 and the scope decision that SMS is strictly for live progress updates. It removes the undisclosed-scope ambiguity most likely driving the TCR "insufficient consent" rejection.

Closes #1922. Part of parent issue #1921 and umbrella #1216.

## Test plan

- [x] Visit `/user_settings/sms_messaging` — disclosure reads "…live race progress updates for participants you choose to follow. Each message reports the participant's name, event, aid station, distance, time of day, and elapsed time, plus a link to view full results."
- [x] Visit `/privacy_policy#sms` — message types list now describes only progress updates; opt-out instructions link to SMS Messaging settings
- [x] Visit `/sms_info` — quoted disclosure (inside the blockquote) reflects the new text
- [x] `bundle exec rspec spec/system/user_settings/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)