### PR TITLE
Fix N+1 person lookup on events/spread (#1929)

### DIFF
--- a/app/presenters/event_spread_display.rb
+++ b/app/presenters/event_spread_display.rb
@@ -18,12 +18,13 @@ class EventSpreadDisplay < EventWithEffortsPresenter
   end
 
   def display_style_hash
-    {elapsed: "Elapsed", ampm: "AM/PM", military: "24-Hour", segment: "Segment"}
+    { elapsed: "Elapsed", ampm: "AM/PM", military: "24-Hour", segment: "Segment" }
   end
 
   def effort_times_rows
     @effort_times_rows ||=
       filtered_ranked_efforts.map do |effort|
+        effort.person = indexed_people[effort.person_id]
         EffortTimesRow.new(effort: effort,
                            lap_splits: lap_splits,
                            split_times: split_times_by_effort.fetch(effort.id, []),
@@ -48,8 +49,8 @@ class EventSpreadDisplay < EventWithEffortsPresenter
   end
 
   def segment_total_header_data
-    {title: aid_times_recorded? ? "Totals" : "Total",
-     extensions: aid_times_recorded? ? %w[Segment Aid] : []}
+    { title: aid_times_recorded? ? "Totals" : "Total",
+      extensions: aid_times_recorded? ? %w[Segment Aid] : [] }
   end
 
   def show_partner_banners?
@@ -62,11 +63,11 @@ class EventSpreadDisplay < EventWithEffortsPresenter
 
   def split_header_data
     lap_splits.map do |lap_split|
-      {title: header_name(lap_split),
-       extensions: header_extensions(lap_split),
-       distance: lap_split.distance_from_start,
-       split_name: lap_split.base_name_without_lap,
-       lap: lap_split.lap}
+      { title: header_name(lap_split),
+        extensions: header_extensions(lap_split),
+        distance: lap_split.distance_from_start,
+        split_name: lap_split.base_name_without_lap,
+        lap: lap_split.lap }
     end
   end
 
@@ -75,13 +76,7 @@ class EventSpreadDisplay < EventWithEffortsPresenter
   delegate :multiple_laps?, to: :event
 
   def default_display_style
-    if simple?
-      "elapsed"
-    elsif available_live
-      "ampm"
-    else
-      "elapsed"
-    end
+    available_live && !simple? ? "ampm" : "elapsed"
   end
 
   def header_name(lap_split)

--- a/spec/view_models/event_spread_display_spec.rb
+++ b/spec/view_models/event_spread_display_spec.rb
@@ -1,8 +1,37 @@
 require "rails_helper"
 
 RSpec.describe EventSpreadDisplay do
-  subject { EventSpreadDisplay.new(event: event, params: prepared_params) }
+  subject { described_class.new(event: event, params: prepared_params) }
+
   let(:prepared_params) { ActionController::Parameters.new(display_style: "ampm") }
+
+  describe "#effort_times_rows" do
+    let(:event) { events(:hardrock_2015) }
+    let(:prepared_params) { ActionController::Parameters.new(display_style: "elapsed") }
+
+    it "does not issue a SELECT people query per row" do
+      subject.send(:split_times)
+
+      person_queries = 0
+      subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
+        next if payload[:name] == "SCHEMA" || payload[:cached]
+
+        person_queries += 1 if payload[:sql] =~ /FROM "people"/
+      end
+
+      rows = subject.effort_times_rows
+      rows.each do |row|
+        row.display_full_name
+        row.bio_historic
+        row.flexible_geolocation
+      end
+
+      expect(rows.size).to be > 1
+      expect(person_queries).to be <= 1
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+    end
+  end
 
   describe "#split_header_data" do
     let(:course) { build_stubbed(:course, name: "Testrock Counter-clockwise", splits: splits) }
@@ -14,9 +43,9 @@ RSpec.describe EventSpreadDisplay do
 
     it "returns an array of hashes containing title, extensions, and distances" do
       expected = [
-        {title: "Starting Point", extensions: [], distance: 0, split_name: "Starting Point", lap: 1},
-        {title: "Aid Station 1", extensions: %w[In Out], distance: 10_000, split_name: "Aid Station 1", lap: 1},
-        {title: "Finishing Point", extensions: [], distance: 20_000, split_name: "Finishing Point", lap: 1}
+        { title: "Starting Point", extensions: [], distance: 0, split_name: "Starting Point", lap: 1 },
+        { title: "Aid Station 1", extensions: %w[In Out], distance: 10_000, split_name: "Aid Station 1", lap: 1 },
+        { title: "Finishing Point", extensions: [], distance: 20_000, split_name: "Finishing Point", lap: 1 }
       ]
       expect(subject.split_header_data).to eq(expected)
     end
@@ -25,8 +54,8 @@ RSpec.describe EventSpreadDisplay do
   describe "#display_style" do
     context "when display_style is provided in the params" do
       let(:prepared_params) { ActionController::Parameters.new(display_style: "ampm") }
-      let(:event) { instance_double("Event", simple?: true, event_group: event_group) }
-      let(:event_group) { instance_double("EventGroup", available_live: true) }
+      let(:event) { instance_double(Event, simple?: true, event_group: event_group) }
+      let(:event_group) { instance_double(EventGroup, available_live: true) }
 
       it "returns the provided display_style" do
         expect(subject.display_style).to eq("ampm")
@@ -35,8 +64,8 @@ RSpec.describe EventSpreadDisplay do
 
     context "when display_style is not provided in the params and the event has only start/finish splits" do
       let(:prepared_params) { ActionController::Parameters.new(display_style: nil) }
-      let(:event) { instance_double("Event", simple?: true, event_group: event_group) }
-      let(:event_group) { instance_double("EventGroup", available_live: true) }
+      let(:event) { instance_double(Event, simple?: true, event_group: event_group) }
+      let(:event_group) { instance_double(EventGroup, available_live: true) }
 
       it "returns elapsed" do
         expect(subject.display_style).to eq("elapsed")
@@ -45,8 +74,8 @@ RSpec.describe EventSpreadDisplay do
 
     context "when display_style is not provided in the params and the event has multiple splits and is available live" do
       let(:prepared_params) { ActionController::Parameters.new(display_style: nil) }
-      let(:event) { instance_double("Event", simple?: false, event_group: event_group) }
-      let(:event_group) { instance_double("EventGroup", available_live: true) }
+      let(:event) { instance_double(Event, simple?: false, event_group: event_group) }
+      let(:event_group) { instance_double(EventGroup, available_live: true) }
 
       it "returns elapsed" do
         expect(subject.display_style).to eq("ampm")
@@ -55,8 +84,8 @@ RSpec.describe EventSpreadDisplay do
 
     context "when display_style is not provided in the params and the event has multiple splits and is not available live" do
       let(:prepared_params) { ActionController::Parameters.new(display_style: nil) }
-      let(:event) { instance_double("Event", simple?: false, event_group: event_group) }
-      let(:event_group) { instance_double("EventGroup", available_live: false) }
+      let(:event) { instance_double(Event, simple?: false, event_group: event_group) }
+      let(:event_group) { instance_double(EventGroup, available_live: false) }
 
       it "returns elapsed" do
         expect(subject.display_style).to eq("elapsed")


### PR DESCRIPTION
## Summary
- `EventSpreadDisplay#effort_times_rows` now pre-assigns `effort.person` from `indexed_people` (inherited from `EventWithEffortsPresenter`), replacing N per-row `SELECT FROM \"people\"` lookups with a single bulk query.
- Mirrors the existing N+1 fix already in place for `EventWithEffortsPresenter#ranked_effort_rows` — no new pattern, just parity.
- Adds a regression spec in `spec/view_models/event_spread_display_spec.rb` that subscribes to `sql.active_record` while rendering rows for `events(:hardrock_2015)` (30 efforts) and asserts at most one `FROM \"people\"` query fires. Verified locally: fails with 30 queries before the fix, passes after.
- Drive-by: collapses a duplicate-branch warning in `default_display_style` (truth table verified identical) and a handful of rubocop autocorrects already flagged on these files.

Closes #1929. Regressed with #1864; companion fix to commit a30415d14 on the serializer path.

## Test plan
- [x] `bin/rspec spec/view_models/event_spread_display_spec.rb` — 6 examples, 0 failures
- [x] `bundle exec rubocop app/presenters/event_spread_display.rb spec/view_models/event_spread_display_spec.rb` — clean
- [x] Regression spec fails without the fix (30 person queries observed)
- [ ] After deploy, verify in Scout that `SELECT \"people\".* FROM \"people\" WHERE \"people\".\"id\" = ?` drops off the `events#spread` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)