### PR TITLE
Throttle rack-attack on real client IP from CF-Connecting-IP

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,9 +2,13 @@ module Rack
   class Attack
     THROTTLED_COUNTRIES = %w[CN SG].freeze
 
-    # Throttle requests by IP for traffic from high-abuse countries (60 requests per minute)
+    # Throttle requests by IP for traffic from high-abuse countries (60 requests per minute).
+    # Prefer CF-Connecting-IP so we throttle actual visitors rather than Cloudflare edge nodes,
+    # which front thousands of unrelated clients and make per-IP limits meaningless.
     throttle("requests by IP", limit: 60, period: 60) do |req|
-      req.ip if THROTTLED_COUNTRIES.include?(req.env["HTTP_CF_IPCOUNTRY"])
+      next unless THROTTLED_COUNTRIES.include?(req.env["HTTP_CF_IPCOUNTRY"])
+
+      req.env["HTTP_CF_CONNECTING_IP"].presence || req.ip
     end
   end
 end


### PR DESCRIPTION
## Summary
- The \"requests by IP\" throttle in \`config/initializers/rack_attack.rb\` was keyed on \`req.ip\`, which in front of Cloudflare resolves to an edge IP (e.g. \`162.158.x.x\`). Since each edge fronts thousands of unrelated visitors, a 60/min-per-IP cap either trips legit users sharing an edge with one abuser or goes unused because no single abuser reaches 60/min per edge.
- Switch the discriminator to \`CF-Connecting-IP\` (the header Cloudflare inserts with the real client IP), falling back to \`req.ip\` if it's absent for any reason.
- The throttle block only runs when \`CF-IPCOUNTRY\` is already \`CN\` or \`SG\`, i.e. only for Cloudflare-fronted traffic, so the header is expected to be present.

Noticed while investigating Solid Cache entries of the form \`rack::attack:…:requests by IP:<cloudflare edge ip>\`.

## Trust boundary note
\`CF-Connecting-IP\` is only trustworthy if the origin doesn't accept non-Cloudflare traffic. If the DigitalOcean droplet/LB accepts direct connections, an attacker could spoof the header to frame a victim IP for a minute of throttling on CN/SG routes. The existing \`req.ip\` version has the same weakness (they could omit \`CF-IPCOUNTRY\` to bypass entirely), so this doesn't widen the surface. Locking down origin ingress to Cloudflare IP ranges via a DO cloud firewall would close both paths — tracked separately, not part of this PR.

## Test plan
- [x] \`bundle exec rubocop config/initializers/rack_attack.rb\` — clean
- [ ] After deploy, confirm new \`rack::attack:…:requests by IP:…\` keys in Solid Cache are keyed on real client IPs (not \`162.158.x.x\` / \`172.68.x.x\` Cloudflare ranges)
- [ ] Monitor for any unexpected 429s in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)