### PR TITLE
Fix N+1 person lookup on events/finish_history (#1937)

### DIFF
--- a/app/presenters/finish_history_presenter.rb
+++ b/app/presenters/finish_history_presenter.rb
@@ -12,7 +12,10 @@ class FinishHistoryPresenter < BasePresenter
   end
 
   def effort_rows
-    @effort_rows ||= efforts.map { |effort| EffortRow.new(effort) }
+    @effort_rows ||= efforts.map do |effort|
+      effort.person = indexed_people[effort.person_id]
+      EffortRow.new(effort)
+    end
   end
 
   def history_for(row)
@@ -30,6 +33,10 @@ class FinishHistoryPresenter < BasePresenter
 
   def efforts
     @efforts ||= event.efforts.ranking_subquery
+  end
+
+  def indexed_people
+    @indexed_people ||= Person.where(id: efforts.map(&:person_id).compact).index_by(&:id)
   end
 
   # @return [Array<FinishHistory>]

--- a/spec/presenters/finish_history_presenter_spec.rb
+++ b/spec/presenters/finish_history_presenter_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe FinishHistoryPresenter do
+  subject { described_class.new(event: event, view_context: view_context) }
+
+  let(:event) { events(:hardrock_2015) }
+  let(:view_context) { double(prepared_params: ActionController::Parameters.new) }
+
+  describe "#effort_rows" do
+    it "does not issue a SELECT people query per row" do
+      person_queries = 0
+      subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
+        next if payload[:name] == "SCHEMA" || payload[:cached]
+
+        person_queries += 1 if payload[:sql] =~ /FROM "people"/
+      end
+
+      rows = subject.effort_rows
+      rows.each do |row|
+        row.display_full_name
+        row.bio_historic
+        row.flexible_geolocation
+      end
+
+      expect(rows.size).to be > 1
+      expect(person_queries).to be <= 1
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `FinishHistoryPresenter#effort_rows` now pre-assigns `effort.person` from a single bulk `Person.where(id: ...).index_by(&:id)` lookup, replacing N per-row `SELECT FROM \"people\"` queries.
- Mirrors the pattern already in `EventWithEffortsPresenter#ranked_effort_rows` and the parallel fix applied to `EventSpreadDisplay` in #1930 — no new pattern, just parity.
- Adds a regression spec in `spec/presenters/finish_history_presenter_spec.rb` that subscribes to `sql.active_record` while rendering rows for `events(:hardrock_2015)` (30 efforts) and asserts at most one `FROM \"people\"` query fires.

Closes #1937. Regressed with #1864; companion fix to #1930 on the spread path.

## Test plan
- [x] `bin/rspec spec/presenters/finish_history_presenter_spec.rb` — 1 example, 0 failures
- [x] `bundle exec rubocop app/presenters/finish_history_presenter.rb spec/presenters/finish_history_presenter_spec.rb` — clean
- [x] Regression spec fails without the fix (30 person queries observed)
- [ ] After deploy, verify in Scout that `SELECT \"people\".* FROM \"people\" WHERE \"people\".\"id\" = ?` drops off the `events#finish_history` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)