### PR TITLE
Fix N+1 person lookup on course_best_efforts (#1938)

### DIFF
--- a/app/presenters/course_best_efforts_display.rb
+++ b/app/presenters/course_best_efforts_display.rb
@@ -20,14 +20,17 @@ class CourseBestEffortsDisplay < BasePresenter
     return @filtered_segments if defined?(@filtered_segments)
 
     scope = BestEffortSegment.from(ranked_segments, :best_effort_segments)
-      .where(effort_id: filtered_efforts)
-      .order(:overall_rank)
+                             .where(effort_id: filtered_efforts)
+                             .order(:overall_rank)
 
     @pagy, @filtered_segments = pagy_countless_from_scope(
       scope,
       limit: per_page,
       page: page
     )
+
+    indexed_people = Person.where(id: @filtered_segments.map(&:person_id).compact).index_by(&:id)
+    @filtered_segments.each { |segment| segment.person = indexed_people[segment.person_id] }
 
     @filtered_segments
   end
@@ -59,15 +62,15 @@ class CourseBestEffortsDisplay < BasePresenter
   end
 
   def earliest_event_date
-    events.last.scheduled_start_time.to_date.to_formatted_s(:long)
+    events.last.scheduled_start_time.to_date.to_fs(:long)
   end
 
   def most_recent_event_date
-    most_recent_event && most_recent_event.scheduled_start_time.to_date.to_formatted_s(:long)
+    most_recent_event && most_recent_event.scheduled_start_time.to_date.to_fs(:long)
   end
 
   def most_recent_event
-    events.select { |event| event.scheduled_start_time < Time.now }.max_by(&:scheduled_start_time)
+    events.select { |event| event.scheduled_start_time < Time.current }.max_by(&:scheduled_start_time)
   end
 
   def relevant_genders
@@ -113,16 +116,20 @@ class CourseBestEffortsDisplay < BasePresenter
 
   def events
     @events ||= course.events
-                  .includes(:event_group)
-                  .order(scheduled_start_time: :desc)
-                  .select(&:visible?)
+                      .includes(:event_group)
+                      .order(scheduled_start_time: :desc)
+                      .select(&:visible?)
   end
 
   def segment
     return @segment if defined?(@segment)
 
-    split1 = ordered_splits.find { |split| [split.id.to_s, split.slug].compact.include?(split_1_id) } || ordered_splits.first
-    split2 = ordered_splits.find { |split| [split.id.to_s, split.slug].compact.include?(split_2_id) } || ordered_splits.last
+    split1 = ordered_splits.find do |split|
+      [split.id.to_s, split.slug].compact.include?(split_1_id)
+    end || ordered_splits.first
+    split2 = ordered_splits.find do |split|
+      [split.id.to_s, split.slug].compact.include?(split_2_id)
+    end || ordered_splits.last
     begin_split, end_split = [split1, split2].sort_by { |split| ordered_splits.index(split) }
     @segment = Segment.new(begin_point: TimePoint.new(1, begin_split.id, begin_split.bitkeys.last),
                            end_point: TimePoint.new(1, end_split.id, end_split.bitkeys.first),
@@ -152,6 +159,6 @@ class CourseBestEffortsDisplay < BasePresenter
 
   def ranked_segments
     BestEffortSegment.from(all_segments, :best_effort_segments)
-        .with_overall_and_gender_rank(:elapsed_seconds)
+                     .with_overall_and_gender_rank(:elapsed_seconds)
   end
 end

--- a/spec/presenters/course_best_efforts_display_spec.rb
+++ b/spec/presenters/course_best_efforts_display_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe CourseBestEffortsDisplay do
+  subject { described_class.new(course, view_context) }
+
+  let(:course) { courses(:hardrock_cw) }
+  let(:request) { instance_double(ActionDispatch::Request, params: {}) }
+  let(:view_context) do
+    double(prepared_params: ActionController::Parameters.new, request: request)
+  end
+
+  # rubocop:disable RSpec/BeforeAfterAll
+  before(:all) do
+    setup_fixtures
+    EffortSegment.set_all
+  end
+
+  after(:all) { EffortSegment.delete_all }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  describe "#filtered_segments" do
+    it "does not issue a SELECT people query per segment" do
+      segments = subject.filtered_segments
+
+      person_queries = 0
+      subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
+        next if payload[:name] == "SCHEMA" || payload[:cached]
+
+        person_queries += 1 if payload[:sql] =~ /FROM "people"/
+      end
+
+      segments.each do |segment|
+        segment.display_full_name
+        segment.bio_historic
+        segment.flexible_geolocation
+      end
+
+      expect(segments.size).to be > 1
+      expect(person_queries).to eq(0)
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `CourseBestEffortsDisplay#filtered_segments` now bulk-loads the page's people via `Person.where(id: ...).index_by(&:id)` and assigns each segment's `person` in memory, replacing one `SELECT FROM \"people\"` per row.
- `BestEffortSegment belongs_to :person` and includes `PersonalInfo`. Since #1864, `display_full_name` consults `person.obscure_name?` via `obscure_name_applied?`, so rendering `_best_effort_segment.html.erb` (which calls `display_full_name` on each segment) fired N person lookups.
- Mirrors the `indexed_people` pattern from `EventWithEffortsPresenter#ranked_effort_rows`, and the parallel fixes in #1930 (spread) and #1939 (finish_history).
- Adds a regression spec in `spec/presenters/course_best_efforts_display_spec.rb` that subscribes to `sql.active_record` while rendering the row methods for `courses(:hardrock_cw)` and asserts zero `FROM \"people\"` queries.
- Drive-by: rubocop autocorrects already flagged on this file.

Closes #1938.

## Test plan
- [x] `bin/rspec spec/presenters/course_best_efforts_display_spec.rb` — 1 example, 0 failures
- [x] `bin/rspec spec/system/courses/course_best_efforts_flow_spec.rb` — 6 examples, 0 failures
- [x] `bundle exec rubocop app/presenters/course_best_efforts_display.rb spec/presenters/course_best_efforts_display_spec.rb` — clean
- [x] Regression spec fails without the fix (14 person queries observed)
- [ ] After deploy, verify in Scout that `SELECT \"people\".* FROM \"people\" WHERE \"people\".\"id\" = ?` drops off the `course_best_efforts#index` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)