### PR TITLE
Fix N+1 person lookup on course_group_best_efforts (#1941)

### DIFF
--- a/app/presenters/course_group_best_efforts_display.rb
+++ b/app/presenters/course_group_best_efforts_display.rb
@@ -21,13 +21,17 @@ class CourseGroupBestEffortsDisplay < BasePresenter
       limit: per_page,
       page: page
     )
+
+    indexed_people = Person.where(id: @filtered_segments.map(&:person_id).compact).index_by(&:id)
+    @filtered_segments.each { |segment| segment.person = indexed_people[segment.person_id] }
+
     @filtered_segments
   end
 
   def filtered_segments_unpaginated
     ::BestEffortSegment.from(ranked_segments, :best_effort_segments)
-      .where(effort: filtered_efforts)
-      .order(:overall_rank)
+                       .where(effort: filtered_efforts)
+                       .order(:overall_rank)
   end
 
   def filtered_segments_count
@@ -53,15 +57,15 @@ class CourseGroupBestEffortsDisplay < BasePresenter
   end
 
   def earliest_event_date
-    events.last.scheduled_start_time.to_date.to_formatted_s(:long)
+    events.last.scheduled_start_time.to_date.to_fs(:long)
   end
 
   def most_recent_event_date
-    most_recent_event && most_recent_event.scheduled_start_time.to_date.to_formatted_s(:long)
+    most_recent_event && most_recent_event.scheduled_start_time.to_date.to_fs(:long)
   end
 
   def most_recent_event
-    events.select { |event| event.scheduled_start_time < Time.now }.max_by(&:scheduled_start_time)
+    events.select { |event| event.scheduled_start_time < Time.current }.max_by(&:scheduled_start_time)
   end
 
   def relevant_genders
@@ -87,9 +91,9 @@ class CourseGroupBestEffortsDisplay < BasePresenter
 
   def events
     @events ||= course_group.events
-                  .includes(:event_group)
-                  .order(scheduled_start_time: :desc)
-                  .select(&:visible?)
+                            .includes(:event_group)
+                            .order(scheduled_start_time: :desc)
+                            .select(&:visible?)
   end
 
   def all_efforts
@@ -106,6 +110,6 @@ class CourseGroupBestEffortsDisplay < BasePresenter
 
   def ranked_segments
     ::BestEffortSegment.from(all_segments, :best_effort_segments)
-      .with_overall_gender_age_and_event_rank
+                       .with_overall_gender_age_and_event_rank
   end
 end

--- a/spec/presenters/course_group_best_efforts_display_spec.rb
+++ b/spec/presenters/course_group_best_efforts_display_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe CourseGroupBestEffortsDisplay do
+  subject { described_class.new(course_group, view_context) }
+
+  let(:course_group) { course_groups(:both_directions) }
+  let(:request) { instance_double(ActionDispatch::Request, params: {}) }
+  let(:view_context) do
+    double(prepared_params: ActionController::Parameters.new, request: request)
+  end
+
+  # rubocop:disable RSpec/BeforeAfterAll
+  before(:all) do
+    setup_fixtures
+    EffortSegment.set_all
+  end
+
+  after(:all) { EffortSegment.delete_all }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  describe "#filtered_segments" do
+    it "does not issue a SELECT people query per segment" do
+      segments = subject.filtered_segments
+
+      person_queries = 0
+      subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
+        next if payload[:name] == "SCHEMA" || payload[:cached]
+
+        person_queries += 1 if payload[:sql] =~ /FROM "people"/
+      end
+
+      segments.each do |segment|
+        segment.display_full_name
+        segment.bio_historic
+        segment.flexible_geolocation
+      end
+
+      expect(segments.size).to be > 1
+      expect(person_queries).to eq(0)
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `CourseGroupBestEffortsDisplay#filtered_segments` now bulk-loads the page's people via `Person.where(id: ...).index_by(&:id)` and assigns each segment's `person` in memory, replacing one `SELECT FROM \"people\"` per row.
- Direct sibling of the fix shipped in #1940 for `CourseBestEffortsDisplay` — same shape, same root cause (PR #1864), same pattern.
- Adds a regression spec in `spec/presenters/course_group_best_efforts_display_spec.rb` using `course_groups(:both_directions)` (spans `hardrock_2014/2015/2016`); subscribes to `sql.active_record` and asserts zero `FROM \"people\"` queries when rendering the row methods.
- Drive-by: rubocop autocorrects already flagged on this file.

Closes #1941.

## Test plan
- [x] `bin/rspec spec/presenters/course_group_best_efforts_display_spec.rb` — 1 example, 0 failures
- [x] `bundle exec rubocop app/presenters/course_group_best_efforts_display.rb spec/presenters/course_group_best_efforts_display_spec.rb` — clean
- [x] Regression spec fails without the fix (person queries observed)
- [ ] After deploy, verify in Scout that `SELECT \"people\".* FROM \"people\" WHERE \"people\".\"id\" = ?` drops off the `course_group_best_efforts#index` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)