### PR TITLE
Add SMS opt-out tracking schema (migrations only)

### DIFF
--- a/db/migrate/20260429064635_add_sms_carrier_opted_out_at_to_users.rb
+++ b/db/migrate/20260429064635_add_sms_carrier_opted_out_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddSmsCarrierOptedOutAtToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :sms_carrier_opted_out_at, :datetime
+    add_index :users, :sms_carrier_opted_out_at
+  end
+end

--- a/db/migrate/20260429065115_create_analytics_sms_inbound_messages.rb
+++ b/db/migrate/20260429065115_create_analytics_sms_inbound_messages.rb
@@ -1,0 +1,18 @@
+class CreateAnalyticsSmsInboundMessages < ActiveRecord::Migration[8.1]
+  def change
+    create_table :analytics_sms_inbound_messages do |t|
+      t.string   :origination_number,  null: false
+      t.string   :destination_number,  null: false
+      t.string   :message_body,        null: false
+      t.datetime :received_at,         null: false
+      t.string   :sns_message_id,      null: false
+      t.string   :inbound_message_id
+      t.string   :keyword
+      t.timestamps
+
+      t.index :sns_message_id,    unique: true
+      t.index :origination_number
+      t.index :received_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_22_151312) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_29_064635) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -915,6 +915,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_151312) do
     t.integer "role"
     t.integer "sign_in_count", default: 0, null: false
     t.string "slug", null: false
+    t.datetime "sms_carrier_opted_out_at"
     t.string "uid"
     t.string "unconfirmed_email"
     t.datetime "updated_at", precision: nil, null: false
@@ -922,6 +923,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_151312) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true
+    t.index ["sms_carrier_opted_out_at"], name: "index_users_on_sms_carrier_opted_out_at"
   end
 
   create_table "versions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_29_064635) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_29_065115) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -84,6 +84,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_29_064635) do
     t.bigint "user_id", null: false
     t.index ["record_type", "record_id"], name: "index_file_downloads_on_record"
     t.index ["user_id"], name: "index_analytics_file_downloads_on_user_id"
+  end
+
+  create_table "analytics_sms_inbound_messages", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "destination_number", null: false
+    t.string "inbound_message_id"
+    t.string "keyword"
+    t.string "message_body", null: false
+    t.string "origination_number", null: false
+    t.datetime "received_at", null: false
+    t.string "sns_message_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["origination_number"], name: "index_analytics_sms_inbound_messages_on_origination_number"
+    t.index ["received_at"], name: "index_analytics_sms_inbound_messages_on_received_at"
+    t.index ["sns_message_id"], name: "index_analytics_sms_inbound_messages_on_sns_message_id", unique: true
   end
 
   create_table "connections", force: :cascade do |t|


### PR DESCRIPTION
## Summary

First of four PRs implementing app-side SMS opt-out tracking (#1947). This PR adds **only** the underlying schema; no application code references the new column or table.

- Adds `users.sms_carrier_opted_out_at` (nullable datetime + index)
- Adds `analytics_sms_inbound_messages` table with a unique index on `sns_message_id`

## Why ship this in isolation?

The full feature is intentionally rolled out across four PRs, each merged AND deployed all the way through staging AND production before the next opens (per the [design doc](https://github.com/SplitTime/OpenSplitTime/issues/1947)):

- **PR 1 (this one):** migrations
- **PR 2:** User model changes (validator + predicates + callback)
- **PR 3:** non-user-facing logic (controller, interactor, job, model, service, routes, recurring config)
- **PR 4:** SMS Messaging settings view

Landing the schema first means PRs 2 and 3 each ship against an already-stable schema with no risk of code/migration deploy skew. The new column and table will sit unused after this PR merges; that's intentional and expected. PR 2 will start populating \`sms_carrier_opted_out_at\` (well, reading it, anyway); PR 3 will start populating both.

## Schema details

### \`users.sms_carrier_opted_out_at\`

Nullable timestamp. Set when a user replies STOP via SMS (mirroring the AWS-side opt-out list); cleared on START. Distinct from \`phone_confirmed_at\`, which represents app-side consent given via the SMS Messaging settings tab. Indexed because the hourly reconciliation job introduced in PR 3 will scan for users currently flagged opted-out.

### \`analytics_sms_inbound_messages\`

Lives alongside \`analytics_email_events\` and \`analytics_file_downloads\` — same naming convention. Stores every inbound SMS the SNS webhook receives, including STOP/START/HELP keyword messages that AWS auto-handles. The unique index on \`sns_message_id\` provides idempotency for SNS retries (the controller in PR 3 relies on \`find_or_create_by!\` + the unique-violation race to dedup). Surfaced via Madmin auto-CRUD in PR 3 — no custom UI.

## Test plan

- [x] Both migrations run cleanly forward
- [x] Both migrations are reversible (\`db:rollback\` then re-\`db:migrate\` produces an identical \`db/schema.rb\`)
- [x] Unique constraint on \`sns_message_id\` actually rejects duplicates (verified in console)
- [x] Full RSpec suite passes against the new schema (no regressions: 4074 examples, 0 failures, 8 pending)

## Deployment

After merge, run \`bin/rails db:migrate\` on staging, verify schema, then on production. No code is affected by these migrations being unapplied for a window, so the staged deploy is safe at any pace.

Refs #1947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)