### PR TITLE
Tighten User phone validator and add SMS carrier opt-out predicates

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ApplicationRecord
   attr_accessor :sms_consent
 
   validates :first_name, :last_name, presence: true, length: { maximum: 64 }
-  validates :phone, format: { with: /\+1\d{9}/, message: "must be a valid US or Canada phone number" }, if: :phone?
+  validates :phone, format: { with: /\A\+1\d{10}\z/, message: "must be a valid US or Canada phone number" }, if: :phone?
 
   after_initialize :set_default_role, if: :new_record?
   before_validation :normalize_phone, if: :phone?
@@ -187,7 +187,12 @@ class User < ApplicationRecord
 
   # @return [Boolean]
   def sms_opted_in?
-    phone_confirmed_at.present? && phone.present?
+    phone_confirmed_at.present? && phone.present? && sms_carrier_opted_out_at.nil?
+  end
+
+  # @return [Boolean]
+  def sms_carrier_opted_out?
+    sms_carrier_opted_out_at.present?
   end
 
   # @return [Boolean]
@@ -213,6 +218,9 @@ class User < ApplicationRecord
   end
 
   def clear_sms_consent_on_phone_change
-    self.phone_confirmed_at = nil if phone_was.present?
+    return if phone_was.blank?
+
+    self.phone_confirmed_at = nil
+    self.sms_carrier_opted_out_at = nil
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -169,6 +169,17 @@ RSpec.describe User, type: :model do
         expect(user).to be_valid
       end
     end
+
+    context "when phone has a leading non-+1 country code" do
+      let(:phone) { "52+15517064638" }
+
+      it "is rejected by the format validator" do
+        user.validate
+        expect(user.phone).to eq("52+15517064638")
+        expect(user).not_to be_valid
+        expect(user.errors[:phone]).to include("must be a valid US or Canada phone number")
+      end
+    end
   end
 
   describe "#steward_of?" do
@@ -231,6 +242,26 @@ RSpec.describe User, type: :model do
 
       it { is_expected.not_to be_sms_opted_in }
     end
+
+    context "when phone and phone_confirmed_at are both present but the user is carrier-opted-out" do
+      subject { build(:user, phone: "+12025551212", phone_confirmed_at: Time.current, sms_carrier_opted_out_at: Time.current) }
+
+      it { is_expected.not_to be_sms_opted_in }
+    end
+  end
+
+  describe "#sms_carrier_opted_out?" do
+    context "when sms_carrier_opted_out_at is set" do
+      subject { build(:user, sms_carrier_opted_out_at: Time.current) }
+
+      it { is_expected.to be_sms_carrier_opted_out }
+    end
+
+    context "when sms_carrier_opted_out_at is nil" do
+      subject { build(:user, sms_carrier_opted_out_at: nil) }
+
+      it { is_expected.not_to be_sms_carrier_opted_out }
+    end
   end
 
   describe "sms consent callbacks" do
@@ -269,6 +300,21 @@ RSpec.describe User, type: :model do
       it "clears phone_confirmed_at" do
         subject.update!(phone: nil)
         expect(subject.phone_confirmed_at).to be_nil
+      end
+    end
+
+    context "when phone is changed and the user is carrier-opted-out" do
+      subject do
+        create(:user,
+               phone: "+12025551212",
+               phone_confirmed_at: Time.current,
+               sms_carrier_opted_out_at: Time.current)
+      end
+
+      it "clears both phone_confirmed_at and sms_carrier_opted_out_at" do
+        subject.update!(phone: "+13035551212")
+        expect(subject.phone_confirmed_at).to be_nil
+        expect(subject.sms_carrier_opted_out_at).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Summary

Second of four PRs implementing app-side SMS opt-out tracking (#1947). This PR introduces the User model changes that PR 3 (controller/job/interactor) will populate and PR 4 (view) will render.

- **Tightened phone format validator** from `/\+1\d{9}/` (unanchored, 9-digit minimum) to `/\A\+1\d{10}\z/` (anchored, exactly 10 digits). The old regex was substring-matching, which is how the malformed prod row in the form of `"52+14445551212"` snuck past it. The data fix for that single row is already done in production.
- **Added `User#sms_carrier_opted_out?`** predicate, returning `sms_carrier_opted_out_at.present?`. Reads the column added by PR #1948.
- **Updated `User#sms_opted_in?`** to additionally require `sms_carrier_opted_out_at.nil?`. A user who replied STOP via SMS is no longer considered opted-in even if their app-side `phone_confirmed_at` is still set.
- **Updated `User#clear_sms_consent_on_phone_change`** to also null `sms_carrier_opted_out_at` when the phone changes — the carrier-opt-out applied to the *old* phone, not the new one.

## Why ship this in isolation?

This is the User-model slice of the four-PR rollout described in the design doc. The new predicate `sms_carrier_opted_out?` has no callers yet — those arrive in PR 3 (the SNS webhook controller / interactor / reconciliation job) and PR 4 (the SMS Messaging settings tab). After this PR ships, the column added in PR #1948 starts being read but is still never written, so behavior in production is unchanged. The validator change is durable on its own.

The staged-rollout cadence rule from the design doc applies: PR 3 won't open until PR 2 is merged AND deployed all the way through staging AND production.

## Test plan

- [x] Targeted RSpec passes for `spec/models/user_spec.rb` and `spec/system/user_settings/sms_messaging_spec.rb` (53 examples, 0 failures, including 5 new examples covering the carrier opt-out predicates, callback extension, and tightened validator)
- [x] RuboCop clean on touched files
- [x] CI green on full suite

## Test cases added

- `#sms_opted_in?` returns false when `sms_carrier_opted_out_at` is set even if phone and `phone_confirmed_at` are also set
- `#sms_carrier_opted_out?` returns true when the column is set, false when nil
- `clear_sms_consent_on_phone_change` clears BOTH `phone_confirmed_at` AND `sms_carrier_opted_out_at` on phone change
- The format validator rejects the previously-accepted malformed shape `"52+15517064638"`

Refs #1947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)