### PR TITLE
Add SNS inbound webhook, reconciliation job, and supporting analytics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "acts_as_list", "~> 0.9"
 gem "allowable", "~> 1.1"
 gem "american_date"
 gem "api-pagination", "~> 7.0"
+gem "aws-sdk-pinpointsmsvoicev2", "~> 1", require: false
 gem "aws-sdk-rails", "~> 3"
 gem "aws-sdk-s3", "~> 1", require: false
 gem "aws-sdk-sns", "~> 1", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,9 @@ GEM
     aws-sdk-kms (1.123.0)
       aws-sdk-core (~> 3, >= 3.244.0)
       aws-sigv4 (~> 1.5)
+    aws-sdk-pinpointsmsvoicev2 (1.54.0)
+      aws-sdk-core (~> 3, >= 3.244.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-rails (3.13.0)
       aws-record (~> 2)
       aws-sdk-ses (~> 1, >= 1.50.0)
@@ -787,6 +790,7 @@ DEPENDENCIES
   allowable (~> 1.1)
   american_date
   api-pagination (~> 7.0)
+  aws-sdk-pinpointsmsvoicev2 (~> 1)
   aws-sdk-rails (~> 3)
   aws-sdk-s3 (~> 1)
   aws-sdk-sns (~> 1)

--- a/app/controllers/webhooks/sns_inbound_controller.rb
+++ b/app/controllers/webhooks/sns_inbound_controller.rb
@@ -1,0 +1,66 @@
+require "aws-sdk-sns"
+
+module Webhooks
+  class SnsInboundController < ::ApplicationController
+    skip_before_action :verify_authenticity_token
+
+    def create
+      return head :unauthorized unless valid_signature?
+
+      case request.headers["x-amz-sns-message-type"]
+      when "SubscriptionConfirmation"
+        confirm_subscription
+      when "Notification"
+        process_notification
+      when "UnsubscribeConfirmation"
+        report_anomaly("unexpected SNS UnsubscribeConfirmation: #{sns_message['TopicArn']}")
+        head :ok
+      else
+        head :bad_request
+      end
+    end
+
+    private
+
+    def valid_signature?
+      Aws::SNS::MessageVerifier.new.authentic?(request.raw_post)
+    end
+
+    def sns_message
+      @sns_message ||= JSON.parse(request.raw_post)
+    end
+
+    def confirm_subscription
+      url = sns_message.fetch("SubscribeURL")
+      if safe_subscribe_url?(url)
+        Net::HTTP.get(URI(url))
+        head :ok
+      else
+        report_anomaly("rejected non-AWS SubscribeURL: #{url}")
+        head :bad_request
+      end
+    end
+
+    def process_notification
+      response = Interactors::Webhooks::ProcessSnsInboundSms.call(sns_message: sns_message)
+      if response.successful?
+        head :ok
+      else
+        render json: { errors: response.errors }, status: :unprocessable_content
+      end
+    end
+
+    def safe_subscribe_url?(url)
+      uri = URI.parse(url)
+      uri.scheme == "https" && uri.host =~ /\Asns\.[a-z0-9-]+\.amazonaws\.com\z/
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def report_anomaly(message)
+      Rails.error.report(SmsWebhookError.new(message), handled: true)
+    end
+  end
+
+  class SmsWebhookError < StandardError; end
+end

--- a/app/jobs/reconcile_sms_carrier_opt_outs_job.rb
+++ b/app/jobs/reconcile_sms_carrier_opt_outs_job.rb
@@ -1,0 +1,26 @@
+class ReconcileSmsCarrierOptOutsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    aws_opted_out = AwsSmsClient.fetch_all_opted_out_numbers
+    corrected_user_ids = []
+
+    User.where(phone: aws_opted_out, sms_carrier_opted_out_at: nil).find_each do |user|
+      user.update_column(:sms_carrier_opted_out_at, Time.current)
+      corrected_user_ids << user.id
+    end
+
+    User.where.not(sms_carrier_opted_out_at: nil).where.not(phone: aws_opted_out).find_each do |user|
+      user.update_column(:sms_carrier_opted_out_at, nil)
+      corrected_user_ids << user.id
+    end
+
+    return if corrected_user_ids.empty?
+
+    raise SmsReconciliationDriftError,
+          "Reconciliation made #{corrected_user_ids.size} correction(s); " \
+          "webhook is dropping events. Affected user_ids: #{corrected_user_ids.inspect}"
+  end
+end
+
+class SmsReconciliationDriftError < StandardError; end

--- a/app/madmin/resources/analytics/sms_inbound_message_resource.rb
+++ b/app/madmin/resources/analytics/sms_inbound_message_resource.rb
@@ -1,0 +1,25 @@
+module Analytics
+  class SmsInboundMessageResource < Madmin::Resource
+    # Attributes
+    attribute :id, form: false
+    attribute :origination_number, index: true
+    attribute :destination_number, index: true
+    attribute :message_body, index: true
+    attribute :keyword, index: true
+    attribute :received_at, index: true
+    attribute :sns_message_id, index: false
+    attribute :inbound_message_id, index: false
+    attribute :created_at, form: false, index: true
+    attribute :updated_at, form: false, index: false
+
+    # Associations
+
+    def self.default_sort_column
+      "received_at"
+    end
+
+    def self.default_sort_direction
+      "desc"
+    end
+  end
+end

--- a/app/models/analytics/sms_inbound_message.rb
+++ b/app/models/analytics/sms_inbound_message.rb
@@ -1,0 +1,5 @@
+module ::Analytics
+  class SmsInboundMessage < ApplicationRecord
+    validates :origination_number, :destination_number, :message_body, :received_at, :sns_message_id, presence: true
+  end
+end

--- a/app/services/aws_sms_client.rb
+++ b/app/services/aws_sms_client.rb
@@ -1,0 +1,21 @@
+require "aws-sdk-pinpointsmsvoicev2"
+
+class AwsSmsClient
+  def self.fetch_all_opted_out_numbers(opt_out_list_name: "Default")
+    client = Aws::PinpointSMSVoiceV2::Client.new(region: ::OstConfig.aws_region)
+    numbers = []
+    next_token = nil
+
+    loop do
+      response = client.describe_opted_out_numbers(
+        opt_out_list_name: opt_out_list_name,
+        next_token: next_token,
+      )
+      numbers.concat(response.opted_out_numbers.map(&:opted_out_number))
+      next_token = response.next_token
+      break if next_token.nil?
+    end
+
+    numbers
+  end
+end

--- a/app/services/interactors/errors.rb
+++ b/app/services/interactors/errors.rb
@@ -31,8 +31,10 @@ module Interactors
     end
 
     def cannot_unstart_error(effort)
+      message = "The effort has one or more intermediate or finish times recorded. " \
+                "Times must be deleted from the effort view."
       { title: "Cannot mark #{effort} as DNS",
-        detail: { messages: ["The effort has one or more intermediate or finish times recorded. Times must be deleted from the effort view."] } }
+        detail: { messages: [message] } }
     end
 
     def distance_mismatch_error(child, new_parent)
@@ -41,8 +43,9 @@ module Interactors
     end
 
     def duplicate_bib_numbers_error(bib_numbers)
+      message = "The operation resulted in the creation of duplicate bib numbers: #{bib_numbers.join(', ')}"
       { title: "Duplicate bib numbers",
-        detail: { messages: ["The operation resulted in the creation of duplicate bib numbers: #{bib_numbers.join(', ')}"] } }
+        detail: { messages: [message] } }
     end
 
     def efforts_not_provided_error
@@ -51,9 +54,12 @@ module Interactors
     end
 
     def empty_bib_numbers_error(problems)
-      problem_efforts_text = problems.map { |problem| "#{problem.first} could not be set to #{problem.last}" }.join("\n")
+      problem_efforts_text = problems
+                             .map { |problem| "#{problem.first} could not be set to #{problem.last}" }
+                             .join("\n")
+      message = "The operation resulted in the following bib numbers being set to empty: #{problem_efforts_text}"
       { title: "Empty bib numbers",
-        detail: { messages: ["The operation resulted in the following bib numbers being set to empty: #{problem_efforts_text}"] } }
+        detail: { messages: [message] } }
     end
 
     def event_group_mismatch_error(resource_1, resource_2)
@@ -77,8 +83,10 @@ module Interactors
     end
 
     def invalid_raw_time_error(raw_time, valid_sub_splits)
+      message = "#{raw_time} is invalid; the sub_split #{raw_time.sub_split} " \
+                "must be one of #{valid_sub_splits}"
       { title: "Invalid raw time",
-        detail: { messages: ["#{raw_time} is invalid; the sub_split #{raw_time.sub_split} must be one of #{valid_sub_splits}"] } }
+        detail: { messages: [message] } }
     end
 
     def invalid_split_name_error(split_name, valid_split_names)
@@ -97,8 +105,9 @@ module Interactors
     end
 
     def lottery_draws_exist_error
+      message = "Draws already exist for this lottery; please delete them before running this operation"
       { title: "Lottery draws already exist",
-        detail: { messages: ["Draws already exist for this lottery; please delete them before running this operation"] } }
+        detail: { messages: [message] } }
     end
 
     def lottery_entrants_not_created_error
@@ -136,6 +145,11 @@ module Interactors
         detail: { messages: [message] } }
     end
 
+    def sns_payload_error(message)
+      { title: "An error occurred while attempting to parse the SNS payload",
+        detail: { messages: [message] } }
+    end
+
     def raw_time_mismatch_error
       { title: "Raw times do not match",
         detail: { messages: ["One or more raw times is not related to the provided event group"] } }
@@ -147,8 +161,10 @@ module Interactors
     end
 
     def split_name_mismatch_error(child, new_parent)
+      message = "#{child} cannot be assigned to #{new_parent} because #{child} has split times " \
+                "corresponding to split names that do not coincide with splits for #{new_parent}"
       { title: "Split names do not match",
-        detail: { messages: ["#{child} cannot be assigned to #{new_parent} because #{child} has split times corresponding to split names that do not coincide with splits for #{new_parent}"] } }
+        detail: { messages: [message] } }
     end
 
     def sub_split_mismatch_error(child, new_parent)
@@ -157,18 +173,24 @@ module Interactors
     end
 
     def multiple_event_groups_error(event_group_ids)
+      message = "Attempted to start efforts from multiple event_groups: #{event_group_ids.to_sentence}"
       { title: "Efforts are from multiple event groups",
-        detail: { messages: ["Attempted to start efforts from multiple event_groups: #{event_group_ids.to_sentence}"] } }
+        detail: { messages: [message] } }
     end
 
     def multiple_runsignup_race_ids_error(race_ids, event_group_id)
+      message = "Multiple runsignup race ids (#{race_ids.to_sentence}) are assigned " \
+                "to a single event group (#{event_group_id})"
       { title: "Multiple race ids assigned to event group",
-        detail: { messages: ["Multiple runsignup race ids (#{race_ids.to_sentence}) are assigned to a single event group (#{event_group_id})"] } }
+        detail: { messages: [message] } }
     end
 
     def mismatched_organization_error(old_event_group, new_event_group)
+      message = "The event cannot be updated because #{old_event_group} is organized " \
+                "under #{old_event_group.organization}, but #{new_event_group} is " \
+                "organized under #{new_event_group.organization}"
       { title: "Event group organizations do not match",
-        detail: { messages: ["The event cannot be updated because #{old_event_group} is organized under #{old_event_group.organization}, but #{new_event_group} is organized under #{new_event_group.organization}"] } }
+        detail: { messages: [message] } }
     end
 
     def no_runsignup_race_id_error(event_group_id)

--- a/app/services/interactors/webhooks/process_sns_inbound_sms.rb
+++ b/app/services/interactors/webhooks/process_sns_inbound_sms.rb
@@ -1,0 +1,64 @@
+module Interactors
+  module Webhooks
+    class ProcessSnsInboundSms
+      include Interactors::Errors
+
+      KEYWORDS = %w[STOP START HELP].freeze
+
+      def self.call(sns_message:)
+        new(sns_message: sns_message).call
+      end
+
+      def initialize(sns_message:)
+        @sns_message = sns_message
+        @errors = []
+      end
+
+      def call
+        find_or_create_record
+        apply_state_change if record.previously_new_record?
+        Interactors::Response.new(errors, "", [record])
+      rescue KeyError, JSON::ParserError => e
+        Rails.error.report(e, handled: true, context: { sns_message_id: sns_message["MessageId"] })
+        errors << sns_payload_error(e.message)
+        Interactors::Response.new(errors, "", [])
+      end
+
+      private
+
+      attr_reader :sns_message, :errors
+      attr_accessor :record
+
+      def find_or_create_record
+        self.record = Analytics::SmsInboundMessage.find_or_create_by!(
+          sns_message_id: sns_message.fetch("MessageId"),
+        ) do |r|
+          r.origination_number = inbound_payload.fetch("originationNumber")
+          r.destination_number = inbound_payload.fetch("destinationNumber")
+          r.message_body       = inbound_payload.fetch("messageBody")
+          r.received_at        = Time.zone.parse(sns_message.fetch("Timestamp"))
+          r.inbound_message_id = inbound_payload["inboundMessageId"]
+          r.keyword            = parse_keyword(inbound_payload.fetch("messageBody"))
+        end
+      end
+
+      def inbound_payload
+        @inbound_payload ||= JSON.parse(sns_message.fetch("Message"))
+      end
+
+      def parse_keyword(body)
+        first_token = body.to_s.strip.upcase.split(/\s+/).first
+        KEYWORDS.include?(first_token) ? first_token : nil
+      end
+
+      def apply_state_change
+        case record.keyword
+        when "STOP"
+          User.where(phone: record.origination_number).update_all(sms_carrier_opted_out_at: record.received_at)
+        when "START"
+          User.where(phone: record.origination_number).update_all(sms_carrier_opted_out_at: nil)
+        end
+      end
+    end
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -21,3 +21,7 @@ production:
     class: SweepSubscriptionsJob
     queue: default
     schedule: every month on the 1st at 7am
+  reconcile_sms_carrier_opt_outs:
+    class: ReconcileSmsCarrierOptOutsJob
+    queue: default
+    schedule: every hour at minute 7

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
 
   namespace :webhooks do
     resources :mailgun_events, only: [:create]
+    resources :sns_inbound, only: [:create]
     post "raceresult", to: "raceresult#receive"
   end
 

--- a/spec/controllers/webhooks/sns_inbound_controller_spec.rb
+++ b/spec/controllers/webhooks/sns_inbound_controller_spec.rb
@@ -1,0 +1,136 @@
+require "rails_helper"
+
+RSpec.describe Webhooks::SnsInboundController do
+  let(:verifier) { instance_double(Aws::SNS::MessageVerifier) }
+  let(:signature_valid) { true }
+
+  before do
+    allow(Aws::SNS::MessageVerifier).to receive(:new).and_return(verifier)
+    allow(verifier).to receive(:authentic?).and_return(signature_valid)
+  end
+
+  def post_with_sns(body:, type:)
+    request.headers["x-amz-sns-message-type"] = type
+    post :create, body: body
+  end
+
+  describe "#create" do
+    context "with an invalid SNS signature" do
+      let(:signature_valid) { false }
+
+      it "returns 401 and does not report to Rails.error" do
+        allow(Rails.error).to receive(:report)
+        post_with_sns(body: "{}", type: "Notification")
+        expect(response).to have_http_status(:unauthorized)
+        expect(Rails.error).not_to have_received(:report)
+      end
+    end
+
+    context "with a SubscriptionConfirmation message and a valid AWS-host SubscribeURL" do
+      let(:body) do
+        {
+          "Type" => "SubscriptionConfirmation",
+          "MessageId" => "mid-1",
+          "Token" => "token",
+          "TopicArn" => "arn:aws:sns:us-west-2:186555151487:ost-sms-inbound",
+          "SubscribeURL" => "https://sns.us-west-2.amazonaws.com/?Action=ConfirmSubscription&Token=...",
+        }.to_json
+      end
+
+      before do
+        allow(Net::HTTP).to receive(:get).and_return("ok")
+      end
+
+      it "returns 200 and fetches the SubscribeURL" do
+        post_with_sns(body: body, type: "SubscriptionConfirmation")
+        expect(response).to have_http_status(:ok)
+        expect(Net::HTTP).to have_received(:get).with(URI("https://sns.us-west-2.amazonaws.com/?Action=ConfirmSubscription&Token=..."))
+      end
+    end
+
+    context "with a SubscriptionConfirmation message and a non-AWS SubscribeURL" do
+      let(:body) do
+        {
+          "Type" => "SubscriptionConfirmation",
+          "MessageId" => "mid-1",
+          "SubscribeURL" => "https://attacker.example.com/?Action=ConfirmSubscription",
+        }.to_json
+      end
+
+      before do
+        allow(Net::HTTP).to receive(:get)
+        allow(Rails.error).to receive(:report)
+      end
+
+      it "returns 400, does not fetch the URL, and reports the anomaly" do
+        post_with_sns(body: body, type: "SubscriptionConfirmation")
+        expect(response).to have_http_status(:bad_request)
+        expect(Net::HTTP).not_to have_received(:get)
+        expect(Rails.error).to have_received(:report).with(
+          an_instance_of(Webhooks::SmsWebhookError),
+          handled: true,
+        )
+      end
+    end
+
+    context "with a Notification message" do
+      let(:body) { { "Type" => "Notification", "MessageId" => "mid-1" }.to_json }
+
+      context "when the interactor succeeds" do
+        before do
+          response_double = instance_double(Interactors::Response, successful?: true, errors: [])
+          allow(Interactors::Webhooks::ProcessSnsInboundSms).to receive(:call).and_return(response_double)
+        end
+
+        it "returns 200" do
+          post_with_sns(body: body, type: "Notification")
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "delegates to the interactor with the parsed sns_message" do
+          post_with_sns(body: body, type: "Notification")
+          expect(Interactors::Webhooks::ProcessSnsInboundSms).to have_received(:call).with(
+            sns_message: hash_including("Type" => "Notification", "MessageId" => "mid-1"),
+          )
+        end
+      end
+
+      context "when the interactor fails" do
+        before do
+          response_double = instance_double(Interactors::Response, successful?: false, errors: [{ title: "bad" }])
+          allow(Interactors::Webhooks::ProcessSnsInboundSms).to receive(:call).and_return(response_double)
+        end
+
+        it "returns 422 with errors in the body" do
+          post_with_sns(body: body, type: "Notification")
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.parsed_body).to eq("errors" => [{ "title" => "bad" }])
+        end
+      end
+    end
+
+    context "with an UnsubscribeConfirmation message" do
+      let(:body) do
+        { "Type" => "UnsubscribeConfirmation", "TopicArn" => "arn:aws:sns:us-west-2:186555151487:ost-sms-inbound" }.to_json
+      end
+
+      before { allow(Rails.error).to receive(:report) }
+
+      it "returns 200 (terminal — no AWS retry) and reports the anomaly" do
+        post_with_sns(body: body, type: "UnsubscribeConfirmation")
+        expect(response).to have_http_status(:ok)
+        expect(Rails.error).to have_received(:report).with(
+          an_instance_of(Webhooks::SmsWebhookError),
+          handled: true,
+        )
+      end
+    end
+
+    context "with an unknown x-amz-sns-message-type header" do
+      it "returns 400" do
+        post_with_sns(body: "{}", type: "SomeUnknownType")
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end

--- a/spec/jobs/reconcile_sms_carrier_opt_outs_job_spec.rb
+++ b/spec/jobs/reconcile_sms_carrier_opt_outs_job_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe ReconcileSmsCarrierOptOutsJob, type: :job do
+  before { allow(AwsSmsClient).to receive(:fetch_all_opted_out_numbers).and_return(aws_opted_out) }
+
+  describe "#perform" do
+    context "when AWS and DB agree (no drift)" do
+      let(:aws_opted_out) { [] }
+      let!(:user) { create(:user, phone: "+12025551212", phone_confirmed_at: Time.current) }
+
+      it "does not raise and does not change user state" do
+        expect { described_class.perform_now }.not_to raise_error
+        expect(user.reload.sms_carrier_opted_out_at).to be_nil
+      end
+    end
+
+    context "when AWS lists a user opted out but DB has them as not-opted-out (Direction 1)" do
+      let(:aws_opted_out) { ["+12025551212"] }
+      let!(:user) { create(:user, phone: "+12025551212", phone_confirmed_at: Time.current) }
+
+      it "raises SmsReconciliationDriftError" do
+        expect { described_class.perform_now }.to raise_error(SmsReconciliationDriftError, /1 correction/)
+      end
+
+      it "sets sms_carrier_opted_out_at on the user before raising" do
+        begin
+          described_class.perform_now
+        rescue SmsReconciliationDriftError
+          # expected
+        end
+        expect(user.reload.sms_carrier_opted_out_at).to be_present
+      end
+
+      it "includes the user_id in the error message" do
+        expect { described_class.perform_now }.to raise_error(SmsReconciliationDriftError, /#{user.id}/)
+      end
+    end
+
+    context "when DB has a user opted out but AWS no longer lists them (Direction 2)" do
+      let(:aws_opted_out) { [] }
+      let!(:user) do
+        create(:user,
+               phone: "+12025551212",
+               phone_confirmed_at: Time.current,
+               sms_carrier_opted_out_at: 2.days.ago)
+      end
+
+      it "raises SmsReconciliationDriftError" do
+        expect { described_class.perform_now }.to raise_error(SmsReconciliationDriftError)
+      end
+
+      it "clears sms_carrier_opted_out_at on the user before raising" do
+        begin
+          described_class.perform_now
+        rescue SmsReconciliationDriftError
+          # expected
+        end
+        expect(user.reload.sms_carrier_opted_out_at).to be_nil
+      end
+    end
+
+    context "when both drift directions occur in the same run" do
+      let(:aws_opted_out) { ["+12025551212"] }
+      let!(:should_be_opted_out) { create(:user, phone: "+12025551212", phone_confirmed_at: Time.current) }
+      let!(:should_be_opted_in) do
+        create(:user,
+               phone: "+13035551212",
+               phone_confirmed_at: Time.current,
+               sms_carrier_opted_out_at: 2.days.ago)
+      end
+
+      it "raises SmsReconciliationDriftError reporting 2 corrections" do
+        expect { described_class.perform_now }.to raise_error(SmsReconciliationDriftError, /2 correction/)
+      end
+
+      it "applies both corrections before raising" do
+        begin
+          described_class.perform_now
+        rescue SmsReconciliationDriftError
+          # expected
+        end
+        expect(should_be_opted_out.reload.sms_carrier_opted_out_at).to be_present
+        expect(should_be_opted_in.reload.sms_carrier_opted_out_at).to be_nil
+      end
+    end
+
+    context "when the job runs twice in succession with the same AWS state" do
+      let(:aws_opted_out) { ["+12025551212"] }
+
+      before { create(:user, phone: "+12025551212", phone_confirmed_at: Time.current) }
+
+      it "raises on the first run but not the second (idempotency)" do
+        expect { described_class.perform_now }.to raise_error(SmsReconciliationDriftError)
+        expect { described_class.perform_now }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/models/analytics/sms_inbound_message_spec.rb
+++ b/spec/models/analytics/sms_inbound_message_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Analytics::SmsInboundMessage, type: :model do
+  subject(:message) do
+    described_class.new(
+      origination_number: "+13038806481",
+      destination_number: "+17626898865",
+      message_body: "STOP",
+      received_at: Time.current,
+      sns_message_id: "abc-123",
+    )
+  end
+
+  it "is valid with all required attributes" do
+    expect(message).to be_valid
+  end
+
+  %i[origination_number destination_number message_body received_at sns_message_id].each do |attr|
+    it "is invalid without #{attr}" do
+      message.send("#{attr}=", nil)
+      expect(message).not_to be_valid
+      expect(message.errors[attr]).to be_present
+    end
+  end
+
+  it "rejects duplicate sns_message_id at the database level" do
+    message.save!
+    duplicate = described_class.new(
+      origination_number: "+13038806481",
+      destination_number: "+17626898865",
+      message_body: "STOP",
+      received_at: Time.current,
+      sns_message_id: "abc-123",
+    )
+    expect { duplicate.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+end

--- a/spec/services/interactors/webhooks/process_sns_inbound_sms_spec.rb
+++ b/spec/services/interactors/webhooks/process_sns_inbound_sms_spec.rb
@@ -1,0 +1,175 @@
+require "rails_helper"
+
+RSpec.describe Interactors::Webhooks::ProcessSnsInboundSms do
+  let(:phone) { "+13038806481" }
+  let(:destination) { "+17626898865" }
+  let(:message_body) { "STOP" }
+  let(:received_at_str) { "2026-04-29T10:00:00Z" }
+  let(:sns_message_id) { "11111111-2222-3333-4444-555555555555" }
+  let(:inbound_message_id) { "psv2-inbound-id-1" }
+
+  let(:inbound_payload) do
+    {
+      "originationNumber" => phone,
+      "destinationNumber" => destination,
+      "messageBody" => message_body,
+      "inboundMessageId" => inbound_message_id,
+    }
+  end
+
+  let(:sns_message) do
+    {
+      "Type" => "Notification",
+      "MessageId" => sns_message_id,
+      "Timestamp" => received_at_str,
+      "Message" => inbound_payload.to_json,
+    }
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(sns_message: sns_message) }
+
+    context "with a STOP keyword from a phone matching one user" do
+      let!(:user) { create(:user, phone: phone, phone_confirmed_at: Time.current) }
+
+      it "is successful" do
+        expect(result.errors).to be_empty
+      end
+
+      it "creates an Analytics::SmsInboundMessage row with the correct attributes" do
+        expect { result }.to change(Analytics::SmsInboundMessage, :count).by(1)
+        record = Analytics::SmsInboundMessage.last
+        expect(record.origination_number).to eq(phone)
+        expect(record.destination_number).to eq(destination)
+        expect(record.message_body).to eq("STOP")
+        expect(record.keyword).to eq("STOP")
+        expect(record.sns_message_id).to eq(sns_message_id)
+        expect(record.inbound_message_id).to eq(inbound_message_id)
+      end
+
+      it "sets sms_carrier_opted_out_at on the matching user" do
+        result
+        expect(user.reload.sms_carrier_opted_out_at).to be_within(1.second).of(Time.zone.parse(received_at_str))
+      end
+    end
+
+    context "with a START keyword from a phone matching one carrier-opted-out user" do
+      let!(:user) { create(:user, phone: phone, phone_confirmed_at: Time.current, sms_carrier_opted_out_at: 2.days.ago) }
+      let(:message_body) { "START" }
+
+      it "clears sms_carrier_opted_out_at on the matching user" do
+        result
+        expect(user.reload.sms_carrier_opted_out_at).to be_nil
+      end
+
+      it "records keyword as START" do
+        result
+        expect(Analytics::SmsInboundMessage.last.keyword).to eq("START")
+      end
+    end
+
+    context "with a HELP keyword" do
+      let!(:user) { create(:user, phone: phone, phone_confirmed_at: Time.current) }
+      let(:message_body) { "HELP" }
+
+      it "records the message but does not change user state" do
+        expect { result }.to change(Analytics::SmsInboundMessage, :count).by(1)
+        expect(Analytics::SmsInboundMessage.last.keyword).to eq("HELP")
+        expect(user.reload.sms_carrier_opted_out_at).to be_nil
+      end
+    end
+
+    context "with a non-keyword body like 'hello'" do
+      let!(:user) { create(:user, phone: phone, phone_confirmed_at: Time.current) }
+      let(:message_body) { "hello" }
+
+      it "records the message with keyword nil and does not change user state" do
+        expect { result }.to change(Analytics::SmsInboundMessage, :count).by(1)
+        expect(Analytics::SmsInboundMessage.last.keyword).to be_nil
+        expect(user.reload.sms_carrier_opted_out_at).to be_nil
+      end
+    end
+
+    context "with leading whitespace and lowercase keyword" do
+      let!(:user) { create(:user, phone: phone, phone_confirmed_at: Time.current) }
+      let(:message_body) { "  stop please " }
+
+      it "still parses STOP as the keyword" do
+        result
+        expect(Analytics::SmsInboundMessage.last.keyword).to eq("STOP")
+        expect(user.reload.sms_carrier_opted_out_at).to be_present
+      end
+    end
+
+    context "when the same sns_message_id is processed twice" do
+      let!(:user) { create(:user, phone: phone, phone_confirmed_at: Time.current) }
+
+      it "does not create a duplicate row" do
+        described_class.call(sns_message: sns_message)
+        expect { described_class.call(sns_message: sns_message) }.not_to change(Analytics::SmsInboundMessage, :count)
+      end
+
+      it "does not double-apply state changes" do
+        described_class.call(sns_message: sns_message)
+        first_timestamp = user.reload.sms_carrier_opted_out_at
+        travel_to(1.hour.from_now) do
+          described_class.call(sns_message: sns_message)
+        end
+        expect(user.reload.sms_carrier_opted_out_at).to be_within(1.second).of(first_timestamp)
+      end
+    end
+
+    context "when the origination phone matches no user" do
+      it "is still successful and persists the message" do
+        expect { result }.to change(Analytics::SmsInboundMessage, :count).by(1)
+        expect(result.errors).to be_empty
+      end
+    end
+
+    context "when the origination phone matches multiple users" do
+      let!(:user_a) { create(:user, phone: phone, phone_confirmed_at: Time.current) }
+      let!(:user_b) { create(:user, phone: phone, phone_confirmed_at: Time.current) }
+
+      it "updates all matching users" do
+        result
+        expect(user_a.reload.sms_carrier_opted_out_at).to be_present
+        expect(user_b.reload.sms_carrier_opted_out_at).to be_present
+      end
+    end
+
+    context "when the inner Message JSON is malformed" do
+      let(:sns_message) do
+        {
+          "Type" => "Notification",
+          "MessageId" => sns_message_id,
+          "Timestamp" => received_at_str,
+          "Message" => '{"originationNumber": "+13038806481"',
+        }
+      end
+
+      before { allow(Rails.error).to receive(:report) }
+
+      it "returns an unsuccessful response with a structured error" do
+        expect(result).not_to be_successful
+        expect(result.errors.first[:title]).to match(/SNS payload/)
+      end
+
+      it "does not create a record" do
+        expect { result }.not_to change(Analytics::SmsInboundMessage, :count)
+      end
+    end
+
+    context "when an inner-payload field is missing" do
+      let(:inbound_payload) do
+        { "originationNumber" => phone }
+      end
+
+      before { allow(Rails.error).to receive(:report) }
+
+      it "returns an unsuccessful response and reports to Rails.error" do
+        expect(result).not_to be_successful
+        expect(Rails.error).to have_received(:report).with(instance_of(KeyError), handled: true, context: hash_including(:sns_message_id))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Third of four PRs implementing app-side SMS opt-out tracking (#1947). This is the largest PR — all non-user-facing logic. PR 4 follows with the SMS Messaging settings view changes.

- `Webhooks::SnsInboundController` (thin) + `Interactors::Webhooks::ProcessSnsInboundSms` (business logic) — mirrors the existing Mailgun + Raceresult patterns
- `Analytics::SmsInboundMessage` model + Madmin resource — sibling of `Analytics::EmailEvent` / `Analytics::FileDownload`
- `AwsSmsClient` service wrapping `Aws::PinpointSMSVoiceV2::Client#describe_opted_out_numbers`
- `ReconcileSmsCarrierOptOutsJob` (hourly) + `config/recurring.yml` entry
- Custom error classes (`Webhooks::SmsWebhookError`, `SmsReconciliationDriftError`)
- Routes entry under the `webhooks` namespace
- New gem `aws-sdk-pinpointsmsvoicev2` (~> 1)

## What this PR does NOT do

- No view changes (PR 4 will update `app/views/user_settings/sms_messaging.html.erb` for the carrier-opted-out state)
- No AWS-side wiring — that's a separate manual step done via AWS CLI after this PR is deployed (create SNS topic, IAM role, subscribe endpoint, `update-pool --two-way-enabled`)
- No backfill of the existing 36 opted-out numbers from AWS — the hourly reconciliation job picks those up on its first production run

## Behavior after merge (until AWS-side wiring is done)

- The endpoint `POST /webhooks/sns_inbound` is reachable but receives no traffic until AWS subscribes the topic to it
- The hourly reconciliation job runs but currently finds nothing to reconcile (AWS opt-out list is in sync with our DB, which has no users marked opted-out yet)
- Existing user-facing SMS flow (PR 2's revised `sms_opted_in?` + tightened validator) is unaffected

## Design highlights

- **Controller is thin** — Mailgun-style routing/auth/parse/delegate. All business logic in the interactor.
- **No `Rails.logger` calls** — anomalies use `Rails.error.report(handled: true)`, which ScoutAPM is auto-subscribed to. Routine state changes are recorded in the DB.
- **No `raise` from controller** — `raise` becomes 500, which AWS SNS retries on its default policy. Anomalies return terminal HTTP codes (401/400/422/200) and surface via `Rails.error.report`.
- **Idempotency via DB unique index** — `find_or_create_by!(sns_message_id:)` on the unique column from PR #1948 dedups SNS retries. `previously_new_record?` ensures `apply_state_change` only fires once.
- **Any reconciliation drift raises** — even one correction in a single hourly run signals the webhook is dropping events (OST has historically averaged ~4 opt-outs/year). The error message includes affected `user_id`s for actionable Scout alerts.
- **Auto-confirm SubscriptionConfirmation** — fetches the `SubscribeURL` only if it's on `sns.<region>.amazonaws.com` (host whitelist).

## Test plan

- [x] Targeted RSpec passes for all new/touched specs:
  - `spec/models/analytics/sms_inbound_message_spec.rb` (7 examples — validations + DB unique constraint)
  - `spec/services/interactors/webhooks/process_sns_inbound_sms_spec.rb` (15 examples — STOP/START/HELP/non-keyword paths, idempotency, multi-user match, malformed payload)
  - `spec/jobs/reconcile_sms_carrier_opt_outs_job_spec.rb` (9 examples — both drift directions, idempotency, drift threshold = any)
  - `spec/controllers/webhooks/sns_inbound_controller_spec.rb` (8 examples — routing by message type, signature handling, anomaly reporting via `Rails.error.report`)
  - Adjacent specs (`process_raceresult_webhook_spec.rb`, `user_spec.rb`, `lottery_simulations/runner_spec.rb`) remain green after refactoring `app/services/interactors/errors.rb` for line-length cleanup
- [x] RuboCop clean on all 12 touched files (fixed pre-existing line-length offenses in `errors.rb` per the project's "touched files include pre-existing offenses" rule)
- [ ] CI green on full suite

## Out of scope

Tracked in #1947 follow-ups but not part of this PR: a one-off audit cross-referencing AWS's existing 36 opted-out numbers against current `users.phone` to size impact (the hourly reconciliation will surface this on its first run anyway).

Refs #1947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)