### PR TITLE
Add missing Madmin controller and route for Analytics::SmsInboundMessage

### DIFF
--- a/app/controllers/madmin/analytics/sms_inbound_messages_controller.rb
+++ b/app/controllers/madmin/analytics/sms_inbound_messages_controller.rb
@@ -1,0 +1,4 @@
+module Madmin
+  class Analytics::SmsInboundMessagesController < Madmin::ResourceController
+  end
+end

--- a/config/routes/madmin.rb
+++ b/config/routes/madmin.rb
@@ -7,6 +7,7 @@ namespace :madmin do
   namespace :analytics do
     resources :file_downloads
     resources :email_events
+    resources :sms_inbound_messages
   end
   resources :connections
   namespace :active_storage do


### PR DESCRIPTION
## Summary

Hotfix for #1950 (PR 3 of #1947). The Madmin resource for `Analytics::SmsInboundMessage` was added without its corresponding controller stub and routes entry, which caused `/madmin` to 500 on staging.

- `app/controllers/madmin/analytics/sms_inbound_messages_controller.rb` — empty subclass of `Madmin::ResourceController`, mirroring `EmailEventsController`/`FileDownloadsController`
- `config/routes/madmin.rb` — `resources :sms_inbound_messages` inside the existing `namespace :analytics` block

## Why this was missed

The Madmin generator (`rails g madmin:resource`) produces all three pieces — model declaration helpers, the resource file, the controller stub, and the routes entry — at once. PR 3 created the resource file by hand to avoid generator-driven schema rebuild, and the controller and route fell through the cracks. Both the existing `email_event_resource.rb` and `file_download_resource.rb` have the same controller-and-route pattern; this restores parity.

## Test plan

- [x] `bundle exec rails routes | grep sms_inbound` shows the seven expected REST routes
- [x] RuboCop clean on touched files
- [x] CI green on full suite
- [ ] On staging post-merge: `/madmin` loads, `/madmin/analytics/sms_inbound_messages` lists rows (empty until two-way SMS is wired up)

Refs #1947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)