### PR TITLE
Render carrier-opted-out state on SMS Messaging settings tab

### DIFF
--- a/app/views/user_settings/sms_messaging.html.erb
+++ b/app/views/user_settings/sms_messaging.html.erb
@@ -42,6 +42,18 @@
             </div>
 
             <div class="mb-3 p-3 bg-light border rounded">
+              <% if current_user.sms_carrier_opted_out? %>
+                <div class="alert alert-warning mb-3" role="alert">
+                  <p class="mb-2">
+                    <i class="fas fa-exclamation-triangle"></i>
+                    <strong><%= t("sms.carrier_opted_out.banner_title", date: l(current_user.sms_carrier_opted_out_at.to_date, format: :long)) %></strong>
+                  </p>
+                  <p class="small mb-0">
+                    <%= t("sms.carrier_opted_out.banner_body_html", last4: current_user.phone.last(4)) %>
+                  </p>
+                </div>
+              <% end %>
+
               <p class="small mb-2">
                 <%= t("sms.consent.disclosure") %>
               </p>
@@ -51,10 +63,15 @@
               </p>
               <div class="form-check">
                 <%= f.check_box :sms_consent, class: "form-check-input", checked: current_user.sms_opted_in?,
+                                              disabled: current_user.sms_carrier_opted_out?,
                                               data: { phone_consent_target: "consent" } %>
                 <%= f.label :sms_consent, t("sms.consent.checkbox_label"), class: "form-check-label" %>
               </div>
-              <% if current_user.sms_opted_in? %>
+              <% if current_user.sms_carrier_opted_out? %>
+                <p class="small text-muted mt-2 mb-0">
+                  <%= t("sms.carrier_opted_out.checkbox_disabled_note") %>
+                </p>
+              <% elsif current_user.sms_opted_in? %>
                 <p class="small text-success mt-2 mb-0">
                   <i class="fas fa-check-circle"></i>
                   <%= t("sms.consent.enabled_since", date: l(current_user.phone_confirmed_at.to_date, format: :long)) %>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -105,6 +105,10 @@ en:
       enabled_since: "SMS enabled since %{date}"
       opted_in: "You have opted in to receive SMS text message updates from OpenSplitTime. Reply STOP to cancel. Reply HELP for help. Msg & data rates may apply."
       opted_out: "You have opted out of SMS text message updates."
+    carrier_opted_out:
+      banner_title: "You replied STOP on %{date} and have been unsubscribed from SMS notifications."
+      banner_body_html: "To receive SMS notifications again, <strong>text START to +1 (762) 689-8865</strong> from your phone (ending in %{last4}). Once you do, the unsubscribe will be lifted automatically."
+      checkbox_disabled_note: "To re-enable SMS, text START as described in the banner above."
     phone:
       hint: "US or Canada mobile number only"
 

--- a/spec/system/user_settings/sms_messaging_spec.rb
+++ b/spec/system/user_settings/sms_messaging_spec.rb
@@ -27,4 +27,27 @@ RSpec.describe "user settings sms messaging", type: :system do
     expect(page).to have_text("link to view full results")
     expect(page).to have_no_text("related information")
   end
+
+  scenario "carrier-opted-out user sees the warning banner with disabled checkbox" do
+    user.update!(phone: "+13038806481", phone_confirmed_at: 2.days.ago, sms_carrier_opted_out_at: 1.hour.ago)
+    login_as user, scope: :user
+    visit user_settings_sms_messaging_path
+
+    expect(page).to have_text("You replied STOP")
+    expect(page).to have_text("text START to +1 (762) 689-8865")
+    expect(page).to have_text("ending in 6481")
+    expect(page).to have_text("To re-enable SMS, text START")
+    expect(page).to have_field("user_sms_consent", disabled: true)
+    expect(page).to have_no_text("SMS enabled since")
+  end
+
+  scenario "opted-in user without carrier opt-out sees the standard 'enabled since' line" do
+    user.update!(phone: "+13038806481", phone_confirmed_at: 5.days.ago)
+    login_as user, scope: :user
+    visit user_settings_sms_messaging_path
+
+    expect(page).to have_text("SMS enabled since")
+    expect(page).to have_no_text("You replied STOP")
+    expect(page).to have_field("user_sms_consent", disabled: false)
+  end
 end


### PR DESCRIPTION
## Summary

Final PR (4 of 4) for app-side SMS opt-out tracking (#1947). User-facing rollout: when a user has `sms_carrier_opted_out_at` set, the SMS Messaging settings tab shows a warning banner with "text START" instructions and disables the consent checkbox.

## Three rendering states

| State | Predicate | What renders |
|---|---|---|
| A | `!sms_opted_in?` and `!sms_carrier_opted_out?` | Existing form, unchecked |
| B | `sms_opted_in?` | Existing form, checked, "Enabled since [date]" |
| C | `sms_carrier_opted_out?` (NEW) | Warning banner + disabled checkbox + "text START" instructions |

## State C copy

> ⚠ **You replied STOP on [date] and have been unsubscribed from SMS notifications.**
>
> To receive SMS notifications again, **text START to +1 (762) 689-8865** from your phone (ending in -XXXX). Once you do, the unsubscribe will be lifted automatically.

The `[date]` is the timestamp the SNS inbound webhook set when the STOP message arrived. The last 4 digits of the phone help users with multiple phones identify which one is on the AWS opt-out list.

## How to escape State C

- Reply START via SMS (the AWS-attested path; webhook clears the column)
- Or change the phone field on this page (the existing `clear_sms_consent_on_phone_change` callback from PR 2 also nulls `sms_carrier_opted_out_at` on phone change, since the carrier opt-out applied to the OLD number, not the new one)

## Test plan

- [x] System spec: carrier-opted-out user sees banner, disabled checkbox, last-4 hint, and NOT the "SMS enabled since" line
- [x] System spec: standard opted-in user (no carrier opt-out) still sees the "SMS enabled since" line and an enabled checkbox
- [x] Pre-existing scenarios for State A/B continue to pass (5 examples total, 0 failures)
- [x] RuboCop clean on touched spec
- [x] erb_lint clean on touched view
- [ ] CI green on full suite

## Production rollout context

The 34 users who showed up in the first hourly reconciliation run will see State C immediately on this PR's deploy — they have `sms_carrier_opted_out_at` set in production. They can reply START to clear it.

Closes #1947 once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)