### PR TITLE
Preserve historical opt-out timestamps from AWS in reconciliation

### DIFF
--- a/app/jobs/reconcile_sms_carrier_opt_outs_job.rb
+++ b/app/jobs/reconcile_sms_carrier_opt_outs_job.rb
@@ -2,15 +2,16 @@ class ReconcileSmsCarrierOptOutsJob < ApplicationJob
   queue_as :default
 
   def perform
-    aws_opted_out = AwsSmsClient.fetch_all_opted_out_numbers
+    opted_out_at_by_phone = AwsSmsClient.opted_out_at_by_phone
+    aws_phones = opted_out_at_by_phone.keys
     corrected_user_ids = []
 
-    User.where(phone: aws_opted_out, sms_carrier_opted_out_at: nil).find_each do |user|
-      user.update_column(:sms_carrier_opted_out_at, Time.current)
+    User.where(phone: aws_phones, sms_carrier_opted_out_at: nil).find_each do |user|
+      user.update_column(:sms_carrier_opted_out_at, opted_out_at_by_phone[user.phone])
       corrected_user_ids << user.id
     end
 
-    User.where.not(sms_carrier_opted_out_at: nil).where.not(phone: aws_opted_out).find_each do |user|
+    User.where.not(sms_carrier_opted_out_at: nil).where.not(phone: aws_phones).find_each do |user|
       user.update_column(:sms_carrier_opted_out_at, nil)
       corrected_user_ids << user.id
     end

--- a/app/services/aws_sms_client.rb
+++ b/app/services/aws_sms_client.rb
@@ -1,9 +1,10 @@
 require "aws-sdk-pinpointsmsvoicev2"
 
 class AwsSmsClient
-  def self.fetch_all_opted_out_numbers(opt_out_list_name: "Default")
+  # @return [Hash{String => Time}] phone (E.164) → opted-out timestamp from AWS
+  def self.opted_out_at_by_phone(opt_out_list_name: "Default")
     client = Aws::PinpointSMSVoiceV2::Client.new(region: ::OstConfig.aws_region)
-    numbers = []
+    index = {}
     next_token = nil
 
     loop do
@@ -11,11 +12,13 @@ class AwsSmsClient
         opt_out_list_name: opt_out_list_name,
         next_token: next_token,
       )
-      numbers.concat(response.opted_out_numbers.map(&:opted_out_number))
+      response.opted_out_numbers.each do |record|
+        index[record.opted_out_number] = record.opted_out_timestamp
+      end
       next_token = response.next_token
       break if next_token.nil?
     end
 
-    numbers
+    index
   end
 end

--- a/db/data/20260429165816_backfill_sms_carrier_opt_out_timestamps.rb
+++ b/db/data/20260429165816_backfill_sms_carrier_opt_out_timestamps.rb
@@ -1,0 +1,22 @@
+class BackfillSmsCarrierOptOutTimestamps < ActiveRecord::Migration[8.1]
+  def up
+    aws_index = AwsSmsClient.opted_out_at_by_phone
+
+    User.where.not(sms_carrier_opted_out_at: nil).find_each do |user|
+      aws_at = aws_index[user.phone]
+      next if aws_at.nil?
+      next if (user.sms_carrier_opted_out_at - aws_at).abs < 1.second
+
+      user.update_column(:sms_carrier_opted_out_at, aws_at)
+    end
+  end
+
+  def down
+    # Irreversible: the original 2026-04-29 backfill timestamps were themselves
+    # synthetic — produced by the first reconciliation run before the job knew
+    # to consult AWS's OptedOutTimestamp. The AWS-reported timestamps that
+    # this migration installs are the truth, so there is no meaningful prior
+    # state to restore.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/jobs/reconcile_sms_carrier_opt_outs_job_spec.rb
+++ b/spec/jobs/reconcile_sms_carrier_opt_outs_job_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.describe ReconcileSmsCarrierOptOutsJob, type: :job do
-  before { allow(AwsSmsClient).to receive(:fetch_all_opted_out_numbers).and_return(aws_opted_out) }
+  before { allow(AwsSmsClient).to receive(:opted_out_at_by_phone).and_return(aws_opted_out) }
 
   describe "#perform" do
     context "when AWS and DB agree (no drift)" do
-      let(:aws_opted_out) { [] }
+      let(:aws_opted_out) { {} }
       let!(:user) { create(:user, phone: "+12025551212", phone_confirmed_at: Time.current) }
 
       it "does not raise and does not change user state" do
@@ -15,20 +15,21 @@ RSpec.describe ReconcileSmsCarrierOptOutsJob, type: :job do
     end
 
     context "when AWS lists a user opted out but DB has them as not-opted-out (Direction 1)" do
-      let(:aws_opted_out) { ["+12025551212"] }
+      let(:historical_opt_out_at) { Time.zone.parse("2017-07-14T21:34:39Z") }
+      let(:aws_opted_out) { { "+12025551212" => historical_opt_out_at } }
       let!(:user) { create(:user, phone: "+12025551212", phone_confirmed_at: Time.current) }
 
       it "raises SmsReconciliationDriftError" do
         expect { described_class.perform_now }.to raise_error(SmsReconciliationDriftError, /1 correction/)
       end
 
-      it "sets sms_carrier_opted_out_at on the user before raising" do
+      it "sets sms_carrier_opted_out_at on the user using the AWS-reported timestamp (not Time.current)" do
         begin
           described_class.perform_now
         rescue SmsReconciliationDriftError
           # expected
         end
-        expect(user.reload.sms_carrier_opted_out_at).to be_present
+        expect(user.reload.sms_carrier_opted_out_at).to be_within(1.second).of(historical_opt_out_at)
       end
 
       it "includes the user_id in the error message" do
@@ -37,7 +38,7 @@ RSpec.describe ReconcileSmsCarrierOptOutsJob, type: :job do
     end
 
     context "when DB has a user opted out but AWS no longer lists them (Direction 2)" do
-      let(:aws_opted_out) { [] }
+      let(:aws_opted_out) { {} }
       let!(:user) do
         create(:user,
                phone: "+12025551212",
@@ -60,7 +61,8 @@ RSpec.describe ReconcileSmsCarrierOptOutsJob, type: :job do
     end
 
     context "when both drift directions occur in the same run" do
-      let(:aws_opted_out) { ["+12025551212"] }
+      let(:opt_out_at) { 1.year.ago }
+      let(:aws_opted_out) { { "+12025551212" => opt_out_at } }
       let!(:should_be_opted_out) { create(:user, phone: "+12025551212", phone_confirmed_at: Time.current) }
       let!(:should_be_opted_in) do
         create(:user,
@@ -79,13 +81,13 @@ RSpec.describe ReconcileSmsCarrierOptOutsJob, type: :job do
         rescue SmsReconciliationDriftError
           # expected
         end
-        expect(should_be_opted_out.reload.sms_carrier_opted_out_at).to be_present
+        expect(should_be_opted_out.reload.sms_carrier_opted_out_at).to be_within(1.second).of(opt_out_at)
         expect(should_be_opted_in.reload.sms_carrier_opted_out_at).to be_nil
       end
     end
 
     context "when the job runs twice in succession with the same AWS state" do
-      let(:aws_opted_out) { ["+12025551212"] }
+      let(:aws_opted_out) { { "+12025551212" => 1.year.ago } }
 
       before { create(:user, phone: "+12025551212", phone_confirmed_at: Time.current) }
 


### PR DESCRIPTION
## Summary

Small follow-up to #1947. The reconciliation job was setting `sms_carrier_opted_out_at = Time.current` on direction-1 corrections, throwing away the actual opt-out date AWS preserves. Some entries in our `Default` opt-out list go back to 2017 — those users replied STOP nine years ago, but our DB now records "opted out 2026-04-29 08:07" because that's when the first reconciliation backfilled them.

Two pieces in this PR:

1. **Going forward** — the job now consults the AWS `OptedOutTimestamp` and stores that on direction-1 corrections.
2. **Backfill** — a data migration aligns the 34 users currently flagged with the synthetic 2026-04-29 timestamp to their real AWS-reported timestamps.

## Code change

- `AwsSmsClient.fetch_all_opted_out_numbers` (returned `[String]`) → `AwsSmsClient.opted_out_at_by_phone` (returns `{String => Time}`)
- `ReconcileSmsCarrierOptOutsJob` looks up the timestamp by phone when correcting drift in direction 1, instead of using `Time.current`

## Backfill (data migration)

`db/data/20260429165816_backfill_sms_carrier_opt_out_timestamps.rb` — fetches the AWS opt-out list once, iterates over already-flagged users, and aligns each one's `sms_carrier_opted_out_at` to AWS's timestamp. Skips users whose phone isn't on the AWS list, and idempotent (skips users already aligned within 1 second). Runs at the next data-migrate step after merge — no manual prod console action needed.

After it runs, the State C banner on `/user_settings/sms_messaging` will show the actual STOP date — for some users, almost a decade ago.

## Test plan

- [x] Targeted RSpec passes for `spec/jobs/reconcile_sms_carrier_opt_outs_job_spec.rb` (9 examples, 0 failures), including a new assertion that direction-1 corrections use the AWS-reported timestamp rather than `Time.current`
- [x] RuboCop clean on touched files
- [ ] CI green on full suite
- [ ] After deploy: run `bin/rails data:migrate` (or whatever the project's deploy hook is); verify the 34 users' timestamps reflect their actual STOP dates from AWS

Refs #1947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)