### PR TITLE
Send welcome message on Subscription create (closes #447)

### DIFF
--- a/app/jobs/sms_subscription_welcome_job.rb
+++ b/app/jobs/sms_subscription_welcome_job.rb
@@ -1,0 +1,7 @@
+class SmsSubscriptionWelcomeJob < ApplicationJob
+  queue_as :default
+
+  def perform(subscription)
+    SmsSubscriptionWelcomeSender.deliver(subscription)
+  end
+end

--- a/app/mailers/subscription_mailer.rb
+++ b/app/mailers/subscription_mailer.rb
@@ -1,0 +1,19 @@
+class SubscriptionMailer < ApplicationMailer
+  def welcome(subscription)
+    @subscription = subscription
+    @user = subscription.user
+    @subscribable = subscription.subscribable
+    mail(to: @user.email, subject: subject_for(@subscribable))
+  end
+
+  private
+
+  def subject_for(subscribable)
+    case subscribable
+    when Effort
+      "You're following #{subscribable.full_name} at #{subscribable.event_name}"
+    when Person
+      "You're following #{subscribable.full_name}"
+    end
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -3,23 +3,26 @@ require "aws-sdk-sns"
 class Subscription < ApplicationRecord
   has_paper_trail
 
-  enum :protocol, [:email, :sms, :http, :https]
+  enum :protocol, { :email => 0, :sms => 1, :http => 2, :https => 3 }
   belongs_to :user
   belongs_to :subscribable, polymorphic: true
 
   before_destroy :delete_resource_key
   after_save :attempt_person_subscription, if: :effort_has_person?
   after_save :attempt_effort_subscriptions, if: :type_is_person?
+  after_create_commit :send_welcome
 
-  validates_presence_of :user_id, :subscribable_type, :subscribable_id, :endpoint, :user, :subscribable, :protocol
+  # rubocop:disable Rails/RedundantPresenceValidationOnBelongsTo -- existing tests assert error messages on the column-level :user_id / :subscribable_id keys, which the explicit presence validators emit and the belongs_to default does not.
+  validates :user_id, :subscribable_type, :subscribable_id, :endpoint, :user, :subscribable, :protocol, presence: true
+  # rubocop:enable Rails/RedundantPresenceValidationOnBelongsTo
   validates_with ResourceKeyValidator
-  validates_uniqueness_of :endpoint,
-                          scope: [:user_id, :subscribable_type, :subscribable_id, :protocol],
-                          message: ->(object, data) do
+  validates :endpoint,
+            uniqueness: { scope: [:user_id, :subscribable_type, :subscribable_id, :protocol],
+                          message: lambda { |object, data|
                             "#{data[:value]} is already subscribed to #{object.subscribable.slug} by #{object.protocol}"
-                          end
+                          } }
 
-  scope :for_user, -> (user) { where(user: user) }
+  scope :for_user, ->(user) { where(user: user) }
   scope :pending, -> { where("resource_key like 'pending%'") }
 
   def delete_resource_key
@@ -27,14 +30,14 @@ class Subscription < ApplicationRecord
       locate_response = SnsSubscriptionManager.locate(subscription: self)
       self.resource_key = locate_response.subscription_arn
     end
-    if confirmed?
-      delete_response = SnsSubscriptionManager.delete(subscription: self)
-      if delete_response.successful?
-        self.resource_key = nil
-      else
-        errors.add(:base, "Could not delete subscription: #{delete_response.error_message}")
-        throw(:abort)
-      end
+    return unless confirmed?
+
+    delete_response = SnsSubscriptionManager.delete(subscription: self)
+    if delete_response.successful?
+      self.resource_key = nil
+    else
+      errors.add(:base, "Could not delete subscription: #{delete_response.error_message}")
+      throw(:abort)
     end
   end
 
@@ -83,5 +86,14 @@ class Subscription < ApplicationRecord
 
   def type_is_person?
     subscribable_type == "Person"
+  end
+
+  def send_welcome
+    case protocol
+    when "email"
+      SubscriptionMailer.welcome(self).deliver_later
+    when "sms"
+      SmsSubscriptionWelcomeJob.perform_later(self)
+    end
   end
 end

--- a/app/services/sms_subscription_welcome_sender.rb
+++ b/app/services/sms_subscription_welcome_sender.rb
@@ -1,0 +1,54 @@
+require "aws-sdk-pinpointsmsvoicev2"
+
+class SmsSubscriptionWelcomeSender
+  def self.deliver(subscription)
+    new(subscription).deliver
+  end
+
+  def initialize(subscription)
+    @subscription = subscription
+  end
+
+  def deliver
+    return unless deliverable?
+
+    client.send_text_message(
+      destination_phone_number: user.phone,
+      origination_identity: ::OstConfig.aws_sms_origination_number,
+      message_body: message_body,
+      message_type: "TRANSACTIONAL",
+    )
+  rescue Aws::PinpointSMSVoiceV2::Errors::ServiceError => e
+    Rails.error.report(e, handled: true, context: { subscription_id: subscription.id })
+  end
+
+  private
+
+  attr_reader :subscription
+
+  def deliverable?
+    ::OstConfig.aws_sms_welcome_enabled? &&
+      ::OstConfig.aws_sms_origination_number.present? &&
+      subscription.subscribable.is_a?(Effort) &&
+      user.phone.present? &&
+      !user.sms_carrier_opted_out?
+  end
+
+  def user
+    subscription.user
+  end
+
+  def effort
+    subscription.subscribable
+  end
+
+  def message_body
+    "OpenSplitTime: You're now subscribed to live progress updates for #{effort.full_name} " \
+      "at #{effort.event_name}. You'll receive an SMS each time #{effort.first_name} " \
+      "passes an aid station. Reply STOP to cancel."
+  end
+
+  def client
+    @client ||= Aws::PinpointSMSVoiceV2::Client.new(region: ::OstConfig.aws_region)
+  end
+end

--- a/app/views/subscription_mailer/_welcome_effort.html.erb
+++ b/app/views/subscription_mailer/_welcome_effort.html.erb
@@ -1,0 +1,13 @@
+<%# locals: (subscription:) %>
+<% effort = subscription.subscribable %>
+<p>
+  You're now subscribed to live progress updates for
+  <strong><%= effort.full_name %></strong>
+  at <strong><%= effort.event_name %></strong>.
+</p>
+<p>
+  You'll receive an email each time <%= effort.first_name %> passes an aid station, so you can follow along in real time.
+</p>
+<p>
+  <%= link_to "View live results for #{effort.full_name}", effort_url(effort) %>
+</p>

--- a/app/views/subscription_mailer/_welcome_effort.text.erb
+++ b/app/views/subscription_mailer/_welcome_effort.text.erb
@@ -1,0 +1,7 @@
+<%# locals: (subscription:) %>
+<% effort = subscription.subscribable -%>
+You're now subscribed to live progress updates for <%= effort.full_name %> at <%= effort.event_name %>.
+
+You'll receive an email each time <%= effort.first_name %> passes an aid station, so you can follow along in real time.
+
+View live results: <%= effort_url(effort) %>

--- a/app/views/subscription_mailer/_welcome_person.html.erb
+++ b/app/views/subscription_mailer/_welcome_person.html.erb
@@ -1,0 +1,8 @@
+<%# locals: (subscription:) %>
+<% person = subscription.subscribable %>
+<p>
+  You're now subscribed to follow <strong><%= person.full_name %></strong>.
+</p>
+<p>
+  We'll send you an email when <%= person.first_name %> is registered for upcoming events on OpenSplitTime, so you can subscribe to live progress updates for those efforts.
+</p>

--- a/app/views/subscription_mailer/_welcome_person.text.erb
+++ b/app/views/subscription_mailer/_welcome_person.text.erb
@@ -1,0 +1,5 @@
+<%# locals: (subscription:) %>
+<% person = subscription.subscribable -%>
+You're now subscribed to follow <%= person.full_name %>.
+
+We'll send you an email when <%= person.first_name %> is registered for upcoming events on OpenSplitTime, so you can subscribe to live progress updates for those efforts.

--- a/app/views/subscription_mailer/welcome.html.erb
+++ b/app/views/subscription_mailer/welcome.html.erb
@@ -1,0 +1,6 @@
+<% case @subscribable
+   when Effort %>
+  <%= render "welcome_effort", subscription: @subscription %>
+<% when Person %>
+  <%= render "welcome_person", subscription: @subscription %>
+<% end %>

--- a/app/views/subscription_mailer/welcome.text.erb
+++ b/app/views/subscription_mailer/welcome.text.erb
@@ -1,0 +1,6 @@
+<% case @subscribable
+   when Effort %>
+<%= render "welcome_effort", subscription: @subscription %>
+<% when Person %>
+<%= render "welcome_person", subscription: @subscription %>
+<% end %>

--- a/config/initializers/01_ost_config.rb
+++ b/config/initializers/01_ost_config.rb
@@ -27,6 +27,10 @@ module OstConfig
     Rails.application.credentials.dig(:aws, :sms_origination_number)
   end
 
+  def self.aws_sms_welcome_enabled?
+    cast_to_boolean(Rails.application.credentials.dig(:aws, :sms_welcome_enabled))
+  end
+
   def self.base_uri
     ENV.fetch("BASE_URI", "localhost:3000")
   end

--- a/spec/mailers/subscription_mailer_spec.rb
+++ b/spec/mailers/subscription_mailer_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe SubscriptionMailer, type: :mailer do
+  let(:user) { users(:admin_user) }
+
+  describe "#welcome" do
+    context "with an Effort subscription" do
+      let(:effort) { efforts(:hardrock_2015_tuan_jacobs) }
+      let(:subscription) do
+        Subscription.create!(user: user, subscribable: effort, protocol: :email, endpoint: user.email)
+      end
+      let(:mail) { described_class.welcome(subscription) }
+
+      it "sends to the subscribed user's email" do
+        expect(mail.to).to eq([user.email])
+      end
+
+      it "puts the participant name and event name in the subject" do
+        expect(mail.subject).to include(effort.full_name)
+        expect(mail.subject).to include(effort.event_name)
+      end
+
+      it "includes the effort full name and event name in the body" do
+        expect(mail.body.encoded).to include(effort.full_name)
+        expect(mail.body.encoded).to include(effort.event_name)
+      end
+
+      it "renders an aid-station mention specific to effort subscriptions" do
+        expect(mail.body.encoded).to match(/aid station/)
+      end
+    end
+
+    context "with a Person subscription" do
+      let(:person) { people(:tuan_jacobs) }
+      let(:subscription) do
+        Subscription.create!(user: user, subscribable: person, protocol: :email, endpoint: user.email)
+      end
+      let(:mail) { described_class.welcome(subscription) }
+
+      it "puts the person name in the subject" do
+        expect(mail.subject).to include(person.full_name)
+      end
+
+      it "includes the person full name in the body" do
+        expect(mail.body.encoded).to include(person.full_name)
+      end
+
+      it "renders the registered-for-event language specific to person subscriptions" do
+        expect(mail.body.encoded).to match(/registered for upcoming events/)
+      end
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Subscription, type: :model do
-  subject(:subscription) { Subscription.new(user: user, subscribable: subscribable, protocol: protocol, endpoint: endpoint) }
+  subject(:subscription) { described_class.new(user: user, subscribable: subscribable, protocol: protocol, endpoint: endpoint) }
+
   let(:user) { users(:admin_user) }
   let(:subscribable) { people(:tuan_jacobs) }
   let(:protocol) { :email }
@@ -10,7 +11,7 @@ RSpec.describe Subscription, type: :model do
   context "when created with a user, a subscribable, a protocol, and an endpoint" do
     it "is valid" do
       expect(subscription).to be_valid
-      expect { subscription.save }.to change { Subscription.count }.by(1)
+      expect { subscription.save }.to change(described_class, :count).by(1)
     end
   end
 
@@ -34,7 +35,7 @@ RSpec.describe Subscription, type: :model do
 
   context "when created with ids instead of user and subscribable objects" do
     subject(:subscription) do
-      Subscription.new(
+      described_class.new(
         user_id: user_id,
         subscribable_type: subscribable_type,
         subscribable_id: subscribable_id,
@@ -42,6 +43,7 @@ RSpec.describe Subscription, type: :model do
         endpoint: endpoint,
       )
     end
+
     let(:user_id) { user.id }
     let(:subscribable_type) { "Person" }
     let(:subscribable_id) { subscribable.id }
@@ -76,6 +78,47 @@ RSpec.describe Subscription, type: :model do
       it "is invalid" do
         expect(subscription).not_to be_valid
         expect(subscription.errors.full_messages).to include(/Subscribable can't be blank/)
+      end
+    end
+  end
+
+  describe "welcome dispatch on create" do
+    let(:user) { users(:admin_user) }
+    let(:effort) { efforts(:hardrock_2015_tuan_jacobs) }
+
+    context "when protocol is email" do
+      it "enqueues the welcome mailer" do
+        expect do
+          described_class.create!(user: user, subscribable: effort, protocol: :email, endpoint: user.email)
+        end.to have_enqueued_mail(SubscriptionMailer, :welcome)
+      end
+    end
+
+    context "when protocol is sms" do
+      it "enqueues the SMS welcome job" do
+        expect do
+          described_class.create!(user: user, subscribable: effort, protocol: :sms, endpoint: "+13035551212")
+        end.to have_enqueued_job(SmsSubscriptionWelcomeJob)
+      end
+    end
+
+    context "when protocol is http" do
+      it "does not enqueue any welcome job or mail" do
+        expect do
+          described_class.create!(user: user, subscribable: effort, protocol: :http, endpoint: "https://example.com/hook")
+        end.not_to have_enqueued_mail(SubscriptionMailer, :welcome)
+      end
+    end
+
+    context "when an existing subscription is updated" do
+      let!(:subscription) do
+        described_class.create!(user: user, subscribable: effort, protocol: :email, endpoint: user.email)
+      end
+
+      it "does not re-fire the welcome (after_create_commit only)" do
+        expect do
+          subscription.update!(endpoint: "new-#{user.email}")
+        end.not_to have_enqueued_mail(SubscriptionMailer, :welcome)
       end
     end
   end

--- a/spec/services/sms_subscription_welcome_sender_spec.rb
+++ b/spec/services/sms_subscription_welcome_sender_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+
+RSpec.describe SmsSubscriptionWelcomeSender do
+  let(:user) { users(:admin_user) }
+  let(:effort) { efforts(:hardrock_2015_tuan_jacobs) }
+  let(:subscription) do
+    Subscription.new(user: user, subscribable: effort, protocol: :sms, endpoint: "+13035551212").tap do |s|
+      s.save(validate: false)
+    end
+  end
+  let(:client) { instance_double(Aws::PinpointSMSVoiceV2::Client, send_text_message: nil) }
+
+  before do
+    allow(Aws::PinpointSMSVoiceV2::Client).to receive(:new).and_return(client)
+    allow(::OstConfig).to receive_messages(aws_sms_origination_number: "+17626898865", aws_sms_welcome_enabled?: true)
+    user.update!(phone: "+13035551212", phone_confirmed_at: Time.current, sms_carrier_opted_out_at: nil)
+  end
+
+  describe ".deliver" do
+    context "when all preconditions are met" do
+      it "calls send_text_message with the right destination, origination, and message body" do
+        described_class.deliver(subscription)
+        expect(client).to have_received(:send_text_message).with(
+          destination_phone_number: user.phone,
+          origination_identity: "+17626898865",
+          message_body: a_string_matching(/You're now subscribed to live progress updates for #{effort.full_name} at #{effort.event_name}/),
+          message_type: "TRANSACTIONAL",
+        )
+      end
+
+      it "uses the participant's first name in the second sentence" do
+        described_class.deliver(subscription)
+        expect(client).to have_received(:send_text_message).with(
+          a_hash_including(message_body: a_string_matching(/each time #{effort.first_name} passes an aid station/)),
+        )
+      end
+
+      it "ends with a STOP reminder" do
+        described_class.deliver(subscription)
+        expect(client).to have_received(:send_text_message).with(
+          a_hash_including(message_body: a_string_ending_with("Reply STOP to cancel.")),
+        )
+      end
+    end
+
+    context "when the welcome feature flag is disabled" do
+      before { allow(::OstConfig).to receive(:aws_sms_welcome_enabled?).and_return(false) }
+
+      it "does not call AWS" do
+        described_class.deliver(subscription)
+        expect(client).not_to have_received(:send_text_message)
+      end
+    end
+
+    context "when no origination number is configured" do
+      before { allow(::OstConfig).to receive(:aws_sms_origination_number).and_return(nil) }
+
+      it "does not call AWS" do
+        described_class.deliver(subscription)
+        expect(client).not_to have_received(:send_text_message)
+      end
+    end
+
+    context "when the subscribable is a Person (not Effort)" do
+      let(:person) { people(:tuan_jacobs) }
+      let(:subscription) do
+        Subscription.new(user: user, subscribable: person, protocol: :sms, endpoint: "+13035551212").tap do |s|
+          s.save(validate: false)
+        end
+      end
+
+      it "does not call AWS (SMS welcomes are effort-only)" do
+        described_class.deliver(subscription)
+        expect(client).not_to have_received(:send_text_message)
+      end
+    end
+
+    context "when the user has no phone" do
+      before { user.update_column(:phone, nil) }
+
+      it "does not call AWS" do
+        described_class.deliver(subscription)
+        expect(client).not_to have_received(:send_text_message)
+      end
+    end
+
+    context "when the user is carrier-opted-out" do
+      before { user.update_column(:sms_carrier_opted_out_at, 1.day.ago) }
+
+      it "does not call AWS" do
+        described_class.deliver(subscription)
+        expect(client).not_to have_received(:send_text_message)
+      end
+    end
+
+    context "when AWS raises a service error" do
+      before do
+        allow(client).to receive(:send_text_message).and_raise(
+          Aws::PinpointSMSVoiceV2::Errors::ValidationException.new(nil, "boom"),
+        )
+        allow(Rails.error).to receive(:report)
+      end
+
+      it "swallows the error and reports it via Rails.error" do
+        expect { described_class.deliver(subscription) }.not_to raise_error
+        expect(Rails.error).to have_received(:report).with(
+          an_instance_of(Aws::PinpointSMSVoiceV2::Errors::ValidationException),
+          handled: true,
+          context: hash_including(:subscription_id),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #447. When a new `Subscription` is created with protocol `:email` or `:sms`, fire a welcome message confirming what the user just signed up for. No welcome for `:http` / `:https` (those are programmatic webhook endpoints).

Architecture follows the [analysis posted on #447](https://github.com/SplitTime/OpenSplitTime/issues/447#issuecomment-4346700620):

- **`Subscription#after_create_commit :send_welcome`** — dispatches per protocol
- **Email**: `SubscriptionMailer.welcome(subscription).deliver_later` via Mailgun. Two view variants based on whether the subscribable is an `Effort` (aid-station language) or `Person` (registered-for-event language)
- **SMS**: `SmsSubscriptionWelcomeJob.perform_later` → `SmsSubscriptionWelcomeSender` calls `Aws::PinpointSMSVoiceV2::Client#send_text_message` directly. Effort-only (per #1924, person subscriptions are email-only)

## SMS message text (matches TCR new-campaign sample 2 verbatim)

```
OpenSplitTime: You're now subscribed to live progress updates for {full_name} at {event_name}. You'll receive an SMS each time {first_name} passes an aid station. Reply STOP to cancel.
```

## Compliance gating + deploy plan

The SMS welcome wording is **only TCR-attested under the new campaign currently in `REVIEWING`** (`registration-c797e6734f654e33b61d21b2522b82d1`). Until that campaign is approved and the phone number cut over to it, the SMS path is gated behind `OstConfig.aws_sms_welcome_enabled?`, which reads `aws.sms_welcome_enabled` from credentials and defaults to `false`.

- **Merge anytime** — email welcomes start firing immediately on deploy (no TCR exposure).
- **After TCR approves** the new campaign AND the phone `+17626898865` is cut over to it, set `aws.sms_welcome_enabled: true` in production credentials and redeploy.
- The flag becomes unconditional once SMS is verified working in prod and can be removed in a follow-up.

## Short-circuit behavior

`SmsSubscriptionWelcomeSender#deliver` returns without calling AWS when:
- The feature flag is disabled (default)
- No origination number is configured
- The subscribable isn't an `Effort`
- The user has no phone
- The user is carrier-opted-out (via the predicate added in #1947)

AWS service errors are swallowed and surfaced via `Rails.error.report(handled: true)` — a failed welcome shouldn't roll back the persisted Subscription.

## Test plan

- [x] **Subscription model spec** (4 new examples): callback fires the right delegate per protocol; doesn't fire on update
- [x] **SubscriptionMailer spec** (7 examples): subject + body for both Effort and Person subscriptions, with effort/person-specific language
- [x] **SmsSubscriptionWelcomeSender spec** (9 examples): all five short-circuit conditions, AWS payload exact-shape, error-rescue path
- [x] RuboCop and erb_lint clean on touched files
- [x] CI green on full suite

Refs #447, #1947, #1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)