### PR TITLE
Skip SMS opt-out backfill migration when AWS is unreachable

### DIFF
--- a/db/data/20260429165816_backfill_sms_carrier_opt_out_timestamps.rb
+++ b/db/data/20260429165816_backfill_sms_carrier_opt_out_timestamps.rb
@@ -1,6 +1,7 @@
 class BackfillSmsCarrierOptOutTimestamps < ActiveRecord::Migration[8.1]
   def up
-    aws_index = AwsSmsClient.opted_out_at_by_phone
+    aws_index = fetch_aws_index
+    return if aws_index.nil?
 
     User.where.not(sms_carrier_opted_out_at: nil).find_each do |user|
       aws_at = aws_index[user.phone]
@@ -18,5 +19,18 @@ class BackfillSmsCarrierOptOutTimestamps < ActiveRecord::Migration[8.1]
     # this migration installs are the truth, so there is no meaningful prior
     # state to restore.
     raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  # Returns nil when AWS is unreachable (e.g., staging environments without
+  # SMS infrastructure or IAM perms wired up). The migration then no-ops
+  # rather than blocking the deploy.
+  def fetch_aws_index
+    AwsSmsClient.opted_out_at_by_phone
+  rescue Aws::Errors::ServiceError, Aws::Errors::MissingCredentialsError => e
+    say "Skipping backfill: AWS opt-out list unreachable (#{e.class}: #{e.message}). " \
+        "Expected in environments without SMS infrastructure."
+    nil
   end
 end


### PR DESCRIPTION
## Summary

Hotfix for staging deploy failures. The data migration from #1954 (`backfill_sms_carrier_opt_out_timestamps`) calls `AwsSmsClient.opted_out_at_by_phone` directly in `up`, and staging doesn't have the SMS-related IAM perms wired up — so every staging deploy fails on this migration.

Production already ran the migration successfully on 2026-04-29 (the 34 affected users are aligned to their actual AWS-reported timestamps), so the rescue only matters for environments without SMS infrastructure.

## Change

Wrap the AWS call in a rescue:

```ruby
rescue Aws::Errors::ServiceError, Aws::Errors::MissingCredentialsError => e
  say "Skipping backfill: AWS opt-out list unreachable (#{e.class}: #{e.message}). " \
      "Expected in environments without SMS infrastructure."
  nil
end
```

When the rescue fires, `fetch_aws_index` returns `nil` and the migration no-ops cleanly. `data_migrate` marks it as run, so subsequent deploys don't retry it.

## Why rescue rather than delete the migration

OST keeps completed one-shot data migrations in the repo as historical record (see `20260421154809_remove_sms_person_subscriptions.rb`, `20260423191631_remove_spread_cache_entries.rb`, etc.). Rescuing matches that pattern. Deleting would also leave orphaned records in the data_migrate tracking table.

## Test plan

- [x] RuboCop clean on the touched file (db/ is excluded from autocorrect; the file passes manual lint)
- [x] CI green on full suite
- [ ] Staging deploy completes successfully after merge (the migration will hit the rescue and no-op)
- Production: no behavior change — the migration already ran there before this PR.

Refs #1947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)