### PR TITLE
Defer email welcome until SNS subscription is confirmed

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -10,7 +10,8 @@ class Subscription < ApplicationRecord
   before_destroy :delete_resource_key
   after_save :attempt_person_subscription, if: :effort_has_person?
   after_save :attempt_effort_subscriptions, if: :type_is_person?
-  after_create_commit :send_welcome
+  after_create_commit :enqueue_sms_welcome, if: :sms?
+  after_save :enqueue_email_welcome, if: :email_just_confirmed?
 
   # rubocop:disable Rails/RedundantPresenceValidationOnBelongsTo -- existing tests assert error messages on the column-level :user_id / :subscribable_id keys, which the explicit presence validators emit and the belongs_to default does not.
   validates :user_id, :subscribable_type, :subscribable_id, :endpoint, :user, :subscribable, :protocol, presence: true
@@ -88,12 +89,15 @@ class Subscription < ApplicationRecord
     subscribable_type == "Person"
   end
 
-  def send_welcome
-    case protocol
-    when "email"
-      SubscriptionMailer.welcome(self).deliver_later
-    when "sms"
-      SmsSubscriptionWelcomeJob.perform_later(self)
-    end
+  def email_just_confirmed?
+    email? && saved_change_to_resource_key? && confirmed?
+  end
+
+  def enqueue_sms_welcome
+    SmsSubscriptionWelcomeJob.perform_later(self)
+  end
+
+  def enqueue_email_welcome
+    SubscriptionMailer.welcome(self).deliver_later
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -82,40 +82,65 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
-  describe "welcome dispatch on create" do
+  describe "welcome dispatch" do
     let(:user) { users(:admin_user) }
     let(:effort) { efforts(:hardrock_2015_tuan_jacobs) }
 
-    context "when protocol is email" do
-      it "enqueues the welcome mailer" do
-        expect do
-          described_class.create!(user: user, subscribable: effort, protocol: :email, endpoint: user.email)
-        end.to have_enqueued_mail(SubscriptionMailer, :welcome)
-      end
-    end
-
-    context "when protocol is sms" do
-      it "enqueues the SMS welcome job" do
+    context "when an SMS subscription is created" do
+      it "enqueues the SMS welcome job immediately" do
         expect do
           described_class.create!(user: user, subscribable: effort, protocol: :sms, endpoint: "+13035551212")
         end.to have_enqueued_job(SmsSubscriptionWelcomeJob)
       end
     end
 
-    context "when protocol is http" do
-      it "does not enqueue any welcome job or mail" do
+    context "when an email subscription is created" do
+      it "does not enqueue the welcome mailer on create — defers until AWS confirms" do
+        expect do
+          described_class.create!(user: user, subscribable: effort, protocol: :email, endpoint: user.email)
+        end.not_to have_enqueued_mail(SubscriptionMailer, :welcome)
+      end
+    end
+
+    context "when an http subscription is created" do
+      it "does not enqueue any welcome" do
         expect do
           described_class.create!(user: user, subscribable: effort, protocol: :http, endpoint: "https://example.com/hook")
         end.not_to have_enqueued_mail(SubscriptionMailer, :welcome)
       end
     end
 
-    context "when an existing subscription is updated" do
-      let!(:subscription) do
+    context "when an email subscription transitions from pending to confirmed" do
+      let(:subscription) do
         described_class.create!(user: user, subscribable: effort, protocol: :email, endpoint: user.email)
       end
+      let(:confirmed_arn) { "arn:aws:sns:us-west-2:186555151487:topic:#{SecureRandom.uuid}" }
 
-      it "does not re-fire the welcome (after_create_commit only)" do
+      before do
+        subscription.update_column(:resource_key, "pending#{SecureRandom.uuid}")
+        subscription.reload
+      end
+
+      it "enqueues the welcome mailer on the transition" do
+        subscription.resource_key = confirmed_arn
+        expect { subscription.save(validate: false) }.to have_enqueued_mail(SubscriptionMailer, :welcome)
+      end
+    end
+
+    context "when an already-confirmed email subscription is saved again" do
+      let(:subscription) do
+        described_class.create!(user: user, subscribable: effort, protocol: :email, endpoint: user.email)
+      end
+      let(:confirmed_arn) { "arn:aws:sns:us-west-2:186555151487:topic:#{SecureRandom.uuid}" }
+
+      before do
+        subscription.update_column(:resource_key, confirmed_arn)
+        allow(SnsSubscriptionManager).to receive(:update).and_return(
+          SnsSubscriptionManager::Response.new(subscription_arn: confirmed_arn),
+        )
+      end
+
+      it "does not re-fire the welcome mailer (no resource_key transition)" do
         expect do
           subscription.update!(endpoint: "new-#{user.email}")
         end.not_to have_enqueued_mail(SubscriptionMailer, :welcome)


### PR DESCRIPTION
## Summary

Follow-up to #1955 (welcome message implementation). The email welcome was firing on `after_create_commit`, but at that moment the subscription is still in pending state — AWS SNS has just sent its confirmation email and the user hasn't clicked the link yet. So our "you're now subscribed" message was both inaccurate and arriving simultaneously with the AWS confirmation request.

## Change

- Remove `:email` from the `after_create_commit` welcome dispatch
- Add `after_save :enqueue_email_welcome, if: :email_just_confirmed?` 
- `email_just_confirmed?` returns true when the resource_key just transitioned from a `pending...` value to a real SNS ARN

The transition is detected automatically: when the existing `RefreshPendingSubscriptionJob` calls `subscription.save`, `ResourceKeyValidator` sees the pending state and calls `SnsSubscriptionManager.locate`, which updates the resource_key if the user has confirmed on AWS's side. The dirty-tracking change then satisfies `email_just_confirmed?` and fires the welcome.

SMS is unchanged — SMS subscriptions auto-confirm at SNS subscribe time, so `after_create_commit` is still correct for that path.

## Tradeoff acknowledged

`RefreshPendingSubscriptionJob` is currently only enqueued from `toggle_helper.rb` when the subscription button is rendered. So users who click the AWS confirmation link but never revisit OST won't get the welcome until/unless they return. They'll still receive progress notifications (those flow through SNS topic publishes, which AWS handles automatically once confirmed) — just not our explicit "you're now subscribed" greeting.

A periodic sweep job that locates every pending subscription would close that gap, but with hundreds-to-thousands of pending subscriptions accumulated in production, the SNS API call volume isn't worth the marginal UX win.

## Test plan

- [x] `Subscription` spec updated:
  - SMS subscription create → enqueues SMS welcome job (existing behavior)
  - Email subscription create → does NOT enqueue welcome mailer (new — defers)
  - HTTP subscription create → no welcome (existing)
  - Email subscription transitions pending → confirmed → welcome mailer enqueues
  - Already-confirmed email subscription saved again with no resource_key change → no re-fire
- [x] All 28 welcome-related specs pass (subscription model + mailer + SMS sender)
- [x] RuboCop clean

Refs #447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)