### PR TITLE
Acknowledge confirmation step in subscription flash messages

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -34,7 +34,8 @@ class SubscriptionsController < ApplicationController
                         end
       redirect_to user_settings_sms_messaging_path
     elsif @subscription.save
-      flash.now[:success] = t("subscriptions.create.success",
+      flash_key = protocol == "sms" ? "subscriptions.create.success" : "subscriptions.create.pending_confirmation"
+      flash.now[:success] = t(flash_key,
                               protocol: protocol,
                               name: @subscribable.name,
                               endpoint: @subscription[:endpoint])

--- a/app/jobs/refresh_pending_subscription_job.rb
+++ b/app/jobs/refresh_pending_subscription_job.rb
@@ -1,4 +1,6 @@
 class RefreshPendingSubscriptionJob < ApplicationJob
+  include FlashBroadcastable
+
   queue_as :default
 
   def perform(subscription_id)
@@ -10,5 +12,13 @@ class RefreshPendingSubscriptionJob < ApplicationJob
     return unless subscription.confirmed?
 
     Turbo::StreamsChannel.broadcast_refresh_to(subscription.subscribable)
+    broadcast_flash(
+      subscription.subscribable,
+      message: I18n.t(
+        "subscriptions.confirmed",
+        protocol: subscription.protocol,
+        name: subscription.subscribable.name,
+      ),
+    )
   end
 end

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -79,8 +79,10 @@ en:
   subscriptions:
     create:
       success: "You have subscribed to %{protocol} notifications for %{name}. Messages will be sent to %{endpoint}."
+      pending_confirmation: "You have subscribed to %{protocol} notifications for %{name}. To activate, click the confirmation link sent to %{endpoint}."
       sms_no_phone: "Please add a mobile phone number and opt in to SMS on your preferences page."
       sms_not_opted_in: "Please opt in to SMS text messages on your preferences page."
+    confirmed: "Your subscription to %{protocol} notifications for %{name} is now active."
     tooltips:
       confirmed: "This subscription is confirmed."
       no_topic: "This subscription does not have a resource key. Click Actions > Refresh to attempt to generate one, or delete this subscription and create a new one."

--- a/spec/jobs/refresh_pending_subscription_job_spec.rb
+++ b/spec/jobs/refresh_pending_subscription_job_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe RefreshPendingSubscriptionJob do
 
       it "broadcasts a Turbo Stream refresh" do
         expect(Turbo::StreamsChannel).to receive(:broadcast_refresh_to).with(effort)
+        allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
+        job.perform(subscription.id)
+      end
+
+      it "broadcasts a confirmation flash to the subscribable's stream" do
+        allow(Turbo::StreamsChannel).to receive(:broadcast_refresh_to)
+        expect(Turbo::StreamsChannel).to receive(:broadcast_replace_to).with(
+          effort,
+          target: "flash",
+          partial: "layouts/broadcast_flash",
+          locals: hash_including(level: :success, message: a_string_matching(/now active/)),
+        )
         job.perform(subscription.id)
       end
     end


### PR DESCRIPTION
## Summary

Two complementary changes to align the flash UX with the actual subscription lifecycle for protocols that require AWS confirmation:

### 1. Create-time flash differs by protocol

The flash for email/http/https subscriptions no longer claims "messages will be sent" — instead it tells the user to click the AWS confirmation link. SMS keeps the original immediate-success wording (SMS subscriptions confirm at SNS-subscribe time, no extra step).

| Protocol | Flash |
|---|---|
| `sms` | "You have subscribed to sms notifications for {name}. Messages will be sent to {endpoint}." (unchanged) |
| `email`, `http`, `https` | "You have subscribed to {protocol} notifications for {name}. To activate, click the confirmation link sent to {endpoint}." (new) |

### 2. Confirmation-time flash broadcast

When `RefreshPendingSubscriptionJob` detects the `pending → confirmed` transition, it now broadcasts a "now active" flash to the subscribable's stream — alongside the existing `broadcast_refresh_to` that updates the toggle button. The flash arrives at the same moment the pending button transitions to confirmed.

```
Your subscription to email notifications for Joseph Mullins is now active.
```

Uses the existing `FlashBroadcastable` concern (`broadcast_replace_to` targeting `target: "flash"`) — same machinery already in use by other broadcast-flash jobs.

## Test plan

- [x] `RefreshPendingSubscriptionJob` spec extended to assert both broadcasts (refresh + flash) when transitioning to confirmed
- [x] System specs for subscribe-to-effort and subscribe-to-person continue to pass — both share the first sentence "You have subscribed to {protocol} notifications for {name}." across the new locale keys
- [x] All 29 welcome- and confirmation-related specs pass
- [x] RuboCop clean on touched Ruby files

Refs #447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)