### PR TITLE
Filter homepage featured events by organization visibility

### DIFF
--- a/app/presenters/visitor_index_presenter.rb
+++ b/app/presenters/visitor_index_presenter.rb
@@ -4,7 +4,12 @@ class VisitorIndexPresenter < BasePresenter
   end
 
   def recent_event_groups(number)
-    EventGroup.having_efforts.visible.by_group_start_time.limit(number)
+    EventGroup
+      .having_efforts
+      .visible
+      .joins(:organization).merge(Organization.visible)
+      .by_group_start_time
+      .limit(number)
   end
 
   def upcoming_courses(number)

--- a/spec/presenters/visitor_index_presenter_spec.rb
+++ b/spec/presenters/visitor_index_presenter_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe VisitorIndexPresenter do
+  subject(:presenter) { described_class.new(user) }
+
+  let(:user) { users(:admin_user) }
+
+  describe "#recent_event_groups" do
+    let(:visible_event_group) { event_groups(:hardrock_2014) }
+    let(:organization) { visible_event_group.organization }
+
+    context "when the event group's organization is visible" do
+      before { organization.update!(concealed: false) }
+
+      it "includes the event group" do
+        expect(presenter.recent_event_groups(50)).to include(visible_event_group)
+      end
+    end
+
+    context "when the event group's organization is concealed" do
+      before { organization.update!(concealed: true) }
+
+      it "excludes the event group even if the event group itself is visible" do
+        expect(visible_event_group.reload.concealed).to be(false)
+        expect(presenter.recent_event_groups(50)).not_to include(visible_event_group)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The homepage's "recent event groups" list was filtering on EventGroup-level concealment but not Organization-level concealment. So events belonging to concealed orgs (e.g., a private/test organization with at least one publicly-visible event group) showed up on the landing page even though the parent org was intentionally hidden.

Concrete case: the owner's `testrock` test organization has the testrock-100 EventGroup marked `concealed: false` because notifications need it to be publicly addressable, but the org itself is meant to be private. With this PR, marking the *organization* as `concealed: true` is sufficient to keep its events out of the homepage featured list while leaving the events themselves publicly accessible.

## Change

Single query update in `VisitorIndexPresenter#recent_event_groups`:

```ruby
EventGroup
  .having_efforts
  .visible
  .joins(:organization).merge(Organization.visible)   # NEW line
  .by_group_start_time
  .limit(number)
```

Uses the existing `Concealable` concern's `visible` scope on both models. No schema change, no new flag, no hardcoded slug.

## Why this approach

OST already has the right semantics for "this org is private": `Organization.concealed`. The existing usage is "concealed orgs are visible only to their creator and stewards." Promoting events from those orgs on the public homepage was inconsistent with that intent — the fix is to apply the same visibility check at the surface level too.

## Operational follow-up (separate)

After merge, set the testrock org to concealed in production:

```ruby
Organization.find_by(slug: "testrock").update!(concealed: true)
```

(or via Madmin)

## Test plan

- [x] New presenter spec covers both branches: visible-org event groups appear; concealed-org event groups don't, even when the event group itself is visible
- [x] Both examples pass, RuboCop clean
- [x] CI green on full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)