### PR TITLE
Add message frequency disclosure to SMS subscription confirmation

### DIFF
--- a/app/services/sms_subscription_welcome_sender.rb
+++ b/app/services/sms_subscription_welcome_sender.rb
@@ -45,7 +45,7 @@ class SmsSubscriptionWelcomeSender
   def message_body
     "OpenSplitTime: You're now subscribed to live progress updates for #{effort.full_name} " \
       "at #{effort.event_name}. You'll receive an SMS each time #{effort.first_name} " \
-      "passes an aid station. Reply STOP to cancel."
+      "passes an aid station. Message frequency varies. Reply STOP to cancel."
   end
 
   def client

--- a/spec/services/sms_subscription_welcome_sender_spec.rb
+++ b/spec/services/sms_subscription_welcome_sender_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe SmsSubscriptionWelcomeSender do
           a_hash_including(message_body: a_string_ending_with("Reply STOP to cancel.")),
         )
       end
+
+      it "includes a message frequency disclosure (TCR-attested)" do
+        described_class.deliver(subscription)
+        expect(client).to have_received(:send_text_message).with(
+          a_hash_including(message_body: a_string_including("Message frequency varies.")),
+        )
+      end
     end
 
     context "when the welcome feature flag is disabled" do


### PR DESCRIPTION
## Summary
- Inserts \"Message frequency varies.\" into `SmsSubscriptionWelcomeSender#message_body` so the per-effort subscription confirmation SMS matches sample 2 of the new TCR campaign (`registration-c797e6734f654e33b61d21b2522b82d1`) exactly.
- v1 of that campaign was denied for missing this disclosure; v3 (currently `REVIEWING`) attests the new wording.
- No-op in production until `aws_sms_welcome_enabled` is flipped on AND the new campaign is approved + the phone number is cut over.

## Test plan
- [x] `bundle exec rspec spec/services/sms_subscription_welcome_sender_spec.rb` (10/10 green; new spec asserts \"Message frequency varies.\" is present)
- [x] `bin/rubocop app/services/sms_subscription_welcome_sender.rb spec/services/sms_subscription_welcome_sender_spec.rb` (no offenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)