### PR TITLE
Send one-time welcome SMS on opt-in to SMS program

### DIFF
--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -39,8 +39,7 @@ class UserSettingsController < ApplicationController
 
     if updated
       flash[:notice] = t("user_settings.update.email_change_requested") if current_user.unconfirmed_email.present?
-      flash[:info] = t("sms.consent.opted_in") if !sms_was_opted_in && current_user.sms_opted_in?
-      flash[:info] = t("sms.consent.opted_out") if sms_was_opted_in && !current_user.sms_opted_in?
+      handle_sms_consent_change(sms_was_opted_in)
       redirect_to request.referrer
     else
       redirect_to request.referrer, notice: current_user.errors.full_messages.join("; ")
@@ -51,6 +50,17 @@ class UserSettingsController < ApplicationController
 
   def authorize_action
     authorize self, policy_class: ::UserSettingsPolicy
+  end
+
+  def handle_sms_consent_change(was_opted_in)
+    return if was_opted_in == current_user.sms_opted_in?
+
+    if current_user.sms_opted_in?
+      flash[:info] = t("sms.consent.opted_in")
+      SmsOptInWelcomeJob.perform_later(current_user)
+    else
+      flash[:info] = t("sms.consent.opted_out")
+    end
   end
 
   def settings_update_params

--- a/app/jobs/sms_opt_in_welcome_job.rb
+++ b/app/jobs/sms_opt_in_welcome_job.rb
@@ -1,0 +1,7 @@
+class SmsOptInWelcomeJob < ApplicationJob
+  queue_as :default
+
+  def perform(user)
+    SmsOptInWelcomeSender.deliver(user)
+  end
+end

--- a/app/services/sms_opt_in_welcome_sender.rb
+++ b/app/services/sms_opt_in_welcome_sender.rb
@@ -1,0 +1,45 @@
+require "aws-sdk-pinpointsmsvoicev2"
+
+class SmsOptInWelcomeSender
+  def self.deliver(user)
+    new(user).deliver
+  end
+
+  def initialize(user)
+    @user = user
+  end
+
+  def deliver
+    return unless deliverable?
+
+    client.send_text_message(
+      destination_phone_number: user.phone,
+      origination_identity: ::OstConfig.aws_sms_origination_number,
+      message_body: message_body,
+      message_type: "TRANSACTIONAL",
+    )
+  rescue Aws::PinpointSMSVoiceV2::Errors::ServiceError => e
+    Rails.error.report(e, handled: true, context: { user_id: user.id })
+  end
+
+  private
+
+  attr_reader :user
+
+  def deliverable?
+    ::OstConfig.aws_sms_welcome_enabled? &&
+      ::OstConfig.aws_sms_origination_number.present? &&
+      user.phone.present? &&
+      !user.sms_carrier_opted_out?
+  end
+
+  def message_body
+    "OpenSplitTime: Thanks for opting in to SMS notifications. " \
+      "You'll receive live progress updates when you subscribe to follow a participant. " \
+      "Reply STOP to cancel, HELP for help. Msg & data rates may apply."
+  end
+
+  def client
+    @client ||= Aws::PinpointSMSVoiceV2::Client.new(region: ::OstConfig.aws_region)
+  end
+end

--- a/spec/requests/user_settings/update_spec.rb
+++ b/spec/requests/user_settings/update_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe "UserSettings#update" do
+  include ActiveJob::TestHelper
+  include Warden::Test::Helpers
+
+  subject(:make_request) { put user_settings_update_path, params: params, headers: { "HTTP_REFERER" => user_settings_sms_messaging_path } }
+
+  let(:user) { users(:third_user) }
+
+  before { login_as user, scope: :user }
+
+  after do
+    clear_enqueued_jobs
+    clear_performed_jobs
+    Warden.test_reset!
+  end
+
+  context "when the user transitions from not-opted-in to opted-in" do
+    let(:params) do
+      {
+        user: {
+          phone: "303-555-1212",
+          sms_consent: "1",
+        },
+      }
+    end
+
+    it "enqueues SmsOptInWelcomeJob with the user" do
+      expect { make_request }.to have_enqueued_job(SmsOptInWelcomeJob).with(user)
+    end
+
+    it "sets the opted-in flash" do
+      make_request
+      expect(flash[:info]).to eq(I18n.t("sms.consent.opted_in"))
+    end
+  end
+
+  context "when the user transitions from opted-in to opted-out" do
+    before { user.update!(phone: "+13035551212", phone_confirmed_at: 5.days.ago) }
+
+    let(:params) do
+      {
+        user: {
+          phone: "303-555-1212",
+          sms_consent: "0",
+        },
+      }
+    end
+
+    it "does not enqueue SmsOptInWelcomeJob" do
+      expect { make_request }.not_to have_enqueued_job(SmsOptInWelcomeJob)
+    end
+
+    it "sets the opted-out flash" do
+      make_request
+      expect(flash[:info]).to eq(I18n.t("sms.consent.opted_out"))
+    end
+  end
+
+  context "when the user updates an unrelated field with no SMS opt-in change" do
+    let(:params) do
+      {
+        user: {
+          first_name: "Renamed",
+        },
+      }
+    end
+
+    it "does not enqueue SmsOptInWelcomeJob" do
+      expect { make_request }.not_to have_enqueued_job(SmsOptInWelcomeJob)
+    end
+  end
+
+  context "when the user re-saves the form while already opted-in (no transition)" do
+    before { user.update!(phone: "+13035551212", phone_confirmed_at: 5.days.ago) }
+
+    let(:params) do
+      {
+        user: {
+          phone: "303-555-1212",
+          sms_consent: "1",
+        },
+      }
+    end
+
+    it "does not enqueue SmsOptInWelcomeJob" do
+      expect { make_request }.not_to have_enqueued_job(SmsOptInWelcomeJob)
+    end
+  end
+end

--- a/spec/services/sms_opt_in_welcome_sender_spec.rb
+++ b/spec/services/sms_opt_in_welcome_sender_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe SmsOptInWelcomeSender do
+  let(:user) { users(:admin_user) }
+  let(:client) { instance_double(Aws::PinpointSMSVoiceV2::Client, send_text_message: nil) }
+
+  before do
+    allow(Aws::PinpointSMSVoiceV2::Client).to receive(:new).and_return(client)
+    allow(::OstConfig).to receive_messages(aws_sms_origination_number: "+17626898865", aws_sms_welcome_enabled?: true)
+    user.update!(phone: "+13035551212", phone_confirmed_at: Time.current, sms_carrier_opted_out_at: nil)
+  end
+
+  describe ".deliver" do
+    context "when all preconditions are met" do
+      it "calls send_text_message with the right destination, origination, and message body" do
+        described_class.deliver(user)
+        expect(client).to have_received(:send_text_message).with(
+          destination_phone_number: user.phone,
+          origination_identity: "+17626898865",
+          message_body: a_string_starting_with("OpenSplitTime: Thanks for opting in to SMS notifications."),
+          message_type: "TRANSACTIONAL",
+        )
+      end
+
+      it "describes what the user has opted in to" do
+        described_class.deliver(user)
+        expect(client).to have_received(:send_text_message).with(
+          a_hash_including(message_body: a_string_including("live progress updates when you subscribe to follow a participant")),
+        )
+      end
+
+      it "ends with the standard CTIA disclosure (STOP, HELP, msg & data rates)" do
+        described_class.deliver(user)
+        expect(client).to have_received(:send_text_message).with(
+          a_hash_including(message_body: a_string_ending_with("Reply STOP to cancel, HELP for help. Msg & data rates may apply.")),
+        )
+      end
+    end
+
+    context "when the welcome feature flag is disabled" do
+      before { allow(::OstConfig).to receive(:aws_sms_welcome_enabled?).and_return(false) }
+
+      it "does not call AWS" do
+        described_class.deliver(user)
+        expect(client).not_to have_received(:send_text_message)
+      end
+    end
+
+    context "when no origination number is configured" do
+      before { allow(::OstConfig).to receive(:aws_sms_origination_number).and_return(nil) }
+
+      it "does not call AWS" do
+        described_class.deliver(user)
+        expect(client).not_to have_received(:send_text_message)
+      end
+    end
+
+    context "when the user has no phone" do
+      before { user.update_column(:phone, nil) }
+
+      it "does not call AWS" do
+        described_class.deliver(user)
+        expect(client).not_to have_received(:send_text_message)
+      end
+    end
+
+    context "when the user is carrier-opted-out" do
+      before { user.update_column(:sms_carrier_opted_out_at, 1.day.ago) }
+
+      it "does not call AWS" do
+        described_class.deliver(user)
+        expect(client).not_to have_received(:send_text_message)
+      end
+    end
+
+    context "when AWS raises a service error" do
+      before do
+        allow(client).to receive(:send_text_message).and_raise(
+          Aws::PinpointSMSVoiceV2::Errors::ValidationException.new(nil, "boom"),
+        )
+        allow(Rails.error).to receive(:report)
+      end
+
+      it "swallows the error and reports it via Rails.error" do
+        expect { described_class.deliver(user) }.not_to raise_error
+        expect(Rails.error).to have_received(:report).with(
+          an_instance_of(Aws::PinpointSMSVoiceV2::Errors::ValidationException),
+          handled: true,
+          context: hash_including(:user_id),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `SmsOptInWelcomeSender` + `SmsOptInWelcomeJob` for the one-time welcome SMS attested as sample 1 of the new TCR campaign (`registration-c797e6734f654e33b61d21b2522b82d1`, currently `REVIEWING`).
- `UserSettingsController#update` enqueues the job when it detects the not-opted-in → opted-in transition (refactored the SMS-flash logic into a small private helper to keep the action readable).
- Reuses the existing `aws_sms_welcome_enabled?` flag and the `aws_sms_origination_number` credential. Short-circuits when the user is carrier-opted-out, has no phone, or the flag is off.
- Mirrors `SmsSubscriptionWelcomeSender`'s pattern (PR #1955) for consistency — same deliverability checks, same Aws::PinpointSMSVoiceV2 client wiring, same error reporting.
- No-op in production until the flag flips and the new TCR campaign is approved + the phone is cut over.

## Message body (verbatim TCR sample 1)

> OpenSplitTime: Thanks for opting in to SMS notifications. You'll receive live progress updates when you subscribe to follow a participant. Reply STOP to cancel, HELP for help. Msg & data rates may apply.

## Test plan
- [x] `bundle exec rspec spec/services/sms_opt_in_welcome_sender_spec.rb` — 8 examples covering happy path, all 4 short-circuit conditions, and AWS error swallowing.
- [x] `bundle exec rspec spec/requests/user_settings/update_spec.rb` — 6 examples covering opt-in transition (enqueues + flash), opt-out transition (no enqueue + flash), unrelated update (no enqueue), and re-save while already opted in (no enqueue).
- [x] No regressions in `spec/system/user_settings/sms_messaging_spec.rb`, `spec/services/sms_subscription_welcome_sender_spec.rb`, `spec/models/subscription_spec.rb`.
- [x] `bin/rubocop` clean on all 5 touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)