### PR TITLE
Key bundler cache by runner image so native gems rebuild on rotation

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -16,6 +16,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          cache-version: ${{ env.ImageOS }}-${{ env.ImageVersion }}
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -157,6 +158,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          cache-version: ${{ env.ImageOS }}-${{ env.ImageVersion }}
 
       - name: Install libvips
         run: sudo apt-get install -y --no-install-recommends libvips42


### PR DESCRIPTION
## Summary

The smarter_csv native extension SIGILLs in CI when GitHub's runner image rotates and the cached \`.so\` was built against the previous image's CPU/glibc. Yesterday a Gemfile.lock bump (1.16.3 → 1.16.4) worked around it by busting the cache, but only until the next rotation re-cached the broken binary against the new image — exactly what just happened on #1967.

This PR adds \`cache-version: \${{ env.ImageOS }}-\${{ env.ImageVersion }}\` to both \`ruby/setup-ruby@v1\` invocations in \`.github/workflows/verify.yml\`. The bundler cache key now includes the runner image fingerprint, so image rotations naturally invalidate the cache and force a fresh native build instead of producing a binary mismatched against the new runtime.

## Why this works
- \`ruby/setup-ruby@v1\` accepts a \`cache-version\` input that gets prepended to the cache key.
- GitHub-hosted runners expose \`\${{ env.ImageOS }}\` (e.g. \`ubuntu24\`) and \`\${{ env.ImageVersion }}\` (e.g. \`20260415.1\`) at workflow expression time.
- Combining them gives a per-image cache. Two builds on the same runner image still hit the cache; a build on a fresh image rebuilds from scratch.

## Test plan
- [ ] CI on this PR rebuilds gems from scratch (no cache hit because the cache-version is new) and the smarter_csv native extension is freshly compiled against the current runner. Unit job should pass.
- [ ] After merge, subsequent PRs hit the cache as long as the runner image is stable — and gracefully rebuild on rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)