### PR TITLE
Sweepers::EventSubscriptionsAndTopicsJob — sweep stale Event subs and topics

### DIFF
--- a/app/jobs/sweepers/event_subscriptions_and_topics_job.rb
+++ b/app/jobs/sweepers/event_subscriptions_and_topics_job.rb
@@ -1,0 +1,109 @@
+module Sweepers
+  class EventSubscriptionsAndTopicsJob < ApplicationJob
+    queue_as :default
+
+    SUBSCRIPTION_AGE_CUTOFF = 3.months
+    TOPIC_AGE_CUTOFF = 30.days
+
+    def perform(dry_run: false)
+      @dry_run = dry_run
+      @start_time = Time.current
+      @report = +""
+      banner = "Started Sweepers::EventSubscriptionsAndTopicsJob for #{OstConfig.app_name} at #{@start_time}"
+      banner += " (DRY RUN — no deletions will be performed)" if dry_run
+      append(banner)
+
+      sweep_stale_event_subscriptions
+      sweep_topics_on_stale_events
+
+      append("Finished job in #{(Time.current - @start_time).round(1)} seconds at #{Time.current}")
+      AdminMailer.job_report(self.class, @report).deliver_now
+    end
+
+    private
+
+    attr_reader :dry_run
+
+    def sweep_stale_event_subscriptions
+      append("\n[Pass 1] Sweeping stale Event subscriptions")
+
+      stale_event_ids = Event.where("events.scheduled_start_time < ?", SUBSCRIPTION_AGE_CUTOFF.ago).select(:id)
+      obsolete_subs = Subscription.where(subscribable_type: "Event", subscribable_id: stale_event_ids)
+      count = obsolete_subs.count
+
+      if count.zero?
+        append("  No stale Event subscriptions found")
+        return
+      end
+
+      append("  Found #{count} stale Event subscription(s)")
+      return append("  DRY RUN — skipping destruction") if dry_run
+
+      problem_ids = []
+      obsolete_subs.find_in_batches do |batch|
+        batch.each { |sub| problem_ids << sub.id unless sub.destroy }
+      end
+
+      if problem_ids.present?
+        append("  Could not destroy #{problem_ids.size} subscription(s): #{problem_ids.join(', ')}")
+      else
+        append("  Destroyed all #{count} stale Event subscription(s)")
+      end
+    end
+
+    def sweep_topics_on_stale_events
+      append("\n[Pass 2] Sweeping topics on stale Events")
+
+      candidates = Event.having_topic_resource_key
+                        .where("events.scheduled_start_time < ?", TOPIC_AGE_CUTOFF.ago)
+
+      total_candidates = candidates.count
+      append("  #{total_candidates} candidate Event(s) past the #{TOPIC_AGE_CUTOFF.inspect} cutoff")
+      return if total_candidates.zero?
+
+      deleted_count = 0
+      skipped_with_subs = 0
+      problem_ids = []
+
+      candidates.find_each do |event|
+        if event.subscriptions.exists?
+          skipped_with_subs += 1
+          next
+        end
+
+        if dry_run
+          append("  [dry-run] would delete topic for Event##{event.id} (#{event.topic_resource_key})")
+          next
+        end
+
+        if delete_topic_for(event)
+          deleted_count += 1
+        else
+          problem_ids << event.id
+        end
+      end
+
+      if skipped_with_subs.positive?
+        append("  Skipped #{skipped_with_subs} Event(s) that still had subscriptions after Pass 1")
+      end
+      append("  Deleted #{deleted_count} topic(s)")
+      append("  Failed on #{problem_ids.size} Event(s): #{problem_ids.join(', ')}") if problem_ids.present?
+    end
+
+    def delete_topic_for(event)
+      event.unassign_topic_resource
+      event.save!
+      true
+    rescue SnsTopicManager::TopicNotDeletedError,
+           Aws::SNS::Errors::ServiceError,
+           ActiveRecord::RecordInvalid => e
+      Rails.logger.warn("  Topic delete failed for Event##{event.id}: #{e.class.name}: #{e.message}")
+      false
+    end
+
+    def append(line)
+      @report << line << "\n"
+      Rails.logger.info(line)
+    end
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -21,6 +21,10 @@ production:
     class: Sweepers::EffortSubscriptionsAndTopicsJob
     queue: default
     schedule: every Sunday at 4am
+  sweep_event_subscriptions_and_topics:
+    class: Sweepers::EventSubscriptionsAndTopicsJob
+    queue: default
+    schedule: every Sunday at 4:30am
   reconcile_sms_carrier_opt_outs:
     class: ReconcileSmsCarrierOptOutsJob
     queue: default

--- a/spec/jobs/sweepers/event_subscriptions_and_topics_job_spec.rb
+++ b/spec/jobs/sweepers/event_subscriptions_and_topics_job_spec.rb
@@ -1,0 +1,164 @@
+require "rails_helper"
+
+RSpec.describe Sweepers::EventSubscriptionsAndTopicsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:user) { users(:admin_user) }
+  let(:sns_client) { Aws::SNS::Client.new(stub_responses: true) }
+
+  let(:now) { Time.zone.parse("2026-05-01 12:00:00") }
+
+  let(:event_old) { events(:hardrock_2014) }
+  let(:event_recent) { events(:hardrock_2015) }
+
+  before do
+    travel_to(now)
+
+    Subscription.delete_all
+    Event.update_all(topic_resource_key: nil)
+
+    allow(SnsClientFactory).to receive(:client).and_return(sns_client)
+    sns_client.stub_responses(:delete_topic, {})
+
+    allow(AdminMailer).to receive(:job_report).and_return(instance_double(ActionMailer::MessageDelivery, deliver_now: true))
+  end
+
+  def make_subscription(event)
+    Subscription.create!(
+      user: user,
+      subscribable: event,
+      protocol: :email,
+      endpoint: user.email,
+      resource_key: "arn:aws:sns:us-west-2:123:subscription-#{SecureRandom.hex(4)}",
+    )
+  end
+
+  describe "Pass 1 — sweep stale Event subscriptions" do
+    it "destroys subscriptions for Events older than 3 months" do
+      event_old.update_columns(scheduled_start_time: 4.months.ago)
+      sub = make_subscription(event_old)
+
+      described_class.perform_now
+
+      expect(Subscription.exists?(sub.id)).to be(false)
+    end
+
+    it "preserves subscriptions for Events younger than 3 months" do
+      event_recent.update_columns(scheduled_start_time: 2.months.ago)
+      sub = make_subscription(event_recent)
+
+      described_class.perform_now
+
+      expect(Subscription.exists?(sub.id)).to be(true)
+    end
+
+    it "does not touch Effort subscriptions" do
+      effort = efforts(:hardrock_2014_finished_first)
+      effort_sub = Subscription.create!(
+        user: user,
+        subscribable: effort,
+        protocol: :email,
+        endpoint: user.email,
+      )
+
+      described_class.perform_now
+
+      expect(Subscription.exists?(effort_sub.id)).to be(true)
+    end
+
+    it "does not touch Person subscriptions" do
+      person = people(:progress_cascade)
+      person_sub = Subscription.create!(
+        user: user,
+        subscribable: person,
+        protocol: :email,
+        endpoint: user.email,
+      )
+
+      described_class.perform_now
+
+      expect(Subscription.exists?(person_sub.id)).to be(true)
+    end
+  end
+
+  describe "Pass 2 — sweep topics on stale Events" do
+    let(:topic_arn) { "arn:aws:sns:us-west-2:123:t-follow-stale-event-topic" }
+
+    it "deletes the topic when stale and no subscribers" do
+      event_old.update_columns(scheduled_start_time: 31.days.ago, topic_resource_key: topic_arn)
+
+      allow(SnsTopicManager).to receive(:delete).and_return(topic_arn)
+
+      described_class.perform_now
+
+      expect(SnsTopicManager).to have_received(:delete).with(resource: event_old)
+      expect(event_old.reload.topic_resource_key).to be_nil
+    end
+
+    it "preserves the topic when subscribers still exist" do
+      event_recent.update_columns(scheduled_start_time: 31.days.ago, topic_resource_key: topic_arn)
+      make_subscription(event_recent)
+
+      expect(SnsTopicManager).not_to receive(:delete)
+
+      described_class.perform_now
+
+      expect(event_recent.reload.topic_resource_key).to eq(topic_arn)
+    end
+
+    it "preserves the topic for Events younger than 30 days" do
+      event_recent.update_columns(scheduled_start_time: 20.days.ago, topic_resource_key: topic_arn)
+
+      expect(SnsTopicManager).not_to receive(:delete)
+
+      described_class.perform_now
+
+      expect(event_recent.reload.topic_resource_key).to eq(topic_arn)
+    end
+  end
+
+  describe "cross-pass interaction" do
+    let(:topic_arn) { "arn:aws:sns:us-west-2:123:t-follow-cross-pass-event" }
+
+    it "Pass 2 deletes the topic of an event whose subscriptions Pass 1 just removed" do
+      event_old.update_columns(scheduled_start_time: 4.months.ago, topic_resource_key: topic_arn)
+      make_subscription(event_old)
+
+      allow(SnsTopicManager).to receive(:delete).and_return(topic_arn)
+
+      described_class.perform_now
+
+      expect(SnsTopicManager).to have_received(:delete).with(resource: event_old)
+      expect(event_old.reload.topic_resource_key).to be_nil
+      expect(Subscription.where(subscribable: event_old)).to be_empty
+    end
+  end
+
+  describe "dry-run mode" do
+    let(:topic_arn) { "arn:aws:sns:us-west-2:123:t-follow-dry-event" }
+
+    it "performs no destruction and no AWS deletes" do
+      event_old.update_columns(scheduled_start_time: 4.months.ago, topic_resource_key: topic_arn)
+      sub = make_subscription(event_old)
+
+      expect(SnsTopicManager).not_to receive(:delete)
+
+      described_class.perform_now(dry_run: true)
+
+      expect(Subscription.exists?(sub.id)).to be(true)
+      expect(event_old.reload.topic_resource_key).to eq(topic_arn)
+    end
+  end
+
+  describe "reporting" do
+    it "sends a job report via AdminMailer" do
+      mail = instance_double(ActionMailer::MessageDelivery, deliver_now: true)
+      allow(AdminMailer).to receive(:job_report).and_return(mail)
+
+      described_class.perform_now
+
+      expect(AdminMailer).to have_received(:job_report).with(described_class, kind_of(String))
+      expect(mail).to have_received(:deliver_now)
+    end
+  end
+end


### PR DESCRIPTION
Implements #1982 (which has been re-scoped to `Event` since `EventGroup` isn't actually `Subscribable` in this codebase — see updated issue body).

## Summary

Two-pass per-resource sweeper paralleling #1981 but for `Event`:

- **Pass 1** destroys `Subscription` rows where `subscribable_type: "Event"` and the event's `scheduled_start_time < 3.months.ago`. Event has no `finished` flag so this is a single time-based criterion.
- **Pass 2** finds Events past the 30-day topic-age cutoff with no remaining subscribers, deletes the AWS topic via `SnsTopicManager.delete`, and saves with `topic_resource_key = nil`. Same shape as Effort job's Pass 2.

No Pass 3 orphan-AWS-topic sweep here — `Sweepers::EffortSubscriptionsAndTopicsJob`'s Pass 3 (#1981) already considers Event `topic_resource_key`s as live, so AWS-side orphans are covered defense-in-depth there.

`dry_run: true` keyword supported; recommended for the first production run.

## Schedule

`every Sunday at 4:30am` — 30 min after the Effort sweeper to avoid AWS rate-limit contention.

## Out of scope

- `Person` — remains indefinitely.
- `Effort` — handled by #1981.

## Test plan

- [x] New spec: `spec/jobs/sweepers/event_subscriptions_and_topics_job_spec.rb` — 10 examples covering each pass, the cross-pass interaction, dry-run, isolation from Effort/Person subs, and AdminMailer reporting.
- [x] Rubocop clean on touched files.
- [ ] Run as `dry_run: true` against production once before scheduling the live version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)