### PR TITLE
Disregard validations on effort subscription sweep

### DIFF
--- a/app/jobs/sweepers/effort_subscriptions_and_topics_job.rb
+++ b/app/jobs/sweepers/effort_subscriptions_and_topics_job.rb
@@ -150,7 +150,7 @@ module Sweepers
 
     def delete_topic_for(effort)
       effort.unassign_topic_resource
-      effort.save!
+      effort.save!(validate: false) # Disregard validations; this operation isn't making it worse
       true
     rescue SnsTopicManager::TopicNotDeletedError,
            Aws::SNS::Errors::ServiceError,


### PR DESCRIPTION
## Summary

Switches the topic-teardown path in `Sweepers::EffortSubscriptionsAndTopicsJob#delete_topic_for` from `effort.save!` to `effort.save!(validate: false)`.

## Why

When the dry-run/initial run hit production data, some old efforts failed current validations even though they were valid when originally saved (validation rules have tightened over time). With strict `save!`, those efforts would raise `ActiveRecord::RecordInvalid`, get caught by the rescue, the AWS topic would be deleted but the DB `topic_resource_key` would remain — leaving a dangling reference and forcing the next run to retry the same already-deleted topic indefinitely.

This sweep only ever clears `topic_resource_key`. It can't make an effort "more invalid" than it already is, so revalidating the rest of the record on the way out is busy-work that breaks the cleanup.

## Test plan

- [x] Existing 19 specs still pass — the change is a one-line behavioral relaxation, not a structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)