### PR TITLE
Fix: filter live-broadcast raw times by active split name filter

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -94,6 +94,9 @@ application.register("notifications", NotificationsController)
 import PopoverController from "./popover_controller"
 application.register("popover", PopoverController)
 
+import RawTimeFilterController from "./raw_time_filter_controller"
+application.register("raw-time-filter", RawTimeFilterController)
+
 import RawTimesPushController from "./raw_times_push_controller"
 application.register("raw-times-push", RawTimesPushController)
 

--- a/app/javascript/controllers/raw_time_filter_controller.js
+++ b/app/javascript/controllers/raw_time_filter_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    parameterizedSplitName: String,
+  }
+
+  connect() {
+    if (!this.matchesCurrentFilters()) {
+      this.element.remove()
+    }
+  }
+
+  matchesCurrentFilters() {
+    const params = new URLSearchParams(window.location.search)
+    const splitNameFilter = params.get("filter[parameterized_split_name]")
+    return !splitNameFilter || this.parameterizedSplitNameValue === splitNameFilter
+  }
+}

--- a/app/views/raw_times/_raw_time.html.erb
+++ b/app/views/raw_times/_raw_time.html.erb
@@ -1,8 +1,9 @@
 <%# locals: (raw_time:, multiple_events:, multiple_sub_splits:, multiple_laps:, monitor_pacers:, home_time_zone:) -%>
 
 <tr id="<%= dom_id(raw_time) %>"
-    data-controller="highlight"
-    data-highlight-timestamp-value="<%= raw_time.updated_at.to_i %>">
+    data-controller="highlight raw-time-filter"
+    data-highlight-timestamp-value="<%= raw_time.updated_at.to_i %>"
+    data-raw-time-filter-parameterized-split-name-value="<%= raw_time.parameterized_split_name %>">
   <td><%= raw_time.bib_number %></td>
   <% if multiple_events %>
     <td><%= raw_time.event&.guaranteed_short_name || "--" %></td>

--- a/spec/system/raw_times/raw_times_list_live_filter_spec.rb
+++ b/spec/system/raw_times/raw_times_list_live_filter_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "Raw times list — client-side filtering of live-broadcast rows", :js, type: :system do
+  let(:admin) { users(:admin_user) }
+  let(:event_group) { event_groups(:sum) }
+  let(:matching_split_param) { "anvil-cg-aid6" }
+  let(:nonmatching_split_param) { "molas-pass-aid1" }
+
+  before { login_as admin, scope: :user }
+
+  # Mimics what a Turbo Stream broadcast lands in the DOM. We inject a <tr> with
+  # the same data attributes the _raw_time partial renders (data-controller and
+  # data-raw-time-filter-parameterized-split-name-value), then assert whether
+  # the raw_time_filter Stimulus controller kept or removed it.
+  def broadcast_row(dom_id:, split_param:)
+    page.execute_script(<<~JS)
+      const tr = document.createElement("tr");
+      tr.id = "#{dom_id}";
+      tr.setAttribute("data-controller", "raw-time-filter");
+      tr.setAttribute("data-raw-time-filter-parameterized-split-name-value", "#{split_param}");
+      tr.innerHTML = "<td colspan='100'>injected</td>";
+      document.getElementById("raw_times").prepend(tr);
+    JS
+  end
+
+  scenario "with no filter, all broadcast rows stay" do
+    visit raw_times_event_group_path(event_group)
+
+    broadcast_row(dom_id: "raw_time_99001", split_param: matching_split_param)
+    broadcast_row(dom_id: "raw_time_99002", split_param: nonmatching_split_param)
+
+    expect(page).to have_selector("#raw_time_99001")
+    expect(page).to have_selector("#raw_time_99002")
+  end
+
+  scenario "with split-name filter active, broadcast rows that don't match are removed" do
+    visit raw_times_event_group_path(event_group, filter: { parameterized_split_name: matching_split_param })
+
+    broadcast_row(dom_id: "raw_time_99003", split_param: matching_split_param)
+    broadcast_row(dom_id: "raw_time_99004", split_param: nonmatching_split_param)
+
+    expect(page).to have_selector("#raw_time_99003")
+    expect(page).to have_no_selector("#raw_time_99004")
+  end
+
+  scenario "rows with empty split name survive when no filter is active" do
+    visit raw_times_event_group_path(event_group)
+
+    broadcast_row(dom_id: "raw_time_99005", split_param: "")
+
+    expect(page).to have_selector("#raw_time_99005")
+  end
+
+  scenario "rows with empty split name are removed when a split filter is active" do
+    visit raw_times_event_group_path(event_group, filter: { parameterized_split_name: matching_split_param })
+
+    broadcast_row(dom_id: "raw_time_99006", split_param: "")
+
+    expect(page).to have_no_selector("#raw_time_99006")
+  end
+end


### PR DESCRIPTION
When I use the Raw Times List page on a live entry event, it streams in new times live, which is great. But when I filter to a particular split, raw times come in from all splits regardless of my filter. This breaks the page's usefulness for us. This PR is attempting to fix this issue by filtering the live-added times on that page.

I tested this manually locally, and it works!

## Summary

- When an event is in live entry mode, `RawTime#after_create_commit` broadcasts a Turbo Stream `prepend` to all subscribers of the event group channel, unconditionally inserting the new row into `#raw_times` regardless of what filters the client has active.
- This adds a Stimulus controller (`raw-time-filter`) that fires on `connect()` for every raw time row and removes the element if the row's `parameterized_split_name` doesn't match the active `filter[parameterized_split_name]` URL param.
- No change to the broadcast or server-side code — the fix is purely client-side.

## Test plan

- [x] Open the raw times list for an event group with **Live Entry** enabled
- [x] Filter by a specific split name (e.g. "Anvil CG (Aid6)")
- [x] Use live entry (or `rails console`) to create a raw time with a **different** split name — confirm the row does **not** appear
- [x] Create a raw time with the **matching** split name — confirm it appears with the highlight animation
- [x] Select "All Splits" and confirm all new raw times appear normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)