### PR TITLE
Restore row highlight + fade on Bootstrap-striped tables

### DIFF
--- a/app/assets/stylesheets/utilities/_colors.scss
+++ b/app/assets/stylesheets/utilities/_colors.scss
@@ -1,5 +1,9 @@
 @import "../variables";
 
 .bg-highlight {
+    // Bootstrap 5 .table cells paint over the <tr> background via an inset box-shadow
+    // driven by --bs-table-bg-state, so set that variable too — otherwise rows in
+    // .table-striped contexts (e.g. raw_times list) never visibly highlight.
+    --bs-table-bg-state: #{lighten($yellow, 20%)};
     background: lighten($yellow, 20%) !important;
 }

--- a/app/assets/stylesheets/utilities/_highlight.scss
+++ b/app/assets/stylesheets/utilities/_highlight.scss
@@ -1,6 +1,24 @@
+// Register --bs-table-bg-state as a <color> so it can be transitioned. Without
+// this, custom-property values change instantaneously and the cell-level inset
+// box-shadow that uses this variable would snap rather than fade.
+@property --bs-table-bg-state {
+    syntax: "<color>";
+    inherits: true;
+    initial-value: transparent;
+}
+
 .bg-highlight-faded {
     transition: background 4s linear;
 }
+.bg-highlight-faded > td,
+.bg-highlight-faded > th {
+    transition: box-shadow 4s linear;
+}
+
 .bg-highlight-faded-fast {
     transition: background 1s linear;
+}
+.bg-highlight-faded-fast > td,
+.bg-highlight-faded-fast > th {
+    transition: box-shadow 1s linear;
 }


### PR DESCRIPTION
## Background

The highlight Stimulus controller adds `.bg-highlight` to a row, then after a brief delay swaps it for `.bg-highlight-faded` (which has a 4s `transition: background`). The intent: a yellow flash that fades to the row's normal color over ~5 seconds.

This stopped working in `<tr>` elements inside any Bootstrap `.table` — most visibly the raw_times list. Suspected to have regressed with the **Bootstrap 5.2 → 5.3 upgrade**: 5.3 changed how table cell backgrounds are painted. Each `<td>` gets

```css
box-shadow: inset 0 0 0 9999px var(--bs-table-bg-state, var(--bs-table-bg-type, var(--bs-table-accent-bg)));
```

— a giant inset shadow that completely paints over any `background` set on the parent `<tr>`. Result: `.bg-highlight` quietly stopped being visible on table rows.

## Fix

**`utilities/_colors.scss`** — also set `--bs-table-bg-state` on `.bg-highlight` so the cell-level inset shadow uses the highlight color too. Keeps the existing `background` declaration so non-table use-sites (lottery draw cards, etc.) continue to work unchanged.

**`utilities/_highlight.scss`** — register `--bs-table-bg-state` via `@property` as a `<color>` so it becomes animatable, then transition `box-shadow` on the affected cells in lockstep with the row's `background` transition. Without the `@property` registration, custom-property values change instantaneously and the cell color would snap back to the stripe color while the (invisible-because-overpainted) row background tries to fade.

## Scope

`bg-highlight` is used in 8 `<tr>` partials across the app — 6 controller-driven flashes and 2 static "problem row" markers (`split_times/_effort_audit_row`, `event_groups/split_raw_times`). All 8 benefit automatically from this class-level fix; no per-file edits. The 5 non-`<tr>` use sites (cards, switches) are unaffected.

## Test plan

- [x] Visit raw_times list with live entry on, create a raw_time → row flashes yellow and fades over ~4s
- [x] Visit a finished effort's audit page; rows with discrepancies should now show the persistent `bg-highlight` (likely been invisible for a while)
- [x] Visit historical facts list, edit a fact → row briefly flashes
- [x] Visit lottery draw page, draw a ticket → card still flashes (verifies the non-table path didn't regress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)