### PR TITLE
Reset topic_resource_key on duplicated events

### DIFF
--- a/app/models/duplicate_event_group.rb
+++ b/app/models/duplicate_event_group.rb
@@ -47,6 +47,10 @@ class DuplicateEventGroup
         beacon_url: nil,
         efforts_count: 0,
         created_by: created_by,
+        # Subscribable#assign_topic_resource only generates a fresh ARN when
+        # topic_resource_key is nil; without this reset the duplicated event
+        # would inherit the source's ARN and never get its own SNS topic.
+        topic_resource_key: nil,
       )
       new_event_group.events << new_event
     end

--- a/app/models/duplicate_event_group.rb
+++ b/app/models/duplicate_event_group.rb
@@ -47,9 +47,6 @@ class DuplicateEventGroup
         beacon_url: nil,
         efforts_count: 0,
         created_by: created_by,
-        # Subscribable#assign_topic_resource only generates a fresh ARN when
-        # topic_resource_key is nil; without this reset the duplicated event
-        # would inherit the source's ARN and never get its own SNS topic.
         topic_resource_key: nil,
       )
       new_event_group.events << new_event

--- a/spec/models/duplicate_event_group_spec.rb
+++ b/spec/models/duplicate_event_group_spec.rb
@@ -52,6 +52,22 @@ RSpec.describe DuplicateEventGroup, type: :model do
       end
     end
 
+    context "when the source events hold topic_resource_keys" do
+      before do
+        event_group.events.each_with_index do |event, i|
+          event.update_column(:topic_resource_key, "arn:aws:sns:us-west-2:000:follow-source-#{i}")
+        end
+      end
+
+      it "does not carry forward topic_resource_key onto the duplicated events" do
+        # Without this reset, every duplicated event would inherit its source's ARN and
+        # never get a fresh topic from the Subscribable callback (regression for #1988).
+        subject.new_event_group.events.each do |new_event|
+          expect(new_event.topic_resource_key).to be_nil
+        end
+      end
+    end
+
     context "with a blank name" do
       let(:new_name) { "" }
 


### PR DESCRIPTION
Resolves #1988.

## Summary

`DuplicateEventGroup#duplicate_event_group` builds new Events via `existing_event.dup` and then `assign_attributes` to clear a few fields. It was clearing `historical_name`, `beacon_url`, `efforts_count` — but not `topic_resource_key`. The duplicated event therefore inherited the source's ARN, and `Subscribable#assign_topic_resource`'s guard (`topic_resource_key.nil? && slug.present?`) caused the after_create callback to skip generating a fresh topic. Result: every duplicate event held a foreign ARN forever.

When that foreign ARN was later cleaned up in AWS (sweep, manual cleanup, etc.), the duplicate was left holding a dead pointer. `after_touch :notify_event_update` cascading from `effort.touch: true` → `event.touch: true` then enqueued `NotifyEventUpdateJob` for every split_time write, which raised "Topic does not exist" and got retried forever — Scout error_group #67668 with 3,096 occurrences in 7 days for the Never Summer 100k 2025 event before its dangling key was manually cleared.

The fix is one line: reset `topic_resource_key: nil` alongside the other duplicate-and-clear attributes. The Subscribable after_create callback then enqueues `SetTopicResourceKeyJob` for the new event, which generates a clean ARN.

## Test plan

- [x] New spec asserts that duplicating an event group with source events that hold `topic_resource_key` results in duplicated events with `topic_resource_key = nil`.
- [x] Full `spec/models/duplicate_event_group_spec.rb` green: 15 examples, 0 failures.
- [x] Rubocop clean.

## Out of scope

- Cleaning up existing dangling pointers — that's #1990's rake task.
- Self-heal in the Notifier path — that's #1989.

🤖 Generated with [Claude Code](https://claude.com/claude-code)