### PR TITLE
Fix NoMethodError on Finish Line page: add display_*_non_obscured to ProjectedArrivalsAtSplit

### DIFF
--- a/app/models/projected_arrivals_at_split.rb
+++ b/app/models/projected_arrivals_at_split.rb
@@ -86,12 +86,12 @@ class ProjectedArrivalsAtSplit < ::ApplicationQuery
                          left join grouped_projected_percentages using (completed_lap, completed_split_id, completed_bitkey)
                 order by cs.effort_id)
 
-      select efforts.id as effort_id, 
-                           first_name, 
-                           last_name, 
-                           bib_number, 
-                           projected_time, 
-                           completed, 
+      select efforts.id as effort_id,#{' '}
+                           first_name,#{' '}
+                           last_name,#{' '}
+                           bib_number,#{' '}
+                           projected_time,#{' '}
+                           completed,#{' '}
                            stopped,
                            short_name as event_short_name
       from efforts
@@ -108,4 +108,13 @@ class ProjectedArrivalsAtSplit < ::ApplicationQuery
   def full_name
     "#{first_name} #{last_name}"
   end
+
+  # The query result has no link to a Person, so the obscure-name preference
+  # isn't reachable here. Define the non-obscured variants explicitly so
+  # callers (e.g. FinishLineHelper) can use the same `_non_obscured` naming
+  # convention as PersonalInfo includers and have it be unambiguous that the
+  # privacy filter is intentionally bypassed.
+  alias display_full_name_non_obscured full_name
+  alias_attribute :display_first_name_non_obscured, :first_name
+  alias_attribute :display_last_name_non_obscured, :last_name
 end

--- a/app/models/projected_arrivals_at_split.rb
+++ b/app/models/projected_arrivals_at_split.rb
@@ -86,12 +86,12 @@ class ProjectedArrivalsAtSplit < ::ApplicationQuery
                          left join grouped_projected_percentages using (completed_lap, completed_split_id, completed_bitkey)
                 order by cs.effort_id)
 
-      select efforts.id as effort_id,#{' '}
-                           first_name,#{' '}
-                           last_name,#{' '}
-                           bib_number,#{' '}
-                           projected_time,#{' '}
-                           completed,#{' '}
+      select efforts.id as effort_id,
+                           first_name,
+                           last_name,
+                           bib_number,
+                           projected_time,
+                           completed,
                            stopped,
                            short_name as event_short_name
       from efforts

--- a/spec/models/projected_arrivals_at_split_spec.rb
+++ b/spec/models/projected_arrivals_at_split_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe ProjectedArrivalsAtSplit do
+  describe "name display methods" do
+    subject do
+      described_class.new(
+        effort_id: 1,
+        first_name: "Joan",
+        last_name: "Smith",
+        bib_number: 42,
+        projected_time: Time.current,
+        completed: false,
+        stopped: false,
+        event_short_name: "100k",
+      )
+    end
+
+    describe "#full_name" do
+      it { expect(subject.full_name).to eq("Joan Smith") }
+    end
+
+    # The privacy-bypass convention used elsewhere in the app (PersonalInfo,
+    # FinishLineHelper) calls *_non_obscured methods to make it explicit that
+    # we're rendering the underlying name regardless of obscure-name
+    # preferences. The query result has no link to a Person, so these are
+    # straight aliases.
+    describe "#display_full_name_non_obscured" do
+      it { expect(subject.display_full_name_non_obscured).to eq("Joan Smith") }
+    end
+
+    describe "#display_first_name_non_obscured" do
+      it { expect(subject.display_first_name_non_obscured).to eq("Joan") }
+    end
+
+    describe "#display_last_name_non_obscured" do
+      it { expect(subject.display_last_name_non_obscured).to eq("Smith") }
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Visiting the Finish Line page on any event group with arrivals raises:

```
NoMethodError - undefined method 'display_full_name_non_obscured' for an instance of ProjectedArrivalsAtSplit
  app/helpers/finish_line_helper.rb:14
  app/views/event_groups/_effort_button_card.html.erb:14
  app/views/event_groups/finish_line.html.erb:42 (or :44)
```

## Root cause

Commit `047f49436` ("Apply privacy-method conventions across all name-rendering views") changed `FinishLineHelper#bib_effort_name_and_event_name` from:

```diff
- bib_and_name = "##{effort.bib_number} #{effort.full_name}"
+ bib_and_name = "##{effort.bib_number} #{effort.display_full_name_non_obscured}"
```

That helper is fed by two distinct callers passing two different types:

| Caller | Argument type | `display_full_name_non_obscured` available? |
|---|---|---|
| `_finish_line_effort.html.erb` | `EffortRow` → `Effort` (includes `PersonalInfo`) | yes |
| `_effort_button_card.html.erb` | `ProjectedArrivalsAtSplit` (custom `ApplicationQuery` row) | **no** |

The helper change was applied without a regression test that exercised the second path, so the bug landed silently and only fires when the page is visited with non-empty arrivals.

## Fix — Option 2 (per discussion)

Define the privacy-bypass methods explicitly on `ProjectedArrivalsAtSplit` so any caller using the `_non_obscured` convention works on either type. The query result has no link to a `Person`, so obscure-name preferences aren't reachable here — straight aliases over `first_name` / `last_name` / `full_name`. Picked over Option 1 (revert the helper to `full_name`) because it preserves the explicit privacy-bypass naming convention everywhere it's now used.

```ruby
alias display_full_name_non_obscured full_name
alias_attribute :display_first_name_non_obscured, :first_name
alias_attribute :display_last_name_non_obscured, :last_name
```

## Test plan

- [x] New `spec/models/projected_arrivals_at_split_spec.rb` with 4 examples covering `full_name` plus the three `*_non_obscured` aliases.
- [x] Rubocop clean.
- [ ] Verify in dev: visit `/event_groups/<hardrock_2016_id>/finish_line` and confirm arrivals render without error.

## Why this is its own PR

Discovered during testing of #2000 (birthday display refactor). It's a pre-existing bug on master, completely independent of the birthday work, and #2000 can't be properly tested in dev until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)