### PR TITLE
Strip whitespace from Runsignup question responses

### DIFF
--- a/lib/connectors/runsignup/fetch_event_participants.rb
+++ b/lib/connectors/runsignup/fetch_event_participants.rb
@@ -95,8 +95,8 @@ module Connectors
           response_obj = responses_by_id[mapping["source_question_id"]]
           next if response_obj.blank?
 
-          raw_value = response_obj["response"].presence ||
-                      Array(response_obj["responses"]).compact_blank.join(", ").presence
+          raw_value = (response_obj["response"].presence ||
+                       Array(response_obj["responses"]).compact_blank.join(", ").presence)&.strip
           next if raw_value.blank?
           next if mapping["suppress_when"].present? && raw_value == mapping["suppress_when"]
 

--- a/spec/lib/connectors/runsignup/fetch_event_participants_spec.rb
+++ b/spec/lib/connectors/runsignup/fetch_event_participants_spec.rb
@@ -410,6 +410,34 @@ RSpec.describe ::Connectors::Runsignup::FetchEventParticipants do
           expect(participant.comments).to be_nil
         end
       end
+
+      context "when responses have leading or trailing whitespace" do
+        let(:page_1_body) do
+          {
+            participants: [{
+              user: { first_name: "Risa", last_name: "K", dob: "1980-01-01", gender: "F",
+                      address: { city: "Boulder", state: "CO", country_code: "US" } },
+              bib_num: 7,
+              question_responses: [
+                { question_id: 100, question_text: "Emergency Contact Name", response: "  Pat Smith  " },
+                { question_id: 200, question_text: "Is this your first attempt?", response: " Yes " },
+                { question_id: 201, question_text: "Bib Name", response: "Risa " },
+                { question_id: 202, question_text: "Fun fact", response: " This is my first time! (she/her)" },
+              ],
+            }],
+          }.to_json
+        end
+
+        it "strips each response value before concatenating into comments" do
+          participant = subject.perform.first
+          expect(participant.comments).to eq("First Attempt, Risa, This is my first time! (she/her)")
+        end
+
+        it "strips dedicated-column values too" do
+          participant = subject.perform.first
+          expect(participant.emergency_contact).to eq("Pat Smith")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Small follow-up to #1998 plumbing.

## Problem

Participants sometimes enter trailing whitespace into Runsignup question fields. Real example from the quad-rock-2026 sync: bib-name response was `"Risa "`, fun-fact was `" This is my first time! (she/her)"`. The comments concatenation produced:

```
Risa , This is my first time! (she/her)
```

Comma butted against the trailing space, leading space at the start of the next part.

## Fix

`String#strip` raw_value once at extraction in `attributes_from_field_mappings`, so both comments concatenation and dedicated-column writes (`emergency_contact`, `emergency_phone`) get clean values. `value_when_present` strings are already configured cleanly via the mapping, so no change there.

## Test plan

- [x] New spec context covering whitespace on multiple destinations.
- [x] Existing 8 examples in `fetch_event_participants_spec` still green; total 10 examples pass.
- [x] Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)