### PR TITLE
Run external-service entrant sync async via ImportJob

### DIFF
--- a/app/controllers/events/connectors/services_controller.rb
+++ b/app/controllers/events/connectors/services_controller.rb
@@ -1,21 +1,27 @@
 module Events
   class Connectors::ServicesController < ::Connectors::ServicesController
-
     # GET /events/1/connector_services/:service_identifier/preview_sync
     def preview_sync
-      preview_presenter = ::EventSyncPreviewPresenter.new(@connectable, view_context, previewer: event_syncing_interactor)
+      preview_presenter = ::EventSyncPreviewPresenter.new(@connectable, view_context,
+                                                          previewer: event_syncing_interactor)
       render :preview_sync, locals: { event: @connectable, presenter: preview_presenter }
     end
 
     # POST /events/1/connector_services/:service_identifier/sync
     def sync
-      response = event_syncing_interactor.perform!(@connectable, current_user)
+      import_job = ImportJob.create!(
+        parent: @connectable,
+        user: current_user,
+        format: service_identifier,
+        status: :waiting,
+      )
+      ::SyncEntrantsJob.perform_later(import_job.id)
 
       render :sync_entrants, locals: {
         event: @connectable,
         service: @service,
         view_context: view_context,
-        interactor_response: response,
+        import_job: import_job,
       }
     end
 

--- a/app/jobs/sync_entrants_job.rb
+++ b/app/jobs/sync_entrants_job.rb
@@ -1,0 +1,10 @@
+class SyncEntrantsJob < ApplicationJob
+  queue_as :default
+
+  def perform(import_job_id)
+    import_job = ImportJob.find(import_job_id)
+    set_current_user(current_user: import_job.user)
+
+    ::SyncEntrantsRunner.run!(import_job)
+  end
+end

--- a/app/models/import_job.rb
+++ b/app/models/import_job.rb
@@ -22,19 +22,30 @@ class ImportJob < ApplicationRecord
     failed: 5
   }
 
-  validates_presence_of :parent_type, :parent_id, :format
+  validates :parent_type, :format, presence: true
+  # File-attachment validations only apply when files are actually attached.
+  # Sync-from-external-service ImportJobs (where format is a Connectors::Service
+  # identifier) carry no files; only file-import ImportJobs do.
   validates :files,
             content_type: { in: %w[text/csv text/plain], message: "must be a CSV file" },
-            size: { less_than: 1.megabyte, message: "must be less than 1 MB" }
+            size: { less_than: 1.megabyte, message: "must be less than 1 MB" },
+            if: -> { files.attached? }
 
   alias_attribute :owner_id, :user_id
+
+  # External-service sync ImportJobs additionally broadcast their status to a
+  # sync-specific target so the connection management page can render live
+  # progress alongside (or instead of) the import_jobs index row.
+  after_update_commit :broadcast_sync_status, if: :external_service_sync?
 
   def parent_name
     parent.name
   end
 
   def parent_path
-    return unless parent.present?
+    return if parent.blank?
+
+    return sync_parent_path if external_service_sync?
 
     case parent_type
     when "Organization"
@@ -50,8 +61,12 @@ class ImportJob < ApplicationRecord
         ::Rails.application.routes.url_helpers.entrants_event_group_path(parent.event_group)
       end
     else
-      raise RuntimeError, "Unknown parent type #{parent_type} for import job #{id}"
+      raise "Unknown parent type #{parent_type} for import job #{id}"
     end
+  end
+
+  def external_service_sync?
+    ::Connectors::Service::IDENTIFIERS.include?(format)
   end
 
   def parsed_errors
@@ -66,5 +81,21 @@ class ImportJob < ApplicationRecord
 
   def start!
     update(started_at: ::Time.current)
+  end
+
+  private
+
+  def sync_parent_path
+    event_group = parent_type == "EventGroup" ? parent : parent.event_group
+    ::Rails.application.routes.url_helpers.event_group_connect_service_path(event_group, format)
+  end
+
+  def broadcast_sync_status
+    broadcast_replace_to(
+      user,
+      target: ActionView::RecordIdentifier.dom_id(self, :sync_status),
+      partial: "events/connectors/services/sync_status",
+      locals: { import_job: self },
+    )
   end
 end

--- a/app/services/sync_entrants_runner.rb
+++ b/app/services/sync_entrants_runner.rb
@@ -1,0 +1,59 @@
+# Drives an external-service entrant sync against an ImportJob row.
+# Updates status as it progresses so the user's broadcast subscription
+# (broadcasts_to :user on ImportJob) renders live status changes.
+class SyncEntrantsRunner
+  def self.run!(import_job)
+    new(import_job).run!
+  end
+
+  def initialize(import_job)
+    @import_job = import_job
+  end
+
+  def run!
+    import_job.start!
+    import_job.update(status: :loading)
+
+    interactor = ::Connectors::Service::SYNCING_INTERACTORS[import_job.format]
+    raise UnknownServiceError, "No syncing interactor for #{import_job.format.inspect}" unless interactor
+
+    response = interactor.perform!(import_job.parent, import_job.user)
+    apply_response(response)
+  rescue StandardError => e
+    apply_failure(e)
+    raise
+  ensure
+    import_job.set_elapsed_time! if import_job.persisted?
+  end
+
+  class UnknownServiceError < StandardError; end
+
+  private
+
+  attr_reader :import_job
+
+  def apply_response(response)
+    created = (response.resources[:created_efforts] || []).size
+    updated = (response.resources[:updated_efforts] || []).size
+    ignored = (response.resources[:ignored_efforts] || []).size
+    deleted = (response.resources[:deleted_efforts] || []).size
+    failed = response.errors.size
+
+    import_job.update(
+      status: response.successful? ? :finished : :failed,
+      row_count: created + updated + ignored + deleted + failed,
+      # Successes include deletions (intentional removal of withdrawn entrants).
+      succeeded_count: created + updated + deleted,
+      ignored_count: ignored,
+      failed_count: failed,
+      error_message: response.errors.any? ? response.errors.to_json : nil,
+    )
+  end
+
+  def apply_failure(exception)
+    import_job.update(
+      status: :failed,
+      error_message: [{ title: exception.class.name, detail: { messages: [exception.message] } }].to_json,
+    )
+  end
+end

--- a/app/views/event_groups/connect_service/show.html.erb
+++ b/app/views/event_groups/connect_service/show.html.erb
@@ -4,6 +4,8 @@
   <% "OpenSplitTime: Event Group - Connect Service - #{connect_service_presenter.service_name} - #{event_group_setup_presenter.event_group.name}" %>
 <% end %>
 
+<%= turbo_stream_from current_user %>
+
 <%= render "shared/mode_widget", event_group: event_group_setup_presenter.event_group %>
 <%= render "event_groups/setup_header",
            presenter: event_group_setup_presenter,

--- a/app/views/events/connectors/services/_sync_efforts_card.html.erb
+++ b/app/views/events/connectors/services/_sync_efforts_card.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (presenter:, event:, interactor_response: nil) -%>
+<%# locals: (presenter:, event:, import_job: nil) -%>
 
 <%= content_tag(:div, id: dom_id(event, :sync_efforts_card)) do %>
   <div class="card my-3">
@@ -8,7 +8,9 @@
           <h4 class="mt-1"><%= event.name %></h4>
         </div>
         <div class="col" id="<%= dom_id(event, :sync_efforts_response) %>">
-          <%= render partial: "events/connectors/services/sync_efforts_response", locals: { interactor_response: interactor_response } %>
+          <% if import_job %>
+            <%= render partial: "events/connectors/services/sync_status", locals: { import_job: import_job } %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/events/connectors/services/_sync_status.html.erb
+++ b/app/views/events/connectors/services/_sync_status.html.erb
@@ -1,0 +1,21 @@
+<%# locals: (import_job:) -%>
+
+<div id="<%= dom_id(import_job, :sync_status) %>" class="text-end">
+  <% if import_job.failed? %>
+    <%= fa_icon("circle-xmark", type: :solid, class: "text-danger", text: "Sync failed") %>
+    <% import_job.parsed_errors.each do |error| %>
+      <% if error.is_a?(Hash) %>
+        <div class="small text-danger"><%= [error["title"], error.dig("detail", "messages")&.join("; ")].compact.join(": ") %></div>
+      <% else %>
+        <div class="small text-danger"><%= error %></div>
+      <% end %>
+    <% end %>
+  <% elsif import_job.finished? %>
+    <%= fa_icon("circle-check", type: :regular, class: "text-success", text: "Sync complete") %>
+    <div class="small text-muted">
+      <%= "#{import_job.succeeded_count} synced, #{import_job.ignored_count} unchanged, #{import_job.failed_count} failed" %>
+    </div>
+  <% else %>
+    <%= fa_icon("spinner", class: "fa-spin", text: "Sync #{import_job.status}…") %>
+  <% end %>
+</div>

--- a/app/views/events/connectors/services/sync_entrants.turbo_stream.erb
+++ b/app/views/events/connectors/services/sync_entrants.turbo_stream.erb
@@ -1,9 +1,9 @@
-<%# locals: (event:, service:, view_context:, interactor_response:) %>
+<%# locals: (event:, service:, view_context:, import_job:) %>
 
 <%= turbo_stream.replace(dom_id(event, :sync_efforts_card),
                          partial: "events/connectors/services/sync_efforts_card",
                          locals: {
                            presenter: ConnectServicePresenter.new(event.event_group, service, view_context),
                            event: event,
-                           interactor_response: interactor_response,
-                         } ) %>
+                           import_job: import_job,
+                         }) %>

--- a/spec/jobs/sync_entrants_job_spec.rb
+++ b/spec/jobs/sync_entrants_job_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe SyncEntrantsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:event) { events(:rufa_2017_24h) }
+  let(:user) { users(:admin_user) }
+  let(:import_job) do
+    ImportJob.create!(parent: event, user: user, format: "runsignup", status: :waiting)
+  end
+
+  it "queues the job" do
+    expect { described_class.perform_later(import_job.id) }
+      .to have_enqueued_job(described_class).with(import_job.id)
+  end
+
+  it "delegates to SyncEntrantsRunner" do
+    expect(SyncEntrantsRunner).to receive(:run!).with(an_instance_of(ImportJob))
+    described_class.perform_now(import_job.id)
+  end
+end

--- a/spec/models/import_job_spec.rb
+++ b/spec/models/import_job_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe ImportJob, type: :model do
   subject { build(:import_job, parent: parent, format: format, started_at: started_at) }
+
   let(:parent) { lotteries(:lottery_without_tickets) }
   let(:format) { :lottery_entrants }
   let(:started_at) { nil }
@@ -9,8 +10,48 @@ RSpec.describe ImportJob, type: :model do
 
   before { travel_to test_start_time }
 
+  describe "#external_service_sync?" do
+    context "when format is a Connectors::Service identifier" do
+      let(:parent) { events(:hardrock_2016) }
+      let(:format) { "runsignup" }
+      it { expect(subject).to be_external_service_sync }
+    end
+
+    context "when format is a file-import format" do
+      it { expect(subject).not_to be_external_service_sync }
+    end
+  end
+
+  describe "validations" do
+    context "without files attached, for an external-service sync" do
+      subject { build(:import_job, parent: events(:hardrock_2016), format: "runsignup") }
+
+      it "is valid (file content_type / size validations don't fire)" do
+        expect(subject).to be_valid
+      end
+    end
+  end
+
   describe "#parent_path" do
     let(:result) { subject.parent_path }
+
+    context "when parent is an event and format is a sync service identifier" do
+      let(:parent) { events(:hardrock_2016) }
+      let(:format) { "runsignup" }
+
+      it "returns the connection management page for that event group + service" do
+        expect(result).to eq("/event_groups/hardrock-2016/connect_service/runsignup")
+      end
+    end
+
+    context "when parent is an event group and format is a sync service identifier" do
+      let(:parent) { event_groups(:hardrock_2016) }
+      let(:format) { "runsignup" }
+
+      it "returns the connection management page for that event group + service" do
+        expect(result).to eq("/event_groups/hardrock-2016/connect_service/runsignup")
+      end
+    end
 
     context "when parent is an organization" do
       let(:parent) { organizations(:hardrock) }
@@ -45,7 +86,6 @@ RSpec.describe ImportJob, type: :model do
         it "returns a course setup path" do
           expect(result).to eq("/event_groups/hardrock-2016/events/hardrock-2016/setup_course")
         end
-
       end
 
       context "when the format is not course_group_splits" do
@@ -67,6 +107,7 @@ RSpec.describe ImportJob, type: :model do
 
       context "when started at time has been set" do
         before { subject.assign_attributes(started_at: 30.seconds.ago) }
+
         it "does not set elapsed time" do
           subject.set_elapsed_time!
           expect(subject.elapsed_time).to be_nil
@@ -76,6 +117,7 @@ RSpec.describe ImportJob, type: :model do
 
     context "when the record has been persisted" do
       before { subject.save! }
+
       context "when started at time has not been set" do
         it "does not set elapsed time" do
           subject.set_elapsed_time!
@@ -85,6 +127,7 @@ RSpec.describe ImportJob, type: :model do
 
       context "when started at time has been set" do
         before { subject.update(started_at: 30.seconds.ago) }
+
         it "sets elapsed time to the amount of time that has passed" do
           subject.set_elapsed_time!
           expect(subject.elapsed_time).to eq(30)

--- a/spec/requests/events/connectors/services_controller_sync_spec.rb
+++ b/spec/requests/events/connectors/services_controller_sync_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "POST /events/:event_id/connector_services/:service_identifier/sync" do
+  include ActiveJob::TestHelper
+  include Warden::Test::Helpers
+
+  let(:user) { users(:admin_user) }
+  let(:turbo_headers) { { "Accept" => "text/vnd.turbo-stream.html" } }
+  let(:event) { events(:rufa_2017_24h) }
+
+  before do
+    login_as user, scope: :user
+    # Avoid hitting Runsignup's real API while rendering the sync_efforts_card
+    # — the presenter is instantiated inside the controller-rendered view so
+    # per-instance stubbing isn't practical. The post-sync render only needs
+    # the ImportJob status to assemble the card; real source data is irrelevant.
+    allow_any_instance_of(ConnectServicePresenter).to receive(:all_sources).and_return([]) # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(ConnectServicePresenter).to receive(:sources_available?).and_return(true) # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(ConnectServicePresenter).to receive(:successful_connection?).and_return(true) # rubocop:disable RSpec/AnyInstance
+  end
+
+  after { Warden.test_reset! }
+
+  it "creates an ImportJob in :waiting status with the service identifier as format" do
+    expect { post sync_event_connector_service_path(event, "runsignup"), headers: turbo_headers }
+      .to change(ImportJob, :count).by(1)
+
+    job = ImportJob.last
+    expect(job.parent).to eq(event)
+    expect(job.user).to eq(user)
+    expect(job.format).to eq("runsignup")
+    expect(job).to be_waiting
+  end
+
+  it "enqueues a SyncEntrantsJob carrying the new ImportJob's id" do
+    expect { post sync_event_connector_service_path(event, "runsignup"), headers: turbo_headers }
+      .to have_enqueued_job(SyncEntrantsJob).with(an_instance_of(Integer))
+  end
+
+  it "renders the sync_entrants turbo_stream with the new ImportJob in the card" do
+    post sync_event_connector_service_path(event, "runsignup"), headers: turbo_headers
+
+    expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+    expect(response.body).to include("Sync waiting")
+  end
+end

--- a/spec/services/sync_entrants_runner_spec.rb
+++ b/spec/services/sync_entrants_runner_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe SyncEntrantsRunner do
+  subject(:run!) { described_class.run!(import_job) }
+
+  let(:event) { events(:rufa_2017_24h) }
+  let(:user) { users(:admin_user) }
+  let(:import_job) do
+    ImportJob.create!(parent: event, user: user, format: "runsignup", status: :waiting)
+  end
+
+  let(:successful_response) do
+    Interactors::Response.new(
+      [],
+      "Sync completed successfully",
+      created_efforts: [Object.new, Object.new],
+      updated_efforts: [Object.new],
+      ignored_efforts: [Object.new, Object.new, Object.new],
+      deleted_efforts: [Object.new],
+    )
+  end
+
+  before do
+    allow(Interactors::SyncRunsignupParticipants).to receive(:perform!).and_return(successful_response)
+  end
+
+  it "transitions the ImportJob through loading and into finished" do
+    run!
+    expect(import_job.reload).to be_finished
+  end
+
+  it "records counts on the ImportJob" do
+    run!
+    import_job.reload
+    expect(import_job.row_count).to eq(7) # 2 created + 1 updated + 3 ignored + 1 deleted
+    expect(import_job.succeeded_count).to eq(4) # created + updated + deleted
+    expect(import_job.ignored_count).to eq(3)
+    expect(import_job.failed_count).to eq(0)
+  end
+
+  it "sets started_at and elapsed_time" do
+    run!
+    import_job.reload
+    expect(import_job.started_at).to be_present
+    expect(import_job.elapsed_time).to be >= 0
+  end
+
+  context "when the interactor returns errors" do
+    let(:unsuccessful_response) do
+      Interactors::Response.new(
+        [{ title: "boom", detail: { messages: ["nope"] } }],
+        "Sync completed with errors",
+        created_efforts: [],
+        updated_efforts: [],
+        ignored_efforts: [],
+        deleted_efforts: [],
+      )
+    end
+
+    before { allow(Interactors::SyncRunsignupParticipants).to receive(:perform!).and_return(unsuccessful_response) }
+
+    it "marks the ImportJob failed and persists the error_message" do
+      run!
+      import_job.reload
+      expect(import_job).to be_failed
+      expect(JSON.parse(import_job.error_message).first["title"]).to eq("boom")
+    end
+  end
+
+  context "when the interactor raises" do
+    before { allow(Interactors::SyncRunsignupParticipants).to receive(:perform!).and_raise(RuntimeError, "kaboom") }
+
+    it "marks the ImportJob failed, persists the error, and re-raises" do
+      expect { run! }.to raise_error(RuntimeError, "kaboom")
+      import_job.reload
+      expect(import_job).to be_failed
+      expect(import_job.error_message).to include("kaboom")
+    end
+  end
+
+  context "when the format does not map to a syncing interactor" do
+    let(:import_job) do
+      ImportJob.new(parent: event, user: user, format: "lottery_entrants", status: :waiting).tap do |j|
+        j.save!(validate: false)
+      end
+    end
+
+    it "raises UnknownServiceError" do
+      expect { run! }.to raise_error(SyncEntrantsRunner::UnknownServiceError)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #2004.

## Summary

The connection-management Sync button used to invoke the syncing interactor synchronously inside the request cycle. For events with 200+ efforts the request hung long enough to time out. Moved the work into Solid Queue and reused `ImportJob` for tracking + Turbo Stream live updates, per the design in #2004.

## Layered changes

### Model — `ImportJob`
- File-attachment validations now only fire when files are actually attached (`validates ..., if: -> { files.attached? }`) so sync ImportJobs without files are valid.
- New `external_service_sync?` predicate (true when `format` is a `Connectors::Service` identifier).
- `parent_path` returns the connection-management page for sync ImportJobs.
- New `broadcast_sync_status` callback (after_update_commit, sync only) that fires a `broadcast_replace_to user, target: dom_id(import_job, :sync_status)` separate from the default `broadcasts_to :user` import_jobs row replace. File-import flow unchanged.

### New service — `SyncEntrantsRunner`
Drives the existing syncing interactor (`Connectors::Service::SYNCING_INTERACTORS[format].perform!`) and updates the ImportJob through `loading → finished | failed`. Counts derived from `Interactors::Response.resources`:
- `succeeded_count` = created + updated + deleted (intentional removals are successes)
- `ignored_count` = ignored
- `failed_count` = errors
- `row_count` = total
- `error_message` = JSON of `response.errors` when present

Unexpected exceptions are captured into `error_message` and re-raised so Solid Queue retries appropriately.

### New job — `SyncEntrantsJob`
ApplicationJob that loads the ImportJob, sets `Current.user`, and delegates to `SyncEntrantsRunner`.

### Controller — `Events::Connectors::ServicesController#sync`
Creates an ImportJob in `:waiting` status, enqueues `SyncEntrantsJob`, renders the existing `sync_entrants` turbo_stream — but with the ImportJob instead of an `Interactors::Response`. Returns immediately.

### View
- New `_sync_status.html.erb` partial replaces the old `_sync_efforts_response` block in the card header.
  - Spinner + "Sync waiting/loading…" during in-flight.
  - Green check + counts on finished.
  - Red X + per-error detail on failed.
- `connect_service/show.html.erb` adds `<%= turbo_stream_from current_user %>` so the model's `broadcast_replace_to` lands in the partial, replacing it live as `status` transitions.

## File-import flow is unaffected

- `validates :files, ..., if: files.attached?` — strict validations still apply when a file is attached.
- `broadcasts_to :user, inserts_by: :prepend` is unchanged. The import_jobs index row still updates on file imports.
- `parent_path` only diverts when the format is a `Connectors::Service` identifier; file-import formats hit the existing case statement unchanged.

## Test plan

- [x] `spec/models/import_job_spec.rb` — new contexts for `external_service_sync?`, conditional file validations, sync-format `parent_path`. Pre-existing tests still pass (16 examples total).
- [x] `spec/services/sync_entrants_runner_spec.rb` — 6 examples: success path with all four resource buckets, failure path on response errors, exception path, unknown service format.
- [x] `spec/jobs/sync_entrants_job_spec.rb` — queues + delegates to runner.
- [x] `spec/requests/events/connectors/services_controller_sync_spec.rb` — POST creates ImportJob, enqueues job, renders turbo_stream with sync_status partial.
- [x] Rubocop + erb_lint clean.
- [ ] Manual end-to-end against quad-rock-2026: click Sync, verify the spinner shows immediately, the page updates live as the job runs, and the final counts appear.

## Out of scope

- Optimizing the per-effort save cost (validation overhead, PaperTrail writes). The async move is the user-facing fix.
- Cancelling an in-flight sync.
- Concurrent sync prevention.
- Renaming `ImportJob` (per #2004 discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)