### PR TITLE
Add Connectors::Runsignup::FetchRaceQuestions

### DIFF
--- a/lib/connectors/runsignup/client.rb
+++ b/lib/connectors/runsignup/client.rb
@@ -13,8 +13,9 @@ module Connectors
         verify_credentials_present!
       end
 
-      def get_race(race_id)
-        self.request = Connectors::Runsignup::Request::GetRace.new(race_id: race_id)
+      def get_race(race_id, include_questions: false)
+        self.request = Connectors::Runsignup::Request::GetRace.new(race_id: race_id,
+                                                                   include_questions: include_questions)
         make_request
       end
 

--- a/lib/connectors/runsignup/fetch_race_questions.rb
+++ b/lib/connectors/runsignup/fetch_race_questions.rb
@@ -1,0 +1,55 @@
+module Connectors
+  module Runsignup
+    # Returns the catalog of distinct registration questions configured on a
+    # Runsignup race via the dedicated /Rest/race/{race_id}?include_questions=T
+    # endpoint, which gives us the question definitions directly without
+    # paginating through participants.
+    #
+    # Cached briefly because the catalog is stable across page loads and the
+    # field-mapping UI re-fetches on every render of the connection page.
+    class FetchRaceQuestions
+      CACHE_TTL = 5.minutes
+
+      # @param [String, Integer] race_id
+      # @param [User] user
+      # @param [::Connectors::Runsignup::Client, nil] client
+      # @return [Array<::Connectors::Runsignup::Models::Question>]
+      def self.perform(race_id:, user:, client: nil)
+        new(race_id: race_id, user: user, client: client).perform
+      end
+
+      def initialize(race_id:, user:, client: nil)
+        @race_id = race_id.to_i
+        @user = user
+        @client = client || ::Connectors::Runsignup::Client.new(user)
+      end
+
+      # @return [Array<::Connectors::Runsignup::Models::Question>]
+      def perform
+        Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) { fetch_uncached }
+      end
+
+      private
+
+      attr_reader :race_id, :user, :client
+
+      def cache_key
+        "runsignup/race/#{race_id}/questions"
+      end
+
+      def fetch_uncached
+        body = client.get_race(race_id, include_questions: true)
+        parsed = JSON.parse(body)
+        parsed = parsed.first if parsed.is_a?(Array)
+
+        questions = parsed.dig("race", "questions") || []
+        questions.map do |q|
+          ::Connectors::Runsignup::Models::Question.new(
+            q["question_id"],
+            q["question_text"].to_s.strip,
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/connectors/runsignup/models/question.rb
+++ b/lib/connectors/runsignup/models/question.rb
@@ -1,0 +1,7 @@
+module Connectors
+  module Runsignup
+    module Models
+      Question = Struct.new(:id, :text)
+    end
+  end
+end

--- a/lib/connectors/runsignup/request/get_race.rb
+++ b/lib/connectors/runsignup/request/get_race.rb
@@ -3,8 +3,10 @@ module Connectors
     module Request
       class GetRace
         # @param [String] race_id
-        def initialize(race_id:)
+        # @param [Boolean] include_questions
+        def initialize(race_id:, include_questions: false)
           @race_id = race_id
+          @include_questions = include_questions
         end
 
         attr_reader :race_id
@@ -16,7 +18,7 @@ module Connectors
 
         # @return [Hash]
         def specific_params
-          {}
+          @include_questions ? { include_questions: "T" } : {}
         end
       end
     end

--- a/spec/lib/connectors/runsignup/fetch_race_questions_spec.rb
+++ b/spec/lib/connectors/runsignup/fetch_race_questions_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe ::Connectors::Runsignup::FetchRaceQuestions do
+  subject(:result) { described_class.perform(race_id: race_id, user: user, client: client) }
+
+  let(:race_id) { 174_571 }
+  let(:client) { instance_double(::Connectors::Runsignup::Client) }
+
+  include_context "user_with_credentials"
+
+  before do
+    Rails.cache.clear
+    allow(client).to receive(:get_race).with(race_id, include_questions: true).and_return(response_body)
+  end
+
+  context "with a typical multi-question race" do
+    let(:response_body) do
+      {
+        race: {
+          race_id: race_id,
+          name: "R",
+          questions: [
+            { question_id: 100, question_text: "Emergency Contact Name", question_type_code: "T" },
+            { question_id: 200, question_text: "Bib Name", question_type_code: "T" },
+            { question_id: 300, question_text: "Fun Fact", question_type_code: "T" },
+          ],
+        },
+      }.to_json
+    end
+
+    it "returns the question definitions directly" do
+      expect(result.map(&:id)).to eq([100, 200, 300])
+      expect(result.map(&:text)).to eq(["Emergency Contact Name", "Bib Name", "Fun Fact"])
+    end
+
+    it "returns an array of Question structs" do
+      expect(result.first).to be_a(::Connectors::Runsignup::Models::Question)
+    end
+  end
+
+  context "when the race has no configured questions" do
+    let(:response_body) do
+      { race: { race_id: race_id, name: "R", questions: [] } }.to_json
+    end
+
+    it "returns an empty array" do
+      expect(result).to eq([])
+    end
+  end
+
+  context "when the race response has no questions key" do
+    let(:response_body) do
+      { race: { race_id: race_id, name: "R" } }.to_json
+    end
+
+    it "returns an empty array without raising" do
+      expect(result).to eq([])
+    end
+  end
+
+  context "when the response is wrapped in an outer array (the API sometimes returns this shape)" do
+    let(:response_body) do
+      [{ race: { race_id: race_id, questions: [{ question_id: 99, question_text: "Q" }] } }].to_json
+    end
+
+    it "unwraps and processes the first element" do
+      expect(result.map(&:id)).to eq([99])
+    end
+  end
+
+  context "when called twice with the same race_id" do
+    let(:response_body) do
+      { race: { race_id: race_id, questions: [{ question_id: 1, question_text: "X" }] } }.to_json
+    end
+
+    around do |example|
+      original_cache = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      example.run
+      Rails.cache = original_cache
+    end
+
+    it "caches the result and only hits the client once" do
+      described_class.perform(race_id: race_id, user: user, client: client)
+      described_class.perform(race_id: race_id, user: user, client: client)
+      expect(client).to have_received(:get_race).once
+    end
+  end
+
+  context "when text has trailing whitespace" do
+    let(:response_body) do
+      { race: { race_id: race_id, questions: [{ question_id: 1, question_text: "  Padded text  " }] } }.to_json
+    end
+
+    it "strips the question_text" do
+      expect(result.first.text).to eq("Padded text")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

First building block for #1998 — splitting the field-mappings UI work into a series of reviewable PRs. This one adds **only** the connector service that fetches the catalog of registration questions from a Runsignup race. No UI, no controller, no model wiring; nothing else in the app consumes it yet.

- `Connectors::Runsignup::FetchRaceQuestions(race_id, user)` → `Array<Models::Question>`
- Hits `/Rest/race/{race_id}?include_questions=T` — one API call regardless of participant count, and works on races with zero registrations.
- 5-minute `Rails.cache.fetch` TTL.
- New `Models::Question = Struct.new(:id, :text)`.
- `Request::GetRace` and `Client#get_race` gain an `include_questions: false` kwarg; default preserves existing `FetchRaceEvents` behavior.

5 files. Safe to deploy ahead of the UI work.

Relates to #1998 — the larger field-mappings UI PR (#2008) will be split into smaller building blocks; this is the first.

## Test plan

- [x] `bundle exec rspec spec/lib/connectors/runsignup/fetch_race_questions_spec.rb` — 7 examples, all green
- [x] `bundle exec rspec spec/lib/connectors/runsignup/` — 27 examples, no regressions
- [x] `rubocop` clean on touched files
- [ ] CI green
