### PR TITLE
Read field_mappings from Race-level Connection in sync

### DIFF
--- a/app/services/interactors/sync_runsignup_participants.rb
+++ b/app/services/interactors/sync_runsignup_participants.rb
@@ -69,7 +69,7 @@ module Interactors
           race_id: runsignup_race_id,
           event_id: connection.source_id,
           user: current_user,
-          field_mappings: connection.field_mappings,
+          field_mappings: field_mappings,
         )
       rescue ::Connectors::Errors::Base => e
         errors << connectors_base_error(e)
@@ -102,6 +102,11 @@ module Interactors
     def runsignup_event_connections
       @runsignup_event_connections ||=
         event.connections.from_service(:runsignup).where(source_type: "Event")
+    end
+
+    def field_mappings
+      @field_mappings ||=
+        event_group.connections.from_service(:runsignup).find_by(source_type: "Race")&.field_mappings || []
     end
 
     def runsignup_race_id

--- a/db/data/20260509033127_backfill_field_mappings_to_race_connection.rb
+++ b/db/data/20260509033127_backfill_field_mappings_to_race_connection.rb
@@ -1,0 +1,30 @@
+class BackfillFieldMappingsToRaceConnection < ActiveRecord::Migration[8.1]
+  # Per #1998 follow-up: field_mappings is now stored on the EventGroup-level
+  # Race Connection rather than the per-event Connections. Production has the
+  # canonical mapping on per-event Connections (set via console snippets while
+  # iterating on the design). Copy each EventGroup's first non-empty per-event
+  # field_mappings onto its Race Connection so the new UI / sync read path
+  # finds the data where it now expects it.
+  def up
+    Connection.where(service_identifier: "runsignup", source_type: "Race").find_each do |race_conn|
+      next if race_conn.field_mappings.present?
+
+      event_group = race_conn.destination
+      next unless event_group.is_a?(EventGroup)
+
+      first_non_empty = event_group.events.flat_map do |event|
+        event.connections.where(service_identifier: "runsignup", source_type: "Event").to_a
+      end.map(&:field_mappings).find(&:present?)
+
+      next if first_non_empty.blank?
+
+      race_conn.update_column(:field_mappings, first_non_empty)
+      say "Backfilled field_mappings onto Race Connection ##{race_conn.id} (EventGroup ##{event_group.id})"
+    end
+  end
+
+  def down
+    # No-op. Reverse direction is ambiguous (which per-event Connection(s) to
+    # populate?) and not useful — the new code reads from Race-level only.
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2025_12_29_145334)
+DataMigrate::Data.define(version: 2026_05_09_033127)

--- a/spec/services/interactors/sync_runsignup_participants_spec.rb
+++ b/spec/services/interactors/sync_runsignup_participants_spec.rb
@@ -4,13 +4,6 @@ RSpec.describe Interactors::SyncRunsignupParticipants do
   subject(:sync) { described_class.perform!(event, current_user) }
 
   let(:event_group) { event_groups(:rufa_2017) }
-  let(:event) { events(:rufa_2017_24h) }
-  let(:current_user) { users(:admin_user) }
-
-  let!(:event_connection) do
-    Connection.create!(service_identifier: :runsignup, source_type: "Event", source_id: "24", destination: event)
-  end
-
   let(:participant) do
     Connectors::Runsignup::Models::Participant.new(
       first_name: "Last",
@@ -26,7 +19,6 @@ RSpec.describe Interactors::SyncRunsignupParticipants do
       scheduled_start_time_local: event.scheduled_start_time_local,
     )
   end
-
   let!(:effort) do
     create(:effort,
            event: event,
@@ -35,8 +27,11 @@ RSpec.describe Interactors::SyncRunsignupParticipants do
            birthdate: participant.birthdate,
            bib_number: ost_bib_number,)
   end
+  let(:event) { events(:rufa_2017_24h) }
+  let(:current_user) { users(:admin_user) }
 
   before do
+    Connection.create!(service_identifier: :runsignup, source_type: "Event", source_id: "24", destination: event)
     Connection.create!(service_identifier: :runsignup, source_type: "Race", source_id: "123", destination: event_group)
     allow(Connectors::Runsignup::FetchEventParticipants).to receive(:perform).and_return([participant])
   end
@@ -95,11 +90,13 @@ RSpec.describe Interactors::SyncRunsignupParticipants do
     end
 
     before do
-      event_connection.update!(field_mappings: field_mappings)
+      # Mapping lives on the Race-level Connection (the canonical store).
+      race_conn = event_group.connections.from_service(:runsignup).find_by(source_type: "Race")
+      race_conn.update!(field_mappings: field_mappings)
       allow(Connectors::Runsignup::FetchEventParticipants).to receive(:perform).and_return([returned_participant])
     end
 
-    it "passes the per-event-connection field_mappings into FetchEventParticipants" do
+    it "passes the Race-level field_mappings into FetchEventParticipants" do
       sync
       expect(Connectors::Runsignup::FetchEventParticipants).to have_received(:perform).with(
         hash_including(field_mappings: field_mappings),


### PR DESCRIPTION
## Summary

Second building block for #1998. Moves the canonical storage location of `field_mappings` from per-event Connections to the EventGroup-level Race Connection.

- **Why**: Runsignup configures registration questions at the race level (one set per race, optional per-event skips). Per-race-shared mapping is the natural model. The Race Connection is also the only Connection guaranteed to exist as soon as a user enters a race ID, so the upcoming UI can write to it before any per-event Connection toggles are flipped on.
- `SyncRunsignupParticipants` now reads `field_mappings` once from the Race-level Connection and forwards the same value to every per-event `FetchEventParticipants` call.
- Spec coverage adjusted: `field_mappings` flow-through test now configures the mapping on the Race Connection, plus a new assertion that `FetchEventParticipants` is called with the Race-level mapping.
- Data migration (`db/data/20260509033127_backfill_field_mappings_to_race_connection.rb`) copies any existing per-event `field_mappings` onto the Race Connection. Idempotent — skips Race Connections that already have a mapping. Production currently has the canonical mapping on per-event Connections (set via console snippets while iterating on the design); this lands the data where the new code reads from.

The web UI to configure mappings is the next building block.

Relates to #1998. Builds on #2009.

## Test plan

- [x] `bundle exec rspec spec/services/interactors/sync_runsignup_participants_spec.rb` — 5 examples, all green
- [x] Data migration ran clean in dev and test (`rails data:migrate` / `RAILS_ENV=test rails data:migrate`)
- [x] `rubocop` clean on touched files
- [x] CI green
- [ ] After deploy: confirm production sync continues to write `comments` / `emergency_contact` / `emergency_phone` correctly on the next quad-rock-2026 sync (Race Connection now carries the mapping post-backfill).
