### PR TITLE
Add EventGroups::FieldMappingsController PATCH endpoint

### DIFF
--- a/app/controllers/event_groups/field_mappings_controller.rb
+++ b/app/controllers/event_groups/field_mappings_controller.rb
@@ -1,0 +1,63 @@
+module EventGroups
+  # Persists Runsignup-question → Effort-attribute mappings configured via the
+  # connection management UI. The mapping is stored on the EventGroup-level
+  # Race Connection (questions are race-level on Runsignup, so one mapping per
+  # race; the Race Connection always exists once the user has entered a race
+  # ID, even before they've toggled on the per-event connection switches).
+  class FieldMappingsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_event_group
+    before_action :set_service
+
+    PERMITTED_DESTINATIONS = %w[comments emergency_contact emergency_phone].freeze
+
+    def update
+      authorize @event_group, :setup?
+
+      conn = race_connection
+      raise ActiveRecord::RecordNotFound if conn.blank?
+
+      conn.update!(field_mappings: normalized_mappings)
+
+      redirect_to event_group_connect_service_path(@event_group, @service.identifier)
+    end
+
+    private
+
+    def set_event_group
+      @event_group = EventGroup.friendly.find(params[:event_group_id])
+    end
+
+    def set_service
+      @service = ::Connectors::Service::BY_IDENTIFIER[params[:connect_service_id]]
+      raise ActiveRecord::RecordNotFound if @service.blank?
+    end
+
+    def race_connection
+      @event_group.connections.from_service(@service.identifier)
+                  .find_by(source_type: @service.resource_map[EventGroup])
+    end
+
+    def normalized_mappings
+      raw = params.fetch(:field_mappings, {})
+      rows = raw.is_a?(ActionController::Parameters) ? raw.to_unsafe_h.values : raw
+
+      rows.filter_map do |row|
+        row = row.to_unsafe_h if row.respond_to?(:to_unsafe_h)
+        destination = row["destination"].to_s.strip
+        next if destination.blank?
+        next unless PERMITTED_DESTINATIONS.include?(destination)
+
+        question_id = Integer(row["source_question_id"], exception: false)
+        next if question_id.nil?
+
+        mapping = { "source_question_id" => question_id, "destination" => destination }
+        suppress_when = row["suppress_when"].to_s.strip
+        value_when_present = row["value_when_present"].to_s.strip
+        mapping["suppress_when"] = suppress_when if suppress_when.present?
+        mapping["value_when_present"] = value_when_present if value_when_present.present?
+        mapping
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,7 +115,9 @@ Rails.application.routes.draw do
   resources :duplicate_event_groups, only: [:new, :create]
 
   resources :event_groups, only: [:index, :show] do
-    resources :connect_service, only: [:show], module: "event_groups"
+    resources :connect_service, only: [:show], module: "event_groups" do
+      resource :field_mappings, only: [:update]
+    end
     resources :connections, only: [:index, :new, :create, :destroy], module: "event_groups"
 
     resources :events, except: [:index, :show] do

--- a/spec/requests/event_groups/field_mappings_controller_spec.rb
+++ b/spec/requests/event_groups/field_mappings_controller_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe "PATCH /event_groups/:event_group_id/connect_service/:connect_service_id/field_mappings" do
+  include Warden::Test::Helpers
+
+  let(:user) { users(:admin_user) }
+  let(:valid_params) do
+    {
+      field_mappings: {
+        "0" => { source_question_id: "100", destination: "emergency_contact" },
+        "1" => { source_question_id: "200", destination: "comments",
+                 suppress_when: "No", value_when_present: "First Attempt" },
+        "2" => { source_question_id: "300", destination: "comments" },
+        "3" => { source_question_id: "999", destination: "" }, # don't sync — should be dropped
+      },
+    }
+  end
+  let(:event_group) { event_groups(:rufa_2017) }
+  let!(:race_connection) do
+    Connection.create!(service_identifier: :runsignup, source_type: "Race", source_id: "174571", destination: event_group)
+  end
+
+  before { login_as user, scope: :user }
+  after { Warden.test_reset! }
+
+  it "writes the normalized mapping to the EventGroup-level Race Connection" do
+    patch event_group_connect_service_field_mappings_path(event_group, "runsignup"), params: valid_params
+
+    race_connection.reload
+
+    expected = [
+      { "source_question_id" => 100, "destination" => "emergency_contact" },
+      { "source_question_id" => 200, "destination" => "comments",
+        "suppress_when" => "No", "value_when_present" => "First Attempt" },
+      { "source_question_id" => 300, "destination" => "comments" },
+    ]
+    expect(race_connection.field_mappings).to eq(expected)
+  end
+
+  it "does not require any per-event Connection to exist" do
+    event_level_count = event_group.events.flat_map { |e| e.connections.from_service(:runsignup).to_a }.size
+    expect(event_level_count).to eq(0)
+
+    expect do
+      patch event_group_connect_service_field_mappings_path(event_group, "runsignup"), params: valid_params
+    end.not_to raise_error
+
+    expect(race_connection.reload.field_mappings).not_to be_empty
+  end
+
+  it "coerces source_question_id strings into integers" do
+    patch event_group_connect_service_field_mappings_path(event_group, "runsignup"), params: valid_params
+
+    race_connection.reload
+    expect(race_connection.field_mappings.first["source_question_id"]).to eq(100)
+  end
+
+  it "drops rows whose destination is blank or unknown" do
+    params = {
+      field_mappings: {
+        "0" => { source_question_id: "100", destination: "comments" },
+        "1" => { source_question_id: "200", destination: "" },
+        "2" => { source_question_id: "300", destination: "not_a_real_column" },
+      },
+    }
+    patch event_group_connect_service_field_mappings_path(event_group, "runsignup"), params: params
+
+    race_connection.reload
+    expect(race_connection.field_mappings.size).to eq(1)
+    expect(race_connection.field_mappings.first["source_question_id"]).to eq(100)
+  end
+
+  it "omits empty suppress_when / value_when_present from the persisted mapping" do
+    params = {
+      field_mappings: {
+        "0" => { source_question_id: "100", destination: "comments",
+                 suppress_when: "", value_when_present: "" },
+      },
+    }
+    patch event_group_connect_service_field_mappings_path(event_group, "runsignup"), params: params
+
+    race_connection.reload
+    expect(race_connection.field_mappings.first.keys).to contain_exactly("source_question_id", "destination")
+  end
+
+  it "redirects back to the connect_service page on success" do
+    patch event_group_connect_service_field_mappings_path(event_group, "runsignup"), params: valid_params
+
+    expect(response).to redirect_to(event_group_connect_service_path(event_group, "runsignup"))
+  end
+
+  it "raises RecordNotFound when no Race Connection exists for the EventGroup" do
+    race_connection.destroy!
+
+    expect do
+      patch event_group_connect_service_field_mappings_path(event_group, "runsignup"), params: valid_params
+    end.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "raises RecordNotFound for an unknown service_identifier" do
+    expect do
+      patch event_group_connect_service_field_mappings_path(event_group, "bogus"), params: valid_params
+    end.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end


### PR DESCRIPTION
## Summary

Third building block for #1998. Adds the server-side PATCH endpoint that persists Runsignup-question → Effort-attribute mappings to the EventGroup-level Race Connection.

- **Route**: `PATCH /event_groups/:event_group_id/connect_service/:service_identifier/field_mappings` (named: `event_group_connect_service_field_mappings`).
- **Controller**: authorizes via `EventGroupPolicy#setup?`, looks up the Race Connection (raises `RecordNotFound` if missing), normalizes incoming rows (whitelist of destinations: `comments` / `emergency_contact` / `emergency_phone`), coerces `source_question_id` strings to integers, drops blank/unknown destinations, and writes the resulting array to the Race Connection's `field_mappings` jsonb column.
- Successful update redirects back to the connect_service show page. **Turbo-stream rendering lands with the view templates in the next building block** — keeping this PR small means the controller currently only responds with HTML redirect.

3 files. Safe to deploy ahead of the UI work — there's no form posting to this route yet.

Relates to #1998. Builds on #2010 (sync read path) and #2009 (FetchRaceQuestions connector).

## Test plan

- [x] `bundle exec rspec spec/requests/event_groups/field_mappings_controller_spec.rb` — 8 examples, all green
- [x] `rubocop` clean on touched files
- [x] Manual: `rails routes | grep field_mapping` shows the new route
- [ ] CI green
