### PR TITLE
Field-mappings card on the Runsignup connect-service page

### DIFF
--- a/app/javascript/controllers/form_disable_submit_controller.js
+++ b/app/javascript/controllers/form_disable_submit_controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
   connect() {
     const controller = this
     const form = this.element
-    this._submitButton = form.querySelector("input[type='submit']")
+    this._submitButton = form.querySelector("input[type='submit'], button[type='submit']")
     if (!this._submitButton) { return }
 
     this.disableSubmitButton()

--- a/app/presenters/connect_service_presenter.rb
+++ b/app/presenters/connect_service_presenter.rb
@@ -3,6 +3,9 @@ class ConnectServicePresenter < BasePresenter
   INTERNAL_SERVICES = [
     "internal_lottery",
   ].freeze
+  FIELD_MAPPING_SERVICES = [
+    "runsignup",
+  ].freeze
 
   def initialize(event_group, service, view_context)
     @event_group = event_group
@@ -78,6 +81,30 @@ class ConnectServicePresenter < BasePresenter
     end
   end
 
+  def field_mappings_supported?
+    service_identifier.in?(FIELD_MAPPING_SERVICES)
+  end
+
+  # @return [Array<::Connectors::Runsignup::Models::Question>]
+  def race_questions
+    return [] if runsignup_race_id.blank?
+
+    ::Connectors::Runsignup::FetchRaceQuestions.perform(race_id: runsignup_race_id, user: current_user)
+  rescue ::Connectors::Errors::Base
+    []
+  end
+
+  # @return [Array<Hash{String => Object}>]
+  def field_mappings
+    @field_mappings ||= race_connection&.field_mappings || []
+  end
+
+  # @param [Integer] question_id
+  # @return [Hash{String => Object}, nil]
+  def field_mapping_for(question_id)
+    field_mappings.find { |m| m["source_question_id"] == question_id }
+  end
+
   private
 
   attr_reader :view_context
@@ -141,7 +168,14 @@ class ConnectServicePresenter < BasePresenter
   end
 
   def runsignup_race_id
-    event_group.connections.from_service(:runsignup).where(source_type: "Race").first&.source_id
+    race_connection&.source_id
+  end
+
+  def race_connection
+    return @race_connection if defined?(@race_connection)
+
+    @race_connection = event_group.connections.from_service(service_identifier)
+                                  .find_by(source_type: event_group_source_type)
   end
 
   def event_group_source_type

--- a/app/views/event_groups/connect_service/runsignup/_field_mappings_card.html.erb
+++ b/app/views/event_groups/connect_service/runsignup/_field_mappings_card.html.erb
@@ -1,0 +1,83 @@
+<%# locals: (connect_service_presenter:) %>
+
+<%= turbo_frame_tag dom_id(connect_service_presenter.event_group, :field_mappings_card) do %>
+  <div class="card my-3">
+    <div class="card-header">
+      <h4 class="mt-1">Field Mappings</h4>
+      <p class="text-muted small mb-0">
+        Map registration question responses to fields on each Effort. Multiple questions
+        mapped to <em>comments</em> are concatenated in mapping order.
+      </p>
+    </div>
+    <div class="card-body">
+      <% if connect_service_presenter.race_questions.empty? %>
+        <p class="text-muted mb-0">
+          No registration questions configured on this RunSignup race.
+        </p>
+      <% else %>
+        <%= form_with(
+              url: event_group_connect_service_field_mappings_path(connect_service_presenter.event_group, connect_service_presenter.service_identifier),
+              method: :patch,
+              data: { controller: "form-disable-submit" },
+            ) do |form| %>
+          <table class="table table-sm align-middle">
+            <thead>
+              <tr>
+                <th>Question</th>
+                <th style="width: 200px;">Destination</th>
+                <th>Override / Suppress (comments only)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% connect_service_presenter.race_questions.each_with_index do |question, index| %>
+                <% existing = connect_service_presenter.field_mapping_for(question.id) %>
+                <% destination = existing&.dig("destination") %>
+                <tr data-controller="field-mapping-row" data-field-mapping-row-comments-only-class-value="d-none">
+                  <td>
+                    <%= question.text %>
+                    <%= form.hidden_field "field_mappings[#{index}][source_question_id]", value: question.id %>
+                  </td>
+                  <td>
+                    <%= form.select "field_mappings[#{index}][destination]",
+                                    [
+                                      ["(don't sync)", ""],
+                                      ["comments", "comments"],
+                                      ["emergency_contact", "emergency_contact"],
+                                      ["emergency_phone", "emergency_phone"],
+                                    ],
+                                    { selected: destination },
+                                    {
+                                      class: "form-select form-select-sm",
+                                      data: { field_mapping_row_target: "destination", action: "change->field-mapping-row#destinationChanged" },
+                                    } %>
+                  </td>
+                  <td data-field-mapping-row-target="commentsOnly" class="<%= destination == "comments" ? "" : "d-none" %>">
+                    <div class="row g-2">
+                      <div class="col">
+                        <%= form.text_field "field_mappings[#{index}][value_when_present]",
+                                            value: existing&.dig("value_when_present"),
+                                            placeholder: "Override text (optional)",
+                                            class: "form-control form-control-sm" %>
+                      </div>
+                      <div class="col">
+                        <%= form.text_field "field_mappings[#{index}][suppress_when]",
+                                            value: existing&.dig("suppress_when"),
+                                            placeholder: "Suppress when response equals…",
+                                            class: "form-control form-control-sm" %>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+          <div class="text-end">
+            <%= form.button "Save mappings",
+                            class: "btn btn-primary",
+                            data: { turbo_submits_with: fa_icon("spinner", class: "fa-spin", text: "Saving") } %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/event_groups/connect_service/show.html.erb
+++ b/app/views/event_groups/connect_service/show.html.erb
@@ -20,6 +20,15 @@
                connect_service_presenter: connect_service_presenter,
              } %>
 
+  <div id="<%= dom_id(event_group_setup_presenter.event_group, :field_mappings_card_slot) %>">
+    <% if connect_service_presenter.field_mappings_supported? && connect_service_presenter.successful_connection? %>
+      <%= render partial: "event_groups/connect_service/runsignup/field_mappings_card",
+                 locals: {
+                   connect_service_presenter: connect_service_presenter,
+                 } %>
+    <% end %>
+  </div>
+
   <div id="<%= dom_id(event_group_setup_presenter.event_group, :connect_service_events_list) %>">
     <%= render partial: "events_list",
                locals: {

--- a/app/views/event_groups/connections/_form.html.erb
+++ b/app/views/event_groups/connections/_form.html.erb
@@ -21,7 +21,10 @@
         <% else %>
           <%= link_to "Remove",
                       event_group_connection_path(connection.destination, connection),
-                      data: { turbo_method: :delete },
+                      data: {
+                        turbo_method: :delete,
+                        turbo_confirm: t(".remove_confirm"),
+                      },
                       class: "btn btn-outline-danger" %>
         <% end %>
       </div>

--- a/config/locales/views.en.yml
+++ b/config/locales/views.en.yml
@@ -6,6 +6,8 @@ en:
           main_text: "Using Connections in OpenSplitTime"
           detail_paragraph_1: "Connections provide a simple way to keep your data synchronized with an outside source (like Runsignup) or an internal source (like an OpenSplitTime Lottery)."
           detail_paragraph_2: "You can manage connections for your Event Group from this page."
+      form:
+        remove_confirm: "Remove this connection? Any event connections and field mappings will be discarded."
     connect_service:
       internal_lottery:
         event_group_card:

--- a/spec/presenters/connect_service_presenter_spec.rb
+++ b/spec/presenters/connect_service_presenter_spec.rb
@@ -122,4 +122,80 @@ RSpec.describe ConnectServicePresenter do
       it { expect(result).to eq([]) }
     end
   end
+
+  describe "Runsignup field mappings" do
+    let(:event_group) { event_groups(:rufa_2017) }
+    let(:service) { ::Connectors::Service::BY_IDENTIFIER[:runsignup] }
+    let(:persisted_mappings) do
+      [
+        { "source_question_id" => 100, "destination" => "emergency_contact" },
+        { "source_question_id" => 200, "destination" => "comments", "value_when_present" => "First Attempt" },
+      ]
+    end
+    before do
+      Connection.create!(service_identifier: :runsignup, source_type: "Race", source_id: "174571",
+                         destination: event_group, field_mappings: persisted_mappings)
+    end
+
+    describe "#field_mappings" do
+      it "returns the array stored on the EventGroup-level Race Connection" do
+        expect(presenter.field_mappings).to eq(persisted_mappings)
+      end
+
+      context "when the Race Connection has no field_mappings configured" do
+        let(:persisted_mappings) { [] }
+
+        it "returns an empty array" do
+          expect(presenter.field_mappings).to eq([])
+        end
+      end
+    end
+
+    describe "#field_mapping_for(question_id)" do
+      it "returns the mapping hash matching the given question_id" do
+        expect(presenter.field_mapping_for(100)).to eq(persisted_mappings.first)
+      end
+
+      it "returns nil when no mapping matches" do
+        expect(presenter.field_mapping_for(9999)).to be_nil
+      end
+    end
+
+    describe "#race_questions" do
+      let(:question_struct) do
+        ::Connectors::Runsignup::Models::Question.new(id: 100, text: "Q")
+      end
+
+      it "delegates to FetchRaceQuestions with the Race Connection's race_id" do
+        allow(::Connectors::Runsignup::FetchRaceQuestions).to receive(:perform).and_return([question_struct])
+
+        expect(presenter.race_questions).to eq([question_struct])
+        expect(::Connectors::Runsignup::FetchRaceQuestions).to have_received(:perform)
+          .with(race_id: "174571", user: user)
+      end
+
+      context "when no Runsignup Race connection is set" do
+        before do
+          event_group.connections.from_service(:runsignup).where(source_type: "Race").destroy_all
+        end
+
+        it "returns an empty array without hitting FetchRaceQuestions" do
+          allow(::Connectors::Runsignup::FetchRaceQuestions).to receive(:perform)
+          expect(presenter.race_questions).to eq([])
+          expect(::Connectors::Runsignup::FetchRaceQuestions).not_to have_received(:perform)
+        end
+      end
+
+      context "when FetchRaceQuestions raises a connector error" do
+        before do
+          allow(::Connectors::Runsignup::FetchRaceQuestions).to receive(:perform)
+            .and_raise(::Connectors::Errors::Base.new("boom"))
+        end
+
+        it "returns an empty array instead of propagating the error" do
+          expect(presenter.race_questions).to eq([])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fourth building block for #1998. With this merged, the field-mappings UI is end-to-end functional: a race director sees their Runsignup race's question catalog, configures destination mappings, and saves them.

**Presenter** (`ConnectServicePresenter`)
- `#race_questions` — guards on race_id, delegates to `FetchRaceQuestions`, swallows connector errors to `[]`. Mirrors the shape of `#all_runsignup_events`. The 5-minute `Rails.cache` TTL inside `FetchRaceQuestions` handles cross-request memoization.
- `#field_mappings` reads the persisted array from the Race Connection (canonical store, per #2010).
- `#field_mapping_for(question_id)` — per-row pre-selection lookup.
- `runsignup_race_id` now reads via a memoized `race_connection` helper.

**View**
- New partial `app/views/event_groups/connect_service/runsignup/_field_mappings_card.html.erb` renders one row per question with a destination dropdown (`comments` / `emergency_contact` / `emergency_phone` / "don't sync") and per-row override / suppress fields that show when destination is `comments`.
- `show.html.erb` gets a slot `<div id=\"...field_mappings_card_slot\">` that conditionally renders the card when the connection is to Runsignup and successful. The slot id sets up a stable turbo_stream target for the next building block.

The form posts to the PATCH endpoint added in #2011 and follows the HTML redirect on success. Turbo-stream rendering of the post-save state lands in the next block.

**Stimulus note**: the partial includes data attributes for a forthcoming `field-mapping-row` controller (lands in 3c) that toggles the override column visibility on dropdown change. Without it registered, Stimulus no-ops on the attributes; initial render already shows/hides via server-side `d-none`, so the only degradation between this PR and 3c is that changing the dropdown won't auto-toggle the override column until 3c lands.

4 files. Relates to #1998. Builds on #2009, #2010, #2011.

## Test plan

- [x] `bundle exec rspec spec/presenters/connect_service_presenter_spec.rb` — 21 examples, all green
- [x] `erb_lint` clean on touched ERB files
- [x] `rubocop` clean on touched Ruby files
- [x] Verified the route helper still resolves: `event_group_connect_service_field_mappings_path(eg, "runsignup")` → `/event_groups/<slug>/connect_service/runsignup/field_mappings`
- [x] CI green
- [x] Manual smoke (post-merge in dev): visit `/event_groups/quad-rock-2026/connect_service/runsignup`, configure mappings on each question, click Save, reload, confirm pre-selection.
