### PR TITLE
Live-update the field-mappings card via turbo_stream

### DIFF
--- a/app/controllers/event_groups/field_mappings_controller.rb
+++ b/app/controllers/event_groups/field_mappings_controller.rb
@@ -19,7 +19,16 @@ module EventGroups
 
       conn.update!(field_mappings: normalized_mappings)
 
-      redirect_to event_group_connect_service_path(@event_group, @service.identifier)
+      respond_to do |format|
+        format.turbo_stream do
+          render "event_groups/field_mappings/update",
+                 locals: {
+                   event_group_setup_presenter: EventGroupSetupPresenter.new(@event_group, view_context),
+                   connect_service_presenter: ConnectServicePresenter.new(@event_group, @service, view_context),
+                 }
+        end
+        format.html { redirect_to event_group_connect_service_path(@event_group, @service.identifier) }
+      end
     end
 
     private

--- a/app/javascript/controllers/field_mapping_row_controller.js
+++ b/app/javascript/controllers/field_mapping_row_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["destination", "commentsOnly"]
+  static classes = ["commentsOnly"]
+
+  connect() {
+    this.toggle()
+  }
+
+  destinationChanged() {
+    this.toggle()
+  }
+
+  toggle() {
+    const isComments = this.destinationTarget.value === "comments"
+    this.commentsOnlyTarget.classList.toggle(this.commentsOnlyClass, !isComments)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -52,6 +52,9 @@ application.register("form-auto-submit", FormAutoSubmitController)
 import FormDisableSubmitController from "./form_disable_submit_controller"
 application.register("form-disable-submit", FormDisableSubmitController)
 
+import FieldMappingRowController from "./field_mapping_row_controller"
+application.register("field-mapping-row", FieldMappingRowController)
+
 import PhoneConsentController from "./phone_consent_controller"
 application.register("phone-consent", PhoneConsentController)
 

--- a/app/views/event_groups/connections/create.turbo_stream.erb
+++ b/app/views/event_groups/connections/create.turbo_stream.erb
@@ -14,3 +14,11 @@
                         locals: {
                           connect_service_presenter: connect_service_presenter,
                         }) %>
+
+<% if connect_service_presenter.field_mappings_supported? && connect_service_presenter.successful_connection? %>
+  <%= turbo_stream.update(dom_id(event_group, :field_mappings_card_slot),
+                          partial: "event_groups/connect_service/runsignup/field_mappings_card",
+                          locals: {
+                            connect_service_presenter: connect_service_presenter,
+                          }) %>
+<% end %>

--- a/app/views/event_groups/connections/destroy.turbo_stream.erb
+++ b/app/views/event_groups/connections/destroy.turbo_stream.erb
@@ -14,3 +14,7 @@
                         locals: {
                           connect_service_presenter: connect_service_presenter,
                         }) %>
+
+<% if connect_service_presenter.field_mappings_supported? %>
+  <%= turbo_stream.update(dom_id(event_group, :field_mappings_card_slot), "") %>
+<% end %>

--- a/app/views/event_groups/field_mappings/update.turbo_stream.erb
+++ b/app/views/event_groups/field_mappings/update.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%# locals: (event_group_setup_presenter:, connect_service_presenter:) %>
+
+<%= turbo_stream.replace(dom_id(connect_service_presenter.event_group, :field_mappings_card),
+                         partial: "event_groups/connect_service/runsignup/field_mappings_card",
+                         locals: { connect_service_presenter: connect_service_presenter }) %>

--- a/spec/requests/event_groups/field_mappings_controller_spec.rb
+++ b/spec/requests/event_groups/field_mappings_controller_spec.rb
@@ -83,10 +83,22 @@ RSpec.describe "PATCH /event_groups/:event_group_id/connect_service/:connect_ser
     expect(race_connection.field_mappings.first.keys).to contain_exactly("source_question_id", "destination")
   end
 
-  it "redirects back to the connect_service page on success" do
+  it "redirects back to the connect_service page on an HTML request" do
     patch event_group_connect_service_field_mappings_path(event_group, "runsignup"), params: valid_params
 
     expect(response).to redirect_to(event_group_connect_service_path(event_group, "runsignup"))
+  end
+
+  it "renders a turbo_stream replace of the field_mappings_card on a turbo request" do
+    allow_any_instance_of(ConnectServicePresenter).to receive(:race_questions).and_return([]) # rubocop:disable RSpec/AnyInstance
+    turbo_headers = { "Accept" => "text/vnd.turbo-stream.html" }
+
+    patch event_group_connect_service_field_mappings_path(event_group, "runsignup"),
+          params: valid_params, headers: turbo_headers
+
+    expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+    expect(response.body).to include("turbo-stream action=\"replace\"")
+    expect(response.body).to include("field_mappings_card")
   end
 
   it "raises RecordNotFound when no Race Connection exists for the EventGroup" do


### PR DESCRIPTION
## Summary

Final building block for #1998. Closes the rough edges around when the field-mappings card appears, disappears, and refreshes — without a full page reload.

- `FieldMappingsController#update` now responds to `format.turbo_stream` by replacing the field-mappings card frame with a freshly rendered partial. `format.html` still redirects (used by tests + non-turbo).
- **New view** `app/views/event_groups/field_mappings/update.turbo_stream.erb` wraps that replace.
- `create.turbo_stream.erb` (race-Connection create) **inserts the field-mappings card** into its slot when the new connection's service supports field mappings AND the connection succeeded — card appears immediately on a successful Save without a reload.
- `destroy.turbo_stream.erb` **empties the slot** when removing a Connection whose service supports field mappings — card disappears immediately on Remove.
- Both turbo_stream views now route on `connect_service_presenter.field_mappings_supported?` rather than a hardcoded `"runsignup"` string, mirroring the show.html.erb pattern.
- **New Stimulus controller** `field-mapping-row` toggles the override / suppress column visibility when the destination dropdown changes, so the user doesn't see those inputs when the row isn't mapped to `comments`. Initial state still set server-side via the `d-none` class so first paint is correct even before Stimulus boots.
- Registered in `app/javascript/controllers/index.js`.
- Spec adds a turbo_stream branch test alongside the existing redirect test.

7 files. Relates to #1998. Builds on #2009, #2010, #2011, #2012.

## Test plan

- [x] `bundle exec rspec spec/requests/event_groups/field_mappings_controller_spec.rb` — 9 examples, all green
- [x] `erb_lint` clean on touched ERB files
- [x] `rubocop` clean on touched Ruby files
- [x] CI green
- [x] Manual smoke (post-merge in dev):
  - Visit a Runsignup connect-service page with no race connection → no field-mappings card.
  - Save a race ID → card appears (no reload) with question rows pre-rendered.
  - Pick a destination = "comments" on a row → override / suppress inputs become visible.
  - Switch destination to "(don't sync)" → those inputs hide.
  - Click Save mappings → card re-renders inline (no reload), selections preserved.
  - Click Remove on the race connection → confirm dialog, then card disappears (no reload).
