### PR TITLE
Back-link from RunSignup API Keys to Event Construction

### DIFF
--- a/docs/runsignup-integration/api-keys.md
+++ b/docs/runsignup-integration/api-keys.md
@@ -34,6 +34,8 @@ Once you have the API key and secret:
 1. Add a RunSignup credential set, pasting the **api_key** and **api_secret** values from RunSignup.
 1. Save.
 
+With your credentials saved, head to [Event Construction → Add Entrants](../getting-started/event-construction/#add-entrants) to connect your RunSignup race to an Event Group.
+
 ## References
 
 - [RunSignup API Documentation](https://runsignup.com/API){:target="_blank"}


### PR DESCRIPTION
## Summary

One-line follow-up to #1828 + #2014. After saving credentials at the end of the RunSignup API Keys walkthrough, the natural next step is connecting a RunSignup race to an Event Group — covered in the new Event Construction page's **Add Entrants** section.

Adds a sentence at the end of the credentials section pointing users there.

## Note on stacking

The link target (`../getting-started/event-construction/#add-entrants`) lands with #2014. Until that merges, the back-link 404s. Doesn't block this PR.