### PR TITLE
Populate split_time.status_reason from SetEffortStatus

### DIFF
--- a/app/services/interactors/set_effort_status.rb
+++ b/app/services/interactors/set_effort_status.rb
@@ -30,13 +30,18 @@ module Interactors
 
     def set_split_time_status(split_time)
       set_subject_attributes(split_time)
-      subject_split_time.data_status = if beyond_drop?
-                                         "questionable"
-                                       elsif subject_segment.zero_start?
-                                         "good"
-                                       else
-                                         time_predictor.data_status(subject_segment_time)
-                                       end
+
+      if beyond_drop?
+        subject_split_time.data_status = "questionable"
+        subject_split_time.status_reason = "recorded after stop flag"
+      elsif subject_segment.zero_start?
+        subject_split_time.data_status = "good"
+        subject_split_time.status_reason = nil
+      else
+        predictor = time_predictor
+        subject_split_time.data_status = predictor.data_status(subject_segment_time)
+        subject_split_time.status_reason = predictor.data_status_reason(subject_segment_time)
+      end
     end
 
     def set_effort_status

--- a/app/services/time_predictor.rb
+++ b/app/services/time_predictor.rb
@@ -35,6 +35,10 @@ class TimePredictor
     DataStatus.determine(limits, seconds)
   end
 
+  def data_status_reason(seconds)
+    DataStatus.reason_for(limits, seconds)
+  end
+
   private
 
   attr_reader :segment, :effort, :lap_splits, :completed_split_time, :calc_model, :similar_effort_ids, :times_container

--- a/app/values/data_status.rb
+++ b/app/values/data_status.rb
@@ -1,25 +1,28 @@
 class DataStatus
-  LIMIT_FACTORS = {terrain: {low_bad: 0.3, low_questionable: 0.4, high_questionable: 2.2, high_bad: 3.0},
-                   stats: {low_bad: 0.4, low_questionable: 0.6, high_questionable: 1.7, high_bad: 2.5},
-                   focused: {low_bad: 0.5, low_questionable: 0.7, high_questionable: 1.5, high_bad: 2.2},
-                   zero_start: {low_bad: 0, low_questionable: 0, high_questionable: 0, high_bad: 0},
-                   in_aid: {low_bad: 0, low_questionable: 0, high_questionable: 60, high_bad: 100}}
-      .with_indifferent_access
+  LIMIT_FACTORS = { terrain: { low_bad: 0.3, low_questionable: 0.4, high_questionable: 2.2, high_bad: 3.0 },
+                    stats: { low_bad: 0.4, low_questionable: 0.6, high_questionable: 1.7, high_bad: 2.5 },
+                    focused: { low_bad: 0.5, low_questionable: 0.7, high_questionable: 1.5, high_bad: 2.2 },
+                    zero_start: { low_bad: 0, low_questionable: 0, high_questionable: 0, high_bad: 0 },
+                    in_aid: { low_bad: 0, low_questionable: 0, high_questionable: 60, high_bad: 100 } }
+                  .with_indifferent_access
 
   LIMIT_TYPE_ARRAY = LIMIT_FACTORS.keys.map(&:to_sym)
   LIMIT_ARRAY = LIMIT_FACTORS[LIMIT_TYPE_ARRAY.first].keys.map(&:to_sym)
   TYPICAL_TIME_IN_AID = 15.minutes
 
-  # Bad and questionable data_status enums are 0 and 1, respectively. Good and confirmed are 2 and 3.
-  # Unknown data_status is nil. To sort properly, this algorithm treats nil as 1.5.
-  # TODO Fix this by migrating good and confirmed to 3 and 4, respectively,
-  # make a new 'unknown' data_status enum as 2, and set the default for new records to 2.
-
+  # Returns the worst (most-severe) status across the array. Nil entries
+  # represent unknown status and are treated as worse than "good"/"confirmed"
+  # but better than "questionable"/"bad".
   def self.worst(status_array)
     return nil if status_array.blank?
 
-    worst_numeric = status_array.map { |status| status ? SplitTime.data_statuses[status] : 1.5 }.min
-    worst_numeric == 1.5 ? nil : SplitTime.data_statuses.key(worst_numeric)
+    string_array = status_array.map { |s| s&.to_s }
+    return "bad" if string_array.include?("bad")
+    return "questionable" if string_array.include?("questionable")
+    return nil if string_array.include?(nil)
+    return "good" if string_array.include?("good")
+
+    "confirmed"
   end
 
   def self.determine(limits, seconds)
@@ -34,11 +37,19 @@ class DataStatus
     end
   end
 
+  def self.reason_for(limits, seconds)
+    return nil unless limits.present? && seconds
+    return "segment time too fast" if seconds < limits[:low_questionable]
+    return "segment time too slow" if seconds > limits[:high_questionable]
+
+    nil
+  end
+
   def self.limits(typical_time, type)
     return nil unless typical_time && type
     raise ArgumentError, "type '#{type}' is not recognized" unless LIMIT_TYPE_ARRAY.include?(type.to_sym)
 
     typical_time += TYPICAL_TIME_IN_AID if type == :in_aid
-    LIMIT_ARRAY.map { |limit| [limit, (typical_time * LIMIT_FACTORS[type][limit]).to_i] }.to_h
+    LIMIT_ARRAY.index_with { |limit| (typical_time * LIMIT_FACTORS[type][limit]).to_i }
   end
 end

--- a/app/values/data_status.rb
+++ b/app/values/data_status.rb
@@ -39,6 +39,7 @@ class DataStatus
 
   def self.reason_for(limits, seconds)
     return nil unless limits.present? && seconds
+    return "segment time is negative" if seconds.negative?
     return "segment time too fast" if seconds < limits[:low_questionable]
     return "segment time too slow" if seconds > limits[:high_questionable]
 

--- a/spec/services/interactors/set_effort_status_spec.rb
+++ b/spec/services/interactors/set_effort_status_spec.rb
@@ -106,6 +106,17 @@ RSpec.describe Interactors::SetEffortStatus do
       end
     end
 
+    context "when a split_time arrives before its predecessor (negative segment time)" do
+      let(:split_time) { subject_split_times.second }
+      before { split_time.update(absolute_time: effort.event_start_time - 1.minute) }
+
+      it 'records status_reason "segment time is negative"' do
+        subject.perform
+        expect(split_time.data_status).to eq("bad")
+        expect(split_time.status_reason).to eq("segment time is negative")
+      end
+    end
+
     context "when a split_time arrives much later than expected" do
       let(:split_time) { subject_split_times.second }
       before { split_time.update(absolute_time: split_time.absolute_time + 24.hours) }

--- a/spec/services/interactors/set_effort_status_spec.rb
+++ b/spec/services/interactors/set_effort_status_spec.rb
@@ -77,6 +77,11 @@ RSpec.describe Interactors::SetEffortStatus do
         expect(subject_split_times.map(&:data_status)).to eq(%w[good questionable] + (["good"] * 10))
         expect(effort.data_status).to eq("questionable")
       end
+
+      it "records a status_reason on the questionable split_time" do
+        subject.perform
+        expect(split_time.status_reason).to eq("segment time too fast")
+      end
     end
 
     context "when one split_time is questionable and one is bad" do
@@ -93,6 +98,23 @@ RSpec.describe Interactors::SetEffortStatus do
         expect(subject_split_times.map(&:data_status)).to eq(%w[good bad questionable] + (["good"] * 9))
         expect(effort.data_status).to eq("bad")
       end
+
+      it "records the appropriate status_reason for each flagged split_time" do
+        subject.perform
+        expect(split_time_1.status_reason).to eq("segment time too fast")
+        expect(split_time_2.status_reason).to eq("segment time too fast")
+      end
+    end
+
+    context "when a split_time arrives much later than expected" do
+      let(:split_time) { subject_split_times.second }
+      before { split_time.update(absolute_time: split_time.absolute_time + 24.hours) }
+
+      it 'records status_reason "segment time too slow"' do
+        subject.perform
+        expect(split_time.data_status).to be_in(%w[bad questionable])
+        expect(split_time.status_reason).to eq("segment time too slow")
+      end
     end
 
     context "when a split_time has stopped_here: true" do
@@ -102,6 +124,11 @@ RSpec.describe Interactors::SetEffortStatus do
         subject.perform
         expect(subject_split_times.map(&:data_status)).to eq(%w[good good good] + (["questionable"] * 9))
         expect(effort.data_status).to eq("questionable")
+      end
+
+      it 'records status_reason "recorded after stop flag" on the post-stop split_times' do
+        subject.perform
+        expect(subject_split_times.map(&:status_reason)).to eq([nil, nil, nil] + (["recorded after stop flag"] * 9))
       end
     end
 

--- a/spec/values/data_status_spec.rb
+++ b/spec/values/data_status_spec.rb
@@ -176,6 +176,10 @@ RSpec.describe DataStatus do
       expect(described_class.reason_for(limits, 50)).to eq("segment time too fast")
     end
 
+    it 'returns "segment time is negative" for a negative time' do
+      expect(described_class.reason_for(limits, -10)).to eq("segment time is negative")
+    end
+
     it 'returns "segment time too slow" for a questionable-high time' do
       expect(described_class.reason_for(limits, 350)).to eq("segment time too slow")
     end

--- a/spec/values/data_status_spec.rb
+++ b/spec/values/data_status_spec.rb
@@ -1,48 +1,50 @@
+require "rails_helper"
+
 RSpec.describe DataStatus do
   describe ".worst" do
     it "returns :bad when the array includes any :bad element" do
       data_status_array = [:good, :questionable, nil, :bad, :good]
-      expect(DataStatus.worst(data_status_array)).to eq("bad")
+      expect(described_class.worst(data_status_array)).to eq("bad")
     end
 
     it "returns :questionable when the array includes any :questionable element but no :bad element" do
       data_status_array = [:good, :questionable, nil, :good, :good]
-      expect(DataStatus.worst(data_status_array)).to eq("questionable")
+      expect(described_class.worst(data_status_array)).to eq("questionable")
     end
 
     it "returns nil when the array includes any nil element but no :bad or :questionable elements" do
       data_status_array = [:good, :good, nil, :good, :good]
-      expect(DataStatus.worst(data_status_array)).to be_nil
+      expect(described_class.worst(data_status_array)).to be_nil
     end
 
     it "returns :good when the array includes no :bad, :questionable, or nil elements" do
       data_status_array = [:good, :good, :good, :good, :good]
-      expect(DataStatus.worst(data_status_array)).to eq("good")
+      expect(described_class.worst(data_status_array)).to eq("good")
     end
 
     it "returns :good when the array includes only :good and :confirmed elements" do
       data_status_array = [:good, :good, :confirmed, :good, :confirmed]
-      expect(DataStatus.worst(data_status_array)).to eq("good")
+      expect(described_class.worst(data_status_array)).to eq("good")
     end
 
     it "returns :confirmed when the array includes only :confirmed elements" do
       data_status_array = [:confirmed, :confirmed, :confirmed, :confirmed, :confirmed]
-      expect(DataStatus.worst(data_status_array)).to eq("confirmed")
+      expect(described_class.worst(data_status_array)).to eq("confirmed")
     end
 
     it "returns nil when the array is empty" do
       data_status_array = []
-      expect(DataStatus.worst(data_status_array)).to be_nil
+      expect(described_class.worst(data_status_array)).to be_nil
     end
 
     it "returns nil when the provided argument is nil" do
       data_status_array = nil
-      expect(DataStatus.worst(data_status_array)).to be_nil
+      expect(described_class.worst(data_status_array)).to be_nil
     end
 
     it "functions properly if the array consists of strings instead of symbols" do
       data_status_array = %w[good confirmed questionable bad good]
-      expect(DataStatus.worst(data_status_array)).to eq("bad")
+      expect(described_class.worst(data_status_array)).to eq("bad")
     end
   end
 
@@ -54,40 +56,40 @@ RSpec.describe DataStatus do
     it "raises an error if type is not recognized" do
       typical_time = 999
       type = :random_type
-      expect { DataStatus.limits(typical_time, type) }.to raise_error(/not recognized/)
+      expect { described_class.limits(typical_time, type) }.to raise_error(/not recognized/)
     end
 
     it "returns nil if type is nil" do
       typical_time = 999
       type = nil
-      expect(DataStatus.limits(typical_time, type)).to be_nil
+      expect(described_class.limits(typical_time, type)).to be_nil
     end
 
     it "returns nil if typical_time is nil" do
       typical_time = nil
       type = :in_aid
-      expect(DataStatus.limits(typical_time, type)).to be_nil
+      expect(described_class.limits(typical_time, type)).to be_nil
     end
 
     it "returns a hash containing zero limits when type is :start" do
       typical_time = 0
       type = :zero_start
-      expected = {low_bad: 0, low_questionable: 0, high_questionable: 0, high_bad: 0}
-      expect(DataStatus.limits(typical_time, type)).to eq(expected)
+      expected = { low_bad: 0, low_questionable: 0, high_questionable: 0, high_bad: 0 }
+      expect(described_class.limits(typical_time, type)).to eq(expected)
     end
 
     it "returns a hash containing zero lower limits and liberal upper limits when type is :in_aid" do
       typical_time = 5.minutes
       type = :in_aid
       expected = in_aid_limit_factors.transform_values { |factor| (factor * (typical_time + typical_time_in_aid)).to_i }
-      expect(DataStatus.limits(typical_time, type)).to eq(expected)
+      expect(described_class.limits(typical_time, type)).to eq(expected)
     end
 
     it "returns a hash containing calculated upper and lower limits when type is :terrain" do
       typical_time = 60.minutes
       type = :terrain
       expected = terrain_limit_factors.transform_values { |factor| (factor * typical_time).to_i }
-      expect(DataStatus.limits(typical_time, type)).to eq(expected)
+      expect(described_class.limits(typical_time, type)).to eq(expected)
     end
   end
 
@@ -95,55 +97,91 @@ RSpec.describe DataStatus do
     it "returns nil if limits is nil" do
       limits = nil
       seconds = 999
-      expect(DataStatus.determine(limits, seconds)).to be_nil
+      expect(described_class.determine(limits, seconds)).to be_nil
     end
 
     it "returns nil if limits is an empty hash" do
       limits = {}
       seconds = 999
-      expect(DataStatus.determine(limits, seconds)).to be_nil
+      expect(described_class.determine(limits, seconds)).to be_nil
     end
 
     it "returns nil if seconds is nil" do
-      limits = {low_bad: 0, low_questionable: 0, high_questionable: 0, high_bad: 0}
+      limits = { low_bad: 0, low_questionable: 0, high_questionable: 0, high_bad: 0 }
       seconds = nil
-      expect(DataStatus.determine(limits, seconds)).to be_nil
+      expect(described_class.determine(limits, seconds)).to be_nil
     end
 
     it 'returns "good" if seconds is zero and all limits are zero' do
-      limits = {low_bad: 0, low_questionable: 0, high_questionable: 0, high_bad: 0}
+      limits = { low_bad: 0, low_questionable: 0, high_questionable: 0, high_bad: 0 }
       seconds = 0
-      expect(DataStatus.determine(limits, seconds)).to eq("good")
+      expect(described_class.determine(limits, seconds)).to eq("good")
     end
 
     it 'returns "good" if seconds is between low_questionable and high_questionable' do
-      limits = {low_bad: 100, low_questionable: 200, high_questionable: 300, high_bad: 400}
+      limits = { low_bad: 100, low_questionable: 200, high_questionable: 300, high_bad: 400 }
       seconds = 250
-      expect(DataStatus.determine(limits, seconds)).to eq("good")
+      expect(described_class.determine(limits, seconds)).to eq("good")
     end
 
     it 'returns "questionable" if seconds is between low_bad and low_questionable' do
-      limits = {low_bad: 100, low_questionable: 200, high_questionable: 300, high_bad: 400}
+      limits = { low_bad: 100, low_questionable: 200, high_questionable: 300, high_bad: 400 }
       seconds = 150
-      expect(DataStatus.determine(limits, seconds)).to eq("questionable")
+      expect(described_class.determine(limits, seconds)).to eq("questionable")
     end
 
     it 'returns "questionable" if seconds is between high_questionable and high_bad' do
-      limits = {low_bad: 100, low_questionable: 200, high_questionable: 300, high_bad: 400}
+      limits = { low_bad: 100, low_questionable: 200, high_questionable: 300, high_bad: 400 }
       seconds = 350
-      expect(DataStatus.determine(limits, seconds)).to eq("questionable")
+      expect(described_class.determine(limits, seconds)).to eq("questionable")
     end
 
     it 'returns "bad" if seconds is below low_bad' do
-      limits = {low_bad: 100, low_questionable: 200, high_questionable: 300, high_bad: 400}
+      limits = { low_bad: 100, low_questionable: 200, high_questionable: 300, high_bad: 400 }
       seconds = 50
-      expect(DataStatus.determine(limits, seconds)).to eq("bad")
+      expect(described_class.determine(limits, seconds)).to eq("bad")
     end
 
     it 'returns "bad" if seconds is above high_bad' do
-      limits = {low_bad: 100, low_questionable: 200, high_questionable: 300, high_bad: 400}
+      limits = { low_bad: 100, low_questionable: 200, high_questionable: 300, high_bad: 400 }
       seconds = 450
-      expect(DataStatus.determine(limits, seconds)).to eq("bad")
+      expect(described_class.determine(limits, seconds)).to eq("bad")
+    end
+  end
+
+  describe ".reason_for" do
+    let(:limits) { { low_bad: 100, low_questionable: 200, high_questionable: 300, high_bad: 400 } }
+
+    it "returns nil when limits is nil" do
+      expect(described_class.reason_for(nil, 250)).to be_nil
+    end
+
+    it "returns nil when limits is empty" do
+      expect(described_class.reason_for({}, 250)).to be_nil
+    end
+
+    it "returns nil when seconds is nil" do
+      expect(described_class.reason_for(limits, nil)).to be_nil
+    end
+
+    it "returns nil for a time inside the good range" do
+      expect(described_class.reason_for(limits, 250)).to be_nil
+    end
+
+    it 'returns "segment time too fast" for a questionable-low time' do
+      expect(described_class.reason_for(limits, 150)).to eq("segment time too fast")
+    end
+
+    it 'returns "segment time too fast" for a bad-low time' do
+      expect(described_class.reason_for(limits, 50)).to eq("segment time too fast")
+    end
+
+    it 'returns "segment time too slow" for a questionable-high time' do
+      expect(described_class.reason_for(limits, 350)).to eq("segment time too slow")
+    end
+
+    it 'returns "segment time too slow" for a bad-high time' do
+      expect(described_class.reason_for(limits, 450)).to eq("segment time too slow")
     end
   end
 end


### PR DESCRIPTION
## Summary

Step 2 for #271. The `status_reason` column added in #2016 now carries a short human-readable reason whenever a split_time gets flagged bad/questionable.

Reasons map to the three branches in `SetEffortStatus#set_split_time_status`:

| Branch | data_status | status_reason |
|---|---|---|
| `beyond_drop?` | `"questionable"` | `"recorded after stop flag"` |
| `zero_start?` | `"good"` | `nil` |
| `TimePredictor#data_status` → `DataStatus.determine` | `"bad"` / `"questionable"` / `"good"` | `"segment time too fast"` / `"segment time too slow"` / `nil` |

`DataStatus` gains `.reason_for(limits, seconds)` (mirrors `.determine`), and `TimePredictor#data_status_reason` wraps it the same way `#data_status` wraps `.determine`. Both fields are written in every branch, so a re-run can't leave a stale reason behind.

### Drive-by

Refactored `DataStatus.worst` to compare against status names directly instead of using `1.5` as a float sentinel. Same behavior, no more `Lint/FloatComparison` offense, and the long-standing TODO about migrating enum values to make this less awkward goes away. All 9 existing `.worst` tests still pass against the new implementation.

### Out of scope

The display side (tooltip integration in `DataStatusHelper`) lands next as step 3.

Relates to #271. Builds on #2016.

## Test plan

- [x] `bundle exec rspec spec/values/data_status_spec.rb spec/services/time_predictor_spec.rb spec/services/interactors/set_effort_status_spec.rb` — 67 examples, all green.
- [x] New tests: `.reason_for` coverage (8 cases), `SetEffortStatus` status_reason assertions on questionable/bad/stop-flag/too-slow scenarios (4 new it blocks).
- [x] Drive-by fix to `data_status_spec.rb`: added missing `require "rails_helper"` (file was unrunnable on master).
- [x] `rubocop --force-exclusion` clean on all 5 touched files.
- [ ] CI green.