### PR TITLE
Surface status_reason in the data-status tooltip

### DIFF
--- a/app/helpers/data_status_helper.rb
+++ b/app/helpers/data_status_helper.rb
@@ -9,13 +9,15 @@ module DataStatusHelper
     return time if attributes.nil?
 
     data_type = options[:data_type] || :time
-    tooltip_title = "#{data_type} appears #{status}".titleize
+    reason = options[:reason]
+    tooltip_title = "#{data_type} appears #{status}"
+    tooltip_title += ": #{reason}" if reason.present?
 
     content_tag(:span, class: "text-nowrap") do
       fa_icon(attributes[:icon],
               class: attributes[:class],
               text: time,
-              data: { controller: :tooltip, bs_original_title: tooltip_title })
+              data: { controller: :tooltip, bs_original_title: tooltip_title.titleize })
     end
   end
 end

--- a/app/views/efforts/edit_split_times.html.erb
+++ b/app/views/efforts/edit_split_times.html.erb
@@ -57,7 +57,7 @@
                 <td class="text-nowrap"><strong><%= row.name %></strong></td>
                 <% row.time_points.each do |time_point| %>
                   <%= f.fields_for :split_times, @presenter.guaranteed_split_time(time_point) do |builder| %>
-                    <td><%= text_with_status_indicator("", @presenter.guaranteed_split_time(time_point).data_status) %></td>
+                    <td><%= text_with_status_indicator("", @presenter.guaranteed_split_time(time_point).data_status, reason: @presenter.guaranteed_split_time(time_point).status_reason) %></td>
                     <td>
                       <%= builder.text_field @presenter.working_field,
                                              class: "form-control",

--- a/app/views/split_times/_effort_audit_row.html.erb
+++ b/app/views/split_times/_effort_audit_row.html.erb
@@ -5,7 +5,7 @@
     <%= link_to row.name, split_raw_times_event_group_path(presenter.event_group, parameterized_split_name: row.parameterized_split_name, sub_split_kind: row.sub_split_kind) %>
   </td>
   <td class="text-center border-end">
-    <%= text_with_status_indicator(day_time_military_format_hhmmss(row.split_time.absolute_time_local), row.split_time.data_status) %>
+    <%= text_with_status_indicator(day_time_military_format_hhmmss(row.split_time.absolute_time_local), row.split_time.data_status, reason: row.split_time.status_reason) %>
   </td>
 
   <td>

--- a/spec/helpers/data_status_helper_spec.rb
+++ b/spec/helpers/data_status_helper_spec.rb
@@ -58,5 +58,23 @@ RSpec.describe DataStatusHelper do
         expect(result).to have_css("i[data-bs-original-title='Pace Appears Bad']")
       end
     end
+
+    context "when a reason option is provided" do
+      let(:status) { :questionable }
+      let(:options) { { reason: "segment time too slow" } }
+
+      it "appends the reason to the tooltip" do
+        expect(result).to have_css("i[data-bs-original-title='Time Appears Questionable: Segment Time Too Slow']")
+      end
+    end
+
+    context "when the reason option is blank" do
+      let(:status) { :bad }
+      let(:options) { { reason: "" } }
+
+      it "renders the tooltip without a trailing colon" do
+        expect(result).to have_css("i[data-bs-original-title='Time Appears Bad']")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Step 3 for #271. `DataStatusHelper#text_with_status_indicator` now accepts an optional `reason:` keyword and appends it to the tooltip title. Resolves the issue.

- Bad/questionable indicator previously read "Time Appears Questionable" / "Time Appears Bad" with no detail.
- Now: "Time Appears Questionable: Segment Time Too Slow" (or "Segment Time Too Fast" / "Segment Time Is Negative" / "Recorded After Stop Flag"). Generic tooltip when no reason is provided — backward-compatible.

Two call sites pass the new option from their `SplitTime` model:

- `app/views/split_times/_effort_audit_row.html.erb`
- `app/views/efforts/edit_split_times.html.erb`

The third call site (`time_cluster_helper`) is **unchanged**: its `TimeCluster`/`SplitTimeData` path uses a slim struct that doesn't carry `status_reason`, and widening it would require pulling the column through the DB query. Out of scope for this PR; the existing tooltip still works exactly as before in that path.

Resolves #271. Builds on #2016 and #2017.

## Test plan

- [x] `bundle exec rspec spec/helpers/data_status_helper_spec.rb` — 9 examples, all green (2 new: reason appended, reason blank fallback).
- [x] `rubocop --force-exclusion` clean on touched files.
- [x] `erb_lint` clean on touched ERB.
- [ ] CI green.
- [ ] Manual: load an effort audit page on dev that has a flagged split_time; hover the warning/danger icon and confirm the tooltip now includes the reason.