### PR TITLE
Backfill status_reason on existing flagged split_times

### DIFF
--- a/db/data/20260512223337_backfill_split_time_status_reasons.rb
+++ b/db/data/20260512223337_backfill_split_time_status_reasons.rb
@@ -1,0 +1,37 @@
+class BackfillSplitTimeStatusReasons < ActiveRecord::Migration[8.1]
+  # Populates status_reason on existing bad/questionable split_times so the
+  # tooltip work from #271 has something to display on historical data.
+  #
+  # Only the status_reason column is persisted. data_status is intentionally
+  # left untouched: re-running SetEffortStatus over old data can flip a
+  # status (e.g. "bad" → "good") because the times_container has changed
+  # since the original computation, and this migration is not the right
+  # place to silently revise that.
+  def up
+    effort_ids = SplitTime
+                 .where(data_status: SplitTime.data_statuses.values_at("bad", "questionable"))
+                 .where(status_reason: nil)
+                 .distinct.pluck(:effort_id)
+
+    say "Backfilling status_reason across #{effort_ids.size} efforts with flagged split_times…"
+    updated_count = 0
+
+    effort_ids.each do |effort_id|
+      effort = Effort.find(effort_id)
+      ::Interactors::SetEffortStatus.perform(effort)
+
+      effort.ordered_split_times.each do |split_time|
+        next if split_time.status_reason.nil?
+
+        SplitTime.where(id: split_time.id).update_all(status_reason: split_time.status_reason)
+        updated_count += 1
+      end
+    end
+
+    say "Backfill complete: status_reason populated on #{updated_count} split_times."
+  end
+
+  def down
+    # One-way; reversing would just blank the column we just populated.
+  end
+end

--- a/db/data/20260512223337_backfill_split_time_status_reasons.rb
+++ b/db/data/20260512223337_backfill_split_time_status_reasons.rb
@@ -1,37 +1,39 @@
 class BackfillSplitTimeStatusReasons < ActiveRecord::Migration[8.1]
-  # Populates status_reason on existing bad/questionable split_times so the
-  # tooltip work from #271 has something to display on historical data.
-  #
-  # Only the status_reason column is persisted. data_status is intentionally
-  # left untouched: re-running SetEffortStatus over old data can flip a
-  # status (e.g. "bad" → "good") because the times_container has changed
-  # since the original computation, and this migration is not the right
-  # place to silently revise that.
+  # Re-runs SetEffortStatus over efforts with any flagged-but-reasonless
+  # split_time, then saves the recompute. status_reason gets populated, and
+  # data_status is brought in line with the current calculation (which may
+  # flip some historical "bad"/"questionable" entries to "good" if the
+  # times_container baseline has shifted in the participant's favor).
   def up
     effort_ids = SplitTime
                  .where(data_status: SplitTime.data_statuses.values_at("bad", "questionable"))
                  .where(status_reason: nil)
                  .distinct.pluck(:effort_id)
 
-    say "Backfilling status_reason across #{effort_ids.size} efforts with flagged split_times…"
-    updated_count = 0
+    say "Re-evaluating status across #{effort_ids.size} efforts with flagged split_times…"
+    split_time_changes = 0
+    effort_changes = 0
 
     effort_ids.each do |effort_id|
       effort = Effort.find(effort_id)
-      ::Interactors::SetEffortStatus.perform(effort)
+      response = ::Interactors::SetEffortStatus.perform(effort)
 
-      effort.ordered_split_times.each do |split_time|
-        next if split_time.status_reason.nil?
+      response.resources.each do |resource|
+        next unless resource.changed?
 
-        SplitTime.where(id: split_time.id).update_all(status_reason: split_time.status_reason)
-        updated_count += 1
+        resource.save!
+        case resource
+        when SplitTime then split_time_changes += 1
+        when Effort then effort_changes += 1
+        end
       end
     end
 
-    say "Backfill complete: status_reason populated on #{updated_count} split_times."
+    say "Backfill complete: updated #{split_time_changes} split_times and #{effort_changes} efforts."
   end
 
   def down
-    # One-way; reversing would just blank the column we just populated.
+    # One-way; reversing would require remembering the old data_status /
+    # status_reason values prior to the recompute.
   end
 end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_05_09_033127)
+DataMigrate::Data.define(version: 2026_05_12_223337)


### PR DESCRIPTION
## Summary

Step 4 (final) for #271. Data migration that populates `status_reason` on historical bad/questionable split_times so the tooltip work from #2018 has something to show on existing data — both for production testing and for keeping fixtures in sync in test.

### Approach

- Find effort_ids whose split_times include any bad/questionable row with `status_reason` still `NULL`.
- For each such effort, run `Interactors::SetEffortStatus` to compute reasons in memory.
- Persist `status_reason` only, via `update_all` on each split_time.

`data_status` is **intentionally left untouched**: re-running `SetEffortStatus` over old data can flip a status (the typical-time baseline drifts as the dataset grows), and silently rewriting historical `data_status` values is out of scope for this migration.

### Run it

```
bundle exec rails data:migrate
```

Idempotent — only updates split_times where `status_reason IS NULL`. Safe to re-run.

Relates to #271. Builds on #2016, #2017, #2018.

## Test plan

- [x] Ran `bundle exec rails data:migrate` in dev — populated status_reason on 9 split_times across 8 efforts, no errors.
- [x] `db/data_schema.rb` version bumped.
- [ ] Run in test env locally before regenerating fixtures.
- [ ] CI green.