### PR TITLE
Surface status_reason in TimeCluster tooltips

### DIFF
--- a/app/helpers/time_cluster_helper.rb
+++ b/app/helpers/time_cluster_helper.rb
@@ -7,10 +7,10 @@ module TimeClusterHelper
 
     content_tag(:span) do
       if with_status
-        time_array = formatted_times.zip(cluster.time_data_statuses)
+        time_array = formatted_times.zip(cluster.time_data_statuses, cluster.time_status_reasons)
 
-        time_array.map.with_index(1) do |(formatted_time, status), i|
-          concat text_with_status_indicator(formatted_time, status)
+        time_array.map.with_index(1) do |(formatted_time, status, reason), i|
+          concat text_with_status_indicator(formatted_time, status, reason: reason)
           concat " / " unless i == time_array.size
         end
       else

--- a/app/models/split_time_data.rb
+++ b/app/models/split_time_data.rb
@@ -6,9 +6,8 @@
 # absolute_time_local_string from the database query.
 
 SplitTimeData = Struct.new(:id, :effort_id, :lap, :split_id, :bitkey, :stopped_here, :pacer, :data_status_numeric,
-                           :absolute_time_string, :absolute_time_local_string, :time_from_start, :segment_time,
-                           :military_time, keyword_init: true) do
-
+                           :status_reason, :absolute_time_string, :absolute_time_local_string, :time_from_start,
+                           :segment_time, :military_time) do
   include TimePointMethods
 
   # absolute_time is an ActiveSupport::TimeWithZone for compatibility and useful math operations.

--- a/app/queries/split_time_query.rb
+++ b/app/queries/split_time_query.rb
@@ -11,18 +11,18 @@ class SplitTimeQuery < BaseQuery
     end_bitkey = segment.end_bitkey.to_i
     focus_clause = effort_ids.present? ? "st1.effort_id IN (#{sql_safe_integer_list(effort_ids)})" : "true"
 
-    query = <<-SQL
+    query = <<~SQL.squish
       with segment_times as
            (select extract(epoch from(st2.absolute_time - st1.absolute_time)) as seconds
             from (select st.effort_id, st.absolute_time
-                 from split_times st 
+                 from split_times st
                  where st.lap = #{begin_lap}
                    and st.split_id = #{begin_id}
                    and st.sub_split_bitkey = #{begin_bitkey}
                    and (st.data_status in (#{valid_statuses_list}) or st.data_status is null))
                  as st1,
                  (select st.effort_id, st.absolute_time
-                 from split_times st 
+                 from split_times st
                  where st.lap = #{end_lap}
                    and st.split_id = #{end_id}
                    and st.sub_split_bitkey = #{end_bitkey}
@@ -34,19 +34,19 @@ class SplitTimeQuery < BaseQuery
           (select percentile_cont(0.25) within group (order by seconds) as q1,
                   percentile_cont(0.75) within group (order by seconds) as q3
           from segment_times),
-              
+
         iqr_stats as
           (select q1,
-                  q3, 
+                  q3,
                   q3 - q1 as iqr
           from quartiles),
-          
+
         bounds as
           (select q1 - (iqr * 1.5) as lower_bound,
                   q3 + (iqr * 1.5) as upper_bound
           from iqr_stats)
 
-      select count(seconds) as effort_count, 
+      select count(seconds) as effort_count,
              round(avg(seconds)) as average
       from segment_times
       where seconds between (select lower_bound from bounds) and (select upper_bound from bounds)
@@ -60,17 +60,17 @@ class SplitTimeQuery < BaseQuery
   def self.with_time_point_rank(existing_scope)
     existing_scope_subquery = sql_for_existing_scope(existing_scope)
 
-    <<-SQL.squish
+    <<~SQL.squish
       (with existing_scope as (#{existing_scope_subquery}),
 
-          split_times_scoped as 
+          split_times_scoped as
               (select split_times.*
                from split_times
                inner join existing_scope on existing_scope.id = split_times.id),
 
           event_ids as
-             (select distinct event_id 
-              from split_times_scoped 
+             (select distinct event_id
+              from split_times_scoped
                 join efforts on efforts.id = split_times_scoped.effort_id),
 
           start_times as
@@ -79,7 +79,7 @@ class SplitTimeQuery < BaseQuery
                   join efforts on efforts.id = split_times.effort_id
                   join splits on splits.id = split_times.split_id
                where efforts.event_id in (select event_id from event_ids)
-                 and split_times.lap = 1 
+                 and split_times.lap = 1
                  and splits.kind = #{Split.kinds[:start]}
                  and split_times.sub_split_bitkey = #{SubSplit::IN_BITKEY}),
 
@@ -91,14 +91,14 @@ class SplitTimeQuery < BaseQuery
                   join splits on splits.id = ast.split_id
                   join start_times on start_times.effort_id = ast.effort_id
                where efforts.event_id in (select event_id from event_ids)),
-            
+
           ranking_subquery as
               (select effort_id, lap, split_id, sub_split_bitkey, distance_from_start,
                   case when distance_from_start = 0 then null else
-                       row_number() over (partition by lap, split_id, sub_split_bitkey 
+                       row_number() over (partition by lap, split_id, sub_split_bitkey
                                           order by lap, distance_from_start, sub_split_bitkey, elapsed_time) end as time_point_rank,
                     case when distance_from_start = 0 then null else
-                       array_agg(effort_id) over (partition by lap, split_id, sub_split_bitkey 
+                       array_agg(effort_id) over (partition by lap, split_id, sub_split_bitkey
                                                   order by lap, distance_from_start, sub_split_bitkey, elapsed_time
                                                   rows between unbounded preceding and 1 preceding) end as effort_ids_ahead
                from elapsed_times)
@@ -117,7 +117,7 @@ class SplitTimeQuery < BaseQuery
     home_time_zone = args[:home_time_zone]
     time_zone = ActiveSupport::TimeZone.find_tzinfo(home_time_zone).identifier
 
-    query = <<~SQL
+    query = <<~SQL.squish
       set timezone='#{time_zone}';
 
       with start_split_times as
@@ -126,7 +126,7 @@ class SplitTimeQuery < BaseQuery
          inner join splits on splits.id = split_times.split_id
          where lap = 1 and kind = 0 and effort_id in (select id from efforts where #{scope})
          order by effort_id)
-     
+
       select st.id,
              st.effort_id,
              st.lap,
@@ -135,14 +135,15 @@ class SplitTimeQuery < BaseQuery
              st.stopped_here,
              st.pacer,
              st.data_status as data_status_numeric,
+             st.status_reason,
              st.absolute_time as absolute_time_string,
              trim(both '"' from to_json(st.absolute_time at time zone 'UTC')::text) as absolute_time_local_string,
              extract(epoch from (st.absolute_time - sst.absolute_time)) as time_from_start,
-             case 
-               when st.effort_id = lag(st.effort_id) over (order by st.effort_id, st.lap, distance_from_start, st.sub_split_bitkey) 
-               then extract(epoch from(st.absolute_time - lag(st.absolute_time) 
-                      over (order by st.effort_id, st.lap, distance_from_start, st.sub_split_bitkey))) 
-               else null 
+             case
+               when st.effort_id = lag(st.effort_id) over (order by st.effort_id, st.lap, distance_from_start, st.sub_split_bitkey)
+               then extract(epoch from(st.absolute_time - lag(st.absolute_time)
+                      over (order by st.effort_id, st.lap, distance_from_start, st.sub_split_bitkey)))
+               else null
              end as segment_time
       from split_times st
       inner join splits on splits.id = st.split_id
@@ -150,7 +151,7 @@ class SplitTimeQuery < BaseQuery
       left join start_split_times sst on sst.effort_id = st.effort_id
       where #{scope}
     SQL
-    result = ActiveRecord::Base.connection.execute(query.squish).map { |row| SplitTimeData.new(row) }
+    result = ActiveRecord::Base.connection.execute(query.squish).map { |row| SplitTimeData.new(**row.symbolize_keys) }
     reset_database_timezone
     result
   end
@@ -159,18 +160,18 @@ class SplitTimeQuery < BaseQuery
     lap, split_id, bitkey = args[:time_point].values
     lowest_time = args[:time_range].begin
     highest_time = args[:time_range].end
-    finished_only = !!args[:finished_only]
+    finished_only = !args[:finished_only].nil?
     limit = args[:limit]
 
-    query = <<~SQL
+    query = <<~SQL.squish
       with
         split_times_scoped as
-          (select * 
+          (select *
            from split_times
            inner join efforts on efforts.id = split_times.effort_id
            inner join events on events.id = efforts.event_id
            inner join event_groups on event_groups.id = events.event_group_id
-           where lap = #{lap} and split_id = #{split_id} and sub_split_bitkey = #{bitkey} 
+           where lap = #{lap} and split_id = #{split_id} and sub_split_bitkey = #{bitkey}
              and event_groups.concealed = 'f'
              and (split_times.data_status in (2, 3) or split_times.data_status is null)),
 
@@ -189,8 +190,8 @@ class SplitTimeQuery < BaseQuery
            order by effort_id),
 
         main_subquery as
-          (select st.effort_id, 
-                  extract(epoch from(st.absolute_time - sst.absolute_time)) as time_from_start, 
+          (select st.effort_id,
+                  extract(epoch from(st.absolute_time - sst.absolute_time)) as time_from_start,
                   sst.absolute_time as start_time,
                   fe.effort_id is not null as finished
            from split_times_scoped st
@@ -211,7 +212,7 @@ class SplitTimeQuery < BaseQuery
   def self.starting_split_times(args)
     scope = where_string_from_hash(args[:scope])
 
-    query = <<~SQL
+    query = <<~SQL.squish
       left join (select effort_id, absolute_time
                  from split_times
                    inner join splits on splits.id = split_times.split_id
@@ -243,18 +244,18 @@ class SplitTimeQuery < BaseQuery
   end
 
   def self.shift_event_absolute_times(event, shift_seconds)
-    query = <<-SQL
-        with time_subquery as 
-           (select st.id, st.absolute_time + (#{shift_seconds} * interval '1 second') as computed_time
-            from split_times st
-              inner join efforts ef on ef.id = st.effort_id
-            where ef.event_id = #{event.id})
-          
-        update split_times
-        set absolute_time = computed_time,
-            updated_at = current_timestamp
-        from time_subquery
-        where split_times.id = time_subquery.id
+    query = <<~SQL.squish
+      with time_subquery as
+         (select st.id, st.absolute_time + (#{shift_seconds} * interval '1 second') as computed_time
+          from split_times st
+            inner join efforts ef on ef.id = st.effort_id
+          where ef.event_id = #{event.id})
+
+      update split_times
+      set absolute_time = computed_time,
+          updated_at = current_timestamp
+      from time_subquery
+      where split_times.id = time_subquery.id
     SQL
     query.squish
   end

--- a/app/view_models/bib_time_row.rb
+++ b/app/view_models/bib_time_row.rb
@@ -25,7 +25,9 @@ BibTimeRow = Struct.new(
   end
 
   def split_times
-    @split_times ||= JSON.parse(guaranteed_string(split_times_attributes)).map { |row| SplitTimeData.new(row) }
+    @split_times ||= JSON.parse(guaranteed_string(split_times_attributes)).map do |row|
+      SplitTimeData.new(**row.symbolize_keys)
+    end
   end
 
   def problem?

--- a/app/view_models/time_cluster.rb
+++ b/app/view_models/time_cluster.rb
@@ -52,6 +52,10 @@ class TimeCluster
     @time_data_statuses ||= split_times_data.map(&:data_status)
   end
 
+  def time_status_reasons
+    @time_status_reasons ||= split_times_data.map(&:status_reason)
+  end
+
   def pacer_flags
     @pacer_flags ||= split_times_data.map(&:pacer)
   end


### PR DESCRIPTION
## Summary

Resolves #2019. The audit / edit views already showed `status_reason` in the data-status tooltip (#2018), but the spread, effort-times, and similar views that go through `TimeCluster` were still rendering the generic *"Time Appears Questionable"* wording. This plumbs the column through the lightweight read path so those tooltips read e.g. *"Time Appears Questionable: Segment Time Too Slow"* too.

### Plumbing

- `SplitTimeData` struct gains `:status_reason`.
- `SplitTimeQuery#time_detail` SELECTs `st.status_reason`.
- `TimeCluster#time_status_reasons` mirrors `#time_data_statuses`.
- `TimeClusterHelper#time_cluster_display_data` zips reasons in alongside statuses and passes `reason:` through to `text_with_status_indicator`.

### Drive-by rubocop cleanups on touched files

- Drop `keyword_init: true` on `SplitTimeData` (`Style/RedundantStructKeywordInit` — redundant in Ruby 4.0). Updated the two call sites that passed a hash positionally (`SplitTimeQuery#time_detail` and `BibTimeRow#split_times`) to splat with symbolized keys.
- `split_time_query.rb`'s older heredocs (`<<-SQL`) had trailing whitespace inside. Rubocop's autofix preserved them via the `#{' '}` interpolation trick — I stripped those per the project rule against that pattern; the SQL is `.squish`-ed before execute so the spaces were never load-bearing.

Closes #2019. Builds on #2016, #2017, #2018, #2020.

## Test plan

- [x] `bundle exec rspec spec/view_models spec/queries spec/helpers` (195 examples, all green).
- [x] `rubocop --force-exclusion` clean on all 5 touched files.
- [x] Manual SQL sanity check: `SplitTimeQuery.time_detail(...)` returns `SplitTimeData` instances with `status_reason` populated for the rows that carry it in the DB.
- [x] CI green.
- [ ] Post-deploy: visit a spread view or effort-times view with a flagged split_time, hover the warning/danger icon, confirm tooltip includes the reason.