### PR TITLE
Add non_profit flag to organizations

### DIFF
--- a/db/migrate/20260513152941_add_non_profit_to_organizations.rb
+++ b/db/migrate/20260513152941_add_non_profit_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddNonProfitToOrganizations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :organizations, :non_profit, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_12_213336) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_13_152941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -520,6 +520,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_213336) do
     t.text "description"
     t.date "good_standing_through"
     t.string "name", limit: 64, null: false
+    t.boolean "non_profit", default: false, null: false
     t.string "slug", null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["slug"], name: "index_organizations_on_slug", unique: true


### PR DESCRIPTION
## Summary
- Adds a `non_profit` boolean column to `organizations` (default `false`, not null).
- Sets the stage for an upcoming admin-only Organization Usage report that separates for-profit and non-profit race directors so we can identify heavy users to reach out to.
- No model or UI changes yet; the flag is admin-classification only.

## Test plan
- [x] `bin/rails db:migrate` succeeds locally; `db/schema.rb` reflects the new column.
- [x] CI green.