### PR TITLE
Add admin Organization Usage report

### DIFF
--- a/app/controllers/madmin/organization_usages_controller.rb
+++ b/app/controllers/madmin/organization_usages_controller.rb
@@ -1,0 +1,12 @@
+module Madmin
+  class OrganizationUsagesController < Madmin::ApplicationController
+    def index
+      @presenter = OrganizationUsageIndexPresenter.new
+    end
+
+    def show
+      @organization = Organization.friendly.find(params[:id])
+      @presenter = OrganizationUsageShowPresenter.new(@organization)
+    end
+  end
+end

--- a/app/madmin/resources/organization_resource.rb
+++ b/app/madmin/resources/organization_resource.rb
@@ -7,6 +7,7 @@ class OrganizationResource < Madmin::Resource
   attribute :updated_at, form: false
   attribute :created_by
   attribute :concealed
+  attribute :non_profit
   attribute :slug
 
   # Associations

--- a/app/presenters/organization_usage_index_presenter.rb
+++ b/app/presenters/organization_usage_index_presenter.rb
@@ -1,0 +1,35 @@
+class OrganizationUsageIndexPresenter
+  Row = Struct.new(:organization, :event_group_count, :event_count, :effort_count)
+
+  def for_profit_rows
+    rows.reject { |row| row.organization.non_profit? }
+  end
+
+  def non_profit_rows
+    rows.select { |row| row.organization.non_profit? }
+  end
+
+  private
+
+  def rows
+    @rows ||= Organization
+              .joins(event_groups: { events: :efforts })
+              .where(event_groups: { concealed: false }, efforts: { started: true })
+              .group("organizations.id")
+              .select(
+                "organizations.*",
+                "COUNT(DISTINCT event_groups.id) AS real_event_group_count",
+                "COUNT(DISTINCT events.id)       AS real_event_count",
+                "COUNT(efforts.id)               AS real_effort_count",
+              )
+              .order(Arel.sql("COUNT(efforts.id) DESC"), :name)
+              .map do |org|
+      Row.new(
+        organization: org,
+        event_group_count: org.real_event_group_count,
+        event_count: org.real_event_count,
+        effort_count: org.real_effort_count,
+      )
+    end
+  end
+end

--- a/app/presenters/organization_usage_show_presenter.rb
+++ b/app/presenters/organization_usage_show_presenter.rb
@@ -1,0 +1,49 @@
+class OrganizationUsageShowPresenter
+  attr_reader :organization
+
+  def initialize(organization)
+    @organization = organization
+  end
+
+  def total_event_groups
+    breakdown.keys.size
+  end
+
+  def total_events
+    Event
+      .joins(:event_group, :efforts)
+      .where(event_groups: { organization_id: organization.id, concealed: false }, efforts: { started: true })
+      .distinct
+      .count
+  end
+
+  def total_efforts
+    breakdown.values.sum { |years| years.values.sum }
+  end
+
+  def chart_series
+    breakdown.map { |(_eg_id, eg_name), years| { name: eg_name, data: years.sort.to_h } }
+  end
+
+  def event_group_rows
+    breakdown.map do |(_eg_id, eg_name), years|
+      { name: eg_name, years: years.sort.to_h, total: years.values.sum }
+    end
+  end
+
+  private
+
+  def breakdown
+    @breakdown ||= raw_counts.each_with_object({}) do |((eg_id, eg_name, year), count), acc|
+      (acc[[eg_id, eg_name]] ||= {})[year.to_i] = count
+    end
+  end
+
+  def raw_counts
+    Effort
+      .joins(event: :event_group)
+      .where(event_groups: { organization_id: organization.id, concealed: false }, started: true)
+      .group("event_groups.id", "event_groups.name", Arel.sql("EXTRACT(YEAR FROM events.scheduled_start_time)"))
+      .count
+  end
+end

--- a/app/views/madmin/dashboard/show.html.erb
+++ b/app/views/madmin/dashboard/show.html.erb
@@ -16,6 +16,9 @@
     <%= link_to "Solid Cache", solid_cache_dashboard_path,
                 target: "_blank",
                 class: "btn btn-primary", rel: "noopener" %>
+
+    <%= link_to "Organization Usage", madmin_organization_usages_path,
+                class: "btn btn-primary" %>
   </div>
 
   <h2 class="text-xl font-semibold mb-4">Database Statistics</h2>

--- a/app/views/madmin/organization_usages/index.html.erb
+++ b/app/views/madmin/organization_usages/index.html.erb
@@ -1,0 +1,46 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <h1 class="text-3xl font-bold mb-6">Organization Usage</h1>
+  <p class="text-sm text-gray-600 mb-8">
+    Organizations with at least one real event — public event group containing at least one started effort.
+    Sorted by total real efforts (descending).
+  </p>
+
+  <% [["For-Profit", @presenter.for_profit_rows], ["Non-Profit", @presenter.non_profit_rows]].each do |heading, rows| %>
+    <section class="mb-10">
+      <h2 class="text-xl font-semibold mb-4"><%= heading %> (<%= rows.size %>)</h2>
+
+      <% if rows.empty? %>
+        <p class="text-sm text-gray-500 italic">No organizations in this category.</p>
+      <% else %>
+        <div class="bg-white rounded-lg shadow overflow-hidden">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Organization</th>
+                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Event Groups</th>
+                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Events</th>
+                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Efforts</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Owner</th>
+              </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+              <% rows.each do |row| %>
+                <tr>
+                  <td class="px-6 py-3 whitespace-nowrap font-medium">
+                    <%= link_to row.organization.name, madmin_organization_usage_path(row.organization), class: "text-blue-600 hover:underline" %>
+                  </td>
+                  <td class="px-6 py-3 whitespace-nowrap text-right"><%= row.event_group_count %></td>
+                  <td class="px-6 py-3 whitespace-nowrap text-right"><%= row.event_count %></td>
+                  <td class="px-6 py-3 whitespace-nowrap text-right font-semibold"><%= row.effort_count %></td>
+                  <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-500">
+                    <%= row.organization.owner_full_name.presence || row.organization.owner_email %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
+    </section>
+  <% end %>
+</div>

--- a/app/views/madmin/organization_usages/show.html.erb
+++ b/app/views/madmin/organization_usages/show.html.erb
@@ -1,0 +1,61 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="flex items-baseline justify-between mb-6">
+    <h1 class="text-3xl font-bold">
+      <%= @organization.name %>
+      <% if @organization.non_profit? %>
+        <span class="ml-2 inline-block px-2 py-0.5 text-xs font-semibold rounded bg-green-100 text-green-800 align-middle">Non-Profit</span>
+      <% else %>
+        <span class="ml-2 inline-block px-2 py-0.5 text-xs font-semibold rounded bg-blue-100 text-blue-800 align-middle">For-Profit</span>
+      <% end %>
+    </h1>
+    <%= link_to "← All organizations", madmin_organization_usages_path, class: "text-sm text-blue-600 hover:underline" %>
+  </div>
+
+  <div class="grid grid-cols-3 gap-4 mb-8">
+    <div class="bg-white rounded-lg shadow p-4">
+      <div class="text-xs uppercase tracking-wider text-gray-500">Event Groups</div>
+      <div class="text-2xl font-bold"><%= @presenter.total_event_groups %></div>
+    </div>
+    <div class="bg-white rounded-lg shadow p-4">
+      <div class="text-xs uppercase tracking-wider text-gray-500">Events</div>
+      <div class="text-2xl font-bold"><%= @presenter.total_events %></div>
+    </div>
+    <div class="bg-white rounded-lg shadow p-4">
+      <div class="text-xs uppercase tracking-wider text-gray-500">Started Efforts</div>
+      <div class="text-2xl font-bold"><%= @presenter.total_efforts %></div>
+    </div>
+  </div>
+
+  <% if @presenter.chart_series.any? %>
+    <h2 class="text-xl font-semibold mb-4">Efforts by year</h2>
+    <div class="bg-white rounded-lg shadow p-4 mb-8">
+      <%= line_chart @presenter.chart_series, library: { plugins: { legend: { position: "bottom" } } } %>
+    </div>
+
+    <h2 class="text-xl font-semibold mb-4">Breakdown</h2>
+    <div class="bg-white rounded-lg shadow overflow-hidden">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Event Group</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Year &times; Efforts</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Total</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <% @presenter.event_group_rows.each do |row| %>
+            <tr>
+              <td class="px-6 py-3 whitespace-nowrap font-medium"><%= row[:name] %></td>
+              <td class="px-6 py-3 text-sm text-gray-700">
+                <%= row[:years].map { |year, count| "#{year}: #{count}" }.join(" • ") %>
+              </td>
+              <td class="px-6 py-3 whitespace-nowrap text-right font-semibold"><%= row[:total] %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-sm text-gray-500 italic">No real efforts recorded for this organization.</p>
+  <% end %>
+</div>

--- a/config/routes/madmin.rb
+++ b/config/routes/madmin.rb
@@ -60,6 +60,7 @@ namespace :madmin do
   resources :results_categories
   resources :raw_times
   resources :courses
+  resources :organization_usages, only: [:index, :show], path: "organization-usage"
   get "dashboard/timeout", to: "dashboard#timeout"
   root to: "dashboard#show"
 end

--- a/spec/fixtures/organizations.yml
+++ b/spec/fixtures/organizations.yml
@@ -21,6 +21,7 @@ running_up_for_air:
   description:
   created_by: 1
   concealed: false
+  non_profit: true
   slug: running-up-for-air
   good_standing_through:
 dirty_30_running:

--- a/spec/presenters/organization_usage_index_presenter_spec.rb
+++ b/spec/presenters/organization_usage_index_presenter_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe OrganizationUsageIndexPresenter do
+  subject(:presenter) { described_class.new }
+
+  describe "#for_profit_rows / #non_profit_rows" do
+    it "places non_profit organizations only in non_profit_rows" do
+      non_profit_org = organizations(:running_up_for_air)
+      expect(non_profit_org).to be_non_profit
+
+      expect(presenter.non_profit_rows.map { |row| row.organization.id }).to include(non_profit_org.id)
+      expect(presenter.for_profit_rows.map { |row| row.organization.id }).not_to include(non_profit_org.id)
+    end
+
+    it "excludes organizations with no real efforts" do
+      empty_org = Organization.create!(
+        name: "Org With Nothing",
+        created_by: users(:admin_user).id,
+        concealed: false,
+      )
+
+      all_org_ids = (presenter.for_profit_rows + presenter.non_profit_rows).map { |row| row.organization.id }
+      expect(all_org_ids).not_to include(empty_org.id)
+    end
+
+    it "excludes organizations whose only event groups are concealed" do
+      hardrock = organizations(:hardrock)
+      hardrock.event_groups.update_all(concealed: true)
+
+      all_org_ids = (presenter.for_profit_rows + presenter.non_profit_rows).map { |row| row.organization.id }
+      expect(all_org_ids).not_to include(hardrock.id)
+    end
+
+    it "sorts each section by effort count descending" do
+      for_profit_counts = presenter.for_profit_rows.map(&:effort_count)
+      non_profit_counts = presenter.non_profit_rows.map(&:effort_count)
+
+      expect(for_profit_counts).to eq(for_profit_counts.sort.reverse)
+      expect(non_profit_counts).to eq(non_profit_counts.sort.reverse)
+    end
+
+    it "counts only started efforts inside non-concealed event groups" do
+      hardrock = organizations(:hardrock)
+      total_started = Effort.joins(event: :event_group)
+                            .where(event_groups: { organization_id: hardrock.id, concealed: false }, started: true)
+                            .count
+
+      row = presenter.for_profit_rows.find { |r| r.organization.id == hardrock.id }
+      expect(row).not_to be_nil
+      expect(row.effort_count).to eq(total_started)
+    end
+  end
+end

--- a/spec/presenters/organization_usage_show_presenter_spec.rb
+++ b/spec/presenters/organization_usage_show_presenter_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe OrganizationUsageShowPresenter do
+  let(:hardrock) { organizations(:hardrock) }
+
+  describe "#chart_series" do
+    it "groups counts by event group and year" do
+      presenter = described_class.new(hardrock)
+
+      expect(presenter.chart_series).not_to be_empty
+      presenter.chart_series.each do |series|
+        expect(series).to include(:name, :data)
+        expect(series[:data]).not_to be_empty
+        series[:data].each_key { |year| expect(year).to be_an(Integer) }
+      end
+    end
+
+    it "is empty when all event groups are concealed" do
+      hardrock.event_groups.update_all(concealed: true)
+      presenter = described_class.new(hardrock)
+
+      expect(presenter.chart_series).to be_empty
+      expect(presenter.total_efforts).to eq(0)
+    end
+  end
+
+  describe "#total_efforts" do
+    it "counts only started efforts" do
+      Effort.joins(event: :event_group)
+            .where(event_groups: { organization_id: hardrock.id })
+            .update_all(started: false)
+      presenter = described_class.new(hardrock)
+
+      expect(presenter.total_efforts).to eq(0)
+    end
+
+    it "matches the sum of all chart data points" do
+      presenter = described_class.new(hardrock)
+
+      chart_sum = presenter.chart_series.sum { |series| series[:data].values.sum }
+      expect(presenter.total_efforts).to eq(chart_sum)
+    end
+  end
+end

--- a/spec/requests/madmin/organization_usages_controller_spec.rb
+++ b/spec/requests/madmin/organization_usages_controller_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe "Madmin::OrganizationUsagesController" do
+  include Warden::Test::Helpers
+
+  let(:admin_user) { users(:admin_user) }
+  let(:non_admin_user) { users(:third_user) }
+
+  after { Warden.test_reset! }
+
+  describe "GET /madmin/organization-usage" do
+    context "when signed in as a non-admin" do
+      before { login_as non_admin_user, scope: :user }
+
+      it "redirects with an unauthorized alert" do
+        get madmin_organization_usages_path
+
+        expect(response).to redirect_to("/")
+        expect(flash[:alert]).to eq("Not authorized.")
+      end
+    end
+
+    context "when signed in as an admin" do
+      before { login_as admin_user, scope: :user }
+
+      it "renders successfully" do
+        get madmin_organization_usages_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Organization Usage")
+      end
+
+      it "lists organizations under both For-Profit and Non-Profit headings" do
+        get madmin_organization_usages_path
+
+        expect(response.body).to include("For-Profit")
+        expect(response.body).to include("Non-Profit")
+        # Running Up For Air is the lone non_profit: true fixture
+        non_profit_half = response.body.split("Non-Profit", 2).last
+        expect(non_profit_half).to include("Running Up For Air")
+      end
+
+      it "excludes organizations with no real efforts" do
+        empty_org = Organization.create!(
+          name: "Org With Nothing",
+          created_by: admin_user.id,
+          concealed: false,
+        )
+
+        get madmin_organization_usages_path
+
+        expect(response.body).not_to include(empty_org.name)
+      end
+    end
+  end
+
+  describe "GET /madmin/organization-usage/:id" do
+    let(:hardrock) { organizations(:hardrock) }
+
+    context "when signed in as a non-admin" do
+      before { login_as non_admin_user, scope: :user }
+
+      it "redirects with an unauthorized alert" do
+        get madmin_organization_usage_path(hardrock)
+
+        expect(response).to redirect_to("/")
+        expect(flash[:alert]).to eq("Not authorized.")
+      end
+    end
+
+    context "when signed in as an admin" do
+      before { login_as admin_user, scope: :user }
+
+      it "renders the organization name and a chart" do
+        get madmin_organization_usage_path(hardrock)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Hardrock")
+        expect(response.body).to include("Efforts by year")
+      end
+
+      it "shows the empty-state message when the org has no real efforts" do
+        hardrock.event_groups.update_all(concealed: true)
+
+        get madmin_organization_usage_path(hardrock)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("No real efforts recorded")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New admin-only page at `/madmin/organization-usage` listing orgs that have at least one real event (public event group with ≥1 started effort), split into **For-Profit** and **Non-Profit** sections and sorted by total started efforts (desc).
- Drill-down at `/madmin/organization-usage/:id` renders a Chartkick line chart with one series per EventGroup (year × started efforts), totals tiles, and a per-EG breakdown table.
- Admins can toggle `non_profit` from `/madmin/organizations/:id/edit` (flag was added in #2024). Not exposed on the org owner's edit form.
- New "Organization Usage" button on the existing `/madmin/dashboard`.

Designed to help identify heavy users — especially for-profit race directors — to reach out to about contributing.

## Test plan
- [x] `bundle exec rspec spec/requests/madmin/organization_usages_controller_spec.rb spec/presenters/organization_usage_index_presenter_spec.rb spec/presenters/organization_usage_show_presenter_spec.rb` → 16 examples, 0 failures.
- [x] Rubocop + erb-lint clean on touched files.
- [ ] Manually visit `/madmin/dashboard` as admin, click "Organization Usage", drill into an org, verify chart + totals render and that signing in as a non-admin redirects.