### PR TITLE
Org Usage: add Last Active Year and Owner Email columns

### DIFF
--- a/app/presenters/organization_usage_index_presenter.rb
+++ b/app/presenters/organization_usage_index_presenter.rb
@@ -1,5 +1,5 @@
 class OrganizationUsageIndexPresenter
-  Row = Struct.new(:organization, :event_group_count, :event_count, :effort_count)
+  Row = Struct.new(:organization, :event_group_count, :event_count, :effort_count, :last_active_year)
 
   def for_profit_rows
     rows.reject { |row| row.organization.non_profit? }
@@ -18,9 +18,10 @@ class OrganizationUsageIndexPresenter
               .group("organizations.id")
               .select(
                 "organizations.*",
-                "COUNT(DISTINCT event_groups.id) AS real_event_group_count",
-                "COUNT(DISTINCT events.id)       AS real_event_count",
-                "COUNT(efforts.id)               AS real_effort_count",
+                "COUNT(DISTINCT event_groups.id)                          AS real_event_group_count",
+                "COUNT(DISTINCT events.id)                                AS real_event_count",
+                "COUNT(efforts.id)                                        AS real_effort_count",
+                "MAX(EXTRACT(YEAR FROM events.scheduled_start_time))::int AS last_active_year",
               )
               .order(Arel.sql("COUNT(efforts.id) DESC"), :name)
               .map do |org|
@@ -29,6 +30,7 @@ class OrganizationUsageIndexPresenter
         event_group_count: org.real_event_group_count,
         event_count: org.real_event_count,
         effort_count: org.real_effort_count,
+        last_active_year: org.last_active_year,
       )
     end
   end

--- a/app/views/organization_usages/index.html.erb
+++ b/app/views/organization_usages/index.html.erb
@@ -37,7 +37,9 @@
               <th class="text-end">Event Groups</th>
               <th class="text-end">Events</th>
               <th class="text-end">Efforts</th>
+              <th class="text-end">Last Active</th>
               <th>Owner</th>
+              <th>Owner Email</th>
             </tr>
           </thead>
           <tbody>
@@ -49,8 +51,12 @@
                 <td class="text-end"><%= row.event_group_count %></td>
                 <td class="text-end"><%= row.event_count %></td>
                 <td class="text-end fw-bold"><%= row.effort_count %></td>
+                <td class="text-end"><%= row.last_active_year %></td>
+                <td class="text-muted"><%= row.organization.owner_full_name %></td>
                 <td class="text-muted">
-                  <%= row.organization.owner_full_name.presence || row.organization.owner_email %>
+                  <% if row.organization.owner_email.present? %>
+                    <%= mail_to row.organization.owner_email %>
+                  <% end %>
                 </td>
               </tr>
             <% end %>

--- a/spec/presenters/organization_usage_index_presenter_spec.rb
+++ b/spec/presenters/organization_usage_index_presenter_spec.rb
@@ -49,5 +49,16 @@ RSpec.describe OrganizationUsageIndexPresenter do
       expect(row).not_to be_nil
       expect(row.effort_count).to eq(total_started)
     end
+
+    it "exposes last_active_year as the most recent year of started efforts" do
+      hardrock = organizations(:hardrock)
+      expected_year = Event.joins(:event_group, :efforts)
+                           .where(event_groups: { organization_id: hardrock.id, concealed: false }, efforts: { started: true })
+                           .maximum("EXTRACT(YEAR FROM events.scheduled_start_time)")
+                           .to_i
+
+      row = presenter.for_profit_rows.find { |r| r.organization.id == hardrock.id }
+      expect(row.last_active_year).to eq(expected_year)
+    end
   end
 end


### PR DESCRIPTION
## Summary
Two new columns on `/organization-usage`:

- **Last Active** — `MAX(YEAR(events.scheduled_start_time))` across the org's real events. Pulled in the same SQL pass as the existing aggregates, no N+1.
- **Owner Email** — split off from the existing Owner column so the email is always visible (rendered as a `mailto:`). Owner column now shows just the full name; previously it fell back to email when the name was blank.

## Test plan
- [x] `bundle exec rspec spec/requests/organization_usages_controller_spec.rb spec/presenters/organization_usage_index_presenter_spec.rb spec/presenters/organization_usage_show_presenter_spec.rb` → 22 examples, 0 failures.
- [x] Rubocop + erb-lint clean.
- [ ] Visit `/organization-usage` as admin and confirm the two new columns render with sensible values.