### PR TITLE
Add monetary_donations table

### DIFF
--- a/db/migrate/20260513211837_create_monetary_donations.rb
+++ b/db/migrate/20260513211837_create_monetary_donations.rb
@@ -1,0 +1,14 @@
+class CreateMonetaryDonations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :monetary_donations do |t|
+      t.references :organization, null: false, foreign_key: true
+      t.date :received_on, null: false
+      t.decimal :amount, precision: 10, scale: 2, null: false
+      t.string :source, null: false
+      t.text :note
+      t.timestamps
+    end
+
+    add_index :monetary_donations, [:organization_id, :received_on]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_13_152941) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_13_211837) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -496,6 +496,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_152941) do
     t.index ["lottery_id", "reference_number"], name: "index_lottery_tickets_on_lottery_id_and_reference_number", unique: true
     t.index ["lottery_id"], name: "index_lottery_tickets_on_lottery_id"
     t.index ["reference_number"], name: "index_lottery_tickets_on_reference_number"
+  end
+
+  create_table "monetary_donations", force: :cascade do |t|
+    t.decimal "amount", precision: 10, scale: 2, null: false
+    t.datetime "created_at", null: false
+    t.text "note"
+    t.bigint "organization_id", null: false
+    t.date "received_on", null: false
+    t.string "source", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id", "received_on"], name: "index_monetary_donations_on_organization_id_and_received_on"
+    t.index ["organization_id"], name: "index_monetary_donations_on_organization_id"
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -989,6 +1001,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_152941) do
   add_foreign_key "lottery_simulations", "lottery_simulation_runs"
   add_foreign_key "lottery_tickets", "lotteries"
   add_foreign_key "lottery_tickets", "lottery_entrants"
+  add_foreign_key "monetary_donations", "organizations"
   add_foreign_key "notifications", "efforts"
   add_foreign_key "people", "users"
   add_foreign_key "projection_assessment_runs", "events"


### PR DESCRIPTION
## Summary
First slice of #2028 — just the schema. Model, madmin CRUD, presenter, view, and specs land in follow-up PRs so each is reviewable on its own.

Columns:
- `organization_id` (FK, NOT NULL)
- `received_on` (date, NOT NULL)
- `amount` (decimal 10,2, NOT NULL) — hand-entered admin records, decimal avoids cents-conversion ceremony at every read/write
- `source` (string, NOT NULL) — enum validated at the model level (paypal / check / bitpay / other) so new sources don't need another migration
- `note` (text, nullable)

Composite index on `(organization_id, received_on)` for the per-org ordered list view to come.

Relates to #2028. (Not auto-closing — issue stays open until the model + view land.)

## Test plan
- [x] `bin/rails db:migrate` succeeds locally; `db/schema.rb` reflects the new table with the expected columns, NOT NULLs, and indexes.
- [x] CI green.