### PR TITLE
Add MonetaryDonation model and admin CRUD

### DIFF
--- a/app/madmin/resources/monetary_donation_resource.rb
+++ b/app/madmin/resources/monetary_donation_resource.rb
@@ -1,0 +1,10 @@
+class MonetaryDonationResource < Madmin::Resource
+  attribute :id, form: false
+  attribute :organization
+  attribute :received_on
+  attribute :amount
+  attribute :source
+  attribute :note
+  attribute :created_at, form: false
+  attribute :updated_at, form: false
+end

--- a/app/models/monetary_donation.rb
+++ b/app/models/monetary_donation.rb
@@ -1,0 +1,11 @@
+class MonetaryDonation < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :organization
+
+  enum :source, { paypal: "paypal", check: "check", bitpay: "bitpay", other: "other" }
+
+  validates :received_on, presence: true
+  validates :amount, presence: true, numericality: { greater_than: 0 }
+  validates :source, presence: true
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -15,6 +15,7 @@ class Organization < ApplicationRecord
   has_many :event_groups, dependent: :destroy
   has_many :historical_facts, dependent: :destroy
   has_many :lotteries, dependent: :destroy
+  has_many :monetary_donations, dependent: :destroy
   has_many :stewardships, dependent: :destroy
   has_many :stewards, through: :stewardships, source: :user
   has_many :event_series, dependent: :destroy
@@ -23,13 +24,17 @@ class Organization < ApplicationRecord
   scope :owned_by, ->(user) { where(created_by: user.id) }
   scope :authorized_for, lambda { |user|
     left_joins(:stewardships)
-        .where("organizations.created_by = ? or stewardships.user_id = ?", user.id, user.id)
-        .distinct
+      .where("organizations.created_by = ? or stewardships.user_id = ?", user.id, user.id)
+      .distinct
   }
   scope :visible_or_authorized_for, lambda { |user|
     left_joins(:stewardships)
-        .where("organizations.concealed is not true or organizations.created_by = ? or stewardships.user_id = ?", user.id, user.id)
-        .distinct
+      .where(
+        "organizations.concealed is not true or organizations.created_by = ? or stewardships.user_id = ?",
+        user.id,
+        user.id,
+      )
+      .distinct
   }
   scope :with_visible_event_count, lambda {
     left_joins(event_groups: :events)
@@ -39,8 +44,8 @@ class Organization < ApplicationRecord
 
   alias_attribute :owner_id, :created_by
 
-  validates_presence_of :name
-  validates_uniqueness_of :name, case_sensitive: false
+  validates :name, presence: true
+  validates :name, uniqueness: { case_sensitive: false } # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates_with OwnerExistsValidator
 
   def to_s
@@ -56,7 +61,9 @@ class Organization < ApplicationRecord
   end
 
   def owner
-    @owner ||= User.find_by(id: owner_id)
+    return @owner if defined?(@owner)
+
+    @owner = User.find_by(id: owner_id)
   end
 
   def owner_full_name

--- a/config/routes/madmin.rb
+++ b/config/routes/madmin.rb
@@ -60,6 +60,7 @@ namespace :madmin do
   resources :results_categories
   resources :raw_times
   resources :courses
+  resources :monetary_donations
   get "dashboard/timeout", to: "dashboard#timeout"
   root to: "dashboard#show"
 end

--- a/spec/fixtures/monetary_donations.yml
+++ b/spec/fixtures/monetary_donations.yml
@@ -1,0 +1,22 @@
+---
+hardrock_paypal_2024:
+  id: 1
+  organization_id: 4
+  received_on: 2024-09-12
+  amount: 250.00
+  source: paypal
+  note: PayPal transaction ABC123
+hardrock_check_2025:
+  id: 2
+  organization_id: 4
+  received_on: 2025-03-04
+  amount: 500.00
+  source: check
+  note: Check #4421
+running_up_for_air_bitpay_2025:
+  id: 3
+  organization_id: 14
+  received_on: 2025-02-15
+  amount: 100.00
+  source: bitpay
+  note:

--- a/spec/models/monetary_donation_spec.rb
+++ b/spec/models/monetary_donation_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe MonetaryDonation, type: :model do
+  let(:hardrock) { organizations(:hardrock) }
+
+  describe "associations" do
+    it "belongs to an organization" do
+      donation = described_class.new(organization: hardrock, received_on: Date.current, amount: 50, source: "paypal")
+
+      expect(donation.organization).to eq(hardrock)
+      expect(donation).to be_valid
+    end
+
+    it "is required to have an organization" do
+      donation = described_class.new(received_on: Date.current, amount: 50, source: "paypal")
+
+      expect(donation).not_to be_valid
+      expect(donation.errors[:organization]).to be_present
+    end
+
+    it "is accessible through Organization#monetary_donations" do
+      expect(hardrock.monetary_donations).to include(monetary_donations(:hardrock_paypal_2024))
+    end
+  end
+
+  describe "validations" do
+    subject { described_class.new(organization: hardrock, received_on: Date.current, amount: 50, source: "paypal") }
+
+    it { is_expected.to be_valid }
+
+    it "requires received_on" do
+      subject.received_on = nil
+      expect(subject).not_to be_valid
+      expect(subject.errors[:received_on]).to be_present
+    end
+
+    it "requires a positive amount" do
+      subject.amount = 0
+      expect(subject).not_to be_valid
+
+      subject.amount = -10
+      expect(subject).not_to be_valid
+
+      subject.amount = nil
+      expect(subject).not_to be_valid
+    end
+
+    it "requires source to be one of the enum values" do
+      expect { subject.source = "wire" }.to raise_error(ArgumentError, /'wire' is not a valid source/)
+    end
+  end
+
+  describe "source enum" do
+    it "exposes the expected sources" do
+      expect(described_class.sources.keys).to match_array(%w[paypal check bitpay other])
+    end
+
+    it "round-trips through the database" do
+      donation = described_class.create!(organization: hardrock, received_on: Date.current, amount: 25, source: "check")
+
+      expect(donation.reload.source).to eq("check")
+      expect(donation).to be_check
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,6 +69,7 @@ RSpec.configure do |config|
     :lottery_entrants,
     :lottery_simulation_runs,
     :lottery_tickets,
+    :monetary_donations,
     :notifications,
     :organizations,
     :partners,


### PR DESCRIPTION
## Summary
Second slice of #2028. Admins can now record/edit/view monetary donations through `/madmin/monetary_donations`. The per-org tile + list on the Organization Usage page lands in the final slice.

- **Model** (`MonetaryDonation`) — `belongs_to :organization`, `source` enum (paypal / check / bitpay / other), presence + positive-amount validations, paper_trail audit (admins write these — change history matters).
- **Association** — `has_many :monetary_donations, dependent: :destroy` on Organization.
- **Admin** — `MonetaryDonationResource` (auto-CRUD via madmin) + `resources :monetary_donations` under the existing madmin namespace. `Madmin::ApplicationController` already gates admin auth, so no new policy work.
- **Specs / fixtures** — 3 fixture rows (paypal / check / bitpay across two orgs) registered in `global_fixtures`; new model spec covers associations, validations, and the source enum.

### About the organization.rb diff
Touching this file (to add the association) means CI runs rubocop on the whole file, which had 8 pre-existing offenses (indentation, validation syntax, `find_by` memoization, line length). Most were autocorrected. The lone inline `rubocop:disable Rails/UniqueValidationWithoutIndex` on the name-uniqueness validation is deferred — the proper fix is a DB unique index on `lower(name)`, which needs its own migration and a duplicate-data audit. Not in scope here.

Relates to #2028. Not auto-closing — issue stays open until the usage-page view lands.

## Test plan
- [x] `bundle exec rspec spec/models/monetary_donation_spec.rb spec/models/organization_spec.rb spec/requests/organization_usages_controller_spec.rb spec/presenters/organization_usage_index_presenter_spec.rb spec/presenters/organization_usage_show_presenter_spec.rb` → 51 examples, 0 failures.
- [x] `bundle exec rubocop` clean on touched Ruby files.
- [x] Visit `/madmin/monetary_donations` as admin; create a row with `source: paypal`, `amount: 50.00`; confirm it appears in the index.