### PR TITLE
Show donations on the Organization Usage detail page

### DIFF
--- a/app/presenters/organization_usage_show_presenter.rb
+++ b/app/presenters/organization_usage_show_presenter.rb
@@ -21,6 +21,14 @@ class OrganizationUsageShowPresenter
     breakdown.values.sum { |years| years.values.sum }
   end
 
+  def total_donated
+    donations.sum(:amount)
+  end
+
+  def donations
+    @donations ||= organization.monetary_donations.order(received_on: :desc)
+  end
+
   def sorted_years
     @sorted_years ||= breakdown.values.flat_map(&:keys).uniq.sort
   end

--- a/app/views/organization_usages/show.html.erb
+++ b/app/views/organization_usages/show.html.erb
@@ -27,7 +27,7 @@
 
 <article class="ost-article container">
   <div class="row mb-4">
-    <div class="col">
+    <div class="col-md-3">
       <div class="card">
         <div class="card-body">
           <div class="text-muted small text-uppercase">Event Groups</div>
@@ -35,7 +35,7 @@
         </div>
       </div>
     </div>
-    <div class="col">
+    <div class="col-md-3">
       <div class="card">
         <div class="card-body">
           <div class="text-muted small text-uppercase">Events</div>
@@ -43,11 +43,19 @@
         </div>
       </div>
     </div>
-    <div class="col">
+    <div class="col-md-3">
       <div class="card">
         <div class="card-body">
           <div class="text-muted small text-uppercase">Started Efforts</div>
           <div class="h3 fw-bold mb-0"><%= @presenter.total_efforts %></div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="card">
+        <div class="card-body">
+          <div class="text-muted small text-uppercase">Total Donated</div>
+          <div class="h3 fw-bold mb-0"><%= number_to_currency(@presenter.total_donated) %></div>
         </div>
       </div>
     </div>
@@ -84,5 +92,34 @@
     </table>
   <% else %>
     <p class="text-muted fst-italic">No real efforts recorded for this organization.</p>
+  <% end %>
+
+  <h2 class="h4 fw-bold mt-4">Donations</h2>
+  <% if @presenter.donations.any? %>
+    <table class="table table-striped align-middle">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th class="text-end">Amount</th>
+          <th>Source</th>
+          <th>Note</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @presenter.donations.each do |donation| %>
+          <tr>
+            <td><%= donation.received_on.iso8601 %></td>
+            <td class="text-end fw-bold"><%= number_to_currency(donation.amount) %></td>
+            <td><span class="badge bg-secondary"><%= donation.source.humanize %></span></td>
+            <td class="text-muted small"><%= donation.note %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p class="text-muted fst-italic">
+      No donations recorded —
+      <%= link_to "record one in the admin area", madmin_monetary_donations_path %>.
+    </p>
   <% end %>
 </article>

--- a/spec/presenters/organization_usage_show_presenter_spec.rb
+++ b/spec/presenters/organization_usage_show_presenter_spec.rb
@@ -86,4 +86,37 @@ RSpec.describe OrganizationUsageShowPresenter do
       expect(presenter.total_efforts).to eq(chart_sum)
     end
   end
+
+  describe "#donations" do
+    it "returns the org's monetary_donations sorted by received_on descending" do
+      presenter = described_class.new(hardrock)
+
+      expect(presenter.donations).to eq(hardrock.monetary_donations.order(received_on: :desc))
+      expect(presenter.donations.map(&:received_on)).to eq(presenter.donations.map(&:received_on).sort.reverse)
+    end
+
+    it "is empty for an organization with no donations" do
+      orphan_org = Organization.create!(name: "No Donations Org", created_by: users(:admin_user).id, concealed: false)
+      presenter = described_class.new(orphan_org)
+
+      expect(presenter.donations).to be_empty
+    end
+  end
+
+  describe "#total_donated" do
+    it "sums the donation amounts" do
+      presenter = described_class.new(hardrock)
+      expected = hardrock.monetary_donations.sum(:amount)
+
+      expect(presenter.total_donated).to eq(expected)
+      expect(expected).to be > 0
+    end
+
+    it "returns zero for an organization with no donations" do
+      orphan_org = Organization.create!(name: "No Donations Org", created_by: users(:admin_user).id, concealed: false)
+      presenter = described_class.new(orphan_org)
+
+      expect(presenter.total_donated).to eq(0)
+    end
+  end
 end

--- a/spec/requests/organization_usages_controller_spec.rb
+++ b/spec/requests/organization_usages_controller_spec.rb
@@ -95,6 +95,25 @@ RSpec.describe "OrganizationUsagesController" do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("No real efforts recorded")
       end
+
+      it "renders the donations section with recorded donations" do
+        get organization_usage_path(hardrock)
+
+        expect(response.body).to include("Donations")
+        expect(response.body).to include("Total Donated")
+        # hardrock_check_2025 fixture: 500.00 check
+        expect(response.body).to include("$500.00")
+        expect(response.body).to include("Check")
+      end
+
+      it "renders the donations empty state with a link to madmin" do
+        org_without_donations = organizations(:rattlesnake_ramble)
+
+        get organization_usage_path(org_without_donations)
+
+        expect(response.body).to include("No donations recorded")
+        expect(response.body).to include(madmin_monetary_donations_path)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Final slice of #2028. The Organization Usage detail page now surfaces monetary donations:

- Fourth summary tile: **Total Donated** (`number_to_currency`). Tiles now use `.col-md-3` so four fit cleanly on the row.
- New **Donations** section below the course breakdown: striped table of Date / Amount / Source / Note, newest first.
- Empty state links to `/madmin/monetary_donations` so the admin can record one without leaving the page.
- Presenter gains `total_donated` and `donations` (both backed by `Organization#monetary_donations`).

Resolves #2028.

## Test plan
- [x] `bundle exec rspec spec/presenters/organization_usage_show_presenter_spec.rb spec/requests/organization_usages_controller_spec.rb spec/models/monetary_donation_spec.rb spec/presenters/organization_usage_index_presenter_spec.rb` → 38 examples, 0 failures.
- [x] Rubocop + erb-lint clean on touched files.
- [ ] Visit `/organization-usage/hardrock` as admin: confirm Total Donated tile renders, donations table shows the fixture rows, source badges format correctly.
- [ ] Visit an org with no donations: confirm the empty-state copy renders with a working link to `/madmin/monetary_donations`.