### PR TITLE
Hotfix: add missing Madmin::MonetaryDonationsController

### DIFF
--- a/app/controllers/madmin/monetary_donations_controller.rb
+++ b/app/controllers/madmin/monetary_donations_controller.rb
@@ -1,0 +1,4 @@
+module Madmin
+  class MonetaryDonationsController < Madmin::ResourceController
+  end
+end

--- a/spec/requests/madmin/monetary_donations_controller_spec.rb
+++ b/spec/requests/madmin/monetary_donations_controller_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Madmin::MonetaryDonationsController" do
+  include Warden::Test::Helpers
+
+  let(:admin_user) { users(:admin_user) }
+
+  before { login_as admin_user, scope: :user }
+  after { Warden.test_reset! }
+
+  it "renders the index" do
+    get "/madmin/monetary_donations"
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "renders the new form" do
+    get "/madmin/monetary_donations/new"
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "renders the show page for an existing donation" do
+    donation = monetary_donations(:hardrock_paypal_2024)
+
+    get "/madmin/monetary_donations/#{donation.id}"
+
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
## Summary
`/madmin/monetary_donations` returns a 500 (`uninitialized constant Madmin::MonetaryDonationsController`) — #2030 added the `MonetaryDonationResource` and the route but missed the controller class itself. Every other madmin resource in this codebase has a one-line subclass of `Madmin::ResourceController` (see e.g. `app/controllers/madmin/notifications_controller.rb`); this PR adds the missing one.

Also adds a request smoke spec covering index / new / show so the regression cannot recur. Verified the spec reproduces the original `uninitialized constant` error without the controller file present, and passes with it.

## Test plan
- [x] `bundle exec rspec spec/requests/madmin/monetary_donations_controller_spec.rb` → 3 examples, 0 failures.
- [x] Confirmed the spec fails with the original `NameError` when the controller file is removed.
- [ ] Manually visit `/madmin/monetary_donations` as admin and confirm it renders the index, the New form, and an existing donation's show page.