### PR TITLE
Move Total Donated from show page to index column

### DIFF
--- a/app/presenters/organization_usage_index_presenter.rb
+++ b/app/presenters/organization_usage_index_presenter.rb
@@ -1,5 +1,15 @@
 class OrganizationUsageIndexPresenter
-  Row = Struct.new(:organization, :event_group_count, :event_count, :effort_count, :last_active_year)
+  Row = Struct.new(:organization, :event_group_count, :event_count, :effort_count, :last_active_year, :total_donated)
+
+  # Correlated subquery rather than joining monetary_donations into the main aggregate —
+  # joining would multiply the effort counts by the donation row count.
+  TOTAL_DONATED_SQL = <<~SQL.squish.freeze
+    (
+      SELECT COALESCE(SUM(monetary_donations.amount), 0)
+      FROM monetary_donations
+      WHERE monetary_donations.organization_id = organizations.id
+    ) AS total_donated
+  SQL
 
   def for_profit_rows
     rows.reject { |row| row.organization.non_profit? }
@@ -22,6 +32,7 @@ class OrganizationUsageIndexPresenter
                 "COUNT(DISTINCT events.id)                                AS real_event_count",
                 "COUNT(efforts.id)                                        AS real_effort_count",
                 "MAX(EXTRACT(YEAR FROM events.scheduled_start_time))::int AS last_active_year",
+                TOTAL_DONATED_SQL,
               )
               .order(Arel.sql("COUNT(efforts.id) DESC"), :name)
               .map do |org|
@@ -31,6 +42,7 @@ class OrganizationUsageIndexPresenter
         event_count: org.real_event_count,
         effort_count: org.real_effort_count,
         last_active_year: org.last_active_year,
+        total_donated: org.total_donated,
       )
     end
   end

--- a/app/presenters/organization_usage_show_presenter.rb
+++ b/app/presenters/organization_usage_show_presenter.rb
@@ -21,14 +21,6 @@ class OrganizationUsageShowPresenter
     breakdown.values.sum { |years| years.values.sum }
   end
 
-  def total_donated
-    donations.sum(:amount)
-  end
-
-  def donations
-    @donations ||= organization.monetary_donations.order(received_on: :desc)
-  end
-
   def sorted_years
     @sorted_years ||= breakdown.values.flat_map(&:keys).uniq.sort
   end

--- a/app/views/organization_usages/index.html.erb
+++ b/app/views/organization_usages/index.html.erb
@@ -38,6 +38,7 @@
               <th class="text-end">Events</th>
               <th class="text-end">Efforts</th>
               <th class="text-end">Last Active</th>
+              <th class="text-end">Total Donated</th>
               <th>Owner</th>
               <th>Owner Email</th>
             </tr>
@@ -52,6 +53,9 @@
                 <td class="text-end"><%= row.event_count %></td>
                 <td class="text-end fw-bold"><%= row.effort_count %></td>
                 <td class="text-end"><%= row.last_active_year %></td>
+                <td class="text-end <%= "text-muted" if row.total_donated.to_d.zero? %>">
+                  <%= number_to_currency(row.total_donated) %>
+                </td>
                 <td class="text-muted"><%= row.organization.owner_full_name %></td>
                 <td class="text-muted">
                   <% if row.organization.owner_email.present? %>

--- a/app/views/organization_usages/show.html.erb
+++ b/app/views/organization_usages/show.html.erb
@@ -27,7 +27,7 @@
 
 <article class="ost-article container">
   <div class="row mb-4">
-    <div class="col-md-3">
+    <div class="col">
       <div class="card">
         <div class="card-body">
           <div class="text-muted small text-uppercase">Event Groups</div>
@@ -35,7 +35,7 @@
         </div>
       </div>
     </div>
-    <div class="col-md-3">
+    <div class="col">
       <div class="card">
         <div class="card-body">
           <div class="text-muted small text-uppercase">Events</div>
@@ -43,19 +43,11 @@
         </div>
       </div>
     </div>
-    <div class="col-md-3">
+    <div class="col">
       <div class="card">
         <div class="card-body">
           <div class="text-muted small text-uppercase">Started Efforts</div>
           <div class="h3 fw-bold mb-0"><%= @presenter.total_efforts %></div>
-        </div>
-      </div>
-    </div>
-    <div class="col-md-3">
-      <div class="card">
-        <div class="card-body">
-          <div class="text-muted small text-uppercase">Total Donated</div>
-          <div class="h3 fw-bold mb-0"><%= number_to_currency(@presenter.total_donated) %></div>
         </div>
       </div>
     </div>
@@ -92,34 +84,5 @@
     </table>
   <% else %>
     <p class="text-muted fst-italic">No real efforts recorded for this organization.</p>
-  <% end %>
-
-  <h2 class="h4 fw-bold mt-4">Donations</h2>
-  <% if @presenter.donations.any? %>
-    <table class="table table-striped align-middle">
-      <thead>
-        <tr>
-          <th>Date</th>
-          <th class="text-end">Amount</th>
-          <th>Source</th>
-          <th>Note</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @presenter.donations.each do |donation| %>
-          <tr>
-            <td><%= donation.received_on.iso8601 %></td>
-            <td class="text-end fw-bold"><%= number_to_currency(donation.amount) %></td>
-            <td><span class="badge bg-secondary"><%= donation.source.humanize %></span></td>
-            <td class="text-muted small"><%= donation.note %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  <% else %>
-    <p class="text-muted fst-italic">
-      No donations recorded —
-      <%= link_to "record one in the admin area", madmin_monetary_donations_path %>.
-    </p>
   <% end %>
 </article>

--- a/spec/presenters/organization_usage_index_presenter_spec.rb
+++ b/spec/presenters/organization_usage_index_presenter_spec.rb
@@ -60,5 +60,24 @@ RSpec.describe OrganizationUsageIndexPresenter do
       row = presenter.for_profit_rows.find { |r| r.organization.id == hardrock.id }
       expect(row.last_active_year).to eq(expected_year)
     end
+
+    it "exposes total_donated as the sum of monetary_donations amounts" do
+      hardrock = organizations(:hardrock)
+      expected_total = hardrock.monetary_donations.sum(:amount)
+
+      row = presenter.for_profit_rows.find { |r| r.organization.id == hardrock.id }
+      expect(row.total_donated).to eq(expected_total)
+      expect(expected_total).to be > 0
+    end
+
+    it "returns zero total_donated for an org with no donations" do
+      # rattlesnake_ramble has no fixture donations but no real efforts either,
+      # so confirm via dirty_30_running which has efforts but no donations.
+      dirty_30 = organizations(:dirty_30_running)
+      row = presenter.for_profit_rows.find { |r| r.organization.id == dirty_30.id }
+
+      expect(row).not_to be_nil
+      expect(row.total_donated).to eq(0)
+    end
   end
 end

--- a/spec/presenters/organization_usage_show_presenter_spec.rb
+++ b/spec/presenters/organization_usage_show_presenter_spec.rb
@@ -86,37 +86,4 @@ RSpec.describe OrganizationUsageShowPresenter do
       expect(presenter.total_efforts).to eq(chart_sum)
     end
   end
-
-  describe "#donations" do
-    it "returns the org's monetary_donations sorted by received_on descending" do
-      presenter = described_class.new(hardrock)
-
-      expect(presenter.donations).to eq(hardrock.monetary_donations.order(received_on: :desc))
-      expect(presenter.donations.map(&:received_on)).to eq(presenter.donations.map(&:received_on).sort.reverse)
-    end
-
-    it "is empty for an organization with no donations" do
-      orphan_org = Organization.create!(name: "No Donations Org", created_by: users(:admin_user).id, concealed: false)
-      presenter = described_class.new(orphan_org)
-
-      expect(presenter.donations).to be_empty
-    end
-  end
-
-  describe "#total_donated" do
-    it "sums the donation amounts" do
-      presenter = described_class.new(hardrock)
-      expected = hardrock.monetary_donations.sum(:amount)
-
-      expect(presenter.total_donated).to eq(expected)
-      expect(expected).to be > 0
-    end
-
-    it "returns zero for an organization with no donations" do
-      orphan_org = Organization.create!(name: "No Donations Org", created_by: users(:admin_user).id, concealed: false)
-      presenter = described_class.new(orphan_org)
-
-      expect(presenter.total_donated).to eq(0)
-    end
-  end
 end

--- a/spec/requests/organization_usages_controller_spec.rb
+++ b/spec/requests/organization_usages_controller_spec.rb
@@ -96,23 +96,12 @@ RSpec.describe "OrganizationUsagesController" do
         expect(response.body).to include("No real efforts recorded")
       end
 
-      it "renders the donations section with recorded donations" do
+      it "does not surface donation data on the show page" do
         get organization_usage_path(hardrock)
 
-        expect(response.body).to include("Donations")
-        expect(response.body).to include("Total Donated")
-        # hardrock_check_2025 fixture: 500.00 check
-        expect(response.body).to include("$500.00")
-        expect(response.body).to include("Check")
-      end
-
-      it "renders the donations empty state with a link to madmin" do
-        org_without_donations = organizations(:rattlesnake_ramble)
-
-        get organization_usage_path(org_without_donations)
-
-        expect(response.body).to include("No donations recorded")
-        expect(response.body).to include(madmin_monetary_donations_path)
+        expect(response.body).not_to include("Donations")
+        expect(response.body).not_to include("Total Donated")
+        expect(response.body).not_to include("monetary_donations")
       end
     end
   end


### PR DESCRIPTION
## Summary
`/organization-usage/:id` will eventually open up to organization owners, so it shouldn't show donation data — and definitely shouldn't link to `/madmin`. The index, by contrast, will stay admin-only and is the right home for a "who has given how much" view.

- **Show page**: removed the Total Donated tile, the Donations table, the empty-state madmin link, and the matching presenter methods (`total_donated` / `donations`).
- **Index page**: new **Total Donated** column rendered with `number_to_currency`, dimmed when zero. Sourced from a correlated `SUM(amount)` subquery in the existing aggregate select — joining `monetary_donations` directly into the main query would multiply effort counts by donation row count.

## Test plan
- [x] `bundle exec rspec spec/presenters/organization_usage_show_presenter_spec.rb spec/presenters/organization_usage_index_presenter_spec.rb spec/requests/organization_usages_controller_spec.rb` → 26 examples, 0 failures.
- [x] Rubocop + erb-lint clean on touched files.
- [ ] Visit `/organization-usage` as admin — confirm the Total Donated column renders, shows `$0.00` (dimmed) for orgs with no donations, and a real amount (in normal weight) for Hardrock and Running Up For Air.
- [ ] Visit `/organization-usage/hardrock` — confirm the Donations section and madmin link are gone, the three tiles fit cleanly, and no donation-related text remains.