### PR TITLE
Admin-only donations section on org usage show page

### DIFF
--- a/app/presenters/organization_usage_show_presenter.rb
+++ b/app/presenters/organization_usage_show_presenter.rb
@@ -38,6 +38,32 @@ class OrganizationUsageShowPresenter
     end
   end
 
+  def donations
+    @donations ||= organization.monetary_donations.order(received_on: :desc)
+  end
+
+  def total_donated
+    donations.sum(:amount)
+  end
+
+  def first_donation_year
+    donations.minimum(:received_on)&.year
+  end
+
+  def last_donation_year
+    donations.maximum(:received_on)&.year
+  end
+
+  # Chart data keyed by stringified year so Chart.js treats the x-axis as discrete
+  # categories (same trick as #chart_series). Years without donations are omitted.
+  def donations_by_year
+    organization.monetary_donations
+                .group(Arel.sql("EXTRACT(YEAR FROM received_on)::int"))
+                .sum(:amount)
+                .sort.to_h
+                .transform_keys(&:to_s)
+  end
+
   private
 
   def breakdown

--- a/app/views/organization_usages/show.html.erb
+++ b/app/views/organization_usages/show.html.erb
@@ -26,6 +26,55 @@
 </header>
 
 <article class="ost-article container">
+  <% if current_user&.admin? %>
+    <section class="card mb-4 border-warning">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <h2 class="h4 fw-bold mb-0">Donations <span class="badge bg-warning text-dark ms-1">admin only</span></h2>
+          <div class="text-end">
+            <div class="text-muted small text-uppercase">Total Donated</div>
+            <div class="h3 fw-bold mb-0"><%= number_to_currency(@presenter.total_donated) %></div>
+            <% if @presenter.first_donation_year %>
+              <div class="text-muted small">
+                <%= @presenter.donations.size %> donations,
+                <%= @presenter.first_donation_year %>–<%= @presenter.last_donation_year %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+
+        <% if @presenter.donations.any? %>
+          <div class="mb-4">
+            <%= column_chart @presenter.donations_by_year, prefix: "$", library: { plugins: { legend: { display: false } } } %>
+          </div>
+
+          <table class="table table-striped table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th class="text-end">Amount</th>
+                <th>Source</th>
+                <th>Note</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @presenter.donations.each do |donation| %>
+                <tr>
+                  <td><%= donation.received_on.iso8601 %></td>
+                  <td class="text-end fw-bold"><%= number_to_currency(donation.amount) %></td>
+                  <td><span class="badge bg-secondary"><%= donation.source.humanize %></span></td>
+                  <td class="text-muted small"><%= donation.note %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% else %>
+          <p class="text-muted fst-italic mb-0">No donations recorded for this organization.</p>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+
   <div class="row mb-4">
     <div class="col">
       <div class="card">

--- a/spec/presenters/organization_usage_show_presenter_spec.rb
+++ b/spec/presenters/organization_usage_show_presenter_spec.rb
@@ -86,4 +86,51 @@ RSpec.describe OrganizationUsageShowPresenter do
       expect(presenter.total_efforts).to eq(chart_sum)
     end
   end
+
+  describe "donations" do
+    let(:presenter) { described_class.new(hardrock) }
+
+    it "returns the org's monetary_donations newest first" do
+      expect(presenter.donations).to eq(hardrock.monetary_donations.order(received_on: :desc))
+    end
+
+    it "totals the donation amounts" do
+      expect(presenter.total_donated).to eq(hardrock.monetary_donations.sum(:amount))
+      expect(presenter.total_donated).to be > 0
+    end
+
+    it "exposes the donation year range" do
+      expect(presenter.first_donation_year).to eq(hardrock.monetary_donations.minimum(:received_on).year)
+      expect(presenter.last_donation_year).to eq(hardrock.monetary_donations.maximum(:received_on).year)
+    end
+
+    it "returns nil donation years when the org has none" do
+      orphan = Organization.create!(name: "No Donations Org", created_by: users(:admin_user).id, concealed: false)
+      empty_presenter = described_class.new(orphan)
+
+      expect(empty_presenter.first_donation_year).to be_nil
+      expect(empty_presenter.last_donation_year).to be_nil
+      expect(empty_presenter.total_donated).to eq(0)
+      expect(empty_presenter.donations_by_year).to be_empty
+    end
+  end
+
+  describe "#donations_by_year" do
+    let(:presenter) { described_class.new(hardrock) }
+
+    it "buckets donation amounts by stringified year, sorted ascending" do
+      data = presenter.donations_by_year
+
+      expect(data).not_to be_empty
+      expect(data.keys).to all(match(/\A\d{4}\z/))
+      expect(data.keys).to eq(data.keys.sort)
+    end
+
+    it "sums donations within the same year" do
+      hardrock.monetary_donations.create!(received_on: Date.new(2024, 9, 12), amount: 100, source: "paypal")
+      hardrock.monetary_donations.create!(received_on: Date.new(2024, 11, 30), amount: 50, source: "paypal")
+
+      expect(presenter.donations_by_year["2024"]).to eq(hardrock.monetary_donations.where("EXTRACT(YEAR FROM received_on) = 2024").sum(:amount))
+    end
+  end
 end

--- a/spec/requests/organization_usages_controller_spec.rb
+++ b/spec/requests/organization_usages_controller_spec.rb
@@ -96,12 +96,25 @@ RSpec.describe "OrganizationUsagesController" do
         expect(response.body).to include("No real efforts recorded")
       end
 
-      it "does not surface donation data on the show page" do
+      it "renders the admin-only donations section with totals and the per-donation table" do
         get organization_usage_path(hardrock)
 
-        expect(response.body).not_to include("Donations")
-        expect(response.body).not_to include("Total Donated")
-        expect(response.body).not_to include("monetary_donations")
+        expect(response.body).to include("Donations")
+        expect(response.body).to include("admin only")
+        expect(response.body).to include("Total Donated")
+        # hardrock_check_2025 fixture: $500.00 check on 2025-03-04
+        expect(response.body).to include("$500.00")
+        expect(response.body).to include("Check")
+      end
+
+      it "shows an empty-state message inside the donations section when the org has none" do
+        # dirty_30_running fixture has real efforts but no monetary_donations
+        dirty_30 = organizations(:dirty_30_running)
+        expect(dirty_30.monetary_donations).to be_empty
+
+        get organization_usage_path(dirty_30)
+
+        expect(response.body).to include("No donations recorded for this organization")
       end
     end
   end


### PR DESCRIPTION
## Summary
Gives admins a triage view on `/organization-usage/:id` — who has donated, how much, year-by-year — so the "who should I ping next?" judgment can be made without leaving the usage page.

- New section anchored at the **top** of the show view, rendered only when `current_user&.admin?` is true. The rest of the page is unaffected, so when the show page is eventually opened up to organization owners the donations section will stay admin-gated automatically.
- Section contents:
  - **Total donated**, donation count, and year range.
  - Single-series **column chart** of donation amounts by year (years stringified so Chart.js uses a discrete category axis, same trick as the efforts chart).
  - Striped table of every donation: Date / Amount / Source / Note.
  - Empty-state copy when an org has no donations recorded.
- Presenter re-gains `total_donated` and `donations` (these were removed in #2033 along with the prior on-show display), plus `first_donation_year` / `last_donation_year` / `donations_by_year`.

## Test plan
- [x] `bundle exec rspec spec/presenters/organization_usage_show_presenter_spec.rb spec/requests/organization_usages_controller_spec.rb` → 25 examples, 0 failures.
- [x] Rubocop + erb-lint clean on touched files.
- [ ] Visit `/organization-usage/hardrock` as admin: verify the section renders at the top with the bar chart, two fixture donations (paypal $250 + check $500), and a year range of 2024–2025.
- [ ] Visit `/organization-usage/dirty-30-running`: verify the empty-state copy renders inside the section.