### PR TITLE
Org Usage: add Current column and section totals

### DIFF
--- a/app/presenters/organization_usage_index_presenter.rb
+++ b/app/presenters/organization_usage_index_presenter.rb
@@ -1,7 +1,24 @@
 class OrganizationUsageIndexPresenter
-  Row = Struct.new(:organization, :event_group_count, :event_count, :effort_count, :last_active_year, :total_donated)
+  Row = Struct.new(:organization, :event_group_count, :event_count, :effort_count, :last_active_year,
+                   :last_donation_year, :total_donated) do
+    # Returns:
+    #   nil       — org isn't active (no real events in the prior or current year)
+    #   :paid     — donated in the same year as the most recent event
+    #   :recent   — donated in the year before the most recent event
+    #   :overdue  — active but donation history doesn't match the above
+    def current_status
+      current_year = Date.current.year
+      return nil if last_active_year.nil? || last_active_year < current_year - 1
+      return :paid if last_donation_year == last_active_year
+      return :recent if last_donation_year == last_active_year - 1
 
-  # Correlated subquery rather than joining monetary_donations into the main aggregate —
+      :overdue
+    end
+  end
+
+  Totals = Struct.new(:event_group_count, :event_count, :effort_count, :total_donated)
+
+  # Correlated subqueries rather than joining monetary_donations into the main aggregate —
   # joining would multiply the effort counts by the donation row count.
   TOTAL_DONATED_SQL = <<~SQL.squish.freeze
     (
@@ -11,12 +28,29 @@ class OrganizationUsageIndexPresenter
     ) AS total_donated
   SQL
 
+  LAST_DONATION_YEAR_SQL = <<~SQL.squish.freeze
+    (
+      SELECT MAX(EXTRACT(YEAR FROM monetary_donations.received_on))::int
+      FROM monetary_donations
+      WHERE monetary_donations.organization_id = organizations.id
+    ) AS last_donation_year
+  SQL
+
   def for_profit_rows
     rows.reject { |row| row.organization.non_profit? }
   end
 
   def non_profit_rows
     rows.select { |row| row.organization.non_profit? }
+  end
+
+  def totals_for(rows)
+    Totals.new(
+      event_group_count: rows.sum(&:event_group_count),
+      event_count: rows.sum(&:event_count),
+      effort_count: rows.sum(&:effort_count),
+      total_donated: rows.sum { |row| row.total_donated.to_d },
+    )
   end
 
   private
@@ -33,6 +67,7 @@ class OrganizationUsageIndexPresenter
                 "COUNT(efforts.id)                                        AS real_effort_count",
                 "MAX(EXTRACT(YEAR FROM events.scheduled_start_time))::int AS last_active_year",
                 TOTAL_DONATED_SQL,
+                LAST_DONATION_YEAR_SQL,
               )
               .order(Arel.sql("COUNT(efforts.id) DESC"), :name)
               .map do |org|
@@ -42,6 +77,7 @@ class OrganizationUsageIndexPresenter
         event_count: org.real_event_count,
         effort_count: org.real_effort_count,
         last_active_year: org.last_active_year,
+        last_donation_year: org.last_donation_year,
         total_donated: org.total_donated,
       )
     end

--- a/app/views/organization_usages/index.html.erb
+++ b/app/views/organization_usages/index.html.erb
@@ -30,6 +30,7 @@
       <% if rows.empty? %>
         <p class="text-muted fst-italic">No organizations in this category.</p>
       <% else %>
+        <% totals = @presenter.totals_for(rows) %>
         <table class="table table-striped table-hover">
           <thead>
             <tr>
@@ -39,6 +40,7 @@
               <th class="text-end">Efforts</th>
               <th class="text-end">Last Active</th>
               <th class="text-end">Total Donated</th>
+              <th class="text-center">Current</th>
               <th>Owner</th>
               <th>Owner Email</th>
             </tr>
@@ -56,6 +58,16 @@
                 <td class="text-end <%= "text-muted" if row.total_donated.to_d.zero? %>">
                   <%= number_to_currency(row.total_donated) %>
                 </td>
+                <td class="text-center">
+                  <% case row.current_status %>
+                  <% when :paid %>
+                    <span class="text-success fw-bold" title="Donated in <%= row.last_active_year %>">&check;</span>
+                  <% when :recent %>
+                    <span class="text-warning fw-bold" title="Last donation in <%= row.last_donation_year %>">?</span>
+                  <% when :overdue %>
+                    <span class="text-danger fw-bold" title="<%= row.last_donation_year ? "Last donation in #{row.last_donation_year}" : "No donations recorded" %>">&times;</span>
+                  <% end %>
+                </td>
                 <td class="text-muted"><%= row.organization.owner_full_name %></td>
                 <td class="text-muted">
                   <% if row.organization.owner_email.present? %>
@@ -65,6 +77,19 @@
               </tr>
             <% end %>
           </tbody>
+          <tfoot class="border-top border-2">
+            <tr class="fw-bold">
+              <td>Total (<%= rows.size %>)</td>
+              <td class="text-end"><%= totals.event_group_count %></td>
+              <td class="text-end"><%= totals.event_count %></td>
+              <td class="text-end"><%= totals.effort_count %></td>
+              <td></td>
+              <td class="text-end"><%= number_to_currency(totals.total_donated) %></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+          </tfoot>
         </table>
       <% end %>
     </section>

--- a/spec/presenters/organization_usage_index_presenter_spec.rb
+++ b/spec/presenters/organization_usage_index_presenter_spec.rb
@@ -79,5 +79,74 @@ RSpec.describe OrganizationUsageIndexPresenter do
       expect(row).not_to be_nil
       expect(row.total_donated).to eq(0)
     end
+
+    it "exposes last_donation_year as the most recent year of donations" do
+      hardrock = organizations(:hardrock)
+      expected_year = hardrock.monetary_donations.maximum(:received_on).year
+
+      row = presenter.for_profit_rows.find { |r| r.organization.id == hardrock.id }
+      expect(row.last_donation_year).to eq(expected_year)
+    end
+  end
+
+  describe "#totals_for" do
+    it "sums event_group_count, event_count, effort_count, and total_donated across the rows" do
+      rows = presenter.for_profit_rows
+      totals = presenter.totals_for(rows)
+
+      expect(totals.event_group_count).to eq(rows.sum(&:event_group_count))
+      expect(totals.event_count).to eq(rows.sum(&:event_count))
+      expect(totals.effort_count).to eq(rows.sum(&:effort_count))
+      expect(totals.total_donated).to eq(rows.sum { |r| r.total_donated.to_d })
+    end
+
+    it "returns zeros for an empty rows array" do
+      totals = presenter.totals_for([])
+
+      expect(totals.event_group_count).to eq(0)
+      expect(totals.event_count).to eq(0)
+      expect(totals.effort_count).to eq(0)
+      expect(totals.total_donated).to eq(0)
+    end
+  end
+
+  describe "Row#current_status" do
+    include ActiveSupport::Testing::TimeHelpers
+
+    def row(last_active:, last_donation:)
+      described_class::Row.new(
+        organization: nil,
+        event_group_count: 0,
+        event_count: 0,
+        effort_count: 0,
+        last_active_year: last_active,
+        last_donation_year: last_donation,
+        total_donated: 0,
+      )
+    end
+
+    before { travel_to Date.new(2026, 6, 1) }
+
+    it "returns nil when the org has no recent activity" do
+      # 2024 is two years before "current" 2026 — not in current or prior year.
+      expect(row(last_active: 2024, last_donation: 2024).current_status).to be_nil
+      expect(row(last_active: nil, last_donation: nil).current_status).to be_nil
+    end
+
+    it "returns :paid when last donation matches the most recent event year" do
+      expect(row(last_active: 2026, last_donation: 2026).current_status).to eq(:paid)
+      expect(row(last_active: 2025, last_donation: 2025).current_status).to eq(:paid)
+    end
+
+    it "returns :recent when last donation is the year before the most recent event" do
+      expect(row(last_active: 2026, last_donation: 2025).current_status).to eq(:recent)
+      expect(row(last_active: 2025, last_donation: 2024).current_status).to eq(:recent)
+    end
+
+    it "returns :overdue when the org is active but donations are stale or missing" do
+      expect(row(last_active: 2026, last_donation: 2023).current_status).to eq(:overdue)
+      expect(row(last_active: 2026, last_donation: nil).current_status).to eq(:overdue)
+      expect(row(last_active: 2025, last_donation: 2022).current_status).to eq(:overdue)
+    end
   end
 end

--- a/spec/requests/organization_usages_controller_spec.rb
+++ b/spec/requests/organization_usages_controller_spec.rb
@@ -59,6 +59,14 @@ RSpec.describe "OrganizationUsagesController" do
 
         expect(response.body).not_to include(empty_org.name)
       end
+
+      it "renders a Current column header and a totals footer for each section" do
+        get organization_usages_path
+
+        expect(response.body).to include("Current")
+        # tfoot row with "Total (N)" appears once per non-empty section
+        expect(response.body.scan(/Total \(\d+\)/).size).to be >= 1
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
Two enhancements to `/organization-usage` so contact-priority surfaces at a glance.

### New "Current" column
Status is derived from `last_active_year` (existing) and a new `last_donation_year` (computed via a correlated `MAX(EXTRACT(YEAR FROM received_on))` subquery — same shape as `TOTAL_DONATED_SQL`, no Cartesian blow-up):

| Status | Meaning |
| --- | --- |
| *(blank)* | No real events in the current or prior year |
| ✓ green | Last donation matches the most recent event year |
| ? yellow | Last donation was the year before the most recent event |
| × red | Active but donations are stale or missing |

Logic lives on `OrganizationUsageIndexPresenter::Row#current_status` (returns `:paid` / `:recent` / `:overdue` / `nil`), so the view just maps the symbol to a color/glyph.

### Per-section totals
`<tfoot>` row on each table showing **Total (n)** with sums for Event Groups, Events, Efforts, and Total Donated. Last Active, Current, Owner, and Owner Email cells are intentionally blank — summing a year or an owner name doesn't make sense. Sums computed in a new `presenter#totals_for(rows)` helper that returns a `Totals` struct.

## Test plan
- [x] `bundle exec rspec spec/presenters/organization_usage_index_presenter_spec.rb spec/requests/organization_usages_controller_spec.rb` → 26 examples, 0 failures.
- [x] Rubocop + erb-lint clean on touched files.
- [ ] Visit `/organization-usage` as admin: confirm Current column renders (will mostly be blank in fixtures since fixture event years are 2014–2017 and "current" is 2026), totals row appears beneath each section's tbody with sane numbers.
- [ ] Once an org has 2026 events + a 2026 donation, confirm it shows a green ✓.