### PR TITLE
Org Usage: hide dormant orgs, use FA status icons

### DIFF
--- a/app/presenters/organization_usage_index_presenter.rb
+++ b/app/presenters/organization_usage_index_presenter.rb
@@ -36,6 +36,10 @@ class OrganizationUsageIndexPresenter
     ) AS last_donation_year
   SQL
 
+  # Orgs whose last real event was more than ACTIVE_WITHIN_YEARS years ago are dropped
+  # — donation outreach for long-dormant orgs isn't actionable.
+  ACTIVE_WITHIN_YEARS = 3
+
   def for_profit_rows
     rows.reject { |row| row.organization.non_profit? }
   end
@@ -56,10 +60,12 @@ class OrganizationUsageIndexPresenter
   private
 
   def rows
+    cutoff_year = Date.current.year - ACTIVE_WITHIN_YEARS
     @rows ||= Organization
               .joins(event_groups: { events: :efforts })
               .where(event_groups: { concealed: false }, efforts: { started: true })
               .group("organizations.id")
+              .having("MAX(EXTRACT(YEAR FROM events.scheduled_start_time)) >= ?", cutoff_year)
               .select(
                 "organizations.*",
                 "COUNT(DISTINCT event_groups.id)                          AS real_event_group_count",

--- a/app/views/organization_usages/index.html.erb
+++ b/app/views/organization_usages/index.html.erb
@@ -61,11 +61,15 @@
                 <td class="text-center">
                   <% case row.current_status %>
                   <% when :paid %>
-                    <span class="text-success fw-bold" title="Donated in <%= row.last_active_year %>">&check;</span>
+                    <span class="fas fa-circle-check good text-success" title="Donated in <%= row.last_active_year %>"
+                          data-controller="tooltip" data-bs-placement="top"></span>
                   <% when :recent %>
-                    <span class="text-warning fw-bold" title="Last donation in <%= row.last_donation_year %>">?</span>
+                    <span class="fas fa-circle-question questionable text-warning" title="Last donation in <%= row.last_donation_year %>"
+                          data-controller="tooltip" data-bs-placement="top"></span>
                   <% when :overdue %>
-                    <span class="text-danger fw-bold" title="<%= row.last_donation_year ? "Last donation in #{row.last_donation_year}" : "No donations recorded" %>">&times;</span>
+                    <% overdue_title = row.last_donation_year ? "Last donation in #{row.last_donation_year}" : "No donations recorded" %>
+                    <span class="fas fa-circle-xmark bad text-danger" title="<%= overdue_title %>"
+                          data-controller="tooltip" data-bs-placement="top"></span>
                   <% end %>
                 </td>
                 <td class="text-muted"><%= row.organization.owner_full_name %></td>

--- a/spec/presenters/organization_usage_index_presenter_spec.rb
+++ b/spec/presenters/organization_usage_index_presenter_spec.rb
@@ -1,7 +1,13 @@
 require "rails_helper"
 
 RSpec.describe OrganizationUsageIndexPresenter do
+  include ActiveSupport::Testing::TimeHelpers
+
   subject(:presenter) { described_class.new }
+
+  # Fixture event years top out at 2017 — pin "today" to a date that keeps those
+  # orgs within the 3-year activity window so the existing assertions stay valid.
+  before { travel_to Date.new(2018, 6, 1) }
 
   describe "#for_profit_rows / #non_profit_rows" do
     it "places non_profit organizations only in non_profit_rows" do
@@ -86,6 +92,26 @@ RSpec.describe OrganizationUsageIndexPresenter do
 
       row = presenter.for_profit_rows.find { |r| r.organization.id == hardrock.id }
       expect(row.last_donation_year).to eq(expected_year)
+    end
+
+    it "drops organizations whose last event is more than 3 years ago" do
+      hardrock = organizations(:hardrock) # last fixture event in 2016
+
+      travel_to Date.new(2020, 1, 1) do
+        # 2016 is exactly 4 years before 2020 — outside the 3-year window.
+        all_org_ids = (presenter.for_profit_rows + presenter.non_profit_rows).map { |r| r.organization.id }
+        expect(all_org_ids).not_to include(hardrock.id)
+      end
+    end
+
+    it "keeps organizations whose last event is exactly 3 years ago" do
+      hardrock = organizations(:hardrock) # last fixture event in 2016
+
+      travel_to Date.new(2019, 1, 1) do
+        # 2016 is exactly 3 years before 2019 — inside the window.
+        all_org_ids = (presenter.for_profit_rows + presenter.non_profit_rows).map { |r| r.organization.id }
+        expect(all_org_ids).to include(hardrock.id)
+      end
     end
   end
 

--- a/spec/requests/organization_usages_controller_spec.rb
+++ b/spec/requests/organization_usages_controller_spec.rb
@@ -2,11 +2,16 @@ require "rails_helper"
 
 RSpec.describe "OrganizationUsagesController" do
   include Warden::Test::Helpers
+  include ActiveSupport::Testing::TimeHelpers
 
   let(:admin_user) { users(:admin_user) }
   let(:non_admin_user) { users(:third_user) }
 
   after { Warden.test_reset! }
+
+  # Fixture event years top out at 2017; pin "today" so the 3-year activity
+  # filter on the index keeps those orgs visible.
+  before { travel_to Date.new(2018, 6, 1) }
 
   describe "GET /organization-usage" do
     context "when not signed in" do
@@ -66,6 +71,22 @@ RSpec.describe "OrganizationUsagesController" do
         expect(response.body).to include("Current")
         # tfoot row with "Total (N)" appears once per non-empty section
         expect(response.body.scan(/Total \(\d+\)/).size).to be >= 1
+      end
+
+      it "renders Font Awesome status icons in the Current column" do
+        get organization_usages_path
+
+        # At least one of the three statuses should appear given the fixture spread.
+        expect(response.body).to match(/fa-circle-(check|question|xmark)/)
+      end
+
+      it "drops organizations whose last real event is more than 3 years ago" do
+        # hardrock fixture's last event year is 2016; 2025 puts it past the 3-year cutoff
+        travel_to Date.new(2025, 1, 1) do
+          get organization_usages_path
+
+          expect(response.body).not_to include(">Hardrock<")
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
Two refinements that make the org-usage tables more actionable for donation outreach:

- **3-year activity cutoff.** Organizations whose most recent real event is more than 3 years ago are dropped from both For-Profit and Non-Profit tables. Implemented as a `HAVING` clause on the existing aggregate query so the filter runs in SQL, not Ruby:

  ```sql
  HAVING MAX(EXTRACT(YEAR FROM events.scheduled_start_time)) >= current_year - 3
  ```

  The threshold sits in a single constant: `OrganizationUsageIndexPresenter::ACTIVE_WITHIN_YEARS`.

- **Font Awesome status icons** in the Current column, matching the good/questionable/bad icons used on the live entry screen (`app/views/live/event_groups/live_entry.html.erb:53-99`):

  | Status | Was | Now |
  | --- | --- | --- |
  | `:paid` | `✓` glyph | `<i class="fas fa-circle-check good text-success">` |
  | `:recent` | `?` glyph | `<i class="fas fa-circle-question questionable text-warning">` |
  | `:overdue` | `×` glyph | `<i class="fas fa-circle-xmark bad text-danger">` |

  Same `title=` tooltip behavior, `data-bs-placement="top"` since the cell is centered in a wide table.

Fixture event years are 2014–2017, so the presenter / request specs that already exercised those orgs now `travel_to Date.new(2018, 6, 1)` to keep them inside the activity window. Two new specs verify the 3-year filter actually drops Hardrock when "today" is 2025 and that the rendered HTML contains at least one `fa-circle-*` class.

## Test plan
- [x] `bundle exec rspec spec/presenters/organization_usage_index_presenter_spec.rb spec/requests/organization_usages_controller_spec.rb` → 30 examples, 0 failures.
- [x] Rubocop + erb-lint clean on touched files.
- [x] Visit `/organization-usage` and confirm the tables are shorter (dormant orgs gone) and the Current column renders FA icons with hoverable tooltips.