### PR TITLE
Cross-link Organization Usage and public Organization show pages

### DIFF
--- a/app/views/organization_usages/show.html.erb
+++ b/app/views/organization_usages/show.html.erb
@@ -21,6 +21,9 @@
           </ul>
         </div>
       </div>
+      <aside class="col-auto">
+        <%= link_to "View public page", organization_path(@organization), class: "btn btn-outline-secondary" %>
+      </aside>
     </div>
   </div>
 </header>

--- a/app/views/organizations/_organization_heading.html.erb
+++ b/app/views/organizations/_organization_heading.html.erb
@@ -21,6 +21,9 @@
     </div>
   </div>
   <aside class="col-auto">
+    <% if current_user&.admin? %>
+      <%= link_to "Usage report", organization_usage_path(presenter.organization), class: "btn btn-outline-secondary" %>
+    <% end %>
     <% if current_user&.authorized_fully?(presenter.organization) %>
       <%= link_to "Edit this organization", edit_organization_path(presenter.organization), class: "btn btn-outline-secondary" %>
     <% end %>

--- a/spec/requests/organization_usages_controller_spec.rb
+++ b/spec/requests/organization_usages_controller_spec.rb
@@ -116,6 +116,13 @@ RSpec.describe "OrganizationUsagesController" do
         expect(response.body).to include("Efforts by year")
       end
 
+      it "links to the public organization page" do
+        get organization_usage_path(hardrock)
+
+        expect(response.body).to include("View public page")
+        expect(response.body).to include(organization_path(hardrock))
+      end
+
       it "shows the empty-state message when the org has no real efforts" do
         hardrock.event_groups.update_all(concealed: true)
 

--- a/spec/requests/organizations/usage_link_visibility_spec.rb
+++ b/spec/requests/organizations/usage_link_visibility_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Organizations usage-report link visibility" do
+  include Warden::Test::Helpers
+
+  let(:hardrock) { organizations(:hardrock) }
+  let(:admin_user) { users(:admin_user) }
+  let(:non_admin_user) { users(:third_user) }
+
+  after { Warden.test_reset! }
+
+  describe "GET /organizations/:id" do
+    it "shows the admin-only Usage report link when signed in as an admin" do
+      login_as admin_user, scope: :user
+
+      get organization_path(hardrock)
+
+      expect(response.body).to include("Usage report")
+      expect(response.body).to include(organization_usage_path(hardrock))
+    end
+
+    it "hides the Usage report link from non-admin users" do
+      login_as non_admin_user, scope: :user
+
+      get organization_path(hardrock)
+
+      expect(response.body).not_to include("Usage report")
+    end
+
+    it "hides the Usage report link from visitors" do
+      get organization_path(hardrock)
+
+      expect(response.body).not_to include("Usage report")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Two small navigation aids so admins can hop between the donation-focused usage view and the public org page without typing URLs.

- **Usage show** (`/organization-usage/:id`) gains a **"View public page"** button on the right of the header, pointing at `organization_path(@organization)`. Visible to anyone who can see the usage page (admin only today, eventually org owners too).
- **Public org show** (`/organizations/:id`) gains an admin-only **"Usage report"** button alongside the existing "Edit this organization" action, gated on `current_user&.admin?`. Renders nothing for visitors and non-admin users.

## Test plan
- [x] `bundle exec rspec spec/requests/organization_usages_controller_spec.rb spec/requests/organizations/usage_link_visibility_spec.rb` → 17 examples, 0 failures.
  - Usage show: asserts "View public page" + the `organization_path` href appear.
  - Public org show: asserts admin sees the link, non-admin and visitor do not.
- [x] Rubocop + erb-lint clean on touched files.
- [ ] As admin, visit `/organizations/hardrock` and `/organization-usage/hardrock`; click each new button to verify it lands on the other page.