### PR TITLE
Add maintenance:remove_person_subscriptions rake task (step 2 of #2041)

### DIFF
--- a/lib/tasks/maintenance/remove_person_subscriptions.rake
+++ b/lib/tasks/maintenance/remove_person_subscriptions.rake
@@ -1,23 +1,37 @@
 namespace :maintenance do
   desc "Destroy participant subscriptions and tear down their SNS topics (idempotent)"
   task remove_person_subscriptions: :environment do
-    # Destroy per-user subscriptions first so Subscription#before_destroy can call
-    # SnsSubscriptionManager.delete cleanly. If we deleted the topic first, AWS
-    # auto-removes the subscription ARNs and the per-subscription cleanup would
-    # have nothing to address.
-    destroyed = 0
-    Subscription.where(subscribable_type: "Person").find_each do |subscription|
-      subscription.destroy!
-      destroyed += 1
-    end
+    ActiveRecord::Base.logger.silence do
+      # Destroy per-user subscriptions first so Subscription#before_destroy can call
+      # SnsSubscriptionManager.delete cleanly. If we deleted the topic first, AWS
+      # auto-removes the subscription ARNs and the per-subscription cleanup would
+      # have nothing to address.
+      subscription_scope = Subscription.where(subscribable_type: "Person")
+      destroyed = subscription_scope.count
+      puts "Destroying #{destroyed} Person subscriptions"
 
-    topics_deleted = 0
-    Person.where.not(topic_resource_key: nil).find_each do |person|
-      SnsTopicManager.delete(resource: person)
-      person.update_column(:topic_resource_key, nil)
-      topics_deleted += 1
-    end
+      if destroyed.positive?
+        subscription_bar = ::ProgressBar.new(destroyed)
+        subscription_scope.find_each do |subscription|
+          subscription.destroy!
+          subscription_bar.increment!
+        end
+      end
 
-    puts "Destroyed #{destroyed} Person subscriptions, tore down #{topics_deleted} SNS topics."
+      person_scope = Person.where.not(topic_resource_key: nil)
+      topics_deleted = person_scope.count
+      puts "Tearing down #{topics_deleted} SNS topics"
+
+      if topics_deleted.positive?
+        topic_bar = ::ProgressBar.new(topics_deleted)
+        person_scope.find_each do |person|
+          SnsTopicManager.delete(resource: person)
+          person.update_column(:topic_resource_key, nil)
+          topic_bar.increment!
+        end
+      end
+
+      puts "Done — destroyed #{destroyed} Person subscriptions, tore down #{topics_deleted} SNS topics."
+    end
   end
 end

--- a/lib/tasks/maintenance/remove_person_subscriptions.rake
+++ b/lib/tasks/maintenance/remove_person_subscriptions.rake
@@ -1,0 +1,23 @@
+namespace :maintenance do
+  desc "Destroy participant subscriptions and tear down their SNS topics (idempotent)"
+  task remove_person_subscriptions: :environment do
+    # Destroy per-user subscriptions first so Subscription#before_destroy can call
+    # SnsSubscriptionManager.delete cleanly. If we deleted the topic first, AWS
+    # auto-removes the subscription ARNs and the per-subscription cleanup would
+    # have nothing to address.
+    destroyed = 0
+    Subscription.where(subscribable_type: "Person").find_each do |subscription|
+      subscription.destroy!
+      destroyed += 1
+    end
+
+    topics_deleted = 0
+    Person.where.not(topic_resource_key: nil).find_each do |person|
+      SnsTopicManager.delete(resource: person)
+      person.update_column(:topic_resource_key, nil)
+      topics_deleted += 1
+    end
+
+    puts "Destroyed #{destroyed} Person subscriptions, tore down #{topics_deleted} SNS topics."
+  end
+end

--- a/spec/lib/tasks/maintenance/remove_person_subscriptions_spec.rb
+++ b/spec/lib/tasks/maintenance/remove_person_subscriptions_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "maintenance:remove_person_subscriptions", type: :task do
 
       output = silent_invoke
 
-      expect(output).to include("Destroyed 2 Person subscriptions")
+      expect(output).to include("destroyed 2 Person subscriptions")
       expect(output).to include("tore down #{affected_count} SNS topics")
     end
 
@@ -94,7 +94,7 @@ RSpec.describe "maintenance:remove_person_subscriptions", type: :task do
 
       output = silent_invoke
 
-      expect(output).to include("Destroyed 0 Person subscriptions")
+      expect(output).to include("destroyed 0 Person subscriptions")
       expect(output).to include("tore down 0 SNS topics")
     end
   end
@@ -108,7 +108,7 @@ RSpec.describe "maintenance:remove_person_subscriptions", type: :task do
     it "runs cleanly and reports zeros" do
       output = silent_invoke
 
-      expect(output).to include("Destroyed 0 Person subscriptions")
+      expect(output).to include("destroyed 0 Person subscriptions")
       expect(output).to include("tore down 0 SNS topics")
     end
   end

--- a/spec/lib/tasks/maintenance/remove_person_subscriptions_spec.rb
+++ b/spec/lib/tasks/maintenance/remove_person_subscriptions_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "maintenance:remove_person_subscriptions", type: :task do
+  let(:task_name) { "maintenance:remove_person_subscriptions" }
+  let(:person) { people(:bruno_fadel) }
+  let(:other_person) { people(:progress_cascade) }
+  let(:admin) { users(:admin_user) }
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.none? { |t| t.name == task_name }
+    Rake::Task[task_name].reenable
+
+    # Stub AWS so the test doesn't reach for the network.
+    allow(SnsTopicManager).to receive(:delete)
+    allow(SnsSubscriptionManager).to receive(:delete).and_return(
+      SnsSubscriptionManager::Response.new(subscription_arn: "arn:aws:sns:us-west-2:123:fake-subscription-arn"),
+    )
+  end
+
+  def silent_invoke
+    capture_stdout { Rake::Task[task_name].invoke }
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  def build_person_subscription(target_person, resource_key: "arn:aws:sns:us-west-2:123:fake-subscription-arn")
+    Subscription.new(
+      user: admin,
+      subscribable: target_person,
+      protocol: :email,
+      endpoint: admin.email,
+      resource_key: resource_key,
+    ).tap { |sub| sub.save(validate: false) }
+  end
+
+  context "with Person topic resources and subscriptions present" do
+    before do
+      build_person_subscription(person)
+      build_person_subscription(other_person)
+    end
+
+    it "destroys all Person-typed subscriptions and nils out the topic_resource_key on every person" do
+      expect { silent_invoke }
+        .to change { Subscription.where(subscribable_type: "Person").count }.to(0)
+        .and change { Person.where.not(topic_resource_key: nil).count }.to(0)
+    end
+
+    it "calls SnsTopicManager.delete with each person that had a topic_resource_key" do
+      affected_count = Person.where.not(topic_resource_key: nil).count
+      expect(affected_count).to be > 0 # fixture sanity check
+
+      silent_invoke
+
+      expect(SnsTopicManager).to have_received(:delete).with(resource: person)
+      expect(SnsTopicManager).to have_received(:delete).with(resource: other_person)
+      expect(SnsTopicManager).to have_received(:delete).exactly(affected_count).times
+    end
+
+    it "fires Subscription#before_destroy so SnsSubscriptionManager.delete is called for confirmed ARNs" do
+      silent_invoke
+
+      expect(SnsSubscriptionManager).to have_received(:delete).twice
+    end
+
+    it "leaves Effort subscriptions alone" do
+      effort_count_before = Subscription.where(subscribable_type: "Effort").count
+      expect(effort_count_before).to be > 0
+
+      silent_invoke
+
+      expect(Subscription.where(subscribable_type: "Effort").count).to eq(effort_count_before)
+    end
+
+    it "reports the counts in the summary output" do
+      affected_count = Person.where.not(topic_resource_key: nil).count
+
+      output = silent_invoke
+
+      expect(output).to include("Destroyed 2 Person subscriptions")
+      expect(output).to include("tore down #{affected_count} SNS topics")
+    end
+
+    it "is idempotent — a second run reports zero work" do
+      silent_invoke
+      Rake::Task[task_name].reenable
+
+      output = silent_invoke
+
+      expect(output).to include("Destroyed 0 Person subscriptions")
+      expect(output).to include("tore down 0 SNS topics")
+    end
+  end
+
+  context "when there is no Person-typed data left" do
+    before do
+      Person.where.not(topic_resource_key: nil).update_all(topic_resource_key: nil)
+      Subscription.where(subscribable_type: "Person").delete_all
+    end
+
+    it "runs cleanly and reports zeros" do
+      output = silent_invoke
+
+      expect(output).to include("Destroyed 0 Person subscriptions")
+      expect(output).to include("tore down 0 SNS topics")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Step 2 of #2041. One-shot production cleanup task that runs **before** the schema migration drops `people.topic_resource_key`. Path: `rake maintenance:remove_person_subscriptions`.

### Order of operations
The task destroys subscriptions first, then deletes topics — for a specific reason:

1. **Subscriptions first.** `Subscription#before_destroy` fires `SnsSubscriptionManager.delete`, which removes the per-user SNS subscription ARN cleanly. If we deleted the topic first, AWS would auto-prune those ARNs and the per-subscription cleanup wouldn't have anything to address.
2. **Topics second.** For each `Person.where.not(topic_resource_key: nil)`, call `SnsTopicManager.delete(resource: person)` (still-present `topic_resource_key` column carries the ARN) and nil the column.

Idempotent on re-run — second run reports 0 / 0.

### Why a separate PR
The earlier code-removal PR (#2042) dropped `include Subscribable` from Person, so the rake task can't reuse `person.unassign_topic_resource` — it talks to `SnsTopicManager` directly using the still-present column value. The migration that drops the column comes in the **next** PR after this one runs in production.

### Test plan
- [x] `bundle exec rspec spec/lib/tasks/maintenance/remove_person_subscriptions_spec.rb` → 7 examples, 0 failures. Coverage: subscription destruction + column nil-out, per-person `SnsTopicManager.delete` call count (matches fixture count of 108 vestigial Person topic_resource_keys), `SnsSubscriptionManager.delete` fires per confirmed-ARN subscription, Effort subscriptions untouched, summary output, idempotency, and clean-state run.
- [x] Rubocop clean on both files.
- [ ] Production: ssh to droplet, `RAILS_ENV=production bundle exec rake maintenance:remove_person_subscriptions`, capture output, verify in psql that `Person.where.not(topic_resource_key: nil).count == 0` and `Subscription.where(subscribable_type: "Person").count == 0`. Re-run for the idempotency sanity check.

Relates to #2041.