### PR TITLE
Hotfix: skip per-row SNS unsubscribe in remove_person_subscriptions

### DIFF
--- a/lib/tasks/maintenance/remove_person_subscriptions.rake
+++ b/lib/tasks/maintenance/remove_person_subscriptions.rake
@@ -2,21 +2,16 @@ namespace :maintenance do
   desc "Destroy participant subscriptions and tear down their SNS topics (idempotent)"
   task remove_person_subscriptions: :environment do
     ActiveRecord::Base.logger.silence do
-      # Destroy per-user subscriptions first so Subscription#before_destroy can call
-      # SnsSubscriptionManager.delete cleanly. If we deleted the topic first, AWS
-      # auto-removes the subscription ARNs and the per-subscription cleanup would
-      # have nothing to address.
+      # delete_all skips Subscription#before_destroy :delete_resource_key. That callback
+      # makes a live sns_client.unsubscribe round-trip per subscription, which was
+      # taking ~30s+ apiece in production and would never reasonably finish for the
+      # full set. The topic-deletion phase below removes the SNS topic itself, which
+      # AWS responds to by auto-pruning every subscription attached to that topic
+      # server-side — so the per-row unsubscribe calls were redundant anyway.
       subscription_scope = Subscription.where(subscribable_type: "Person")
       destroyed = subscription_scope.count
-      puts "Destroying #{destroyed} Person subscriptions"
-
-      if destroyed.positive?
-        subscription_bar = ::ProgressBar.new(destroyed)
-        subscription_scope.find_each do |subscription|
-          subscription.destroy!
-          subscription_bar.increment!
-        end
-      end
+      puts "Deleting #{destroyed} Person subscriptions"
+      subscription_scope.delete_all if destroyed.positive?
 
       person_scope = Person.where.not(topic_resource_key: nil)
       topics_deleted = person_scope.count
@@ -31,7 +26,7 @@ namespace :maintenance do
         end
       end
 
-      puts "Done — destroyed #{destroyed} Person subscriptions, tore down #{topics_deleted} SNS topics."
+      puts "Done — deleted #{destroyed} Person subscriptions, tore down #{topics_deleted} SNS topics."
     end
   end
 end

--- a/spec/lib/tasks/maintenance/remove_person_subscriptions_spec.rb
+++ b/spec/lib/tasks/maintenance/remove_person_subscriptions_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe "maintenance:remove_person_subscriptions", type: :task do
 
     # Stub AWS so the test doesn't reach for the network.
     allow(SnsTopicManager).to receive(:delete)
-    allow(SnsSubscriptionManager).to receive(:delete).and_return(
-      SnsSubscriptionManager::Response.new(subscription_arn: "arn:aws:sns:us-west-2:123:fake-subscription-arn"),
-    )
+    allow(SnsSubscriptionManager).to receive(:delete)
   end
 
   def silent_invoke
@@ -47,7 +45,7 @@ RSpec.describe "maintenance:remove_person_subscriptions", type: :task do
       build_person_subscription(other_person)
     end
 
-    it "destroys all Person-typed subscriptions and nils out the topic_resource_key on every person" do
+    it "deletes all Person-typed subscriptions and nils out the topic_resource_key on every person" do
       expect { silent_invoke }
         .to change { Subscription.where(subscribable_type: "Person").count }.to(0)
         .and change { Person.where.not(topic_resource_key: nil).count }.to(0)
@@ -64,10 +62,10 @@ RSpec.describe "maintenance:remove_person_subscriptions", type: :task do
       expect(SnsTopicManager).to have_received(:delete).exactly(affected_count).times
     end
 
-    it "fires Subscription#before_destroy so SnsSubscriptionManager.delete is called for confirmed ARNs" do
+    it "skips per-subscription SnsSubscriptionManager.delete (topic deletion auto-prunes ARNs server-side)" do
       silent_invoke
 
-      expect(SnsSubscriptionManager).to have_received(:delete).twice
+      expect(SnsSubscriptionManager).not_to have_received(:delete)
     end
 
     it "leaves Effort subscriptions alone" do
@@ -84,7 +82,7 @@ RSpec.describe "maintenance:remove_person_subscriptions", type: :task do
 
       output = silent_invoke
 
-      expect(output).to include("destroyed 2 Person subscriptions")
+      expect(output).to include("deleted 2 Person subscriptions")
       expect(output).to include("tore down #{affected_count} SNS topics")
     end
 
@@ -94,7 +92,7 @@ RSpec.describe "maintenance:remove_person_subscriptions", type: :task do
 
       output = silent_invoke
 
-      expect(output).to include("destroyed 0 Person subscriptions")
+      expect(output).to include("deleted 0 Person subscriptions")
       expect(output).to include("tore down 0 SNS topics")
     end
   end
@@ -108,7 +106,7 @@ RSpec.describe "maintenance:remove_person_subscriptions", type: :task do
     it "runs cleanly and reports zeros" do
       output = silent_invoke
 
-      expect(output).to include("destroyed 0 Person subscriptions")
+      expect(output).to include("deleted 0 Person subscriptions")
       expect(output).to include("tore down 0 SNS topics")
     end
   end


### PR DESCRIPTION
## Summary
Production run of `maintenance:remove_person_subscriptions` stalled at 4/1767 because each `subscription.destroy!` was firing `Subscription#before_destroy :delete_resource_key`, which makes a live `sns_client.unsubscribe` round-trip per subscription. AWS was responding in ~30s+ apiece — the full set would never reasonably finish, and Ctrl-C only freed the worker between rows.

### Fix
Switch the subscriptions phase from `find_each { |s| s.destroy! }` to `scope.delete_all`. Drops ~2000 AWS round-trips and lands the cleanup in seconds.

Skipping the per-row SNS unsubscribe call is safe for this task:
- The very next phase deletes the SNS topic itself, and **AWS auto-prunes every subscription attached to a deleted topic server-side**, so the per-row unsubscribe was redundant cleanup we paid for twice.
- `delete_all` also skips PaperTrail, but Person subscriptions are being abandoned wholesale — per-row audit history isn't useful.

### Operator instructions
After this merges and deploys to the droplet, just re-run the task. It'll burn through the remaining ~1763 subscriptions instantly, then proceed to topic deletion (which uses `SnsTopicManager.delete` directly — also one round-trip per topic, but topic deletion is fast and the progress bar will keep moving).

```
ssh user@droplet
cd /path/to/opensplittime
RAILS_ENV=production bundle exec rake maintenance:remove_person_subscriptions
```

## Test plan
- [x] `bundle exec rspec spec/lib/tasks/maintenance/remove_person_subscriptions_spec.rb` → 7 examples, 0 failures. New regression guard asserts `SnsSubscriptionManager.delete` is NOT called for Person subscriptions.
- [x] Rubocop clean.
- [ ] Re-run task in production; confirm both phases complete; `Person.where.not(topic_resource_key: nil).count` and `Subscription.where(subscribable_type: "Person").count` both 0.

Relates to #2041.