### PR TITLE
Live-activity heartbeat dot on Raw Times page

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -41,6 +41,7 @@
 @import "./utilities/header";
 @import "./utilities/highlight";
 @import "./utilities/hr";
+@import "./utilities/live_activity_dot";
 @import "./utilities/icons";
 @import "./utilities/layout";
 @import "./utilities/modals";

--- a/app/assets/stylesheets/utilities/_live_activity_dot.scss
+++ b/app/assets/stylesheets/utilities/_live_activity_dot.scss
@@ -6,7 +6,7 @@
     background-color: var(--bs-secondary, #6c757d);
     opacity: 0.4;
     vertical-align: middle;
-    margin-left: 0.4rem;
+    margin-right: 0.4rem;
 }
 
 .live-activity-dot--pulsing {

--- a/app/assets/stylesheets/utilities/_live_activity_dot.scss
+++ b/app/assets/stylesheets/utilities/_live_activity_dot.scss
@@ -1,0 +1,27 @@
+.live-activity-dot {
+    display: inline-block;
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background-color: var(--bs-secondary, #6c757d);
+    opacity: 0.4;
+    vertical-align: middle;
+    margin-left: 0.4rem;
+}
+
+.live-activity-dot--pulsing {
+    animation: live-activity-pulse 600ms ease-out;
+}
+
+@keyframes live-activity-pulse {
+    0% {
+        background-color: var(--bs-success, #198754);
+        opacity: 1;
+        transform: scale(1.4);
+    }
+    100% {
+        background-color: var(--bs-secondary, #6c757d);
+        opacity: 0.4;
+        transform: scale(1);
+    }
+}

--- a/app/views/event_groups/_live_activity_dot.html.erb
+++ b/app/views/event_groups/_live_activity_dot.html.erb
@@ -1,0 +1,3 @@
+<span id="live_activity_dot"
+      class="live-activity-dot live-activity-dot--pulsing"
+      aria-hidden="true"></span>

--- a/app/views/event_groups/_raw_times_list.html.erb
+++ b/app/views/event_groups/_raw_times_list.html.erb
@@ -24,7 +24,10 @@
 <article class="ost-article container">
   <% if @presenter.event_group.available_live? %>
     <%= turbo_stream_from @presenter.event_group %>
-    <h6 class="text-center">Live updating</h6>
+    <h6 class="text-center">
+      Live updating
+      <%= render "event_groups/live_activity_dot" %>
+    </h6>
     <div class="back-and-forth-path">
       <span class="back-and-forth-shape trail"></span>
     </div>

--- a/app/views/event_groups/_raw_times_list.html.erb
+++ b/app/views/event_groups/_raw_times_list.html.erb
@@ -25,8 +25,8 @@
   <% if @presenter.event_group.available_live? %>
     <%= turbo_stream_from @presenter.event_group %>
     <h6 class="text-center">
-      Live updating
       <%= render "event_groups/live_activity_dot" %>
+      Live updating
     </h6>
     <div class="back-and-forth-path">
       <span class="back-and-forth-shape trail"></span>

--- a/app/views/raw_times/_created.turbo_stream.erb
+++ b/app/views/raw_times/_created.turbo_stream.erb
@@ -14,3 +14,6 @@
 <%= turbo_stream.replace :raw_times_count,
                          partial: "event_groups/raw_times_count",
                          locals: { raw_times_count: event_group.raw_times.count } %>
+
+<%= turbo_stream.replace :live_activity_dot,
+                         partial: "event_groups/live_activity_dot" %>

--- a/app/views/raw_times/_destroyed.turbo_stream.erb
+++ b/app/views/raw_times/_destroyed.turbo_stream.erb
@@ -5,3 +5,6 @@
 <%= turbo_stream.replace :raw_times_count,
                          partial: "event_groups/raw_times_count",
                          locals: { raw_times_count: event_group.raw_times.count } %>
+
+<%= turbo_stream.replace :live_activity_dot,
+                         partial: "event_groups/live_activity_dot" %>

--- a/app/views/raw_times/_destroyed.turbo_stream.erb
+++ b/app/views/raw_times/_destroyed.turbo_stream.erb
@@ -5,6 +5,3 @@
 <%= turbo_stream.replace :raw_times_count,
                          partial: "event_groups/raw_times_count",
                          locals: { raw_times_count: event_group.raw_times.count } %>
-
-<%= turbo_stream.replace :live_activity_dot,
-                         partial: "event_groups/live_activity_dot" %>

--- a/app/views/raw_times/_updated.turbo_stream.erb
+++ b/app/views/raw_times/_updated.turbo_stream.erb
@@ -10,3 +10,6 @@
                            monitor_pacers: event_group.monitor_pacers?,
                            home_time_zone: event_group.home_time_zone,
                          } %>
+
+<%= turbo_stream.replace :live_activity_dot,
+                         partial: "event_groups/live_activity_dot" %>

--- a/app/views/raw_times/_updated.turbo_stream.erb
+++ b/app/views/raw_times/_updated.turbo_stream.erb
@@ -10,6 +10,3 @@
                            monitor_pacers: event_group.monitor_pacers?,
                            home_time_zone: event_group.home_time_zone,
                          } %>
-
-<%= turbo_stream.replace :live_activity_dot,
-                         partial: "event_groups/live_activity_dot" %>


### PR DESCRIPTION
## Summary
Resolves #1997. When the Raw Times page applies a client-side filter (split name today, more soon via #1996), non-matching rows are silently dropped by `raw_time_filter_controller`. If the operator's filter is tight, the page can look frozen even when broadcasts are flowing — only the count column gives any hint. 

This PR adds a small always-visible dot next to the existing "Live updating" banner that briefly pulses on every raw_time broadcast, independent of filter outcome.

### Approach
Server-driven, no Stimulus controller. Each raw_time turbo-stream template (`_created`, `_updated`, `_destroyed`) gains a second action that replaces `#live_activity_dot` with a fresh render of `event_groups/_live_activity_dot.html.erb`. Because the element is replaced, the CSS animation on `.live-activity-dot--pulsing` restarts each time — no `addEventListener` lifecycle, no `setTimeout` reset logic, no DOM-event filtering needed.

Considered a JS listener that pulses on a `turbo:before-stream-render` event (the issue's original sketch), but the server-driven approach is simpler: one extra partial + one extra action on each broadcast vs. a new controller with subscribe/unsubscribe + class-add/timeout/remove. Trade-off acknowledged: future broadcast paths need to remember to include the indicator replace; today there's only one and it's now wired.

### Why the pulse fires regardless of filter
The visible row gets filtered client-side **after** the broadcast lands. The indicator is in a separate turbo-stream target (`live_activity_dot`) that's outside the filter controller's reach, so the indicator update applies whether or not the row survives.

### Files
- `app/views/event_groups/_live_activity_dot.html.erb` (new) — the dot.
- `app/views/event_groups/_raw_times_list.html.erb` — renders the dot next to "Live updating", inside the existing `available_live?` block.
- `app/views/raw_times/_created.turbo_stream.erb` / `_updated.turbo_stream.erb` / `_destroyed.turbo_stream.erb` — each gains a `turbo_stream.replace :live_activity_dot` action.
- `app/assets/stylesheets/utilities/_live_activity_dot.scss` (new) — idle (`.live-activity-dot`) + 600ms keyframe (`.live-activity-dot--pulsing`).
- `app/assets/stylesheets/application.bootstrap.scss` — imports the new partial alphabetically.

## Test plan
- [x] `bundle exec rspec spec/system/raw_times/ spec/models/raw_time_spec.rb` → 62 examples, 0 failures.
- [x] erb-lint clean on all touched ERB.
- [x] Manual: `bin/dev`, two browser windows on an event_group Raw Times page. Post a raw_time from one (or via live entry). Watch the dot pulse on the other. Repeat with the split-name filter active and a broadcast that doesn't match → row stays hidden, dot still pulses. Repeat for an update (edit) and a destroy. Verify the dot is **not** rendered on a non-`available_live?` event group (it sits inside that conditional).

This is a follow-up to the filtering PR by @yanatan16 (#1986)