### PR TITLE
Donations chart spans every year from first event to today

### DIFF
--- a/app/presenters/organization_usage_show_presenter.rb
+++ b/app/presenters/organization_usage_show_presenter.rb
@@ -55,13 +55,17 @@ class OrganizationUsageShowPresenter
   end
 
   # Chart data keyed by stringified year so Chart.js treats the x-axis as discrete
-  # categories (same trick as #chart_series). Years without donations are omitted.
+  # categories (same trick as #chart_series). Spans the full range from the org's
+  # first real event year to the current year, filling years without donations with 0
+  # so the chart shows a continuous timeline rather than skipping over quiet years.
   def donations_by_year
-    organization.monetary_donations
-                .group(Arel.sql("EXTRACT(YEAR FROM received_on)::int"))
-                .sum(:amount)
-                .sort.to_h
-                .transform_keys(&:to_s)
+    start_year = sorted_years.first || first_donation_year
+    return {} if start_year.nil?
+
+    amounts = organization.monetary_donations
+                          .group(Arel.sql("EXTRACT(YEAR FROM received_on)::int"))
+                          .sum(:amount)
+    (start_year..Date.current.year).to_h { |year| [year.to_s, amounts[year] || 0] }
   end
 
   private

--- a/spec/presenters/organization_usage_show_presenter_spec.rb
+++ b/spec/presenters/organization_usage_show_presenter_spec.rb
@@ -116,6 +116,8 @@ RSpec.describe OrganizationUsageShowPresenter do
   end
 
   describe "#donations_by_year" do
+    include ActiveSupport::Testing::TimeHelpers
+
     let(:presenter) { described_class.new(hardrock) }
 
     it "buckets donation amounts by stringified year, sorted ascending" do
@@ -131,6 +133,30 @@ RSpec.describe OrganizationUsageShowPresenter do
       hardrock.monetary_donations.create!(received_on: Date.new(2024, 11, 30), amount: 50, source: "paypal")
 
       expect(presenter.donations_by_year["2024"]).to eq(hardrock.monetary_donations.where("EXTRACT(YEAR FROM received_on) = 2024").sum(:amount))
+    end
+
+    it "spans every year from the org's first real event to the current year, filling quiet years with zero" do
+      # Hardrock fixture events run 2014-2016. Pin "today" to 2026 to get the full range.
+      travel_to Date.new(2026, 5, 15) do
+        data = presenter.donations_by_year
+
+        expect(data.keys).to eq((2014..2026).map(&:to_s))
+        # Years with no donations come back as zero, not missing
+        zero_years = data.select { |_year, amount| amount.zero? }.keys
+        expect(zero_years).to include("2015", "2016", "2017") # quiet years inside the range
+      end
+    end
+
+    it "falls back to the first donation year when the org has no real events" do
+      orphan = Organization.create!(name: "Donor No Events", created_by: users(:admin_user).id, concealed: false)
+      orphan.monetary_donations.create!(received_on: Date.new(2023, 6, 1), amount: 100, source: "paypal")
+      orphan.monetary_donations.create!(received_on: Date.new(2024, 6, 1), amount: 200, source: "check")
+
+      travel_to Date.new(2025, 1, 1) do
+        data = described_class.new(orphan).donations_by_year
+        expect(data.keys).to eq(%w[2023 2024 2025])
+        expect(data["2025"]).to eq(0)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
`donations_by_year` used to emit only the years that actually had a donation, so the bar chart on `/organization-usage/:id` skipped quiet years entirely — an org that donated in 2022 and 2025 rendered the same as one that donated in two consecutive years.

Now the range runs **from the org's first real-event year through `Date.current.year`**, with intermediate quiet years filled in at $0. Falls back to the org's first donation year if there are no real events on record (edge case for a pure-donor org).

`sorted_years.first` is already the org's first real-event year (it comes out of the same `breakdown` the rest of the show page uses), so no new SQL — just reusing the existing aggregate.

## Test plan
- [x] `bundle exec rspec spec/presenters/organization_usage_show_presenter_spec.rb` → 17 examples, 0 failures.
- [x] Rubocop clean.
- [ ] Visit `/organization-usage/hardrock` as admin and confirm the bar chart now has a tick for every year 2014–today, with $0 columns where appropriate.