### PR TITLE
Fix Current column: treat post-event donations as paid

### DIFF
--- a/app/presenters/organization_usage_index_presenter.rb
+++ b/app/presenters/organization_usage_index_presenter.rb
@@ -3,13 +3,14 @@ class OrganizationUsageIndexPresenter
                    :last_donation_year, :total_donated) do
     # Returns:
     #   nil       — org isn't active (no real events in the prior or current year)
-    #   :paid     — donated in the same year as the most recent event
+    #   :paid     — donated in the same year as the most recent event, or any year since
     #   :recent   — donated in the year before the most recent event
-    #   :overdue  — active but donation history doesn't match the above
+    #   :overdue  — active but donation history is older than that, or nonexistent
     def current_status
       current_year = Date.current.year
       return nil if last_active_year.nil? || last_active_year < current_year - 1
-      return :paid if last_donation_year == last_active_year
+      return :overdue if last_donation_year.nil?
+      return :paid if last_donation_year >= last_active_year
       return :recent if last_donation_year == last_active_year - 1
 
       :overdue

--- a/spec/presenters/organization_usage_index_presenter_spec.rb
+++ b/spec/presenters/organization_usage_index_presenter_spec.rb
@@ -164,6 +164,11 @@ RSpec.describe OrganizationUsageIndexPresenter do
       expect(row(last_active: 2025, last_donation: 2025).current_status).to eq(:paid)
     end
 
+    it "returns :paid when last donation is more recent than the most recent event" do
+      # The race ran in 2025 and they donated in 2026 — fully current.
+      expect(row(last_active: 2025, last_donation: 2026).current_status).to eq(:paid)
+    end
+
     it "returns :recent when last donation is the year before the most recent event" do
       expect(row(last_active: 2026, last_donation: 2025).current_status).to eq(:recent)
       expect(row(last_active: 2025, last_donation: 2024).current_status).to eq(:recent)


### PR DESCRIPTION
## Summary
The "Current" column on `/organization-usage` flagged an org red ✗ when its last race was in 2025 and they donated in 2026. The literal "same year as event" rule (`==`) missed donations that arrived **after** the most recent event — which is, if anything, a stronger signal of recency than a same-year payment.

Broaden the `:paid` rule from `==` to `>=` so any donation in the event year or later counts as current.

| Case | last_active | last_donation | Before | After |
| --- | --- | --- | --- | --- |
| Donated same year | 2025 | 2025 | :paid ✓ | :paid ✓ |
| **Donated after event** | 2025 | 2026 | **:overdue ✗** | **:paid ✓** |
| Pre-paid for upcoming season | 2025 | 2024 | :recent ? | :recent ? |
| Stale donation | 2025 | 2022 | :overdue ✗ | :overdue ✗ |
| Never donated | 2025 | nil | :overdue ✗ | :overdue ✗ |

## Test plan
- [x] `bundle exec rspec spec/presenters/organization_usage_index_presenter_spec.rb` → 18 examples, 0 failures. New spec example covers the `last_active: 2025, last_donation: 2026 → :paid` case.
- [x] Rubocop clean.
- [ ] Confirm in production: the organization that just made a 2026 donation following a 2025 race now shows a green ✓ on the index.