### PR TITLE
Broaden reconcile_topic_arns to scan all rows

### DIFF
--- a/lib/tasks/maintenance/reconcile_topic_arns.rake
+++ b/lib/tasks/maintenance/reconcile_topic_arns.rake
@@ -20,24 +20,25 @@ namespace :maintenance do
 end
 
 def reconcile_class(klass, sns_client, apply:)
-  records = klass.where.not(topic_resource_key: nil).to_a
-  if records.empty?
+  scope = klass.where.not(topic_resource_key: nil)
+  total = scope.count
+  if total.zero?
     puts "#{klass.name}: no rows with topic_resource_key"
     return
   end
 
-  puts "#{klass.name}: #{records.size} row(s) — checking AWS"
-  exists_matched = []
-  exists_drifted = []
+  puts "#{klass.name}: #{total} row(s) — checking AWS"
+  exists_matched = 0
+  exists_drifted = 0
   missing = []
   errored = []
 
-  progress = ::ProgressBar.new(records.size)
-  records.each do |record|
+  progress = ::ProgressBar.new(total)
+  scope.find_each do |record|
     progress.increment!
     begin
       sns_client.get_topic_attributes(topic_arn: record.topic_resource_key)
-      slug_matches_arn?(record) ? exists_matched << record : exists_drifted << record
+      slug_matches_arn?(record) ? exists_matched += 1 : exists_drifted += 1
     rescue ::Aws::SNS::Errors::NotFound
       missing << record
     rescue ::Aws::SNS::Errors::ServiceError => e
@@ -45,8 +46,8 @@ def reconcile_class(klass, sns_client, apply:)
     end
   end
 
-  puts "  exists in AWS (slug matches):           #{exists_matched.size}"
-  puts "  exists in AWS (slug-renamed, harmless): #{exists_drifted.size}"
+  puts "  exists in AWS (slug matches):           #{exists_matched}"
+  puts "  exists in AWS (slug-renamed, harmless): #{exists_drifted}"
   puts "  MISSING in AWS (dangling pointers):     #{missing.size}"
   puts "  errors during AWS check:                #{errored.size}"
 

--- a/lib/tasks/maintenance/reconcile_topic_arns.rake
+++ b/lib/tasks/maintenance/reconcile_topic_arns.rake
@@ -1,13 +1,15 @@
-# Reconciles Subscribable topic_resource_key values against AWS SNS. Reports drift
-# (rows whose topic name doesn't match the row's slug) and splits into "topic still
-# exists in AWS" (harmless slug renames) vs "topic missing in AWS" (dangling
-# pointers — the cause of repeated NotifyEventUpdateJob etc. failures).
-# Pass APPLY=true to nil out topic_resource_key on the dangling rows.
+# Reconciles Subscribable topic_resource_key values against AWS SNS. For every
+# row with a topic_resource_key, calls GetTopicAttributes and classifies:
+#   - exists in AWS, slug matches the ARN (healthy)
+#   - exists in AWS, slug differs from the ARN (drift — harmless slug rename)
+#   - missing in AWS (dangling pointer — what causes NotifyEventUpdateJob etc.
+#     to fail and self-heal repeatedly)
+# Pass APPLY=true to nil topic_resource_key on the dangling rows.
 namespace :maintenance do
-  desc "Reports drifted topic_resource_keys; APPLY=true to nil dangling pointers"
+  desc "Reports topic_resource_key vs AWS; APPLY=true clears dangling pointers"
   task reconcile_topic_arns: :environment do
     apply = ENV["APPLY"] == "true"
-    klasses = [::Event, ::Effort, ::Person]
+    klasses = [::Event, ::Effort]
     sns_client = ::SnsClientFactory.client
 
     puts "Mode: #{apply ? 'APPLY (will nil topic_resource_key on dangling rows)' : 'DRY RUN (read-only)'}"
@@ -18,23 +20,24 @@ namespace :maintenance do
 end
 
 def reconcile_class(klass, sns_client, apply:)
-  drifted = collect_drift(klass)
-  if drifted.empty?
-    puts "#{klass.name}: no drift"
+  records = klass.where.not(topic_resource_key: nil).to_a
+  if records.empty?
+    puts "#{klass.name}: no rows with topic_resource_key"
     return
   end
 
-  puts "#{klass.name}: #{drifted.size} drifted — checking AWS"
-  exists = []
+  puts "#{klass.name}: #{records.size} row(s) — checking AWS"
+  exists_matched = []
+  exists_drifted = []
   missing = []
   errored = []
 
-  progress = ::ProgressBar.new(drifted.size)
-  drifted.each do |record|
+  progress = ::ProgressBar.new(records.size)
+  records.each do |record|
     progress.increment!
     begin
       sns_client.get_topic_attributes(topic_arn: record.topic_resource_key)
-      exists << record
+      slug_matches_arn?(record) ? exists_matched << record : exists_drifted << record
     rescue ::Aws::SNS::Errors::NotFound
       missing << record
     rescue ::Aws::SNS::Errors::ServiceError => e
@@ -42,12 +45,13 @@ def reconcile_class(klass, sns_client, apply:)
     end
   end
 
-  puts "  exists in AWS (slug-renamed, harmless): #{exists.size}"
+  puts "  exists in AWS (slug matches):           #{exists_matched.size}"
+  puts "  exists in AWS (slug-renamed, harmless): #{exists_drifted.size}"
   puts "  MISSING in AWS (dangling pointers):     #{missing.size}"
   puts "  errors during AWS check:                #{errored.size}"
 
   if missing.any?
-    puts "\n  Dangling records:"
+    puts "\n  Dangling rows:"
     missing.each { |r| puts "    #{klass.name}##{r.id}  slug=#{r.slug}  arn=#{r.topic_resource_key}" }
   end
 
@@ -75,11 +79,9 @@ def reconcile_class(klass, sns_client, apply:)
   puts
 end
 
-def collect_drift(klass)
-  klass.where.not(topic_resource_key: nil).find_each.reject do |record|
-    # Tolerate both eras (follow_/follow-) and any single-letter env prefix
-    # (d-, s-, t-) so this works in non-prod environments too.
-    arn_slug = record.topic_resource_key.split(":").last.to_s.sub(/\A([a-z]-)?follow[-_]/, "")
-    arn_slug == record.slug
-  end
+def slug_matches_arn?(record)
+  # Tolerate both eras (follow_/follow-) and any single-letter env prefix
+  # (d-, s-, t-) so this works in non-prod environments too.
+  arn_slug = record.topic_resource_key.split(":").last.to_s.sub(/\A([a-z]-)?follow[-_]/, "")
+  arn_slug == record.slug
 end


### PR DESCRIPTION
## Summary
- Hits AWS `GetTopicAttributes` for every Subscribable row with a `topic_resource_key`, not just those with slug/ARN drift. Buckets results into exists+matches, exists+drift, missing, errored. `APPLY=true` still clears the missing rows.
- The drift filter was too narrow: it misses dangling pointers from the pre-`validate: false` sweeper window (before `600cf8e71`) where `unassign_topic_resource` deleted the AWS topic but a later `save!` raised `RecordInvalid`, leaving `topic_resource_key` populated even though AWS no longer had the topic. Those rows aren't "drifted" — the ARN still matches the slug — so the previous task skipped them, and every subsequent touch (e.g. concealment cascade hitting Event#1278 testrock-100) was producing an `Aws::SNS::Errors::NotFound` self-heal report in Scout.
- Drive-by: drop `::Person` from the klass list. `people.topic_resource_key` was removed in `a2f51c2fd`; the old task errored out trying to query a non-existent column on Person.

## Test plan
- [ ] `bundle exec rake maintenance:reconcile_topic_arns` (dry-run) in production — confirm a non-zero "MISSING in AWS" count, and that Event#1278 shows up.
- [ ] `APPLY=true bundle exec rake maintenance:reconcile_topic_arns` — clear dangling rows.
- [ ] Watch Scout for `Aws::SNS::Errors::NotFound` self-heal captures — should drop to ~zero once the backfill runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)