### PR TITLE
Quiet AWS SDK per-call logs in reconcile_topic_arns

### DIFF
--- a/app/services/sns_client_factory.rb
+++ b/app/services/sns_client_factory.rb
@@ -5,16 +5,16 @@ class SnsClientFactory
   STUB_SUBSCRIPTION_ARN = "arn:aws:sns:us-west-2:000000000000:dev-stub-topic:dev-stub-subscription".freeze
 
   # @return [Aws::SNS::Client]
-  def self.client
+  def self.client(**overrides)
     if ::OstConfig.aws_stub_responses?
-      Aws::SNS::Client.new(stub_responses: true).tap do |stubbed|
+      Aws::SNS::Client.new(stub_responses: true, **overrides).tap do |stubbed|
         stubbed.stub_responses(:create_topic, topic_arn: STUB_TOPIC_ARN)
         stubbed.stub_responses(:subscribe, subscription_arn: STUB_SUBSCRIPTION_ARN)
         stubbed.stub_responses(:unsubscribe, {})
         stubbed.stub_responses(:delete_topic, {})
       end
     else
-      Aws::SNS::Client.new
+      Aws::SNS::Client.new(**overrides)
     end
   end
 end

--- a/lib/tasks/maintenance/reconcile_topic_arns.rake
+++ b/lib/tasks/maintenance/reconcile_topic_arns.rake
@@ -10,7 +10,9 @@ namespace :maintenance do
   task reconcile_topic_arns: :environment do
     apply = ENV["APPLY"] == "true"
     klasses = [::Event, ::Effort]
-    sns_client = ::SnsClientFactory.client
+    # Pass logger: nil so the aws-sdk-rails railtie's per-call INFO logging
+    # doesn't drown the progress bar in one line per GetTopicAttributes.
+    sns_client = ::SnsClientFactory.client(logger: nil)
 
     puts "Mode: #{apply ? 'APPLY (will nil topic_resource_key on dangling rows)' : 'DRY RUN (read-only)'}"
     puts


### PR DESCRIPTION
## Summary
- `SnsClientFactory.client` now accepts a `**overrides` splat that passes through to `Aws::SNS::Client.new`.
- `maintenance:reconcile_topic_arns` calls it with `logger: nil` so the AWS SDK's per-call INFO logging is suppressed for the duration of the scan.

## Why
`aws-sdk-rails` 3.13's railtie sets `Aws.config[:logger] = Rails.logger`, which makes the SDK's `Plugins::Logging` emit one line per request:

```
I, [2026-05-16T18:58:10] INFO -- : [Aws::SNS::Client 200 0.051066 0 retries] get_topic_attributes(topic_arn:"arn:aws:sns:...:follow_2019-rattlesnake-...")
```

Over thousands of rows those drown out the progress bar and the post-scan summary. The plugin only installs its handler when `config.logger` is set (`aws-sdk-core-3.244.0/lib/aws-sdk-core/plugins/logging.rb:33-35`), so passing `logger: nil` per-client cleanly disables it. Verified locally with a real `Aws::SNS::Client` that the per-client override beats the global `Aws.config[:logger]`.

## Test plan
- [ ] Re-run `bundle exec rake maintenance:reconcile_topic_arns` in production and confirm only the progress bar + classification summary appears (no per-call SDK log lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)