### PR TITLE
Sweep effort topics for unfinished efforts past 3-month cutoff

### DIFF
--- a/app/jobs/sweepers/effort_subscriptions_and_topics_job.rb
+++ b/app/jobs/sweepers/effort_subscriptions_and_topics_job.rb
@@ -4,7 +4,8 @@ module Sweepers
 
     SUBSCRIPTION_FINISHED_CUTOFF = 10.days
     SUBSCRIPTION_ABSOLUTE_CUTOFF = 3.months
-    TOPIC_AGE_CUTOFF = 30.days
+    TOPIC_FINISHED_CUTOFF = 30.days
+    TOPIC_ABSOLUTE_CUTOFF = 3.months
     ORPHANED_DRIFT_THRESHOLD = 100
 
     class OrphanedTopicDriftError < StandardError; end
@@ -59,18 +60,21 @@ module Sweepers
     end
 
     def sweep_topics_on_stale_efforts
-      append("\n[Pass 2] Sweeping topics on stale finished Efforts")
+      append("\n[Pass 2] Sweeping topics on stale Efforts")
 
       candidates = Effort.joins(:event)
                          .having_topic_resource_key
-                         .where(finished: true)
                          .where(
-                           "COALESCE(efforts.scheduled_start_time, events.scheduled_start_time) < ?",
-                           TOPIC_AGE_CUTOFF.ago,
+                           "(efforts.finished = TRUE AND " \
+                           "COALESCE(efforts.scheduled_start_time, events.scheduled_start_time) < ?) " \
+                           "OR COALESCE(efforts.scheduled_start_time, events.scheduled_start_time) < ?",
+                           TOPIC_FINISHED_CUTOFF.ago,
+                           TOPIC_ABSOLUTE_CUTOFF.ago,
                          )
 
       total_candidates = candidates.count
-      append("  #{total_candidates} candidate Effort(s) past the #{TOPIC_AGE_CUTOFF.inspect} cutoff")
+      append("  #{total_candidates} candidate Effort(s) " \
+             "(finished + #{TOPIC_FINISHED_CUTOFF.inspect}, or any + #{TOPIC_ABSOLUTE_CUTOFF.inspect})")
       return if total_candidates.zero?
 
       deleted_count = 0

--- a/spec/jobs/sweepers/effort_subscriptions_and_topics_job_spec.rb
+++ b/spec/jobs/sweepers/effort_subscriptions_and_topics_job_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Sweepers::EffortSubscriptionsAndTopicsJob, type: :job do
       expect(effort_recent_finished.reload.topic_resource_key).to eq(topic_arn)
     end
 
-    it "preserves the topic when the Effort is not finished" do
+    it "preserves the topic when the Effort is not finished and younger than 3 months" do
       effort_active_unfinished.update_columns(
         finished: false,
         scheduled_start_time: 31.days.ago,
@@ -134,6 +134,21 @@ RSpec.describe Sweepers::EffortSubscriptionsAndTopicsJob, type: :job do
       described_class.perform_now
 
       expect(effort_active_unfinished.reload.topic_resource_key).to eq(topic_arn)
+    end
+
+    it "deletes the topic for unfinished Efforts older than 3 months (safety belt)" do
+      effort_active_unfinished.update_columns(
+        finished: false,
+        scheduled_start_time: 4.months.ago,
+        topic_resource_key: topic_arn,
+      )
+
+      allow(SnsTopicManager).to receive(:delete).and_return(topic_arn)
+
+      described_class.perform_now
+
+      expect(SnsTopicManager).to have_received(:delete).with(resource: effort_active_unfinished)
+      expect(effort_active_unfinished.reload.topic_resource_key).to be_nil
     end
 
     it "preserves the topic for finished Efforts younger than 30 days" do


### PR DESCRIPTION
## Summary
- Broaden `Sweepers::EffortSubscriptionsAndTopicsJob#sweep_topics_on_stale_efforts` so it also targets unfinished efforts once they're past an absolute 3-month cutoff, not just finished efforts past the 30-day cutoff.
- Mirrors Pass 1's two-arm shape (`finished + SUBSCRIPTION_FINISHED_CUTOFF` OR `any + SUBSCRIPTION_ABSOLUTE_CUTOFF`).
- Renamed `TOPIC_AGE_CUTOFF` → `TOPIC_FINISHED_CUTOFF` and added `TOPIC_ABSOLUTE_CUTOFF = 3.months`. Constants were only referenced inside this file.

## Why
Production has 8,563 efforts with `topic_resource_key` set; 7,943 of them (93%) are unfinished. The previous Pass 2 query had `where(finished: true)`, so DNS/DNF rows and abandoned event groups kept their `topic_resource_key` forever — invisible to the sweeper no matter how old the event got. Each surviving row is a candidate for the `Aws::SNS::Errors::NotFound` self-heal path once its AWS topic eventually disappears.

3 months is safe because Pass 1's `SUBSCRIPTION_ABSOLUTE_CUTOFF` (also 3 months) has already destroyed every subscription on these efforts, so the topic has zero subscribers. Pass 2 still has its `subscriptions.exists?` guard for late stragglers.

## Test plan
- [x] Existing 19 specs pass, including the case that asserts unfinished + 31 days does *not* sweep.
- [x] New spec: unfinished + 4 months *does* sweep (verifies the absolute cutoff arm).
- [ ] First production run will produce a large Pass 2 delete count (one-time backlog) — confirm via the AdminMailer report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)