### PR TITLE
Scope entrant CSV export to a single event group

### DIFF
--- a/app/controllers/efforts_controller.rb
+++ b/app/controllers/efforts_controller.rb
@@ -1,28 +1,9 @@
 class EffortsController < ApplicationController
   before_action :authenticate_user!,
-                except: [:index, :show, :mini_table, :show_photo, :projections, :analyze, :place, :live_entry_table]
-  before_action :set_effort, except: [:index, :new, :create, :create_split_time_from_raw_time, :mini_table]
+                except: [:show, :mini_table, :show_photo, :projections, :analyze, :place, :live_entry_table]
+  before_action :set_effort, except: [:new, :create, :create_split_time_from_raw_time, :mini_table]
   after_action :verify_authorized,
-               except: [:index, :show, :mini_table, :show_photo, :projections, :analyze, :place, :live_entry_table]
-
-  # GET /efforts
-  def index
-    @efforts = policy_scope(Effort).order(prepared_params[:sort] || :bib_number, :last_name, :first_name)
-                                   .where(prepared_params[:filter])
-    respond_to do |format|
-      format.csv do
-        builder = CsvBuilder.new(Effort, @efforts)
-        filename = if prepared_params[:filter] == { "id" => "0" }
-                     "ost-effort-import-template.csv"
-                   else
-                     "#{prepared_params[:filter].to_param}-#{builder.model_class_name}" \
-                       "-#{Time.zone.now.strftime('%Y-%m-%d')}.csv"
-                   end
-
-        send_data(builder.full_string, type: "text/csv", filename: filename)
-      end
-    end
-  end
+               except: [:show, :mini_table, :show_photo, :projections, :analyze, :place, :live_entry_table]
 
   # GET /efforts/1
   def show

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -431,6 +431,20 @@ class EventGroupsController < ApplicationController
     redirect_to setup_event_group_path(@event_group)
   end
 
+  # GET /event_groups/1/export_entrants
+  def export_entrants
+    authorize @event_group
+    efforts = @event_group.efforts.order(:bib_number, :last_name, :first_name)
+    builder = CsvBuilder.new(Effort, efforts)
+
+    respond_to do |format|
+      format.csv do
+        send_data(builder.full_string, type: "text/csv",
+                                       filename: "#{@event_group.name.parameterize}-entrants-#{Time.zone.today}.csv")
+      end
+    end
+  end
+
   # GET /event_groups/1/export_raw_times
   def export_raw_times
     authorize @event_group

--- a/app/policies/event_group_policy.rb
+++ b/app/policies/event_group_policy.rb
@@ -146,6 +146,10 @@ class EventGroupPolicy < ApplicationPolicy
     user.authorized_to_edit?(event_group)
   end
 
+  def export_entrants?
+    user.authorized_to_edit?(event_group)
+  end
+
   def export_raw_times?
     user.authorized_to_edit?(event_group)
   end

--- a/app/views/event_groups/_entrants_list.html.erb
+++ b/app/views/event_groups/_entrants_list.html.erb
@@ -22,7 +22,7 @@
                   <%= link_to "Manage Photos", manage_entrant_photos_event_group_path(presenter.event_group), class: "dropdown-item" %>
                   <%= link_to "Manage Start Times", manage_start_times_event_group_path(presenter.event_group), class: "dropdown-item" %>
                   <div class="dropdown-divider"></div>
-                  <%= link_to "Export", efforts_path(filter: { event_id: presenter.events.ids }, format: :csv), class: "dropdown-item" %>
+                  <%= link_to "Export", export_entrants_event_group_path(presenter.event_group, format: :csv), class: "dropdown-item" %>
                   <div class="dropdown-divider"></div>
                   <%= link_to_strong_confirm "Delete all entrants", delete_all_efforts_event_group_path(presenter.event_group),
                                              class: "dropdown-item text-danger",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,7 @@ Rails.application.routes.draw do
 
   resources :credentials, only: [:create, :update, :destroy]
 
-  resources :efforts do
+  resources :efforts, except: [:index] do
     resources :subscriptions, only: [:create, :destroy], module: "efforts"
     get "subscription_button/:notification_protocol",
         to: "efforts/subscriptions#button",
@@ -136,6 +136,7 @@ Rails.application.routes.draw do
       get :drop_list
       get :efforts
       get :entrants
+      get :export_entrants
       get :export_raw_times
       get :finish_line
       get :follow

--- a/spec/requests/event_groups/export_entrants_spec.rb
+++ b/spec/requests/event_groups/export_entrants_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe "EventGroups#export_entrants" do
+  include Warden::Test::Helpers
+
+  subject(:make_request) { get export_entrants_event_group_path(event_group, format: :csv) }
+
+  let(:event_group) { event_groups(:hardrock_2015) }
+  let(:organization) { event_group.organization }
+  let(:admin_user) { users(:admin_user) }
+  let(:other_user) { users(:third_user) }
+  let(:owner_user) { users(:fourth_user) }
+  let(:steward_user) { users(:fifth_user) }
+
+  after { Warden.test_reset! }
+
+  context "when the user is not signed in" do
+    it "does not return CSV" do
+      make_request
+      expect(response).not_to have_http_status(:ok)
+    end
+  end
+
+  context "when the user is not authorized to edit the event group" do
+    before { login_as other_user, scope: :user }
+
+    it "does not return CSV" do
+      make_request
+      expect(response).not_to have_http_status(:ok)
+    end
+  end
+
+  context "when the user is an admin" do
+    before { login_as admin_user, scope: :user }
+
+    it "returns CSV scoped to this event group's entrants" do
+      make_request
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with("text/csv")
+      expect(response.headers["Content-Disposition"]).to include("hardrock-2015-entrants-")
+
+      table = ::CSV.parse(response.body, headers: true)
+      expect(table.headers).to include("First name", "Last name", "Bib number", "Email", "Phone")
+      expect(table.count).to eq(event_group.efforts.count)
+      expect(table["Last name"]).to include("Jacobs") # hardrock_2015_tuan_jacobs fixture
+    end
+  end
+
+  context "when the user owns the organization" do
+    before do
+      organization.update!(created_by: owner_user.id)
+      login_as owner_user, scope: :user
+    end
+
+    it "renders successfully" do
+      make_request
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "when the user is a steward of the organization" do
+    before do
+      organization.stewards << steward_user
+      login_as steward_user, scope: :user
+    end
+
+    it "renders successfully" do
+      make_request
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Replaces the anonymous-reachable `GET /efforts.csv` (`EffortsController#index`) — which returned a CSV of every non-concealed effort in the database with PII (phone, email, emergency contact info, birthdate, etc.) — with `EventGroupsController#export_entrants`, scoped to a single event group and authorized at edit level via a new `EventGroupPolicy#export_entrants?`.
- Repoints the lone caller (`app/views/event_groups/_entrants_list.html.erb:25`) at the new route.
- Removes `:index` from `resources :efforts` and deletes the dead `filter == { "id" => "0" }` "import template" branch in the same pass.

## Why
The combined effect of:
- `EffortsController` excluding `:index` from `authenticate_user!`
- `policy_scope(Effort).where(prepared_params[:filter])` accepting an absent filter
- `ApplicationPolicy::Scope#resolve_viewable` falling through to `Effort.visible` for anonymous users

…meant `curl https://www.opensplittime.org/efforts.csv` dumped every non-concealed row in `efforts` to any anonymous caller. The lone legitimate caller always passed `filter: { event_id: presenter.events.ids }`, so an event-group-scoped route loses nothing in real usage. Full diagnosis in issue #2059.

The new action mirrors the existing `EventGroupsController#export_raw_times` (auth pattern, filename pattern) and reuses the existing `CsvBuilder` serializer, so the CSV format is unchanged for the legitimate use case.

## Test plan
- [x] `spec/requests/event_groups/export_entrants_spec.rb` (new) — 5 cases: anonymous (no CSV), non-authorized user (no CSV), admin (CSV with correct headers, row count == `event_group.efforts.count`, includes a known fixture last name), org owner (success), org steward (success).
- [x] Adjacent specs in `spec/requests/event_groups/`, `spec/requests/efforts/`, `spec/system/event_groups/` all pass (61 examples).
- [x] Local manual: log in as admin, hit an event group's entrants → Actions → Export, confirm CSV downloads with the expected columns. Log out and `curl -i http://localhost:3000/efforts.csv` → 404 (route removed). `curl -i http://localhost:3000/event_groups/<slug>/export_entrants.csv` → redirect to sign-in.

Resolves #2059

🤖 Generated with [Claude Code](https://claude.com/claude-code)