### PR TITLE
Remove dead subregion_options routes on efforts and people

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,7 +86,6 @@ Rails.application.routes.draw do
         as: :subscription_button,
         constraints: { notification_protocol: /email|sms/ }
     collection do
-      get :subregion_options
       post :mini_table
     end
     member do
@@ -275,7 +274,6 @@ Rails.application.routes.draw do
   end
 
   resources :people, only: [:index, :show, :edit, :update, :destroy] do
-    collection { get :subregion_options }
     member { patch :avatar_claim }
     member { get :merge }
     member { put :combine }


### PR DESCRIPTION
## Summary
- Removes `get :subregion_options` from `resources :efforts` and `resources :people` in `config/routes.rb`.
- Neither controller defines a `subregion_options` action; the route helpers have zero callers in `app/`, `config/`, or JS. Hitting either path would raise `AbstractController::ActionNotFound`.
- The active replacement, `carmen/subregion_options` (`CarmenController`), is wired directly from the JS form controllers and isn't touched.

## Test plan
- [x] `bundle exec rails routes | grep subregion` shows only `carmen_subregion_options`.
- [x] Efforts + people request/system specs pass (14 examples, 0 failures).

Resolves #2061

🤖 Generated with [Claude Code](https://claude.com/claude-code)