### PR TITLE
Make lotteries a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -39,6 +39,7 @@ module FixtureHelper
   # rather than id in other fixture tables.
   PORTABLE_FIXTURE_TABLES = [
     :course_groups,
+    :lotteries,
     :organizations,
     :results_categories,
     :results_templates,

--- a/spec/fixtures/lotteries.yml
+++ b/spec/fixtures/lotteries.yml
@@ -1,19 +1,17 @@
 ---
-lottery_without_tickets:
-  organization: hardrock
-  id: 3
-  calculation_class:
-  concealed:
-  name: Lottery Without Tickets
-  scheduled_start_date: 2022-12-06
-  slug: lottery-without-tickets
-  status: 0
 lottery_with_tickets_and_draws:
   organization: hardrock
-  id: 4
   calculation_class:
   concealed:
   name: Lottery With Tickets And Draws
   scheduled_start_date: 2020-11-11
   slug: lottery-with-tickets-and-draws
   status: 1
+lottery_without_tickets:
+  organization: hardrock
+  calculation_class:
+  concealed:
+  name: Lottery Without Tickets
+  scheduled_start_date: 2022-12-06
+  slug: lottery-without-tickets
+  status: 0

--- a/spec/fixtures/lottery_divisions.yml
+++ b/spec/fixtures/lottery_divisions.yml
@@ -1,31 +1,31 @@
 ---
 lottery_division_0001:
+  lottery: lottery_with_tickets_and_draws
   id: 1
-  lottery_id: 4
   maximum_entries: 3
   maximum_wait_list: 2
   name: Never Ever Evers
 lottery_division_0002:
+  lottery: lottery_with_tickets_and_draws
   id: 2
-  lottery_id: 4
   maximum_entries: 3
   maximum_wait_list: 3
   name: Veterans
 lottery_division_0003:
+  lottery: lottery_without_tickets
   id: 6
-  lottery_id: 3
   maximum_entries: 5
   maximum_wait_list: 3
   name: Fast People
 lottery_division_0004:
+  lottery: lottery_without_tickets
   id: 7
-  lottery_id: 3
   maximum_entries: 5
   maximum_wait_list: 3
   name: Slow People
 lottery_division_0005:
+  lottery: lottery_with_tickets_and_draws
   id: 8
-  lottery_id: 4
   maximum_entries: 3
   maximum_wait_list: 5
   name: Elses

--- a/spec/fixtures/lottery_draws.yml
+++ b/spec/fixtures/lottery_draws.yml
@@ -3,48 +3,48 @@ lottery_draw_0001:
   id: 110
   created_at: 2021-10-02 16:24:20.181722000 Z
   lottery_division_id: 1
-  lottery_id: 4
+  lottery_id:
   lottery_ticket_id: 18
   position:
 lottery_draw_0002:
   id: 111
   created_at: 2021-10-02 16:29:20.183865000 Z
   lottery_division_id: 1
-  lottery_id: 4
+  lottery_id:
   lottery_ticket_id: 10
   position:
 lottery_draw_0003:
   id: 112
   created_at: 2021-10-02 16:43:20.186126000 Z
   lottery_division_id: 1
-  lottery_id: 4
+  lottery_id:
   lottery_ticket_id: 17
   position:
 lottery_draw_0004:
   id: 113
   created_at: 2021-10-02 16:46:20.188331000 Z
   lottery_division_id: 1
-  lottery_id: 4
+  lottery_id:
   lottery_ticket_id: 13
   position:
 lottery_draw_0005:
   id: 114
   created_at: 2021-10-02 16:45:20.190595000 Z
   lottery_division_id: 1
-  lottery_id: 4
+  lottery_id:
   lottery_ticket_id: 9
   position:
 lottery_draw_0006:
   id: 119
   created_at: 2021-10-02 16:28:20.202115000 Z
   lottery_division_id: 8
-  lottery_id: 4
+  lottery_id:
   lottery_ticket_id: 3
   position:
 lottery_draw_0007:
   id: 124
   created_at: 2021-10-02 17:25:58.420681000 Z
   lottery_division_id: 8
-  lottery_id: 4
+  lottery_id:
   lottery_ticket_id: 6
   position:

--- a/spec/fixtures/lottery_simulation_runs.yml
+++ b/spec/fixtures/lottery_simulation_runs.yml
@@ -1,11 +1,11 @@
 ---
 lottery_simulation_run_0001:
+  lottery: lottery_without_tickets
   id: 813529981
   context:
   elapsed_time:
   error_message:
   failure_count:
-  lottery_id: 3
   name:
   requested_count: 2
   started_at:

--- a/spec/fixtures/lottery_tickets.yml
+++ b/spec/fixtures/lottery_tickets.yml
@@ -1,157 +1,157 @@
 ---
 lottery_ticket_0001:
+  lottery: lottery_with_tickets_and_draws
   id: 1
   lottery_division_id: 8
   lottery_entrant_id: 28
-  lottery_id: 4
   reference_number: 10000
 lottery_ticket_0002:
+  lottery: lottery_with_tickets_and_draws
   id: 2
   lottery_division_id: 1
   lottery_entrant_id: 5
-  lottery_id: 4
   reference_number: 10001
 lottery_ticket_0003:
+  lottery: lottery_with_tickets_and_draws
   id: 3
   lottery_division_id: 8
   lottery_entrant_id: 27
-  lottery_id: 4
   reference_number: 10002
 lottery_ticket_0004:
+  lottery: lottery_with_tickets_and_draws
   id: 4
   lottery_division_id: 2
   lottery_entrant_id: 12
-  lottery_id: 4
   reference_number: 10003
 lottery_ticket_0005:
+  lottery: lottery_with_tickets_and_draws
   id: 5
   lottery_division_id: 2
   lottery_entrant_id: 6
-  lottery_id: 4
   reference_number: 10004
 lottery_ticket_0006:
+  lottery: lottery_with_tickets_and_draws
   id: 6
   lottery_division_id: 8
   lottery_entrant_id: 24
-  lottery_id: 4
   reference_number: 10005
 lottery_ticket_0007:
+  lottery: lottery_with_tickets_and_draws
   id: 7
   lottery_division_id: 1
   lottery_entrant_id: 5
-  lottery_id: 4
   reference_number: 10006
 lottery_ticket_0008:
+  lottery: lottery_with_tickets_and_draws
   id: 8
   lottery_division_id: 8
   lottery_entrant_id: 25
-  lottery_id: 4
   reference_number: 10007
 lottery_ticket_0009:
+  lottery: lottery_with_tickets_and_draws
   id: 9
   lottery_division_id: 1
   lottery_entrant_id: 4
-  lottery_id: 4
   reference_number: 10008
 lottery_ticket_0010:
+  lottery: lottery_with_tickets_and_draws
   id: 10
   lottery_division_id: 1
   lottery_entrant_id: 7
-  lottery_id: 4
   reference_number: 10009
 lottery_ticket_0011:
+  lottery: lottery_with_tickets_and_draws
   id: 11
   lottery_division_id: 1
   lottery_entrant_id: 5
-  lottery_id: 4
   reference_number: 10010
 lottery_ticket_0012:
+  lottery: lottery_with_tickets_and_draws
   id: 12
   lottery_division_id: 8
   lottery_entrant_id: 26
-  lottery_id: 4
   reference_number: 10011
 lottery_ticket_0013:
+  lottery: lottery_with_tickets_and_draws
   id: 13
   lottery_division_id: 1
   lottery_entrant_id: 11
-  lottery_id: 4
   reference_number: 10012
 lottery_ticket_0014:
+  lottery: lottery_with_tickets_and_draws
   id: 14
   lottery_division_id: 2
   lottery_entrant_id: 8
-  lottery_id: 4
   reference_number: 10013
 lottery_ticket_0015:
+  lottery: lottery_with_tickets_and_draws
   id: 15
   lottery_division_id: 8
   lottery_entrant_id: 27
-  lottery_id: 4
   reference_number: 10014
 lottery_ticket_0016:
+  lottery: lottery_with_tickets_and_draws
   id: 16
   lottery_division_id: 1
   lottery_entrant_id: 5
-  lottery_id: 4
   reference_number: 10015
 lottery_ticket_0017:
+  lottery: lottery_with_tickets_and_draws
   id: 17
   lottery_division_id: 1
   lottery_entrant_id: 9
-  lottery_id: 4
   reference_number: 10016
 lottery_ticket_0018:
+  lottery: lottery_with_tickets_and_draws
   id: 18
   lottery_division_id: 1
   lottery_entrant_id: 13
-  lottery_id: 4
   reference_number: 10017
 lottery_ticket_0019:
+  lottery: lottery_with_tickets_and_draws
   id: 19
   lottery_division_id: 8
   lottery_entrant_id: 27
-  lottery_id: 4
   reference_number: 10018
 lottery_ticket_0020:
+  lottery: lottery_with_tickets_and_draws
   id: 20
   lottery_division_id: 1
   lottery_entrant_id: 11
-  lottery_id: 4
   reference_number: 10019
 lottery_ticket_0021:
+  lottery: lottery_with_tickets_and_draws
   id: 21
   lottery_division_id: 2
   lottery_entrant_id: 10
-  lottery_id: 4
   reference_number: 10020
 lottery_ticket_0022:
+  lottery: lottery_with_tickets_and_draws
   id: 22
   lottery_division_id: 8
   lottery_entrant_id: 24
-  lottery_id: 4
   reference_number: 10021
 lottery_ticket_0023:
+  lottery: lottery_with_tickets_and_draws
   id: 23
   lottery_division_id: 1
   lottery_entrant_id: 5
-  lottery_id: 4
   reference_number: 10022
 lottery_ticket_0024:
+  lottery: lottery_with_tickets_and_draws
   id: 24
   lottery_division_id: 2
   lottery_entrant_id: 10
-  lottery_id: 4
   reference_number: 10023
 lottery_ticket_0025:
+  lottery: lottery_with_tickets_and_draws
   id: 25
   lottery_division_id: 2
   lottery_entrant_id: 6
-  lottery_id: 4
   reference_number: 10024
 lottery_ticket_0026:
+  lottery: lottery_with_tickets_and_draws
   id: 26
   lottery_division_id: 2
   lottery_entrant_id: 6
-  lottery_id: 4
   reference_number: 10025


### PR DESCRIPTION
## Summary

Third per-table portability conversion under #2065. Adds `:lotteries` to `PORTABLE_FIXTURE_TABLES`. `lottery_divisions`, `lottery_simulation_runs`, and `lottery_tickets` now reference their parent lottery by slug (`lottery: lottery_with_tickets_and_draws`).

**Side cleanup:** `lottery_draws.lottery_id` is in `LotteryDraw.ignored_columns` — the model reads the lottery via `has_one :lottery, through: :division`. The rake task doesn't rewrite ignored-column FKs, so the previous raw `lottery_id: 4` would break fixture loading once lotteries got hash-derived ids. Null the column out — it's unused and nullable. The column itself can be dropped in a follow-up.

Lottery fixture labels are preserved, so no spec changes needed.

## Test plan
- [x] `bundle exec rspec spec/models/{lottery,lottery_draw,lottery_entrant}_spec.rb` — 48/0.
- [x] `db:from_fixtures && db:to_fixtures` is idempotent.
- [x] Rubocop clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)