### PR TITLE
Make partners a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -41,6 +41,7 @@ module FixtureHelper
     :course_groups,
     :lotteries,
     :organizations,
+    :partners,
     :results_categories,
     :results_templates,
     :results_template_categories,
@@ -52,6 +53,7 @@ module FixtureHelper
   # Pick columns that uniquely identify a row by its real-world identity.
   ORDER_BY_MAP = {
     effort_segments: "begin_split_id, begin_bitkey, end_split_id, end_bitkey, effort_id, lap",
+    partners: "partnerable_type, partnerable_id, name",
     results_template_categories: "results_template_id, position, results_category_id",
   }.freeze
 

--- a/spec/fixtures/partners.yml
+++ b/spec/fixtures/partners.yml
@@ -1,13 +1,11 @@
 ---
 partner_0001:
-  id: 5
   banner_link: www.blackdiamondequipment.com
   name: Black Diamond Equipment
   partnerable_id: 27
   partnerable_type: EventGroup
   weight: 1
 partner_0002:
-  id: 6
   banner_link: blackdiamondequipment.com
   name: BD
   partnerable_id: 32


### PR DESCRIPTION
## Summary
- Adds `:partners` to `PORTABLE_FIXTURE_TABLES`
- Adds an `ORDER_BY_MAP` entry for `partners` (no slug, so order by `partnerable_type, partnerable_id, name` for stable labels)
- Regenerates `spec/fixtures/partners.yml` — drops explicit `id:` lines, keys become `partner_NNNN`

Polymorphic `partnerable` references stay as raw `partnerable_id` integers since `event_groups` is not yet portable (expected per issue #2065's "Known wrinkles").

Relates to #2065

## Test plan
- [x] `rake db:from_fixtures` + `rake db:to_fixtures` is idempotent (zero diff on second run)
- [x] Full local rspec run — single pre-existing flaky failure unrelated to fixtures (`connections/create_and_destroy_connection_spec.rb` RunSignup)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)