### PR TITLE
Make credentials a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -53,7 +53,7 @@ module FixtureHelper
   # column could become an unexpected sort key, scrambling every label and FK reference).
   # Pick columns that uniquely identify a row by its real-world identity.
   ORDER_BY_MAP = {
-    credentials: "user_id, service_identifier, key",
+    credentials: "service_identifier, key, user_id",
     effort_segments: "begin_split_id, begin_bitkey, end_split_id, end_bitkey, effort_id, lap",
     partners: "partnerable_type, partnerable_id, name",
     results_template_categories: "results_template_id, position, results_category_id",

--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -39,6 +39,7 @@ module FixtureHelper
   # rather than id in other fixture tables.
   PORTABLE_FIXTURE_TABLES = [
     :course_groups,
+    :credentials,
     :lotteries,
     :organizations,
     :partners,
@@ -52,6 +53,7 @@ module FixtureHelper
   # column could become an unexpected sort key, scrambling every label and FK reference).
   # Pick columns that uniquely identify a row by its real-world identity.
   ORDER_BY_MAP = {
+    credentials: "user_id, service_identifier, key",
     effort_segments: "begin_split_id, begin_bitkey, end_split_id, end_bitkey, effort_id, lap",
     partners: "partnerable_type, partnerable_id, name",
     results_template_categories: "results_template_id, position, results_category_id",

--- a/spec/fixtures/credentials.yml
+++ b/spec/fixtures/credentials.yml
@@ -1,25 +1,21 @@
 ---
 credential_0001:
-  id: 179223681
-  key: api_key
-  service_identifier: runsignup
-  user_id: 3
-  value: '1234'
-credential_0002:
-  id: 658364642
   key: email
   service_identifier: rattlesnake_ramble
   user_id: 3
   value: user@example.com
-credential_0003:
-  id: 773744130
-  key: api_secret
-  service_identifier: runsignup
-  user_id: 3
-  value: '2345'
-credential_0004:
-  id: 962153797
+credential_0002:
   key: password
   service_identifier: rattlesnake_ramble
   user_id: 3
   value: password
+credential_0003:
+  key: api_key
+  service_identifier: runsignup
+  user_id: 3
+  value: '1234'
+credential_0004:
+  key: api_secret
+  service_identifier: runsignup
+  user_id: 3
+  value: '2345'

--- a/spec/system/user_settings/credentials_spec.rb
+++ b/spec/system/user_settings/credentials_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "user settings preferences", type: :system, js: true do
+RSpec.describe "user settings preferences", :js, type: :system do
   let(:user) { users(:third_user) }
 
   scenario "visitor attempts to reach the page" do
@@ -15,8 +15,7 @@ RSpec.describe "user settings preferences", type: :system, js: true do
 
     expect(page).to have_text("Add Credentials")
     within("#credentials_list") do
-      within(first(".card")) do
-        expect(page).to have_text("RunSignup")
+      within(find(".card", text: "RunSignup")) do
         expect(page).to have_button("Reveal")
 
         expect(page).not_to have_text("api_key")


### PR DESCRIPTION
## Summary
- Adds `:credentials` to `PORTABLE_FIXTURE_TABLES`
- Adds `ORDER_BY_MAP` entry: `user_id, service_identifier, key` (composite uniquely identifies a credential)
- Regenerates `spec/fixtures/credentials.yml` — drops `id:` lines
- `user_id` foreign keys stay as integers (users not yet portable)

## Spec fix
The new alphabetical insert order changed which credential appears first in the rendered card list. `spec/system/user_settings/credentials_spec.rb` was using `first(".card")` which previously hit the RunSignup card by accident of id-based ordering. Replaced with an explicit text-based lookup (`find(".card", text: "RunSignup")`). Also picked up a couple of pre-existing rubocop autocorrects in the same file.

Relates to #2065

## Test plan
- [x] `rake db:from_fixtures` + `rake db:to_fixtures` idempotent
- [x] Local rspec run of credential-related specs (`spec/models/credential_spec.rb`, `spec/system/user_settings/credentials_spec.rb`, both runsignup/rattlesnake_ramble client specs) all green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)