### PR TITLE
Drop dead effort_segments entry from ORDER_BY_MAP

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -54,7 +54,6 @@ module FixtureHelper
   # Pick columns that uniquely identify a row by its real-world identity.
   ORDER_BY_MAP = {
     credentials: "service_identifier, key, user_id",
-    effort_segments: "begin_split_id, begin_bitkey, end_split_id, end_bitkey, effort_id, lap",
     partners: "partnerable_type, partnerable_id, name",
     results_template_categories: "results_template_id, position, results_category_id",
   }.freeze


### PR DESCRIPTION
## Summary
`effort_segments` was added to `ORDER_BY_MAP` defensively in 2023 (commit 9f94f29fd), but:

- It is not in `FIXTURE_TABLES`
- There is no `spec/fixtures/effort_segments.yml`
- The table itself is materialized-view-style (`id: false` in schema) — never something we'd want to round-trip through fixtures

The rake task only reads `ORDER_BY_MAP` for tables it's iterating from `FIXTURE_TABLES`, so this entry has never been consulted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)