### PR TITLE
Make historical_facts a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -40,6 +40,7 @@ module FixtureHelper
   PORTABLE_FIXTURE_TABLES = [
     :course_groups,
     :credentials,
+    :historical_facts,
     :lotteries,
     :organizations,
     :partners,
@@ -55,6 +56,7 @@ module FixtureHelper
   # Pick columns that uniquely identify a row by its real-world identity.
   ORDER_BY_MAP = {
     credentials: "service_identifier, key, user_id",
+    historical_facts: "last_name, first_name, year, kind, personal_info_hash",
     partners: "partnerable_type, partnerable_id, name",
     results_template_categories: "results_template_id, position, results_category_id",
   }.freeze

--- a/spec/fixtures/historical_facts.yml
+++ b/spec/fixtures/historical_facts.yml
@@ -1,536 +1,7 @@
 ---
 historical_fact_0001:
   organization: hardrock
-  person: antony_grady
-  id: 158
-  address: 7332 Kassulke Skyway
-  birthdate:
-  city: Bednarshire
-  comments:
-  country_code: US
-  country_name: United States
-  email: dominica@rau.info
-  external_id:
-  first_name: Antony
-  gender: 0
-  kind: 0
-  last_name: Grady
-  personal_info_hash: 21df48c361d0534aba8859979021f3d1
-  phone: '7797152514'
-  quantity:
-  state_code: VA
-  state_name: Virginia
-  year: 2019
-historical_fact_0002:
-  organization: hardrock
-  person: antony_grady
-  id: 159
-  address: 7332 Kassulke Skyway
-  birthdate:
-  city: Bednarshire
-  comments: Dominque Corkery, 2236531216
-  country_code: US
-  country_name: United States
-  email: dominica@rau.info
-  external_id:
-  first_name: Antony
-  gender: 0
-  kind: 5
-  last_name: Grady
-  personal_info_hash: 21df48c361d0534aba8859979021f3d1
-  phone: '7797152514'
-  quantity:
-  state_code: VA
-  state_name: Virginia
-  year: 2023
-historical_fact_0003:
-  organization: hardrock
-  person: antony_grady
-  id: 160
-  address: 7332 Kassulke Skyway
-  birthdate:
-  city: Bednarshire
-  comments:
-  country_code: US
-  country_name: United States
-  email: dominica@rau.info
-  external_id:
-  first_name: Antony
-  gender: 0
-  kind: 7
-  last_name: Grady
-  personal_info_hash: 21df48c361d0534aba8859979021f3d1
-  phone: '7797152514'
-  quantity: 2
-  state_code: VA
-  state_name: Virginia
-  year: 2023
-historical_fact_0004:
-  organization: hardrock
-  person: antony_grady
-  id: 161
-  address: 7332 Kassulke Skyway
-  birthdate:
-  city: Bednarshire
-  comments: Never
-  country_code: US
-  country_name: United States
-  email: dominica@rau.info
-  external_id:
-  first_name: Antony
-  gender: 0
-  kind: 8
-  last_name: Grady
-  personal_info_hash: 21df48c361d0534aba8859979021f3d1
-  phone: '7797152514'
-  quantity:
-  state_code: VA
-  state_name: Virginia
-  year: 2023
-historical_fact_0005:
-  organization: hardrock
-  person: beryl_kutch
-  id: 162
-  address: 94813 Swaniawski Ranch
-  birthdate:
-  city: Littleberg
-  comments:
-  country_code: 'NO'
-  country_name: Norway
-  email: candra@thiel.name
-  external_id:
-  first_name: Beryl
-  gender: 1
-  kind: 0
-  last_name: Kutch
-  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
-  phone: '4747239760'
-  quantity:
-  state_code: NOR
-  state_name:
-  year: 2016
-historical_fact_0006:
-  organization: hardrock
-  person: beryl_kutch
-  id: 163
-  address: 94813 Swaniawski Ranch
-  birthdate:
-  city: Littleberg
-  comments:
-  country_code: 'NO'
-  country_name: Norway
-  email: candra@thiel.name
-  external_id:
-  first_name: Beryl
-  gender: 1
-  kind: 0
-  last_name: Kutch
-  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
-  phone: '4747239760'
-  quantity:
-  state_code: NOR
-  state_name:
-  year: 2017
-historical_fact_0007:
-  organization: hardrock
-  person: beryl_kutch
-  id: 164
-  address: 94813 Swaniawski Ranch
-  birthdate:
-  city: Littleberg
-  comments:
-  country_code: 'NO'
-  country_name: Norway
-  email: candra@thiel.name
-  external_id:
-  first_name: Beryl
-  gender: 1
-  kind: 0
-  last_name: Kutch
-  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
-  phone: '4747239760'
-  quantity:
-  state_code: NOR
-  state_name:
-  year: 2018
-historical_fact_0008:
-  organization: hardrock
-  person: beryl_kutch
-  id: 165
-  address: 94813 Swaniawski Ranch
-  birthdate:
-  city: Littleberg
-  comments:
-  country_code: 'NO'
-  country_name: Norway
-  email: candra@thiel.name
-  external_id:
-  first_name: Beryl
-  gender: 1
-  kind: 0
-  last_name: Kutch
-  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
-  phone: '4747239760'
-  quantity:
-  state_code: NOR
-  state_name:
-  year: 2019
-historical_fact_0009:
-  organization: hardrock
-  person: beryl_kutch
-  id: 166
-  address: 94813 Swaniawski Ranch
-  birthdate:
-  city: Littleberg
-  comments: Shellie Krajcik, 4747239722
-  country_code: 'NO'
-  country_name: Norway
-  email: candra@thiel.name
-  external_id:
-  first_name: Beryl
-  gender: 1
-  kind: 5
-  last_name: Kutch
-  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
-  phone: '4747239760'
-  quantity:
-  state_code: NOR
-  state_name:
-  year: 2023
-historical_fact_0010:
-  organization: hardrock
-  person: beryl_kutch
-  id: 167
-  address: 94813 Swaniawski Ranch
-  birthdate:
-  city: Littleberg
-  comments:
-  country_code: 'NO'
-  country_name: Norway
-  email: candra@thiel.name
-  external_id:
-  first_name: Beryl
-  gender: 1
-  kind: 7
-  last_name: Kutch
-  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
-  phone: '4747239760'
-  quantity: 16
-  state_code: NOR
-  state_name:
-  year: 2023
-historical_fact_0011:
-  organization: hardrock
-  person: beryl_kutch
-  id: 168
-  address: 94813 Swaniawski Ranch
-  birthdate:
-  city: Littleberg
-  comments: Never
-  country_code: 'NO'
-  country_name: Norway
-  email: candra@thiel.name
-  external_id:
-  first_name: Beryl
-  gender: 1
-  kind: 8
-  last_name: Kutch
-  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
-  phone: '4747239760'
-  quantity:
-  state_code: NOR
-  state_name:
-  year: 2023
-historical_fact_0012:
-  organization: hardrock
-  person: dorothy_fahey
-  id: 169
-  address: 9497 Hirthe Lake
-  birthdate:
-  city: Pfannerstillberg
-  comments:
-  country_code: US
-  country_name: United States
-  email: alphonso@carterjaskolski.com
-  external_id:
-  first_name: Dorothy
-  gender: 1
-  kind: 0
-  last_name: Fahey
-  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
-  phone: '8952939469'
-  quantity:
-  state_code: WA
-  state_name: Washington
-  year: 2015
-historical_fact_0013:
-  organization: hardrock
-  person: dorothy_fahey
-  id: 170
-  address: 9497 Hirthe Lake
-  birthdate:
-  city: Pfannerstillberg
-  comments:
-  country_code: US
-  country_name: United States
-  email: alphonso@carterjaskolski.com
-  external_id:
-  first_name: Dorothy
-  gender: 1
-  kind: 0
-  last_name: Fahey
-  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
-  phone: '8952939469'
-  quantity:
-  state_code: WA
-  state_name: Washington
-  year: 2016
-historical_fact_0014:
-  organization: hardrock
-  person: dorothy_fahey
-  id: 171
-  address: 9497 Hirthe Lake
-  birthdate:
-  city: Pfannerstillberg
-  comments: Sonja Christiansen, 8615039757
-  country_code: US
-  country_name: United States
-  email: alphonso@carterjaskolski.com
-  external_id:
-  first_name: Dorothy
-  gender: 1
-  kind: 5
-  last_name: Fahey
-  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
-  phone: '8952939469'
-  quantity:
-  state_code: WA
-  state_name: Washington
-  year: 2023
-historical_fact_0015:
-  organization: hardrock
-  person: dorothy_fahey
-  id: 172
-  address: 9497 Hirthe Lake
-  birthdate:
-  city: Pfannerstillberg
-  comments:
-  country_code: US
-  country_name: United States
-  email: alphonso@carterjaskolski.com
-  external_id:
-  first_name: Dorothy
-  gender: 1
-  kind: 7
-  last_name: Fahey
-  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
-  phone: '8952939469'
-  quantity: 4
-  state_code: WA
-  state_name: Washington
-  year: 2023
-historical_fact_0016:
-  organization: hardrock
-  person: dorothy_fahey
-  id: 173
-  address: 9497 Hirthe Lake
-  birthdate:
-  city: Pfannerstillberg
-  comments: Never
-  country_code: US
-  country_name: United States
-  email: alphonso@carterjaskolski.com
-  external_id:
-  first_name: Dorothy
-  gender: 1
-  kind: 8
-  last_name: Fahey
-  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
-  phone: '8952939469'
-  quantity:
-  state_code: WA
-  state_name: Washington
-  year: 2023
-historical_fact_0017:
-  organization: hardrock
-  person: bethany_sanford
-  id: 174
-  address: 123 rue des Frères Lumières
-  birthdate: 1988-05-01
-  city: Villefranche Sur Saône
-  comments:
-  country_code: FR
-  country_name: France
-  email: fran.bar@gmail.com
-  external_id:
-  first_name: Bethany
-  gender: 1
-  kind: 0
-  last_name: Sanford
-  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
-  phone: '601271155'
-  quantity:
-  state_code: FRA
-  state_name:
-  year: 2022
-historical_fact_0018:
-  organization: hardrock
-  person: bethany_sanford
-  id: 175
-  address: 123 rue des Frères Lumières
-  birthdate: 1988-05-01
-  city: Villefranche Sur Saône
-  comments:
-  country_code: FR
-  country_name: France
-  email: fran.bar@gmail.com
-  external_id:
-  first_name: Bethany
-  gender: 1
-  kind: 0
-  last_name: Sanford
-  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
-  phone: '601271155'
-  quantity:
-  state_code: FRA
-  state_name:
-  year: 2023
-historical_fact_0019:
-  organization: hardrock
-  person: bethany_sanford
-  id: 176
-  address: 123 rue des Frères Lumières
-  birthdate: 1988-05-01
-  city: Villefranche Sur Saône
-  comments: '2022 OCT: Diagonale des Fous (Reunion Is)'
-  country_code: FR
-  country_name: France
-  email: fran.bar@gmail.com
-  external_id:
-  first_name: Bethany
-  gender: 1
-  kind: 4
-  last_name: Sanford
-  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
-  phone: '601271155'
-  quantity:
-  state_code: FRA
-  state_name:
-  year: 2023
-historical_fact_0020:
-  organization: hardrock
-  person: bethany_sanford
-  id: 177
-  address: 123 rue des Frères Lumières
-  birthdate: 1988-05-01
-  city: Villefranche Sur Saône
-  comments: Aberkane, 695511156
-  country_code: FR
-  country_name: France
-  email: fran.bar@gmail.com
-  external_id:
-  first_name: Bethany
-  gender: 1
-  kind: 5
-  last_name: Sanford
-  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
-  phone: '601271155'
-  quantity:
-  state_code: FRA
-  state_name:
-  year: 2023
-historical_fact_0021:
-  organization: hardrock
-  person: bethany_sanford
-  id: 178
-  address: 123 rue des Frères Lumières
-  birthdate: 1988-05-01
-  city: Villefranche Sur Saône
-  comments:
-  country_code: FR
-  country_name: France
-  email: fran.bar@gmail.com
-  external_id:
-  first_name: Bethany
-  gender: 1
-  kind: 7
-  last_name: Sanford
-  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
-  phone: '601271155'
-  quantity: 4
-  state_code: FRA
-  state_name:
-  year: 2023
-historical_fact_0022:
-  organization: hardrock
-  person: bethany_sanford
-  id: 179
-  address: 123 rue des Frères Lumières
-  birthdate: 1988-05-01
-  city: Villefranche Sur Saône
-  comments: Never
-  country_code: FR
-  country_name: France
-  email: fran.bar@gmail.com
-  external_id:
-  first_name: Bethany
-  gender: 1
-  kind: 8
-  last_name: Sanford
-  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
-  phone: '601271155'
-  quantity:
-  state_code: FRA
-  state_name:
-  year: 2023
-historical_fact_0023:
-  organization: hardrock
-  person: freddy_maggio
-  id: 180
-  address: 9876 Damian Valley
-  birthdate: 1995-06-21
-  city: Port Kandice
-  comments:
-  country_code: CA
-  country_name: Canada
-  email: leighann.schoen@adams.us
-  external_id:
-  first_name: Freddy
-  gender: 0
-  kind: 7
-  last_name: Maggio
-  personal_info_hash: 9a68ffede91950516d62650371d69eb4
-  phone: '9584628190'
-  quantity: 1
-  state_code: AB
-  state_name: Alberta
-  year: 2023
-historical_fact_0024:
-  organization: hardrock
-  person: freddy_maggio
-  id: 181
-  address: 9876 Damian Valley
-  birthdate: 1995-06-21
-  city: Port Kandice
-  comments: Never
-  country_code: CA
-  country_name: Canada
-  email: leighann.schoen@adams.us
-  external_id:
-  first_name: Freddy
-  gender: 0
-  kind: 8
-  last_name: Maggio
-  personal_info_hash: 9a68ffede91950516d62650371d69eb4
-  phone: '9584628190'
-  quantity:
-  state_code: AB
-  state_name: Alberta
-  year: 2023
-historical_fact_0025:
-  organization: hardrock
   person: carmine_adams
-  id: 182
   address: 2575 Mariela Brook
   birthdate: 1997-05-25
   city: Kassulkemouth
@@ -549,10 +20,9 @@ historical_fact_0025:
   state_code: WA
   state_name: Washington
   year: 2014
-historical_fact_0026:
+historical_fact_0002:
   organization: hardrock
   person: carmine_adams
-  id: 183
   address: 2575 Mariela Brook
   birthdate: 1997-05-25
   city: Kassulkemouth
@@ -571,10 +41,9 @@ historical_fact_0026:
   state_code: WA
   state_name: Washington
   year: 2015
-historical_fact_0027:
+historical_fact_0003:
   organization: hardrock
   person: carmine_adams
-  id: 184
   address: 2575 Mariela Brook
   birthdate: 1997-05-25
   city: Kassulkemouth
@@ -593,10 +62,9 @@ historical_fact_0027:
   state_code: WA
   state_name: Washington
   year: 2016
-historical_fact_0028:
+historical_fact_0004:
   organization: hardrock
   person: carmine_adams
-  id: 185
   address: 2575 Mariela Brook
   birthdate: 1997-05-25
   city: Kassulkemouth
@@ -615,10 +83,9 @@ historical_fact_0028:
   state_code: WA
   state_name: Washington
   year: 2017
-historical_fact_0029:
+historical_fact_0005:
   organization: hardrock
   person: carmine_adams
-  id: 186
   address: 2575 Mariela Brook
   birthdate: 1997-05-25
   city: Kassulkemouth
@@ -637,10 +104,9 @@ historical_fact_0029:
   state_code: WA
   state_name: Washington
   year: 2018
-historical_fact_0030:
+historical_fact_0006:
   organization: hardrock
   person: carmine_adams
-  id: 187
   address: 2575 Mariela Brook
   birthdate: 1997-05-25
   city: Kassulkemouth
@@ -659,10 +125,9 @@ historical_fact_0030:
   state_code: WA
   state_name: Washington
   year: 2019
-historical_fact_0031:
+historical_fact_0007:
   organization: hardrock
   person: carmine_adams
-  id: 188
   address: 2575 Mariela Brook
   birthdate: 1997-05-25
   city: Kassulkemouth
@@ -681,10 +146,9 @@ historical_fact_0031:
   state_code: WA
   state_name: Washington
   year: 2023
-historical_fact_0032:
+historical_fact_0008:
   organization: hardrock
   person: carmine_adams
-  id: 189
   address: 2575 Mariela Brook
   birthdate: 1997-05-25
   city: Kassulkemouth
@@ -703,10 +167,9 @@ historical_fact_0032:
   state_code: WA
   state_name: Washington
   year: 2023
-historical_fact_0033:
+historical_fact_0009:
   organization: hardrock
   person: carmine_adams
-  id: 190
   address: 2575 Mariela Brook
   birthdate: 1997-05-25
   city: Kassulkemouth
@@ -725,758 +188,30 @@ historical_fact_0033:
   state_code: WA
   state_name: Washington
   year: 2023
-historical_fact_0034:
+historical_fact_0010:
   organization: hardrock
-  person: pat_schaden
-  id: 191
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 0
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2003
-historical_fact_0035:
-  organization: hardrock
-  person: pat_schaden
-  id: 192
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 9
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2004
-historical_fact_0036:
-  organization: hardrock
-  person: pat_schaden
-  id: 193
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 9
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2005
-historical_fact_0037:
-  organization: hardrock
-  person: pat_schaden
-  id: 194
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 9
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2006
-historical_fact_0038:
-  organization: hardrock
-  person: pat_schaden
-  id: 195
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 9
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2007
-historical_fact_0039:
-  organization: hardrock
-  person: pat_schaden
-  id: 196
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 0
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2008
-historical_fact_0040:
-  organization: hardrock
-  person: pat_schaden
-  id: 197
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 9
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2009
-historical_fact_0041:
-  organization: hardrock
-  person: pat_schaden
-  id: 198
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 0
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2010
-historical_fact_0042:
-  organization: hardrock
-  person: pat_schaden
-  id: 199
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 0
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2011
-historical_fact_0043:
-  organization: hardrock
-  person: pat_schaden
-  id: 200
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 0
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2012
-historical_fact_0044:
-  organization: hardrock
-  person: pat_schaden
-  id: 201
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 0
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2013
-historical_fact_0045:
-  organization: hardrock
-  person: pat_schaden
-  id: 202
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 9
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2014
-historical_fact_0046:
-  organization: hardrock
-  person: pat_schaden
-  id: 203
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 3
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity: 5
-  state_code:
-  state_name:
-  year: 2023
-historical_fact_0047:
-  organization: hardrock
-  person: pat_schaden
-  id: 204
-  address:
-  birthdate:
-  city:
-  comments:
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 7
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity: 2
-  state_code:
-  state_name:
-  year: 2023
-historical_fact_0048:
-  organization: hardrock
-  person: pat_schaden
-  id: 205
-  address:
-  birthdate:
-  city:
-  comments: Else
-  country_code:
-  country_name:
-  email:
-  external_id:
-  first_name: Pat
-  gender: 0
-  kind: 8
-  last_name: Schaden
-  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
-  phone:
-  quantity:
-  state_code:
-  state_name:
-  year: 2023
-historical_fact_0049:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 206
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
+  person: carmine_adams
+  address: 2575 Mariela Brook
+  birthdate: 1997-05-25
+  city: Kassulkemouth
   comments:
   country_code: US
   country_name: United States
-  email: woodrow@runte.ca
+  email: jarod@millermoore.com
   external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 9
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity:
-  state_code: CO
-  state_name: Colorado
-  year: 2013
-historical_fact_0050:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 207
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments:
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 10
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity:
-  state_code: CO
-  state_name: Colorado
-  year: 2015
-historical_fact_0051:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 208
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments:
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 10
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity:
-  state_code: CO
-  state_name: Colorado
-  year: 2014
-historical_fact_0052:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 209
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments:
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 0
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity:
-  state_code: CO
-  state_name: Colorado
-  year: 2017
-historical_fact_0053:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 210
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments:
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 0
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity:
-  state_code: CO
-  state_name: Colorado
-  year: 2018
-historical_fact_0054:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 211
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments:
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 0
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity:
-  state_code: CO
-  state_name: Colorado
-  year: 2019
-historical_fact_0055:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 212
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments:
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 0
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity:
-  state_code: CO
-  state_name: Colorado
-  year: 2021
-historical_fact_0056:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 213
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments:
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 0
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity:
-  state_code: CO
-  state_name: Colorado
-  year: 2022
-historical_fact_0057:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 214
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments:
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 3
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity: 1
-  state_code: CO
-  state_name: Colorado
-  year: 2023
-historical_fact_0058:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 215
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments: Winnifred Yost, 982-416-8561
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 5
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity:
-  state_code: CO
-  state_name: Colorado
-  year: 2023
-historical_fact_0059:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 216
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments:
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 7
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity: 8
-  state_code: CO
-  state_name: Colorado
-  year: 2023
-historical_fact_0060:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 217
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments: Else
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 8
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity:
-  state_code: CO
-  state_name: Colorado
-  year: 2023
-historical_fact_0061:
-  organization: hardrock
-  person: fredrick_wiza
-  id: 218
-  address: 0141 Belva Mill
-  birthdate:
-  city: East Shenitaport
-  comments:
-  country_code: US
-  country_name: United States
-  email: martin.bruen@christiansen.name
-  external_id:
-  first_name: Fredrick
+  first_name: Carmine
   gender: 0
-  kind: 0
-  last_name: Wiza
-  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
-  phone: '5046722864'
+  kind: 11
+  last_name: Adams
+  personal_info_hash: 8737a3d4b174a796d8b666a7ead80dde
+  phone: '9526029499'
   quantity:
-  state_code: MT
-  state_name: Montana
-  year: 2015
-historical_fact_0062:
-  organization: hardrock
-  person: fredrick_wiza
-  id: 219
-  address: 0141 Belva Mill
-  birthdate:
-  city: East Shenitaport
-  comments:
-  country_code: US
-  country_name: United States
-  email: martin.bruen@christiansen.name
-  external_id:
-  first_name: Fredrick
-  gender: 0
-  kind: 0
-  last_name: Wiza
-  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
-  phone: '5046722864'
-  quantity:
-  state_code: MT
-  state_name: Montana
-  year: 2016
-historical_fact_0063:
-  organization: hardrock
-  person: fredrick_wiza
-  id: 220
-  address: 0141 Belva Mill
-  birthdate:
-  city: East Shenitaport
-  comments:
-  country_code: US
-  country_name: United States
-  email: martin.bruen@christiansen.name
-  external_id:
-  first_name: Fredrick
-  gender: 0
-  kind: 0
-  last_name: Wiza
-  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
-  phone: '5046722864'
-  quantity:
-  state_code: MT
-  state_name: Montana
-  year: 2017
-historical_fact_0064:
-  organization: hardrock
-  person: fredrick_wiza
-  id: 221
-  address: 0141 Belva Mill
-  birthdate:
-  city: East Shenitaport
-  comments:
-  country_code: US
-  country_name: United States
-  email: martin.bruen@christiansen.name
-  external_id:
-  first_name: Fredrick
-  gender: 0
-  kind: 0
-  last_name: Wiza
-  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
-  phone: '5046722864'
-  quantity:
-  state_code: MT
-  state_name: Montana
-  year: 2018
-historical_fact_0065:
-  organization: hardrock
-  person: fredrick_wiza
-  id: 222
-  address: 0141 Belva Mill
-  birthdate:
-  city: East Shenitaport
-  comments: Penney Turner, 737-930-2991
-  country_code: US
-  country_name: United States
-  email: martin.bruen@christiansen.name
-  external_id:
-  first_name: Fredrick
-  gender: 0
-  kind: 5
-  last_name: Wiza
-  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
-  phone: '5046722864'
-  quantity:
-  state_code: MT
-  state_name: Montana
-  year: 2023
-historical_fact_0066:
-  organization: hardrock
-  person: fredrick_wiza
-  id: 223
-  address: 0141 Belva Mill
-  birthdate:
-  city: East Shenitaport
-  comments:
-  country_code: US
-  country_name: United States
-  email: martin.bruen@christiansen.name
-  external_id:
-  first_name: Fredrick
-  gender: 0
-  kind: 7
-  last_name: Wiza
-  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
-  phone: '5046722864'
-  quantity: 16
-  state_code: MT
-  state_name: Montana
-  year: 2023
-historical_fact_0067:
-  organization: hardrock
-  person: fredrick_wiza
-  id: 224
-  address: 0141 Belva Mill
-  birthdate:
-  city: East Shenitaport
-  comments: Never
-  country_code: US
-  country_name: United States
-  email: martin.bruen@christiansen.name
-  external_id:
-  first_name: Fredrick
-  gender: 0
-  kind: 8
-  last_name: Wiza
-  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
-  phone: '5046722864'
-  quantity:
-  state_code: MT
-  state_name: Montana
-  year: 2023
-historical_fact_0068:
+  state_code: WA
+  state_name: Washington
+  year: 2024
+historical_fact_0011:
   organization: hardrock
   person: alfreda_cruickshank
-  id: 225
   address: 49869 Stark Ranch
   birthdate:
   city: Pandoraborough
@@ -1495,10 +230,9 @@ historical_fact_0068:
   state_code: CO
   state_name: Colorado
   year: 2015
-historical_fact_0069:
+historical_fact_0012:
   organization: hardrock
   person: alfreda_cruickshank
-  id: 226
   address: 49869 Stark Ranch
   birthdate:
   city: Pandoraborough
@@ -1517,10 +251,9 @@ historical_fact_0069:
   state_code: CO
   state_name: Colorado
   year: 2016
-historical_fact_0070:
+historical_fact_0013:
   organization: hardrock
   person: alfreda_cruickshank
-  id: 227
   address: 49869 Stark Ranch
   birthdate:
   city: Pandoraborough
@@ -1539,10 +272,9 @@ historical_fact_0070:
   state_code: CO
   state_name: Colorado
   year: 2017
-historical_fact_0071:
+historical_fact_0014:
   organization: hardrock
   person: alfreda_cruickshank
-  id: 228
   address: 49869 Stark Ranch
   birthdate:
   city: Pandoraborough
@@ -1561,10 +293,9 @@ historical_fact_0071:
   state_code: CO
   state_name: Colorado
   year: 2023
-historical_fact_0072:
+historical_fact_0015:
   organization: hardrock
   person: alfreda_cruickshank
-  id: 229
   address: 49869 Stark Ranch
   birthdate:
   city: Pandoraborough
@@ -1583,10 +314,9 @@ historical_fact_0072:
   state_code: CO
   state_name: Colorado
   year: 2023
-historical_fact_0073:
+historical_fact_0016:
   organization: hardrock
   person: alfreda_cruickshank
-  id: 230
   address: 49869 Stark Ranch
   birthdate:
   city: Pandoraborough
@@ -1605,362 +335,9 @@ historical_fact_0073:
   state_code: CO
   state_name: Colorado
   year: 2023
-historical_fact_0074:
-  organization: hardrock
-  person: lavon_paucek
-  id: 233
-  address: 4679 Lazaro Hill
-  birthdate:
-  city: West Ariel
-  comments:
-  country_code: US
-  country_name: United States
-  email: lashunda@koelpin.co.uk
-  external_id:
-  first_name: Lavon
-  gender: 1
-  kind: 0
-  last_name: Paucek
-  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
-  phone: '6919767666'
-  quantity:
-  state_code: AR
-  state_name: Arkansas
-  year: 2012
-historical_fact_0075:
-  organization: hardrock
-  person: lavon_paucek
-  id: 234
-  address: 4679 Lazaro Hill
-  birthdate:
-  city: West Ariel
-  comments:
-  country_code: US
-  country_name: United States
-  email: lashunda@koelpin.co.uk
-  external_id:
-  first_name: Lavon
-  gender: 1
-  kind: 0
-  last_name: Paucek
-  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
-  phone: '6919767666'
-  quantity:
-  state_code: AR
-  state_name: Arkansas
-  year: 2015
-historical_fact_0076:
-  organization: hardrock
-  person: lavon_paucek
-  id: 235
-  address: 4679 Lazaro Hill
-  birthdate:
-  city: West Ariel
-  comments:
-  country_code: US
-  country_name: United States
-  email: lashunda@koelpin.co.uk
-  external_id:
-  first_name: Lavon
-  gender: 1
-  kind: 10
-  last_name: Paucek
-  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
-  phone: '6919767666'
-  quantity:
-  state_code: AR
-  state_name: Arkansas
-  year: 2016
-historical_fact_0077:
-  organization: hardrock
-  person: lavon_paucek
-  id: 236
-  address: 4679 Lazaro Hill
-  birthdate:
-  city: West Ariel
-  comments:
-  country_code: US
-  country_name: United States
-  email: lashunda@koelpin.co.uk
-  external_id:
-  first_name: Lavon
-  gender: 1
-  kind: 0
-  last_name: Paucek
-  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
-  phone: '6919767666'
-  quantity:
-  state_code: AR
-  state_name: Arkansas
-  year: 2017
-historical_fact_0078:
-  organization: hardrock
-  person: lavon_paucek
-  id: 237
-  address: 4679 Lazaro Hill
-  birthdate:
-  city: West Ariel
-  comments:
-  country_code: US
-  country_name: United States
-  email: lashunda@koelpin.co.uk
-  external_id:
-  first_name: Lavon
-  gender: 1
-  kind: 0
-  last_name: Paucek
-  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
-  phone: '6919767666'
-  quantity:
-  state_code: AR
-  state_name: Arkansas
-  year: 2018
-historical_fact_0079:
-  organization: hardrock
-  person: lavon_paucek
-  id: 238
-  address: 4679 Lazaro Hill
-  birthdate:
-  city: West Ariel
-  comments: Brynn Hermiston, 950-975-4391
-  country_code: US
-  country_name: United States
-  email: lashunda@koelpin.co.uk
-  external_id:
-  first_name: Lavon
-  gender: 1
-  kind: 5
-  last_name: Paucek
-  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
-  phone: '6919767666'
-  quantity:
-  state_code: AR
-  state_name: Arkansas
-  year: 2023
-historical_fact_0080:
-  organization: hardrock
-  person: lavon_paucek
-  id: 239
-  address: 4679 Lazaro Hill
-  birthdate:
-  city: West Ariel
-  comments:
-  country_code: US
-  country_name: United States
-  email: lashunda@koelpin.co.uk
-  external_id:
-  first_name: Lavon
-  gender: 1
-  kind: 7
-  last_name: Paucek
-  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
-  phone: '6919767666'
-  quantity: 4
-  state_code: AR
-  state_name: Arkansas
-  year: 2023
-historical_fact_0081:
-  organization: hardrock
-  person: lavon_paucek
-  id: 240
-  address: 4679 Lazaro Hill
-  birthdate:
-  city: West Ariel
-  comments: Else
-  country_code: US
-  country_name: United States
-  email: lashunda@koelpin.co.uk
-  external_id:
-  first_name: Lavon
-  gender: 1
-  kind: 8
-  last_name: Paucek
-  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
-  phone: '6919767666'
-  quantity:
-  state_code: AR
-  state_name: Arkansas
-  year: 2023
-historical_fact_0082:
-  organization: hardrock
-  person: antony_grady
-  id: 245
-  address: 7332 Kassulke Skyway
-  birthdate:
-  city: Bednarshire
-  comments: 'Ultrasignup order id: 123'
-  country_code: US
-  country_name: United States
-  email: dominica@rau.info
-  external_id:
-  first_name: Antony
-  gender: 0
-  kind: 11
-  last_name: Grady
-  personal_info_hash: 21df48c361d0534aba8859979021f3d1
-  phone: '7797152514'
-  quantity:
-  state_code: VA
-  state_name: Virginia
-  year: 2024
-historical_fact_0083:
-  organization: hardrock
-  person: beryl_kutch
-  id: 246
-  address: 94813 Swaniawski Ranch
-  birthdate:
-  city: Littleberg
-  comments: 'Ultrasignup order id: 456'
-  country_code: 'NO'
-  country_name: Norway
-  email: candra@thiel.name
-  external_id:
-  first_name: Beryl
-  gender: 1
-  kind: 11
-  last_name: Kutch
-  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
-  phone: '4747239760'
-  quantity:
-  state_code: NOR
-  state_name:
-  year: 2024
-historical_fact_0084:
-  organization: hardrock
-  person: dorothy_fahey
-  id: 247
-  address: 9497 Hirthe Lake
-  birthdate:
-  city: Pfannerstillberg
-  comments: 'Ultrasignup order id: 789'
-  country_code: US
-  country_name: United States
-  email: alphonso@carterjaskolski.com
-  external_id:
-  first_name: Dorothy
-  gender: 1
-  kind: 11
-  last_name: Fahey
-  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
-  phone: '8952939469'
-  quantity:
-  state_code: WA
-  state_name: Washington
-  year: 2024
-historical_fact_0085:
-  organization: hardrock
-  person: bethany_sanford
-  id: 248
-  address: 123 rue des Frères Lumières
-  birthdate: 1988-05-01
-  city: Villefranche Sur Saône
-  comments:
-  country_code: FR
-  country_name: France
-  email: fran.bar@gmail.com
-  external_id:
-  first_name: Bethany
-  gender: 1
-  kind: 11
-  last_name: Sanford
-  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
-  phone: '601271155'
-  quantity:
-  state_code: FRA
-  state_name:
-  year: 2024
-historical_fact_0086:
-  organization: hardrock
-  person: freddy_maggio
-  id: 249
-  address: 9876 Damian Valley
-  birthdate: 1995-06-21
-  city: Port Kandice
-  comments:
-  country_code: CA
-  country_name: Canada
-  email: leighann.schoen@adams.us
-  external_id:
-  first_name: Freddy
-  gender: 0
-  kind: 11
-  last_name: Maggio
-  personal_info_hash: 9a68ffede91950516d62650371d69eb4
-  phone: '9584628190'
-  quantity:
-  state_code: AB
-  state_name: Alberta
-  year: 2024
-historical_fact_0087:
-  organization: hardrock
-  person: carmine_adams
-  id: 250
-  address: 2575 Mariela Brook
-  birthdate: 1997-05-25
-  city: Kassulkemouth
-  comments:
-  country_code: US
-  country_name: United States
-  email: jarod@millermoore.com
-  external_id:
-  first_name: Carmine
-  gender: 0
-  kind: 11
-  last_name: Adams
-  personal_info_hash: 8737a3d4b174a796d8b666a7ead80dde
-  phone: '9526029499'
-  quantity:
-  state_code: WA
-  state_name: Washington
-  year: 2024
-historical_fact_0088:
-  organization: hardrock
-  person: rachelle_eichmann
-  id: 251
-  address: '028 Kunze Freeway'
-  birthdate: 1992-01-11
-  city: Tamartown
-  comments:
-  country_code: US
-  country_name: United States
-  email: woodrow@runte.ca
-  external_id:
-  first_name: Rachelle
-  gender: 1
-  kind: 11
-  last_name: Eichmann
-  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
-  phone: '7764262796'
-  quantity:
-  state_code: CO
-  state_name: Colorado
-  year: 2024
-historical_fact_0089:
-  organization: hardrock
-  person: fredrick_wiza
-  id: 252
-  address: 0141 Belva Mill
-  birthdate:
-  city: East Shenitaport
-  comments:
-  country_code: US
-  country_name: United States
-  email: martin.bruen@christiansen.name
-  external_id:
-  first_name: Fredrick
-  gender: 0
-  kind: 11
-  last_name: Wiza
-  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
-  phone: '5046722864'
-  quantity:
-  state_code: MT
-  state_name: Montana
-  year: 2024
-historical_fact_0090:
+historical_fact_0017:
   organization: hardrock
   person: alfreda_cruickshank
-  id: 253
   address: 49869 Stark Ranch
   birthdate:
   city: Pandoraborough
@@ -1979,10 +356,912 @@ historical_fact_0090:
   state_code: CO
   state_name: Colorado
   year: 2024
-historical_fact_0091:
+historical_fact_0018:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments:
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 9
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity:
+  state_code: CO
+  state_name: Colorado
+  year: 2013
+historical_fact_0019:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments:
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 10
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity:
+  state_code: CO
+  state_name: Colorado
+  year: 2014
+historical_fact_0020:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments:
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 10
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity:
+  state_code: CO
+  state_name: Colorado
+  year: 2015
+historical_fact_0021:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments:
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 0
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity:
+  state_code: CO
+  state_name: Colorado
+  year: 2017
+historical_fact_0022:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments:
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 0
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity:
+  state_code: CO
+  state_name: Colorado
+  year: 2018
+historical_fact_0023:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments:
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 0
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity:
+  state_code: CO
+  state_name: Colorado
+  year: 2019
+historical_fact_0024:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments:
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 0
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity:
+  state_code: CO
+  state_name: Colorado
+  year: 2021
+historical_fact_0025:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments:
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 0
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity:
+  state_code: CO
+  state_name: Colorado
+  year: 2022
+historical_fact_0026:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments:
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 3
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity: 1
+  state_code: CO
+  state_name: Colorado
+  year: 2023
+historical_fact_0027:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments: Winnifred Yost, 982-416-8561
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 5
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity:
+  state_code: CO
+  state_name: Colorado
+  year: 2023
+historical_fact_0028:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments:
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 7
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity: 8
+  state_code: CO
+  state_name: Colorado
+  year: 2023
+historical_fact_0029:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments: Else
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 8
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity:
+  state_code: CO
+  state_name: Colorado
+  year: 2023
+historical_fact_0030:
+  organization: hardrock
+  person: rachelle_eichmann
+  address: '028 Kunze Freeway'
+  birthdate: 1992-01-11
+  city: Tamartown
+  comments:
+  country_code: US
+  country_name: United States
+  email: woodrow@runte.ca
+  external_id:
+  first_name: Rachelle
+  gender: 1
+  kind: 11
+  last_name: Eichmann
+  personal_info_hash: deabe1ed7755c167fcff71181bcd5457
+  phone: '7764262796'
+  quantity:
+  state_code: CO
+  state_name: Colorado
+  year: 2024
+historical_fact_0031:
+  organization: hardrock
+  person: dorothy_fahey
+  address: 9497 Hirthe Lake
+  birthdate:
+  city: Pfannerstillberg
+  comments:
+  country_code: US
+  country_name: United States
+  email: alphonso@carterjaskolski.com
+  external_id:
+  first_name: Dorothy
+  gender: 1
+  kind: 0
+  last_name: Fahey
+  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
+  phone: '8952939469'
+  quantity:
+  state_code: WA
+  state_name: Washington
+  year: 2015
+historical_fact_0032:
+  organization: hardrock
+  person: dorothy_fahey
+  address: 9497 Hirthe Lake
+  birthdate:
+  city: Pfannerstillberg
+  comments:
+  country_code: US
+  country_name: United States
+  email: alphonso@carterjaskolski.com
+  external_id:
+  first_name: Dorothy
+  gender: 1
+  kind: 0
+  last_name: Fahey
+  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
+  phone: '8952939469'
+  quantity:
+  state_code: WA
+  state_name: Washington
+  year: 2016
+historical_fact_0033:
+  organization: hardrock
+  person: dorothy_fahey
+  address: 9497 Hirthe Lake
+  birthdate:
+  city: Pfannerstillberg
+  comments: Sonja Christiansen, 8615039757
+  country_code: US
+  country_name: United States
+  email: alphonso@carterjaskolski.com
+  external_id:
+  first_name: Dorothy
+  gender: 1
+  kind: 5
+  last_name: Fahey
+  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
+  phone: '8952939469'
+  quantity:
+  state_code: WA
+  state_name: Washington
+  year: 2023
+historical_fact_0034:
+  organization: hardrock
+  person: dorothy_fahey
+  address: 9497 Hirthe Lake
+  birthdate:
+  city: Pfannerstillberg
+  comments:
+  country_code: US
+  country_name: United States
+  email: alphonso@carterjaskolski.com
+  external_id:
+  first_name: Dorothy
+  gender: 1
+  kind: 7
+  last_name: Fahey
+  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
+  phone: '8952939469'
+  quantity: 4
+  state_code: WA
+  state_name: Washington
+  year: 2023
+historical_fact_0035:
+  organization: hardrock
+  person: dorothy_fahey
+  address: 9497 Hirthe Lake
+  birthdate:
+  city: Pfannerstillberg
+  comments: Never
+  country_code: US
+  country_name: United States
+  email: alphonso@carterjaskolski.com
+  external_id:
+  first_name: Dorothy
+  gender: 1
+  kind: 8
+  last_name: Fahey
+  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
+  phone: '8952939469'
+  quantity:
+  state_code: WA
+  state_name: Washington
+  year: 2023
+historical_fact_0036:
+  organization: hardrock
+  person: dorothy_fahey
+  address: 9497 Hirthe Lake
+  birthdate:
+  city: Pfannerstillberg
+  comments: 'Ultrasignup order id: 789'
+  country_code: US
+  country_name: United States
+  email: alphonso@carterjaskolski.com
+  external_id:
+  first_name: Dorothy
+  gender: 1
+  kind: 11
+  last_name: Fahey
+  personal_info_hash: 1c900831381a7c7c1679af5e0f97a88c
+  phone: '8952939469'
+  quantity:
+  state_code: WA
+  state_name: Washington
+  year: 2024
+historical_fact_0037:
+  organization: hardrock
+  person: antony_grady
+  address: 7332 Kassulke Skyway
+  birthdate:
+  city: Bednarshire
+  comments:
+  country_code: US
+  country_name: United States
+  email: dominica@rau.info
+  external_id:
+  first_name: Antony
+  gender: 0
+  kind: 0
+  last_name: Grady
+  personal_info_hash: 21df48c361d0534aba8859979021f3d1
+  phone: '7797152514'
+  quantity:
+  state_code: VA
+  state_name: Virginia
+  year: 2019
+historical_fact_0038:
+  organization: hardrock
+  person: antony_grady
+  address: 7332 Kassulke Skyway
+  birthdate:
+  city: Bednarshire
+  comments: Dominque Corkery, 2236531216
+  country_code: US
+  country_name: United States
+  email: dominica@rau.info
+  external_id:
+  first_name: Antony
+  gender: 0
+  kind: 5
+  last_name: Grady
+  personal_info_hash: 21df48c361d0534aba8859979021f3d1
+  phone: '7797152514'
+  quantity:
+  state_code: VA
+  state_name: Virginia
+  year: 2023
+historical_fact_0039:
+  organization: hardrock
+  person: antony_grady
+  address: 7332 Kassulke Skyway
+  birthdate:
+  city: Bednarshire
+  comments:
+  country_code: US
+  country_name: United States
+  email: dominica@rau.info
+  external_id:
+  first_name: Antony
+  gender: 0
+  kind: 7
+  last_name: Grady
+  personal_info_hash: 21df48c361d0534aba8859979021f3d1
+  phone: '7797152514'
+  quantity: 2
+  state_code: VA
+  state_name: Virginia
+  year: 2023
+historical_fact_0040:
+  organization: hardrock
+  person: antony_grady
+  address: 7332 Kassulke Skyway
+  birthdate:
+  city: Bednarshire
+  comments: Never
+  country_code: US
+  country_name: United States
+  email: dominica@rau.info
+  external_id:
+  first_name: Antony
+  gender: 0
+  kind: 8
+  last_name: Grady
+  personal_info_hash: 21df48c361d0534aba8859979021f3d1
+  phone: '7797152514'
+  quantity:
+  state_code: VA
+  state_name: Virginia
+  year: 2023
+historical_fact_0041:
+  organization: hardrock
+  person: antony_grady
+  address: 7332 Kassulke Skyway
+  birthdate:
+  city: Bednarshire
+  comments: 'Ultrasignup order id: 123'
+  country_code: US
+  country_name: United States
+  email: dominica@rau.info
+  external_id:
+  first_name: Antony
+  gender: 0
+  kind: 11
+  last_name: Grady
+  personal_info_hash: 21df48c361d0534aba8859979021f3d1
+  phone: '7797152514'
+  quantity:
+  state_code: VA
+  state_name: Virginia
+  year: 2024
+historical_fact_0042:
+  organization: hardrock
+  person: beryl_kutch
+  address: 94813 Swaniawski Ranch
+  birthdate:
+  city: Littleberg
+  comments:
+  country_code: 'NO'
+  country_name: Norway
+  email: candra@thiel.name
+  external_id:
+  first_name: Beryl
+  gender: 1
+  kind: 0
+  last_name: Kutch
+  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
+  phone: '4747239760'
+  quantity:
+  state_code: NOR
+  state_name:
+  year: 2016
+historical_fact_0043:
+  organization: hardrock
+  person: beryl_kutch
+  address: 94813 Swaniawski Ranch
+  birthdate:
+  city: Littleberg
+  comments:
+  country_code: 'NO'
+  country_name: Norway
+  email: candra@thiel.name
+  external_id:
+  first_name: Beryl
+  gender: 1
+  kind: 0
+  last_name: Kutch
+  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
+  phone: '4747239760'
+  quantity:
+  state_code: NOR
+  state_name:
+  year: 2017
+historical_fact_0044:
+  organization: hardrock
+  person: beryl_kutch
+  address: 94813 Swaniawski Ranch
+  birthdate:
+  city: Littleberg
+  comments:
+  country_code: 'NO'
+  country_name: Norway
+  email: candra@thiel.name
+  external_id:
+  first_name: Beryl
+  gender: 1
+  kind: 0
+  last_name: Kutch
+  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
+  phone: '4747239760'
+  quantity:
+  state_code: NOR
+  state_name:
+  year: 2018
+historical_fact_0045:
+  organization: hardrock
+  person: beryl_kutch
+  address: 94813 Swaniawski Ranch
+  birthdate:
+  city: Littleberg
+  comments:
+  country_code: 'NO'
+  country_name: Norway
+  email: candra@thiel.name
+  external_id:
+  first_name: Beryl
+  gender: 1
+  kind: 0
+  last_name: Kutch
+  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
+  phone: '4747239760'
+  quantity:
+  state_code: NOR
+  state_name:
+  year: 2019
+historical_fact_0046:
+  organization: hardrock
+  person: beryl_kutch
+  address: 94813 Swaniawski Ranch
+  birthdate:
+  city: Littleberg
+  comments: Shellie Krajcik, 4747239722
+  country_code: 'NO'
+  country_name: Norway
+  email: candra@thiel.name
+  external_id:
+  first_name: Beryl
+  gender: 1
+  kind: 5
+  last_name: Kutch
+  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
+  phone: '4747239760'
+  quantity:
+  state_code: NOR
+  state_name:
+  year: 2023
+historical_fact_0047:
+  organization: hardrock
+  person: beryl_kutch
+  address: 94813 Swaniawski Ranch
+  birthdate:
+  city: Littleberg
+  comments:
+  country_code: 'NO'
+  country_name: Norway
+  email: candra@thiel.name
+  external_id:
+  first_name: Beryl
+  gender: 1
+  kind: 7
+  last_name: Kutch
+  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
+  phone: '4747239760'
+  quantity: 16
+  state_code: NOR
+  state_name:
+  year: 2023
+historical_fact_0048:
+  organization: hardrock
+  person: beryl_kutch
+  address: 94813 Swaniawski Ranch
+  birthdate:
+  city: Littleberg
+  comments: Never
+  country_code: 'NO'
+  country_name: Norway
+  email: candra@thiel.name
+  external_id:
+  first_name: Beryl
+  gender: 1
+  kind: 8
+  last_name: Kutch
+  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
+  phone: '4747239760'
+  quantity:
+  state_code: NOR
+  state_name:
+  year: 2023
+historical_fact_0049:
+  organization: hardrock
+  person: beryl_kutch
+  address: 94813 Swaniawski Ranch
+  birthdate:
+  city: Littleberg
+  comments: 'Ultrasignup order id: 456'
+  country_code: 'NO'
+  country_name: Norway
+  email: candra@thiel.name
+  external_id:
+  first_name: Beryl
+  gender: 1
+  kind: 11
+  last_name: Kutch
+  personal_info_hash: fcbdaf1ed2bfa5abf2455bf9a653293b
+  phone: '4747239760'
+  quantity:
+  state_code: NOR
+  state_name:
+  year: 2024
+historical_fact_0050:
+  organization: hardrock
+  person: freddy_maggio
+  address: 9876 Damian Valley
+  birthdate: 1995-06-21
+  city: Port Kandice
+  comments:
+  country_code: CA
+  country_name: Canada
+  email: leighann.schoen@adams.us
+  external_id:
+  first_name: Freddy
+  gender: 0
+  kind: 7
+  last_name: Maggio
+  personal_info_hash: 9a68ffede91950516d62650371d69eb4
+  phone: '9584628190'
+  quantity: 1
+  state_code: AB
+  state_name: Alberta
+  year: 2023
+historical_fact_0051:
+  organization: hardrock
+  person: freddy_maggio
+  address: 9876 Damian Valley
+  birthdate: 1995-06-21
+  city: Port Kandice
+  comments: Never
+  country_code: CA
+  country_name: Canada
+  email: leighann.schoen@adams.us
+  external_id:
+  first_name: Freddy
+  gender: 0
+  kind: 8
+  last_name: Maggio
+  personal_info_hash: 9a68ffede91950516d62650371d69eb4
+  phone: '9584628190'
+  quantity:
+  state_code: AB
+  state_name: Alberta
+  year: 2023
+historical_fact_0052:
+  organization: hardrock
+  person: freddy_maggio
+  address: 9876 Damian Valley
+  birthdate: 1995-06-21
+  city: Port Kandice
+  comments:
+  country_code: CA
+  country_name: Canada
+  email: leighann.schoen@adams.us
+  external_id:
+  first_name: Freddy
+  gender: 0
+  kind: 11
+  last_name: Maggio
+  personal_info_hash: 9a68ffede91950516d62650371d69eb4
+  phone: '9584628190'
+  quantity:
+  state_code: AB
+  state_name: Alberta
+  year: 2024
+historical_fact_0053:
   organization: hardrock
   person: lavon_paucek
-  id: 254
+  address: 4679 Lazaro Hill
+  birthdate:
+  city: West Ariel
+  comments:
+  country_code: US
+  country_name: United States
+  email: lashunda@koelpin.co.uk
+  external_id:
+  first_name: Lavon
+  gender: 1
+  kind: 0
+  last_name: Paucek
+  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
+  phone: '6919767666'
+  quantity:
+  state_code: AR
+  state_name: Arkansas
+  year: 2012
+historical_fact_0054:
+  organization: hardrock
+  person: lavon_paucek
+  address: 4679 Lazaro Hill
+  birthdate:
+  city: West Ariel
+  comments:
+  country_code: US
+  country_name: United States
+  email: lashunda@koelpin.co.uk
+  external_id:
+  first_name: Lavon
+  gender: 1
+  kind: 0
+  last_name: Paucek
+  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
+  phone: '6919767666'
+  quantity:
+  state_code: AR
+  state_name: Arkansas
+  year: 2015
+historical_fact_0055:
+  organization: hardrock
+  person: lavon_paucek
+  address: 4679 Lazaro Hill
+  birthdate:
+  city: West Ariel
+  comments:
+  country_code: US
+  country_name: United States
+  email: lashunda@koelpin.co.uk
+  external_id:
+  first_name: Lavon
+  gender: 1
+  kind: 10
+  last_name: Paucek
+  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
+  phone: '6919767666'
+  quantity:
+  state_code: AR
+  state_name: Arkansas
+  year: 2016
+historical_fact_0056:
+  organization: hardrock
+  person: lavon_paucek
+  address: 4679 Lazaro Hill
+  birthdate:
+  city: West Ariel
+  comments:
+  country_code: US
+  country_name: United States
+  email: lashunda@koelpin.co.uk
+  external_id:
+  first_name: Lavon
+  gender: 1
+  kind: 0
+  last_name: Paucek
+  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
+  phone: '6919767666'
+  quantity:
+  state_code: AR
+  state_name: Arkansas
+  year: 2017
+historical_fact_0057:
+  organization: hardrock
+  person: lavon_paucek
+  address: 4679 Lazaro Hill
+  birthdate:
+  city: West Ariel
+  comments:
+  country_code: US
+  country_name: United States
+  email: lashunda@koelpin.co.uk
+  external_id:
+  first_name: Lavon
+  gender: 1
+  kind: 0
+  last_name: Paucek
+  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
+  phone: '6919767666'
+  quantity:
+  state_code: AR
+  state_name: Arkansas
+  year: 2018
+historical_fact_0058:
+  organization: hardrock
+  person: lavon_paucek
+  address: 4679 Lazaro Hill
+  birthdate:
+  city: West Ariel
+  comments: Brynn Hermiston, 950-975-4391
+  country_code: US
+  country_name: United States
+  email: lashunda@koelpin.co.uk
+  external_id:
+  first_name: Lavon
+  gender: 1
+  kind: 5
+  last_name: Paucek
+  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
+  phone: '6919767666'
+  quantity:
+  state_code: AR
+  state_name: Arkansas
+  year: 2023
+historical_fact_0059:
+  organization: hardrock
+  person: lavon_paucek
+  address: 4679 Lazaro Hill
+  birthdate:
+  city: West Ariel
+  comments:
+  country_code: US
+  country_name: United States
+  email: lashunda@koelpin.co.uk
+  external_id:
+  first_name: Lavon
+  gender: 1
+  kind: 7
+  last_name: Paucek
+  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
+  phone: '6919767666'
+  quantity: 4
+  state_code: AR
+  state_name: Arkansas
+  year: 2023
+historical_fact_0060:
+  organization: hardrock
+  person: lavon_paucek
+  address: 4679 Lazaro Hill
+  birthdate:
+  city: West Ariel
+  comments: Else
+  country_code: US
+  country_name: United States
+  email: lashunda@koelpin.co.uk
+  external_id:
+  first_name: Lavon
+  gender: 1
+  kind: 8
+  last_name: Paucek
+  personal_info_hash: 12f185f68030f2c4c91a881f4f8a6692
+  phone: '6919767666'
+  quantity:
+  state_code: AR
+  state_name: Arkansas
+  year: 2023
+historical_fact_0061:
+  organization: hardrock
+  person: lavon_paucek
   address: 4679 Lazaro Hill
   birthdate:
   city: West Ariel
@@ -2000,4 +1279,634 @@ historical_fact_0091:
   quantity:
   state_code: AR
   state_name: Arkansas
+  year: 2024
+historical_fact_0062:
+  organization: hardrock
+  person: bethany_sanford
+  address: 123 rue des Frères Lumières
+  birthdate: 1988-05-01
+  city: Villefranche Sur Saône
+  comments:
+  country_code: FR
+  country_name: France
+  email: fran.bar@gmail.com
+  external_id:
+  first_name: Bethany
+  gender: 1
+  kind: 0
+  last_name: Sanford
+  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
+  phone: '601271155'
+  quantity:
+  state_code: FRA
+  state_name:
+  year: 2022
+historical_fact_0063:
+  organization: hardrock
+  person: bethany_sanford
+  address: 123 rue des Frères Lumières
+  birthdate: 1988-05-01
+  city: Villefranche Sur Saône
+  comments:
+  country_code: FR
+  country_name: France
+  email: fran.bar@gmail.com
+  external_id:
+  first_name: Bethany
+  gender: 1
+  kind: 0
+  last_name: Sanford
+  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
+  phone: '601271155'
+  quantity:
+  state_code: FRA
+  state_name:
+  year: 2023
+historical_fact_0064:
+  organization: hardrock
+  person: bethany_sanford
+  address: 123 rue des Frères Lumières
+  birthdate: 1988-05-01
+  city: Villefranche Sur Saône
+  comments: '2022 OCT: Diagonale des Fous (Reunion Is)'
+  country_code: FR
+  country_name: France
+  email: fran.bar@gmail.com
+  external_id:
+  first_name: Bethany
+  gender: 1
+  kind: 4
+  last_name: Sanford
+  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
+  phone: '601271155'
+  quantity:
+  state_code: FRA
+  state_name:
+  year: 2023
+historical_fact_0065:
+  organization: hardrock
+  person: bethany_sanford
+  address: 123 rue des Frères Lumières
+  birthdate: 1988-05-01
+  city: Villefranche Sur Saône
+  comments: Aberkane, 695511156
+  country_code: FR
+  country_name: France
+  email: fran.bar@gmail.com
+  external_id:
+  first_name: Bethany
+  gender: 1
+  kind: 5
+  last_name: Sanford
+  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
+  phone: '601271155'
+  quantity:
+  state_code: FRA
+  state_name:
+  year: 2023
+historical_fact_0066:
+  organization: hardrock
+  person: bethany_sanford
+  address: 123 rue des Frères Lumières
+  birthdate: 1988-05-01
+  city: Villefranche Sur Saône
+  comments:
+  country_code: FR
+  country_name: France
+  email: fran.bar@gmail.com
+  external_id:
+  first_name: Bethany
+  gender: 1
+  kind: 7
+  last_name: Sanford
+  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
+  phone: '601271155'
+  quantity: 4
+  state_code: FRA
+  state_name:
+  year: 2023
+historical_fact_0067:
+  organization: hardrock
+  person: bethany_sanford
+  address: 123 rue des Frères Lumières
+  birthdate: 1988-05-01
+  city: Villefranche Sur Saône
+  comments: Never
+  country_code: FR
+  country_name: France
+  email: fran.bar@gmail.com
+  external_id:
+  first_name: Bethany
+  gender: 1
+  kind: 8
+  last_name: Sanford
+  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
+  phone: '601271155'
+  quantity:
+  state_code: FRA
+  state_name:
+  year: 2023
+historical_fact_0068:
+  organization: hardrock
+  person: bethany_sanford
+  address: 123 rue des Frères Lumières
+  birthdate: 1988-05-01
+  city: Villefranche Sur Saône
+  comments:
+  country_code: FR
+  country_name: France
+  email: fran.bar@gmail.com
+  external_id:
+  first_name: Bethany
+  gender: 1
+  kind: 11
+  last_name: Sanford
+  personal_info_hash: db16effbacc5cedcdee92e5659e2e5d1
+  phone: '601271155'
+  quantity:
+  state_code: FRA
+  state_name:
+  year: 2024
+historical_fact_0069:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 0
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2003
+historical_fact_0070:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 9
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2004
+historical_fact_0071:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 9
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2005
+historical_fact_0072:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 9
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2006
+historical_fact_0073:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 9
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2007
+historical_fact_0074:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 0
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2008
+historical_fact_0075:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 9
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2009
+historical_fact_0076:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 0
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2010
+historical_fact_0077:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 0
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2011
+historical_fact_0078:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 0
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2012
+historical_fact_0079:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 0
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2013
+historical_fact_0080:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 9
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2014
+historical_fact_0081:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 3
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity: 5
+  state_code:
+  state_name:
+  year: 2023
+historical_fact_0082:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments:
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 7
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity: 2
+  state_code:
+  state_name:
+  year: 2023
+historical_fact_0083:
+  organization: hardrock
+  person: pat_schaden
+  address:
+  birthdate:
+  city:
+  comments: Else
+  country_code:
+  country_name:
+  email:
+  external_id:
+  first_name: Pat
+  gender: 0
+  kind: 8
+  last_name: Schaden
+  personal_info_hash: 29fc1be7dae9c7df527fc6d9fc2b2401
+  phone:
+  quantity:
+  state_code:
+  state_name:
+  year: 2023
+historical_fact_0084:
+  organization: hardrock
+  person: fredrick_wiza
+  address: 0141 Belva Mill
+  birthdate:
+  city: East Shenitaport
+  comments:
+  country_code: US
+  country_name: United States
+  email: martin.bruen@christiansen.name
+  external_id:
+  first_name: Fredrick
+  gender: 0
+  kind: 0
+  last_name: Wiza
+  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
+  phone: '5046722864'
+  quantity:
+  state_code: MT
+  state_name: Montana
+  year: 2015
+historical_fact_0085:
+  organization: hardrock
+  person: fredrick_wiza
+  address: 0141 Belva Mill
+  birthdate:
+  city: East Shenitaport
+  comments:
+  country_code: US
+  country_name: United States
+  email: martin.bruen@christiansen.name
+  external_id:
+  first_name: Fredrick
+  gender: 0
+  kind: 0
+  last_name: Wiza
+  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
+  phone: '5046722864'
+  quantity:
+  state_code: MT
+  state_name: Montana
+  year: 2016
+historical_fact_0086:
+  organization: hardrock
+  person: fredrick_wiza
+  address: 0141 Belva Mill
+  birthdate:
+  city: East Shenitaport
+  comments:
+  country_code: US
+  country_name: United States
+  email: martin.bruen@christiansen.name
+  external_id:
+  first_name: Fredrick
+  gender: 0
+  kind: 0
+  last_name: Wiza
+  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
+  phone: '5046722864'
+  quantity:
+  state_code: MT
+  state_name: Montana
+  year: 2017
+historical_fact_0087:
+  organization: hardrock
+  person: fredrick_wiza
+  address: 0141 Belva Mill
+  birthdate:
+  city: East Shenitaport
+  comments:
+  country_code: US
+  country_name: United States
+  email: martin.bruen@christiansen.name
+  external_id:
+  first_name: Fredrick
+  gender: 0
+  kind: 0
+  last_name: Wiza
+  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
+  phone: '5046722864'
+  quantity:
+  state_code: MT
+  state_name: Montana
+  year: 2018
+historical_fact_0088:
+  organization: hardrock
+  person: fredrick_wiza
+  address: 0141 Belva Mill
+  birthdate:
+  city: East Shenitaport
+  comments: Penney Turner, 737-930-2991
+  country_code: US
+  country_name: United States
+  email: martin.bruen@christiansen.name
+  external_id:
+  first_name: Fredrick
+  gender: 0
+  kind: 5
+  last_name: Wiza
+  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
+  phone: '5046722864'
+  quantity:
+  state_code: MT
+  state_name: Montana
+  year: 2023
+historical_fact_0089:
+  organization: hardrock
+  person: fredrick_wiza
+  address: 0141 Belva Mill
+  birthdate:
+  city: East Shenitaport
+  comments:
+  country_code: US
+  country_name: United States
+  email: martin.bruen@christiansen.name
+  external_id:
+  first_name: Fredrick
+  gender: 0
+  kind: 7
+  last_name: Wiza
+  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
+  phone: '5046722864'
+  quantity: 16
+  state_code: MT
+  state_name: Montana
+  year: 2023
+historical_fact_0090:
+  organization: hardrock
+  person: fredrick_wiza
+  address: 0141 Belva Mill
+  birthdate:
+  city: East Shenitaport
+  comments: Never
+  country_code: US
+  country_name: United States
+  email: martin.bruen@christiansen.name
+  external_id:
+  first_name: Fredrick
+  gender: 0
+  kind: 8
+  last_name: Wiza
+  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
+  phone: '5046722864'
+  quantity:
+  state_code: MT
+  state_name: Montana
+  year: 2023
+historical_fact_0091:
+  organization: hardrock
+  person: fredrick_wiza
+  address: 0141 Belva Mill
+  birthdate:
+  city: East Shenitaport
+  comments:
+  country_code: US
+  country_name: United States
+  email: martin.bruen@christiansen.name
+  external_id:
+  first_name: Fredrick
+  gender: 0
+  kind: 11
+  last_name: Wiza
+  personal_info_hash: ec7e8e7b56ffd284791b016d5f04907a
+  phone: '5046722864'
+  quantity:
+  state_code: MT
+  state_name: Montana
   year: 2024

--- a/spec/models/historical_fact_spec.rb
+++ b/spec/models/historical_fact_spec.rb
@@ -128,10 +128,18 @@ RSpec.describe HistoricalFact, type: :model do
       let(:result) { subject.related_facts }
 
       context "when related facts exist" do
-        subject { historical_facts(:historical_fact_0001) }
+        subject { described_class.where(personal_info_hash: shared_hash).first }
+
+        let(:shared_hash) do
+          described_class.where.not(personal_info_hash: nil)
+                         .group(:personal_info_hash)
+                         .having("COUNT(*) > 1")
+                         .count.keys.first
+        end
+        let(:expected_related_count) { described_class.where(personal_info_hash: shared_hash).count - 1 }
 
         it "returns all facts that have the same personal_info_hash" do
-          expect(result.count).to eq(4)
+          expect(result.count).to eq(expected_related_count)
           expect(result.map(&:personal_info_hash)).to all be_present
           expect(result.map(&:personal_info_hash)).to all eq(subject.personal_info_hash)
         end


### PR DESCRIPTION
## Summary
- Adds `:historical_facts` to `PORTABLE_FIXTURE_TABLES`
- Adds `ORDER_BY_MAP` entry: `last_name, first_name, year, kind, personal_info_hash` (the hash column is a tiebreaker for the rare case of duplicate last/first/year/kind tuples — partial unique indexes cover most kinds but not all)
- Regenerates `spec/fixtures/historical_facts.yml` — drops `id:` lines; labels reshuffled from id order to alphabetical-by-name

## Spec fix
The label reordering broke `spec/models/historical_fact_spec.rb`'s `#related_facts` test, which had hardcoded `historical_facts(:historical_fact_0001)` and assumed that row's `personal_info_hash` was shared by exactly 5 facts (Antony Grady, in the old id ordering). Refactored the test to look up the subject by attribute — any fact whose hash is shared by >1 sibling — so it no longer depends on a particular row's position.

Relates to #2065

## Test plan
- [x] `rake db:from_fixtures` + `rake db:to_fixtures` idempotent
- [x] Local rspec: all 11 spec files referencing `HistoricalFact` green (model, ETL strategies, jobs, reconciler services)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)