### PR TITLE
Make users a portable fixture table

### DIFF
--- a/app/models/event_group.rb
+++ b/app/models/event_group.rb
@@ -23,6 +23,7 @@ class EventGroup < ApplicationRecord
   has_many :efforts, through: :events
   has_many :raw_times, dependent: :destroy
   belongs_to :organization
+  belongs_to :creator, class_name: "User", optional: true, foreign_key: "created_by"
 
   has_many_attached :entrant_photos do |photo|
     photo.variant :thumbnail, resize_to_limit: [50, 50]

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,6 +10,8 @@ class Organization < ApplicationRecord
 
   NOT_FOUND_OWNER_ID = -1
 
+  belongs_to :owner, class_name: "User", foreign_key: "created_by", optional: true
+
   has_many :courses, dependent: :destroy
   has_many :course_groups, dependent: :destroy
   has_many :event_groups, dependent: :destroy
@@ -58,12 +60,6 @@ class Organization < ApplicationRecord
     else
       Event.where(event_group_id: event_groups.ids)
     end
-  end
-
-  def owner
-    return @owner if defined?(@owner)
-
-    @owner = User.find_by(id: owner_id)
   end
 
   def owner_full_name

--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -48,6 +48,7 @@ module FixtureHelper
     :results_categories,
     :results_templates,
     :results_template_categories,
+    :users,
   ].freeze
 
   # ORDER BY clause used when dumping fixtures. Required for any non-slug portable table

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :organization do
     name { FFaker::Company.unique.name }
-    owner_id { 1 }
+    owner_id { ActiveRecord::FixtureSet.identify(:admin_user) }
   end
 end

--- a/spec/fixtures/credentials.yml
+++ b/spec/fixtures/credentials.yml
@@ -1,21 +1,21 @@
 ---
 credential_0001:
+  user: third_user
   key: email
   service_identifier: rattlesnake_ramble
-  user_id: 3
   value: user@example.com
 credential_0002:
+  user: third_user
   key: password
   service_identifier: rattlesnake_ramble
-  user_id: 3
   value: password
 credential_0003:
+  user: third_user
   key: api_key
   service_identifier: runsignup
-  user_id: 3
   value: '1234'
 credential_0004:
+  user: third_user
   key: api_secret
   service_identifier: runsignup
-  user_id: 3
   value: '2345'

--- a/spec/fixtures/event_groups.yml
+++ b/spec/fixtures/event_groups.yml
@@ -1,10 +1,10 @@
 ---
 ramble:
   organization: rattlesnake_ramble
+  creator: admin_user
   id: 4
   available_live: false
   concealed: false
-  created_by: 1
   data_entry_grouping_strategy: 0
   home_time_zone: Mountain Time (US & Canada)
   monitor_pacers: false
@@ -13,10 +13,10 @@ ramble:
   webhook_token:
 hardrock_2014:
   organization: hardrock
+  creator: admin_user
   id: 7
   available_live: false
   concealed: false
-  created_by: 1
   data_entry_grouping_strategy: 0
   home_time_zone: Mountain Time (US & Canada)
   monitor_pacers: true
@@ -25,10 +25,10 @@ hardrock_2014:
   webhook_token:
 hardrock_2015:
   organization: hardrock
+  creator: admin_user
   id: 17
   available_live: true
   concealed: false
-  created_by: 1
   data_entry_grouping_strategy: 0
   home_time_zone: Mountain Time (US & Canada)
   monitor_pacers: true
@@ -37,10 +37,10 @@ hardrock_2015:
   webhook_token:
 rufa_2016:
   organization: running_up_for_air
+  creator: admin_user
   id: 25
   available_live: false
   concealed: false
-  created_by: 1
   data_entry_grouping_strategy: 0
   home_time_zone: Mountain Time (US & Canada)
   monitor_pacers: false
@@ -49,10 +49,10 @@ rufa_2016:
   webhook_token:
 dirty_30:
   organization: dirty_30_running
+  creator: admin_user
   id: 27
   available_live: true
   concealed: false
-  created_by: 1
   data_entry_grouping_strategy: 1
   home_time_zone: Mountain Time (US & Canada)
   monitor_pacers: false
@@ -61,10 +61,10 @@ dirty_30:
   webhook_token:
 hardrock_2016:
   organization: hardrock
+  creator: admin_user
   id: 28
   available_live: true
   concealed: false
-  created_by: 1
   data_entry_grouping_strategy: 0
   home_time_zone: Mountain Time (US & Canada)
   monitor_pacers: true
@@ -73,10 +73,10 @@ hardrock_2016:
   webhook_token:
 sum:
   organization: dirty_30_running
+  creator: admin_user
   id: 32
   available_live: true
   concealed: false
-  created_by: 1
   data_entry_grouping_strategy: 0
   home_time_zone: Mountain Time (US & Canada)
   monitor_pacers: false
@@ -85,10 +85,10 @@ sum:
   webhook_token:
 rufa_2017:
   organization: running_up_for_air
+  creator: admin_user
   id: 59
   available_live: true
   concealed: false
-  created_by: 1
   data_entry_grouping_strategy: 0
   home_time_zone: Mountain Time (US & Canada)
   monitor_pacers: false

--- a/spec/fixtures/organizations.yml
+++ b/spec/fixtures/organizations.yml
@@ -1,31 +1,31 @@
 ---
 dirty_30_running:
+  owner: admin_user
   concealed: false
-  created_by: 1
   description:
   good_standing_through:
   name: Dirty 30 Running
   slug: dirty-30-running
   non_profit: false
 hardrock:
+  owner: admin_user
   concealed: false
-  created_by: 1
   description: A long race
   good_standing_through:
   name: Hardrock
   slug: hardrock
   non_profit: false
 rattlesnake_ramble:
+  owner: admin_user
   concealed: false
-  created_by: 1
   description: Bill's Race to benefit Eldorado Canyon State Park
   good_standing_through:
   name: Rattlesnake Ramble
   slug: rattlesnake-ramble
   non_profit: false
 running_up_for_air:
+  owner: admin_user
   concealed: false
-  created_by: 1
   description:
   good_standing_through:
   name: Running Up For Air

--- a/spec/fixtures/people.yml
+++ b/spec/fixtures/people.yml
@@ -1,5 +1,6 @@
 ---
 across_dst_change:
+  claimant:
   birthdate:
   city:
   concealed: false
@@ -13,10 +14,10 @@ across_dst_change:
   slug: across-dst-change
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 alfreda_cruickshank:
+  claimant:
   birthdate:
   city: Pandoraborough
   concealed: false
@@ -30,10 +31,10 @@ alfreda_cruickshank:
   slug: alfreda-cruickshank
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 antony_grady:
+  claimant:
   birthdate:
   city: Bednarshire
   concealed: false
@@ -47,10 +48,10 @@ antony_grady:
   slug: antony-grady
   state_code: VA
   state_name: Virginia
-  user_id:
   hide_age: false
   obscure_name: false
 bad_finish:
+  claimant:
   birthdate: 1995-07-25
   city:
   concealed: false
@@ -64,10 +65,10 @@ bad_finish:
   slug: bad-finish
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 bad_status:
+  claimant:
   birthdate: 1994-04-18
   city: Erie
   concealed: false
@@ -81,10 +82,10 @@ bad_status:
   slug: bad-status
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 benedict_davis:
+  claimant:
   birthdate: 1983-06-28
   city:
   concealed: false
@@ -98,10 +99,10 @@ benedict_davis:
   slug: benedict-davis
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 benito_moen:
+  claimant:
   birthdate: 1964-01-16
   city:
   concealed: false
@@ -115,10 +116,10 @@ benito_moen:
   slug: benito-moen
   state_code: OH
   state_name: Ohio
-  user_id:
   hide_age: false
   obscure_name: false
 beryl_kutch:
+  claimant:
   birthdate:
   city:
   concealed: false
@@ -132,10 +133,10 @@ beryl_kutch:
   slug: beryl-kutch
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 bethany_sanford:
+  claimant:
   birthdate: 1988-05-01
   city:
   concealed: false
@@ -149,10 +150,10 @@ bethany_sanford:
   slug: bethany-sanford
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 brinda_fisher:
+  claimant:
   birthdate: 1994-07-12
   city:
   concealed: false
@@ -166,10 +167,10 @@ brinda_fisher:
   slug: brinda-fisher
   state_code: SC
   state_name: South Carolina
-  user_id:
   hide_age: false
   obscure_name: false
 bruno_fadel:
+  claimant:
   birthdate: 1988-05-11
   city:
   concealed: false
@@ -183,10 +184,10 @@ bruno_fadel:
   slug: bruno-fadel
   state_code: CA
   state_name: California
-  user_id:
   hide_age: false
   obscure_name: false
 carmine_adams:
+  claimant:
   birthdate: 1997-05-25
   city: Kassulkemouth
   concealed: false
@@ -200,10 +201,10 @@ carmine_adams:
   slug: carmine-adams
   state_code: WA
   state_name: Washington
-  user_id:
   hide_age: false
   obscure_name: false
 cassondra_nienow:
+  claimant:
   birthdate: 1958-09-07
   city:
   concealed: false
@@ -217,10 +218,10 @@ cassondra_nienow:
   slug: cassondra-nienow
   state_code: OH
   state_name: Ohio
-  user_id:
   hide_age: false
   obscure_name: false
 cedric_windler:
+  claimant:
   birthdate: 1979-07-10
   city:
   concealed: false
@@ -234,10 +235,10 @@ cedric_windler:
   slug: cedric-windler
   state_code: TN
   state_name: Tennessee
-  user_id:
   hide_age: false
   obscure_name: false
 charlie_mueller:
+  claimant:
   birthdate: 1989-06-10
   city:
   concealed: false
@@ -251,10 +252,10 @@ charlie_mueller:
   slug: charlie-mueller
   state_code: OR
   state_name: Oregon
-  user_id:
   hide_age: false
   obscure_name: false
 chris_rempel:
+  claimant:
   birthdate: 1988-12-28
   city:
   concealed: false
@@ -268,10 +269,10 @@ chris_rempel:
   slug: chris-rempel
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 clarence_goyette:
+  claimant:
   birthdate: 1961-09-18
   city:
   concealed: false
@@ -285,10 +286,10 @@ clarence_goyette:
   slug: clarence-goyette
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 claudio_wunsch:
+  claimant:
   birthdate:
   city:
   concealed: false
@@ -302,10 +303,10 @@ claudio_wunsch:
   slug: claudio-wunsch
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 darius_jacobson:
+  claimant:
   birthdate: 1985-03-21
   city: Carbondale
   concealed: false
@@ -319,10 +320,10 @@ darius_jacobson:
   slug: darius-jacobson
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 demetrius_moen:
+  claimant:
   birthdate: 1975-06-06
   city:
   concealed: false
@@ -336,10 +337,10 @@ demetrius_moen:
   slug: demetrius-moen
   state_code: OR
   state_name: Oregon
-  user_id:
   hide_age: false
   obscure_name: false
 donn_mckenzie:
+  claimant:
   birthdate: 1998-12-29
   city:
   concealed: false
@@ -353,10 +354,10 @@ donn_mckenzie:
   slug: donn-mckenzie
   state_code: WY
   state_name: Wyoming
-  user_id:
   hide_age: false
   obscure_name: false
 donte_spencer:
+  claimant:
   birthdate: 1984-07-14
   city: Eden
   concealed: false
@@ -370,10 +371,10 @@ donte_spencer:
   slug: donte-spencer
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 dorothy_fahey:
+  claimant:
   birthdate:
   city: Pfannerstillberg
   concealed: false
@@ -387,10 +388,10 @@ dorothy_fahey:
   slug: dorothy-fahey
   state_code: WA
   state_name: Washington
-  user_id:
   hide_age: false
   obscure_name: false
 douglas_vandervort:
+  claimant:
   birthdate:
   city:
   concealed: false
@@ -404,10 +405,10 @@ douglas_vandervort:
   slug: douglas-vandervort
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 drop_aid4:
+  claimant:
   birthdate: 1998-11-08
   city:
   concealed: false
@@ -421,10 +422,10 @@ drop_aid4:
   slug: drop-aid4
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 drop_anvil:
+  claimant:
   birthdate: 1988-09-29
   city:
   concealed: false
@@ -438,10 +439,10 @@ drop_anvil:
   slug: drop-anvil
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 drop_bandera:
+  claimant:
   birthdate: 1998-08-31
   city:
   concealed: false
@@ -455,10 +456,10 @@ drop_bandera:
   slug: drop-bandera
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 drop_ouray:
+  claimant:
   birthdate: 1974-01-05
   city: Boulder Creek
   concealed: false
@@ -472,10 +473,10 @@ drop_ouray:
   slug: drop-ouray
   state_code: CA
   state_name: California
-  user_id:
   hide_age: false
   obscure_name: false
 dropped_grouse:
+  claimant:
   birthdate: 1969-05-13
   city:
   concealed: false
@@ -489,10 +490,10 @@ dropped_grouse:
   slug: dropped-grouse
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 eddy_goldner:
+  claimant:
   birthdate: 1997-07-26
   city:
   concealed: false
@@ -506,10 +507,10 @@ eddy_goldner:
   slug: eddy-goldner
   state_code: WA
   state_name: Washington
-  user_id:
   hide_age: false
   obscure_name: false
 elden_morissette:
+  claimant:
   birthdate: 1972-11-21
   city:
   concealed: false
@@ -523,10 +524,10 @@ elden_morissette:
   slug: elden-morissette
   state_code: WI
   state_name: Wisconsin
-  user_id:
   hide_age: false
   obscure_name: false
 erich_larson:
+  claimant:
   birthdate: 1979-07-10
   city:
   concealed: false
@@ -540,10 +541,10 @@ erich_larson:
   slug: erich-larson
   state_code: MT
   state_name: Montana
-  user_id:
   hide_age: false
   obscure_name: false
 finished_first:
+  claimant:
   birthdate: 1997-01-25
   city:
   concealed: false
@@ -557,10 +558,10 @@ finished_first:
   slug: finished-first
   state_code: AZ
   state_name: Arizona
-  user_id:
   hide_age: false
   obscure_name: false
 finished_first_2019_02_01:
+  claimant:
   birthdate: 1957-02-04
   city:
   concealed: false
@@ -574,10 +575,10 @@ finished_first_2019_02_01:
   slug: finished-first-2019-02-01
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 finished_first_colorado_us:
+  claimant:
   birthdate: 1973-08-18
   city:
   concealed: false
@@ -591,10 +592,10 @@ finished_first_colorado_us:
   slug: finished-first-colorado-us
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 finished_first_france:
+  claimant:
   birthdate: 1993-06-05
   city:
   concealed: false
@@ -608,10 +609,10 @@ finished_first_france:
   slug: finished-first-france
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 finished_first_japan:
+  claimant:
   birthdate: 1995-04-25
   city:
   concealed: false
@@ -625,10 +626,10 @@ finished_first_japan:
   slug: finished-first-japan
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 finished_first_utah_us:
+  claimant:
   birthdate: 1969-04-04
   city:
   concealed: false
@@ -642,10 +643,10 @@ finished_first_utah_us:
   slug: finished-first-utah-us
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 finished_lap6:
+  claimant:
   birthdate: 1963-03-07
   city:
   concealed: false
@@ -659,10 +660,10 @@ finished_lap6:
   slug: finished-lap6
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 finished_last:
+  claimant:
   birthdate: 1976-05-03
   city:
   concealed: false
@@ -676,10 +677,10 @@ finished_last:
   slug: finished-last
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 finished_second_colorado_us:
+  claimant:
   birthdate: 1973-07-23
   city: Boulder
   concealed: false
@@ -693,10 +694,10 @@ finished_second_colorado_us:
   slug: finished-second-colorado-us
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 finished_second_montana_us:
+  claimant:
   birthdate: 1994-08-16
   city: Bozeman
   concealed: false
@@ -710,10 +711,10 @@ finished_second_montana_us:
   slug: finished-second-montana-us
   state_code: MT
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 finished_with_stop:
+  claimant:
   birthdate: 1974-03-03
   city:
   concealed: false
@@ -727,10 +728,10 @@ finished_with_stop:
   slug: finished-with-stop
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 finished_without_stop:
+  claimant:
   birthdate:
   city: Salt Lake City
   concealed: false
@@ -744,10 +745,10 @@ finished_without_stop:
   slug: finished-without-stop
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 freddy_maggio:
+  claimant:
   birthdate: 1995-06-21
   city: Port Kandice
   concealed: false
@@ -761,10 +762,10 @@ freddy_maggio:
   slug: freddy-maggio
   state_code: AB
   state_name: Alberta
-  user_id:
   hide_age: false
   obscure_name: false
 fredrick_wiza:
+  claimant:
   birthdate:
   city: East Shenitaport
   concealed: false
@@ -778,10 +779,10 @@ fredrick_wiza:
   slug: fredrick-wiza
   state_code: MT
   state_name: Montana
-  user_id:
   hide_age: false
   obscure_name: false
 garry_kuhlman:
+  claimant:
   birthdate: 1969-10-10
   city:
   concealed: false
@@ -795,10 +796,10 @@ garry_kuhlman:
   slug: garry-kuhlman
   state_code: MT
   state_name: Montana
-  user_id:
   hide_age: false
   obscure_name: false
 gilberto_mckenzie:
+  claimant:
   birthdate: 1970-06-02
   city:
   concealed: false
@@ -812,10 +813,10 @@ gilberto_mckenzie:
   slug: gilberto-mckenzie
   state_code: WA
   state_name: Washington
-  user_id:
   hide_age: false
   obscure_name: false
 gus_walker:
+  claimant:
   birthdate: 1960-11-23
   city: Boulder
   concealed: false
@@ -829,10 +830,10 @@ gus_walker:
   slug: gus-walker
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 hoyt_macejkovic:
+  claimant:
   birthdate: 1960-07-23
   city:
   concealed: false
@@ -846,10 +847,10 @@ hoyt_macejkovic:
   slug: hoyt-macejkovic
   state_code: TX
   state_name: Texas
-  user_id:
   hide_age: false
   obscure_name: false
 humberto_adams:
+  claimant:
   birthdate: 1990-04-25
   city:
   concealed: false
@@ -863,10 +864,10 @@ humberto_adams:
   slug: humberto-adams
   state_code: NM
   state_name: New Mexico
-  user_id:
   hide_age: false
   obscure_name: false
 irvin_corkery:
+  claimant:
   birthdate: 1991-11-01
   city:
   concealed: false
@@ -880,10 +881,10 @@ irvin_corkery:
   slug: irvin-corkery
   state_code: DC
   state_name: District of Columbia
-  user_id:
   hide_age: false
   obscure_name: false
 irvin_harber:
+  claimant:
   birthdate: 1996-07-05
   city:
   concealed: false
@@ -897,10 +898,10 @@ irvin_harber:
   slug: irvin-harber
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 junior_lesch:
+  claimant:
   birthdate: 1967-02-21
   city:
   concealed: false
@@ -914,10 +915,10 @@ junior_lesch:
   slug: junior-lesch
   state_code: NM
   state_name: New Mexico
-  user_id:
   hide_age: false
   obscure_name: false
 keith_metz:
+  claimant:
   birthdate: 1971-11-06
   city:
   concealed: false
@@ -931,10 +932,10 @@ keith_metz:
   slug: keith-metz
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 ken_bradtke:
+  claimant:
   birthdate: 1966-07-21
   city:
   concealed: false
@@ -948,10 +949,10 @@ ken_bradtke:
   slug: ken-bradtke
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 kendall_koch:
+  claimant:
   birthdate: 1976-02-05
   city: Littleton
   concealed: false
@@ -965,10 +966,10 @@ kendall_koch:
   slug: kendall-koch
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 kory_kulas:
+  claimant:
   birthdate: 1974-01-25
   city:
   concealed: false
@@ -982,10 +983,10 @@ kory_kulas:
   slug: kory-kulas
   state_code: CA
   state_name: California
-  user_id:
   hide_age: false
   obscure_name: false
 lavon_paucek:
+  claimant:
   birthdate: 1974-07-29
   city: West Ariel
   concealed: false
@@ -999,10 +1000,10 @@ lavon_paucek:
   slug: lavon-paucek
   state_code: AR
   state_name: Arkansas
-  user_id:
   hide_age: false
   obscure_name: false
 leandro_cole:
+  claimant:
   birthdate: 1970-06-26
   city:
   concealed: false
@@ -1016,10 +1017,10 @@ leandro_cole:
   slug: leandro-cole
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 leif_carter:
+  claimant:
   birthdate: 1960-02-01
   city:
   concealed: false
@@ -1033,10 +1034,10 @@ leif_carter:
   slug: leif-carter
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 leroy_leffler:
+  claimant:
   birthdate: 1967-06-18
   city:
   concealed: false
@@ -1050,10 +1051,10 @@ leroy_leffler:
   slug: leroy-leffler
   state_code: NM
   state_name: New Mexico
-  user_id:
   hide_age: false
   obscure_name: false
 major_green:
+  claimant:
   birthdate: 1955-09-29
   city:
   concealed: false
@@ -1067,10 +1068,10 @@ major_green:
   slug: major-green
   state_code: NC
   state_name: North Carolina
-  user_id:
   hide_age: false
   obscure_name: false
 mervin_smitham:
+  claimant:
   birthdate: 1991-10-08
   city:
   concealed: false
@@ -1084,10 +1085,10 @@ mervin_smitham:
   slug: mervin-smitham
   state_code: NM
   state_name: New Mexico
-  user_id:
   hide_age: false
   obscure_name: false
 multiple_stops:
+  claimant:
   birthdate: 1954-03-21
   city:
   concealed: false
@@ -1101,10 +1102,10 @@ multiple_stops:
   slug: multiple-stops
   state_code: HI
   state_name: Hawaii
-  user_id:
   hide_age: false
   obscure_name: false
 multiple_stops_utah_us:
+  claimant:
   birthdate: 1973-11-14
   city:
   concealed: false
@@ -1118,10 +1119,10 @@ multiple_stops_utah_us:
   slug: multiple-stops-utah-us
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 not_started:
+  claimant:
   birthdate: 1986-03-23
   city:
   concealed: false
@@ -1135,10 +1136,10 @@ not_started:
   slug: not-started
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 not_started_2019_02_01:
+  claimant:
   birthdate: 1989-03-22
   city:
   concealed: false
@@ -1152,10 +1153,10 @@ not_started_2019_02_01:
   slug: not-started-2019-02-01
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 not_started_colorado_us:
+  claimant:
   birthdate: 1995-03-06
   city: Greeley
   concealed: false
@@ -1169,10 +1170,10 @@ not_started_colorado_us:
   slug: not-started-colorado-us
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 not_started_colorado_us_2019_02_01:
+  claimant:
   birthdate: 1981-03-31
   city:
   concealed: false
@@ -1186,10 +1187,10 @@ not_started_colorado_us_2019_02_01:
   slug: not-started-colorado-us-2019-02-01
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 not_started_utah_us:
+  claimant:
   birthdate:
   city:
   concealed: false
@@ -1203,10 +1204,10 @@ not_started_utah_us:
   slug: not-started-utah-us
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 omer_yundt:
+  claimant:
   birthdate: 1974-06-23
   city:
   concealed: false
@@ -1220,10 +1221,10 @@ omer_yundt:
   slug: omer-yundt
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 on_dst_change:
+  claimant:
   birthdate:
   city:
   concealed: false
@@ -1237,10 +1238,10 @@ on_dst_change:
   slug: on-dst-change
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 pat_schaden:
+  claimant:
   birthdate: 1960-09-09
   city:
   concealed: false
@@ -1254,10 +1255,10 @@ pat_schaden:
   slug: pat-schaden
   state_code: AZ
   state_name: Arizona
-  user_id:
   hide_age: false
   obscure_name: false
 progress_aid3:
+  claimant:
   birthdate: 1986-03-04
   city:
   concealed: false
@@ -1271,10 +1272,10 @@ progress_aid3:
   slug: progress-aid3
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 progress_aid4:
+  claimant:
   birthdate: 1982-03-29
   city:
   concealed: false
@@ -1288,10 +1289,10 @@ progress_aid4:
   slug: progress-aid4
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 progress_cascade:
+  claimant:
   birthdate: 1997-05-20
   city: Provo
   concealed: false
@@ -1305,10 +1306,10 @@ progress_cascade:
   slug: progress-cascade
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 progress_lap1:
+  claimant:
   birthdate: 1967-03-21
   city:
   concealed: false
@@ -1322,10 +1323,10 @@ progress_lap1:
   slug: progress-lap1
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 progress_lap2:
+  claimant:
   birthdate: 1992-10-06
   city:
   concealed: false
@@ -1339,10 +1340,10 @@ progress_lap2:
   slug: progress-lap2
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 progress_lap5_partial:
+  claimant:
   birthdate: 1988-09-15
   city:
   concealed: false
@@ -1356,10 +1357,10 @@ progress_lap5_partial:
   slug: progress-lap5-partial
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 progress_lap6:
+  claimant:
   birthdate:
   city:
   concealed: false
@@ -1373,10 +1374,10 @@ progress_lap6:
   slug: progress-lap6
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 progress_rolling:
+  claimant:
   birthdate: 1962-04-23
   city:
   concealed: false
@@ -1390,10 +1391,10 @@ progress_rolling:
   slug: progress-rolling
   state_code: CA
   state_name: California
-  user_id:
   hide_age: false
   obscure_name: false
 progress_sherman:
+  claimant:
   birthdate: 1982-07-28
   city:
   concealed: false
@@ -1407,10 +1408,10 @@ progress_sherman:
   slug: progress-sherman
   state_code: ID
   state_name: Idaho
-  user_id:
   hide_age: false
   obscure_name: false
 progress_sherman_colorado_us:
+  claimant:
   birthdate: 1977-12-15
   city:
   concealed: false
@@ -1424,10 +1425,10 @@ progress_sherman_colorado_us:
   slug: progress-sherman-colorado-us
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 rachelle_eichmann:
+  claimant:
   birthdate: 1992-01-11
   city: Tamartown
   concealed: false
@@ -1441,10 +1442,10 @@ rachelle_eichmann:
   slug: rachelle-eichmann
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 raphael_swift:
+  claimant:
   birthdate: 1974-07-14
   city:
   concealed: false
@@ -1458,10 +1459,10 @@ raphael_swift:
   slug: raphael-swift
   state_code: AR
   state_name: Arkansas
-  user_id:
   hide_age: false
   obscure_name: false
 rene_mclaughlin:
+  claimant:
   birthdate: 1984-04-30
   city:
   concealed: false
@@ -1475,10 +1476,10 @@ rene_mclaughlin:
   slug: rene-mclaughlin
   state_code: TX
   state_name: Texas
-  user_id:
   hide_age: false
   obscure_name: false
 robby_gerlach:
+  claimant:
   birthdate: 1970-05-18
   city:
   concealed: false
@@ -1492,10 +1493,10 @@ robby_gerlach:
   slug: robby-gerlach
   state_code: VA
   state_name: Virginia
-  user_id:
   hide_age: false
   obscure_name: false
 robt_wintheiser:
+  claimant:
   birthdate:
   city: Durango
   concealed: false
@@ -1509,10 +1510,10 @@ robt_wintheiser:
   slug: robt-wintheiser
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 samara_vandervort:
+  claimant:
   birthdate: 1992-12-15
   city: Truckee
   concealed: false
@@ -1526,10 +1527,10 @@ samara_vandervort:
   slug: samara-vandervort
   state_code: CA
   state_name: California
-  user_id:
   hide_age: false
   obscure_name: false
 santa_green:
+  claimant:
   birthdate: 1977-10-27
   city:
   concealed: false
@@ -1543,10 +1544,10 @@ santa_green:
   slug: santa-green
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 series_finisher:
+  claimant:
   birthdate: 1983-03-03
   city: Louisville
   concealed: false
@@ -1560,10 +1561,10 @@ series_finisher:
   slug: series-finisher
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 shad_hirthe:
+  claimant:
   birthdate: 1975-09-05
   city: Crested Butte
   concealed: false
@@ -1577,10 +1578,10 @@ shad_hirthe:
   slug: shad-hirthe
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 slow_finisher:
+  claimant:
   birthdate: 1953-03-03
   city: Orem
   concealed: false
@@ -1594,10 +1595,10 @@ slow_finisher:
   slug: slow-finisher
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 start_only:
+  claimant:
   birthdate: 1972-12-19
   city:
   concealed: false
@@ -1611,10 +1612,10 @@ start_only:
   slug: start-only
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 start_only_2019_02_01:
+  claimant:
   birthdate: 1968-07-11
   city:
   concealed: false
@@ -1628,10 +1629,10 @@ start_only_2019_02_01:
   slug: start-only-2019-02-01
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 start_only_2019_02_01_07_19_53:
+  claimant:
   birthdate: 1985-11-14
   city:
   concealed: false
@@ -1645,10 +1646,10 @@ start_only_2019_02_01_07_19_53:
   slug: start-only-2019-02-01-07-19-53
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 start_only_colorado_us:
+  claimant:
   birthdate: 1989-09-09
   city: Aurora
   concealed: false
@@ -1662,10 +1663,10 @@ start_only_colorado_us:
   slug: start-only-colorado-us
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 start_only_colorado_us_2019_02_01:
+  claimant:
   birthdate: 1967-10-27
   city:
   concealed: false
@@ -1679,10 +1680,10 @@ start_only_colorado_us_2019_02_01:
   slug: start-only-colorado-us-2019-02-01
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 start_only_maine_us:
+  claimant:
   birthdate: 1990-04-23
   city:
   concealed: false
@@ -1696,10 +1697,10 @@ start_only_maine_us:
   slug: start-only-maine-us
   state_code: ME
   state_name: Maine
-  user_id:
   hide_age: false
   obscure_name: false
 susanna_abshire:
+  claimant:
   birthdate: 1980-08-17
   city:
   concealed: false
@@ -1713,10 +1714,10 @@ susanna_abshire:
   slug: susanna-abshire
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 tuan_jacobs:
+  claimant:
   birthdate: 1998-03-19
   city:
   concealed: false
@@ -1730,10 +1731,10 @@ tuan_jacobs:
   slug: tuan-jacobs
   state_code:
   state_name:
-  user_id:
   hide_age: false
   obscure_name: false
 un_started:
+  claimant:
   birthdate: 1988-09-01
   city: Fort Collins
   concealed: false
@@ -1747,10 +1748,10 @@ un_started:
   slug: un-started
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 vern_buckridge:
+  claimant:
   birthdate: 1981-10-15
   city:
   concealed: false
@@ -1764,10 +1765,10 @@ vern_buckridge:
   slug: vern-buckridge
   state_code: TX
   state_name: Texas
-  user_id:
   hide_age: false
   obscure_name: false
 vesta_borer:
+  claimant:
   birthdate: 1995-04-24
   city:
   concealed: false
@@ -1781,10 +1782,10 @@ vesta_borer:
   slug: vesta-borer
   state_code: UT
   state_name: Utah
-  user_id:
   hide_age: false
   obscure_name: false
 vince_willms:
+  claimant:
   birthdate: 1964-10-22
   city:
   concealed: false
@@ -1798,10 +1799,10 @@ vince_willms:
   slug: vince-willms
   state_code: CO
   state_name: Colorado
-  user_id:
   hide_age: false
   obscure_name: false
 willis_murray:
+  claimant:
   birthdate: 1998-02-04
   city:
   concealed: false
@@ -1815,10 +1816,10 @@ willis_murray:
   slug: willis-murray
   state_code: FL
   state_name: Florida
-  user_id:
   hide_age: false
   obscure_name: false
 without_start:
+  claimant:
   birthdate: 1965-04-23
   city:
   concealed: false
@@ -1832,6 +1833,5 @@ without_start:
   slug: without-start
   state_code: MT
   state_name: Montana
-  user_id:
   hide_age: false
   obscure_name: false

--- a/spec/fixtures/raw_times.yml
+++ b/spec/fixtures/raw_times.yml
@@ -1,10 +1,11 @@
 ---
 raw_time_0001:
+  creator: admin_user
+  reviewer: admin_user
   id: 49
   absolute_time: 2017-07-07 16:31:00.000000000 Z
   bib_number: '102'
   bitkey: 1
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -14,7 +15,6 @@ raw_time_0001:
   parameterized_split_name: pole-creek
   remarks:
   reviewed_at: 2017-07-08 22:38:12.817174000 Z
-  reviewed_by: 1
   sortable_bib_number: 102
   source: internal
   split_name: Pole Creek
@@ -22,11 +22,12 @@ raw_time_0001:
   stopped_here:
   with_pacer:
 raw_time_0002:
+  creator: admin_user
+  reviewer: admin_user
   id: 50
   absolute_time: 2017-07-07 20:20:00.000000000 Z
   bib_number: '103'
   bitkey: 64
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -36,7 +37,6 @@ raw_time_0002:
   parameterized_split_name: pole-creek
   remarks:
   reviewed_at: 2017-07-08 22:38:12.817174000 Z
-  reviewed_by: 1
   sortable_bib_number: 103
   source: internal
   split_name: Pole Creek
@@ -44,11 +44,12 @@ raw_time_0002:
   stopped_here:
   with_pacer:
 raw_time_0003:
+  creator: admin_user
+  reviewer:
   id: 67
   absolute_time:
   bib_number: '130'
   bitkey: 1
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -58,7 +59,6 @@ raw_time_0003:
   parameterized_split_name: molas-pass-aid1
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 130
   source: ost-live-entry
   split_name: Molas Pass (Aid1)
@@ -66,11 +66,12 @@ raw_time_0003:
   stopped_here:
   with_pacer: false
 raw_time_0004:
+  creator: admin_user
+  reviewer:
   id: 68
   absolute_time:
   bib_number: '130'
   bitkey: 64
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -80,7 +81,6 @@ raw_time_0004:
   parameterized_split_name: molas-pass-aid1
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 130
   source: ost-live-entry
   split_name: Molas Pass (Aid1)
@@ -88,11 +88,12 @@ raw_time_0004:
   stopped_here:
   with_pacer: false
 raw_time_0005:
+  creator: admin_user
+  reviewer:
   id: 69
   absolute_time:
   bib_number: '999'
   bitkey: 1
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -102,7 +103,6 @@ raw_time_0005:
   parameterized_split_name: anvil-cg-aid6
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Anvil CG (Aid6)
@@ -110,11 +110,12 @@ raw_time_0005:
   stopped_here:
   with_pacer: false
 raw_time_0006:
+  creator: admin_user
+  reviewer:
   id: 70
   absolute_time:
   bib_number: '999'
   bitkey: 64
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -124,7 +125,6 @@ raw_time_0006:
   parameterized_split_name: anvil-cg-aid6
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Anvil CG (Aid6)
@@ -132,11 +132,12 @@ raw_time_0006:
   stopped_here:
   with_pacer: false
 raw_time_0007:
+  creator: admin_user
+  reviewer:
   id: 73
   absolute_time:
   bib_number: '999'
   bitkey: 1
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -146,7 +147,6 @@ raw_time_0007:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
@@ -154,11 +154,12 @@ raw_time_0007:
   stopped_here:
   with_pacer: false
 raw_time_0008:
+  creator: admin_user
+  reviewer:
   id: 74
   absolute_time:
   bib_number: '999'
   bitkey: 64
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -168,7 +169,6 @@ raw_time_0008:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
@@ -176,11 +176,12 @@ raw_time_0008:
   stopped_here:
   with_pacer: false
 raw_time_0009:
+  creator: admin_user
+  reviewer: admin_user
   id: 75
   absolute_time:
   bib_number: '130'
   bitkey: 1
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -190,7 +191,6 @@ raw_time_0009:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
-  reviewed_by: 1
   sortable_bib_number: 130
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
@@ -198,11 +198,12 @@ raw_time_0009:
   stopped_here:
   with_pacer: false
 raw_time_0010:
+  creator: admin_user
+  reviewer: admin_user
   id: 76
   absolute_time:
   bib_number: '130'
   bitkey: 64
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -212,7 +213,6 @@ raw_time_0010:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
-  reviewed_by: 1
   sortable_bib_number: 130
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
@@ -220,11 +220,12 @@ raw_time_0010:
   stopped_here:
   with_pacer: false
 raw_time_0011:
+  creator: admin_user
+  reviewer:
   id: 77
   absolute_time:
   bib_number: '999'
   bitkey: 1
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -234,7 +235,6 @@ raw_time_0011:
   parameterized_split_name: start
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Start
@@ -242,11 +242,12 @@ raw_time_0011:
   stopped_here:
   with_pacer: false
 raw_time_0012:
+  creator: admin_user
+  reviewer:
   id: 78
   absolute_time:
   bib_number: '999'
   bitkey: 1
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -256,7 +257,6 @@ raw_time_0012:
   parameterized_split_name: molas-pass-aid1
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Molas Pass (Aid1)
@@ -264,11 +264,12 @@ raw_time_0012:
   stopped_here:
   with_pacer: false
 raw_time_0013:
+  creator: admin_user
+  reviewer:
   id: 79
   absolute_time:
   bib_number: '999'
   bitkey: 64
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -278,7 +279,6 @@ raw_time_0013:
   parameterized_split_name: molas-pass-aid1
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Molas Pass (Aid1)
@@ -286,11 +286,12 @@ raw_time_0013:
   stopped_here:
   with_pacer: false
 raw_time_0014:
+  creator: admin_user
+  reviewer:
   id: 80
   absolute_time:
   bib_number: '999'
   bitkey: 1
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -300,7 +301,6 @@ raw_time_0014:
   parameterized_split_name: cascade-creek-rd-aid3
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Cascade Creek Rd (Aid3)
@@ -308,11 +308,12 @@ raw_time_0014:
   stopped_here:
   with_pacer: false
 raw_time_0015:
+  creator: admin_user
+  reviewer:
   id: 81
   absolute_time:
   bib_number: '999'
   bitkey: 64
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -322,7 +323,6 @@ raw_time_0015:
   parameterized_split_name: cascade-creek-rd-aid3
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Cascade Creek Rd (Aid3)
@@ -330,11 +330,12 @@ raw_time_0015:
   stopped_here:
   with_pacer: false
 raw_time_0016:
+  creator: admin_user
+  reviewer:
   id: 82
   absolute_time:
   bib_number: '999'
   bitkey: 1
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -344,7 +345,6 @@ raw_time_0016:
   parameterized_split_name: engineer-mtn-th-aid4
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Engineer Mtn TH (Aid4)
@@ -352,11 +352,12 @@ raw_time_0016:
   stopped_here:
   with_pacer: false
 raw_time_0017:
+  creator: admin_user
+  reviewer:
   id: 83
   absolute_time:
   bib_number: '999'
   bitkey: 64
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -366,7 +367,6 @@ raw_time_0017:
   parameterized_split_name: engineer-mtn-th-aid4
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Engineer Mtn TH (Aid4)
@@ -374,11 +374,12 @@ raw_time_0017:
   stopped_here:
   with_pacer: false
 raw_time_0018:
+  creator: admin_user
+  reviewer: admin_user
   id: 84
   absolute_time:
   bib_number: '101'
   bitkey: 1
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -388,7 +389,6 @@ raw_time_0018:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
-  reviewed_by: 1
   sortable_bib_number: 101
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
@@ -396,11 +396,12 @@ raw_time_0018:
   stopped_here:
   with_pacer: false
 raw_time_0019:
+  creator: admin_user
+  reviewer: admin_user
   id: 85
   absolute_time:
   bib_number: '101'
   bitkey: 64
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -410,7 +411,6 @@ raw_time_0019:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
-  reviewed_by: 1
   sortable_bib_number: 101
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
@@ -418,11 +418,12 @@ raw_time_0019:
   stopped_here:
   with_pacer: false
 raw_time_0020:
+  creator:
+  reviewer: admin_user
   id: 86
   absolute_time:
   bib_number: '999'
   bitkey: 1
-  created_by:
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -432,7 +433,6 @@ raw_time_0020:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
-  reviewed_by: 1
   sortable_bib_number: 999
   source: internal
   split_name: Rolling Pass (Aid2)
@@ -440,11 +440,12 @@ raw_time_0020:
   stopped_here:
   with_pacer:
 raw_time_0021:
+  creator:
+  reviewer: admin_user
   id: 87
   absolute_time:
   bib_number: '999'
   bitkey: 64
-  created_by:
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -454,7 +455,6 @@ raw_time_0021:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2018-04-30 22:46:06.425174000 Z
-  reviewed_by: 1
   sortable_bib_number: 999
   source: internal
   split_name: Rolling Pass (Aid2)
@@ -462,11 +462,12 @@ raw_time_0021:
   stopped_here:
   with_pacer:
 raw_time_0022:
+  creator: admin_user
+  reviewer: admin_user
   id: 88
   absolute_time:
   bib_number: '999'
   bitkey: 64
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -476,7 +477,6 @@ raw_time_0022:
   parameterized_split_name: rolling-pass-aid2
   remarks: ''
   reviewed_at: 2018-07-27 03:39:21.949460000 Z
-  reviewed_by: 1
   sortable_bib_number: 999
   source: internal
   split_name: Rolling Pass (Aid2)
@@ -484,11 +484,12 @@ raw_time_0022:
   stopped_here:
   with_pacer:
 raw_time_0023:
+  creator: admin_user
+  reviewer:
   id: 89
   absolute_time:
   bib_number: '130'
   bitkey: 64
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -498,7 +499,6 @@ raw_time_0023:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at:
-  reviewed_by:
   sortable_bib_number: 130
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
@@ -506,11 +506,12 @@ raw_time_0023:
   stopped_here: false
   with_pacer: false
 raw_time_0024:
+  creator: admin_user
+  reviewer: admin_user
   id: 91
   absolute_time: 2018-06-30 13:00:00.000000000 Z
   bib_number: '777'
   bitkey: 1
-  created_by: 1
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -520,7 +521,6 @@ raw_time_0024:
   parameterized_split_name: start
   remarks: ''
   reviewed_at: 2018-07-27 03:40:08.987644000 Z
-  reviewed_by: 1
   sortable_bib_number: 777
   source: internal
   split_name: Start
@@ -528,11 +528,12 @@ raw_time_0024:
   stopped_here: false
   with_pacer: false
 raw_time_0025:
+  creator:
+  reviewer: admin_user
   id: 92
   absolute_time:
   bib_number: '777'
   bitkey: 1
-  created_by:
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -542,7 +543,6 @@ raw_time_0025:
   parameterized_split_name: start
   remarks:
   reviewed_at: 2018-07-27 03:24:12.907737000 Z
-  reviewed_by: 1
   sortable_bib_number: 777
   source: internal
   split_name: Start
@@ -550,11 +550,12 @@ raw_time_0025:
   stopped_here: false
   with_pacer: false
 raw_time_0026:
+  creator:
+  reviewer: admin_user
   id: 176
   absolute_time:
   bib_number: '130'
   bitkey: 1
-  created_by:
   data_status:
   disassociated_from_effort:
   entered_lap:
@@ -564,7 +565,6 @@ raw_time_0026:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2018-11-14 05:48:02.521295000 Z
-  reviewed_by: 1
   sortable_bib_number: 130
   source: another
   split_name: Rolling Pass (Aid2)
@@ -572,11 +572,12 @@ raw_time_0026:
   stopped_here: false
   with_pacer: false
 raw_time_0027:
+  creator: admin_user
+  reviewer: admin_user
   id: 177
   absolute_time:
   bib_number: '130'
   bitkey: 1
-  created_by: 1
   data_status: 0
   disassociated_from_effort:
   entered_lap:
@@ -586,7 +587,6 @@ raw_time_0027:
   parameterized_split_name: rolling-pass-aid2
   remarks: ''
   reviewed_at: 2018-11-14 05:48:25.812628000 Z
-  reviewed_by: 1
   sortable_bib_number: 130
   source: another
   split_name: Rolling Pass (Aid2)
@@ -594,11 +594,12 @@ raw_time_0027:
   stopped_here: false
   with_pacer: false
 raw_time_0028:
+  creator: admin_user
+  reviewer: admin_user
   id: 178
   absolute_time:
   bib_number: '130'
   bitkey: 1
-  created_by: 1
   data_status: 0
   disassociated_from_effort:
   entered_lap:
@@ -608,7 +609,6 @@ raw_time_0028:
   parameterized_split_name: rolling-pass-aid2
   remarks: ''
   reviewed_at: 2018-11-14 05:48:27.582171000 Z
-  reviewed_by: 1
   sortable_bib_number: 130
   source: another
   split_name: Rolling Pass (Aid2)
@@ -616,11 +616,12 @@ raw_time_0028:
   stopped_here: false
   with_pacer: false
 raw_time_0029:
+  creator: admin_user
+  reviewer: admin_user
   id: 1100
   absolute_time:
   bib_number: '130'
   bitkey: 1
-  created_by: 1
   data_status: 2
   disassociated_from_effort:
   entered_lap:
@@ -630,7 +631,6 @@ raw_time_0029:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2018-11-14 05:48:22.553830000 Z
-  reviewed_by: 1
   sortable_bib_number: 130
   source: Live Entry (1)
   split_name: Rolling Pass (Aid2)
@@ -638,11 +638,12 @@ raw_time_0029:
   stopped_here: false
   with_pacer: false
 raw_time_0030:
+  creator: admin_user
+  reviewer: admin_user
   id: 1106
   absolute_time:
   bib_number: '103'
   bitkey: 64
-  created_by: 1
   data_status: 2
   disassociated_from_effort:
   entered_lap:
@@ -652,7 +653,6 @@ raw_time_0030:
   parameterized_split_name: bandera-mine-aid5
   remarks:
   reviewed_at: 2018-12-09 02:24:15.750492000 Z
-  reviewed_by: 1
   sortable_bib_number: 103
   source: Live Entry (1)
   split_name: Bandera Mine (Aid5)
@@ -660,11 +660,12 @@ raw_time_0030:
   stopped_here: false
   with_pacer: false
 raw_time_0031:
+  creator: admin_user
+  reviewer: admin_user
   id: 1110
   absolute_time:
   bib_number: '103'
   bitkey: 1
-  created_by: 1
   data_status: 2
   disassociated_from_effort:
   entered_lap:
@@ -674,7 +675,6 @@ raw_time_0031:
   parameterized_split_name: anvil-cg-aid6
   remarks:
   reviewed_at: 2018-12-09 02:25:03.158304000 Z
-  reviewed_by: 1
   sortable_bib_number: 103
   source: Live Entry (1)
   split_name: Anvil CG (Aid6)
@@ -682,11 +682,12 @@ raw_time_0031:
   stopped_here: false
   with_pacer: false
 raw_time_0032:
+  creator: admin_user
+  reviewer: admin_user
   id: 1111
   absolute_time:
   bib_number: '103'
   bitkey: 64
-  created_by: 1
   data_status: 2
   disassociated_from_effort:
   entered_lap:
@@ -696,7 +697,6 @@ raw_time_0032:
   parameterized_split_name: anvil-cg-aid6
   remarks:
   reviewed_at: 2018-12-09 02:26:54.169992000 Z
-  reviewed_by: 1
   sortable_bib_number: 103
   source: Live Entry (1)
   split_name: Anvil CG (Aid6)
@@ -704,11 +704,12 @@ raw_time_0032:
   stopped_here: true
   with_pacer: false
 raw_time_0033:
+  creator: admin_user
+  reviewer: admin_user
   id: 1117
   absolute_time:
   bib_number: '103'
   bitkey: 1
-  created_by: 1
   data_status: 2
   disassociated_from_effort:
   entered_lap:
@@ -718,7 +719,6 @@ raw_time_0033:
   parameterized_split_name: anvil-cg-aid6
   remarks:
   reviewed_at: 2018-12-15 17:29:59.171376000 Z
-  reviewed_by: 1
   sortable_bib_number: 103
   source: Live Entry (1)
   split_name: Anvil CG (Aid6)
@@ -726,11 +726,12 @@ raw_time_0033:
   stopped_here: true
   with_pacer: false
 raw_time_0034:
+  creator: admin_user
+  reviewer: admin_user
   id: 1122
   absolute_time:
   bib_number: '101'
   bitkey: 1
-  created_by: 1
   data_status: 2
   disassociated_from_effort:
   entered_lap:
@@ -740,7 +741,6 @@ raw_time_0034:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2019-01-25 00:23:15.068615000 Z
-  reviewed_by: 1
   sortable_bib_number: 101
   source: Live Entry (1)
   split_name: Rolling Pass (Aid2)
@@ -748,11 +748,12 @@ raw_time_0034:
   stopped_here: false
   with_pacer: false
 raw_time_0035:
+  creator: admin_user
+  reviewer: admin_user
   id: 1123
   absolute_time:
   bib_number: '101'
   bitkey: 64
-  created_by: 1
   data_status: 2
   disassociated_from_effort:
   entered_lap:
@@ -762,7 +763,6 @@ raw_time_0035:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2019-01-25 00:23:15.075358000 Z
-  reviewed_by: 1
   sortable_bib_number: 101
   source: Live Entry (1)
   split_name: Rolling Pass (Aid2)
@@ -770,11 +770,12 @@ raw_time_0035:
   stopped_here: false
   with_pacer: false
 raw_time_0036:
+  creator: admin_user
+  reviewer: admin_user
   id: 1124
   absolute_time:
   bib_number: '101'
   bitkey: 1
-  created_by: 1
   data_status: 2
   disassociated_from_effort:
   entered_lap:
@@ -784,7 +785,6 @@ raw_time_0036:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2019-01-25 00:23:57.468470000 Z
-  reviewed_by: 1
   sortable_bib_number: 101
   source: Live Entry (1)
   split_name: Rolling Pass (Aid2)
@@ -792,11 +792,12 @@ raw_time_0036:
   stopped_here: false
   with_pacer: false
 raw_time_0037:
+  creator: admin_user
+  reviewer: admin_user
   id: 1125
   absolute_time:
   bib_number: '101'
   bitkey: 64
-  created_by: 1
   data_status: 2
   disassociated_from_effort:
   entered_lap:
@@ -806,7 +807,6 @@ raw_time_0037:
   parameterized_split_name: rolling-pass-aid2
   remarks:
   reviewed_at: 2019-01-25 00:23:57.472413000 Z
-  reviewed_by: 1
   sortable_bib_number: 101
   source: Live Entry (1)
   split_name: Rolling Pass (Aid2)
@@ -814,11 +814,12 @@ raw_time_0037:
   stopped_here: false
   with_pacer: false
 raw_time_0038:
+  creator: admin_user
+  reviewer: admin_user
   id: 1126
   absolute_time:
   bib_number: '114'
   bitkey: 1
-  created_by: 1
   data_status: 2
   disassociated_from_effort:
   entered_lap:
@@ -828,7 +829,6 @@ raw_time_0038:
   parameterized_split_name: start
   remarks:
   reviewed_at: 2019-01-25 00:25:12.563910000 Z
-  reviewed_by: 1
   sortable_bib_number: 114
   source: Live Entry (1)
   split_name: Start

--- a/spec/fixtures/subscriptions.yml
+++ b/spec/fixtures/subscriptions.yml
@@ -1,17 +1,17 @@
 ---
 subscription_0001:
+  user: admin_user
   id: 2
   endpoint:
   protocol: 1
   resource_key: arn:aws:sns:us-west-2:998989370925:d-follow-rufa-2017-12h-not-started:c7853bd1-f4c2-44e8-bb25-e814aafdf134
   subscribable_id: 16673
   subscribable_type: Effort
-  user_id: 1
 subscription_0002:
+  user: admin_user
   id: 4
   endpoint:
   protocol: 0
   resource_key: arn:aws:sns:us-west-2:998989370925:d-follow-rufa-2017-12h-not-started:c7853bd1-f4c2-44e8-bb25-e814aafdf134
   subscribable_id: 16673
   subscribable_type: Effort
-  user_id: 1

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,6 +1,5 @@
 ---
 admin_user:
-  id: 1
   confirmed_at: 2016-04-16 19:25:07.374438000 Z
   current_sign_in_at: 2022-03-08 08:40:31.063076000 Z
   current_sign_in_ip: 127.0.0.1
@@ -25,20 +24,19 @@ admin_user:
   uid:
   unconfirmed_email:
   sms_carrier_opted_out_at:
-third_user:
-  id: 3
-  confirmed_at: 2016-04-16 19:25:07.514373000 Z
-  current_sign_in_at: 2019-01-25 22:45:17.386817000 Z
+fifth_user:
+  confirmed_at: 2018-01-10 06:34:50.173537000 Z
+  current_sign_in_at: 2018-01-10 06:35:01.065288000 Z
   current_sign_in_ip: 127.0.0.1
-  email: thirduser@example.com
-  encrypted_password: "$2a$10$/i14/9oGIR.0UWJaQYofNOeS85UAUgU0LOpd9C1mn.x4ZJxIZTSCy"
-  first_name: Third
+  email: fifthuser@example.com
+  encrypted_password: "$2a$10$OEXtV8bNIUspArW48HCjGO86WR3aUnPqSJLClYo.kINpUvdSFBQxu"
+  first_name: Fifth
   http_endpoint:
   https_endpoint:
   last_name: User
-  last_sign_in_at: 2019-01-25 22:41:52.540192000 Z
+  last_sign_in_at: 2018-01-10 06:35:01.065288000 Z
   last_sign_in_ip: 127.0.0.1
-  phone:
+  phone: "+13038806481"
   phone_confirmation_sent_at:
   phone_confirmation_token:
   phone_confirmed_at:
@@ -46,13 +44,12 @@ third_user:
   pref_elevation_unit: 0
   provider:
   role: 0
-  sign_in_count: 22
-  slug: third-user
+  sign_in_count: 1
+  slug: fifth-user
   uid:
   unconfirmed_email:
   sms_carrier_opted_out_at:
 fourth_user:
-  id: 4
   confirmed_at: 2016-04-16 19:25:07.568372000 Z
   current_sign_in_at:
   current_sign_in_ip:
@@ -77,20 +74,19 @@ fourth_user:
   uid:
   unconfirmed_email:
   sms_carrier_opted_out_at:
-fifth_user:
-  id: 11
-  confirmed_at: 2018-01-10 06:34:50.173537000 Z
-  current_sign_in_at: 2018-01-10 06:35:01.065288000 Z
+third_user:
+  confirmed_at: 2016-04-16 19:25:07.514373000 Z
+  current_sign_in_at: 2019-01-25 22:45:17.386817000 Z
   current_sign_in_ip: 127.0.0.1
-  email: fifthuser@example.com
-  encrypted_password: "$2a$10$OEXtV8bNIUspArW48HCjGO86WR3aUnPqSJLClYo.kINpUvdSFBQxu"
-  first_name: Fifth
+  email: thirduser@example.com
+  encrypted_password: "$2a$10$/i14/9oGIR.0UWJaQYofNOeS85UAUgU0LOpd9C1mn.x4ZJxIZTSCy"
+  first_name: Third
   http_endpoint:
   https_endpoint:
   last_name: User
-  last_sign_in_at: 2018-01-10 06:35:01.065288000 Z
+  last_sign_in_at: 2019-01-25 22:41:52.540192000 Z
   last_sign_in_ip: 127.0.0.1
-  phone: "+13038806481"
+  phone:
   phone_confirmation_sent_at:
   phone_confirmation_token:
   phone_confirmed_at:
@@ -98,8 +94,8 @@ fifth_user:
   pref_elevation_unit: 0
   provider:
   role: 0
-  sign_in_count: 1
-  slug: fifth-user
+  sign_in_count: 22
+  slug: third-user
   uid:
   unconfirmed_email:
   sms_carrier_opted_out_at:

--- a/spec/models/raw_time_spec.rb
+++ b/spec/models/raw_time_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe RawTime, type: :model do
       before { raw_time.save! }
 
       it "broadcasts a turbo stream to the event group channel" do
-        expect { raw_time.update!(reviewed_by: 1) }
+        expect { raw_time.update!(reviewed_by: users(:admin_user).id) }
           .to have_enqueued_job(Turbo::Streams::BroadcastJob)
           .on_queue(:default)
       end


### PR DESCRIPTION
## Summary

Makes `users` a portable fixture table — the last of the tables that hardcoded ids in `spec/fixtures`. Users are now assigned ids by Rails and referenced by label rather than a pinned `id`.

- Add `:users` to `PORTABLE_FIXTURE_TABLES` and drop the explicit ids from `users.yml`.
- Update referencing fixtures to use association labels instead of `user_id`/`created_by`/`reviewed_by`:
  - `credentials` → `user`
  - `subscriptions` → `user`
  - `people` → `claimant`
  - `raw_times` → `creator` / `reviewer`

### `created_by` columns without an association

`organizations` and `event_groups` referenced users through the un-associated `created_by` column. The fixture dump can only portably represent FKs that are backed by a `belongs_to` to a portable table, so these would otherwise have been left as a now-meaningless hardcoded `created_by: 1`.

To fix this properly, mirroring the existing `RawTime#creator`/`#reviewer` pattern:

- `Organization belongs_to :owner` (replaces the hand-rolled `#owner` method) → fixtures dump as `owner: admin_user`.
- `EventGroup belongs_to :creator` → fixtures dump as `creator: admin_user`.

### Spec/factory fallout from unpinning ids

- `spec/factories/organization.rb` hardcoded `owner_id { 1 }`, which failed `OwnerExistsValidator` once no user had id 1 (this cascaded into a large number of failures via `create(:course)`/`create(:event_group)` etc.). It now resolves the admin user by fixture identity.
- `raw_time_spec` hardcoded `reviewed_by: 1`, which violated the FK constraint; it now references the admin user's id.

## Testing

Ran a focused local selection (~330 examples across model, controller, presenter, request, and ETL specs touching the affected fixtures and associations) — all green, rubocop clean. Relying on CI for the full suite.