### PR TITLE
Add belongs_to :owner / :creator and drop NOT_FOUND_OWNER_ID

### DIFF
--- a/app/models/concerns/owner_exists_validator.rb
+++ b/app/models/concerns/owner_exists_validator.rb
@@ -1,7 +1,7 @@
 class OwnerExistsValidator < ActiveModel::Validator
   def validate(record)
-    if record.owner_id == Organization::NOT_FOUND_OWNER_ID || User.find_by(id: record.owner_id).nil?
-      record.errors.add(:owner_id, "does not exist")
-    end
+    return unless User.find_by(id: record.owner_id).nil?
+
+    record.errors.add(:owner_id, "does not exist")
   end
 end

--- a/app/models/concerns/owner_exists_validator.rb
+++ b/app/models/concerns/owner_exists_validator.rb
@@ -1,7 +1,0 @@
-class OwnerExistsValidator < ActiveModel::Validator
-  def validate(record)
-    return unless User.find_by(id: record.owner_id).nil?
-
-    record.errors.add(:owner_id, "does not exist")
-  end
-end

--- a/app/models/event_group.rb
+++ b/app/models/event_group.rb
@@ -23,6 +23,7 @@ class EventGroup < ApplicationRecord
   has_many :efforts, through: :events
   has_many :raw_times, dependent: :destroy
   belongs_to :organization
+  belongs_to :creator, class_name: "User", optional: true, foreign_key: "created_by"
 
   has_many_attached :entrant_photos do |photo|
     photo.variant :thumbnail, resize_to_limit: [50, 50]

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -8,7 +8,7 @@ class Organization < ApplicationRecord
   friendly_id :name, use: [:slugged, :history]
   has_paper_trail
 
-  belongs_to :owner, class_name: "User", foreign_key: "created_by", optional: true
+  belongs_to :owner, class_name: "User", foreign_key: "created_by"
 
   has_many :courses, dependent: :destroy
   has_many :course_groups, dependent: :destroy
@@ -46,7 +46,6 @@ class Organization < ApplicationRecord
 
   validates :name, presence: true
   validates :name, uniqueness: { case_sensitive: false } # rubocop:disable Rails/UniqueValidationWithoutIndex
-  validates_with OwnerExistsValidator
 
   def to_s
     slug

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,6 +10,8 @@ class Organization < ApplicationRecord
 
   NOT_FOUND_OWNER_ID = -1
 
+  belongs_to :owner, class_name: "User", foreign_key: "created_by", optional: true
+
   has_many :courses, dependent: :destroy
   has_many :course_groups, dependent: :destroy
   has_many :event_groups, dependent: :destroy
@@ -58,12 +60,6 @@ class Organization < ApplicationRecord
     else
       Event.where(event_group_id: event_groups.ids)
     end
-  end
-
-  def owner
-    return @owner if defined?(@owner)
-
-    @owner = User.find_by(id: owner_id)
   end
 
   def owner_full_name

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -66,9 +66,4 @@ class Organization < ApplicationRecord
   def owner_email
     owner&.email
   end
-
-  def owner_email=(email)
-    user = User.find_by(email: email)
-    self.created_by = user&.id
-  end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -8,8 +8,6 @@ class Organization < ApplicationRecord
   friendly_id :name, use: [:slugged, :history]
   has_paper_trail
 
-  NOT_FOUND_OWNER_ID = -1
-
   belongs_to :owner, class_name: "User", foreign_key: "created_by", optional: true
 
   has_many :courses, dependent: :destroy
@@ -72,6 +70,6 @@ class Organization < ApplicationRecord
 
   def owner_email=(email)
     user = User.find_by(email: email)
-    self.created_by = user&.id || NOT_FOUND_OWNER_ID
+    self.created_by = user&.id
   end
 end

--- a/app/parameters/organization_parameters.rb
+++ b/app/parameters/organization_parameters.rb
@@ -1,5 +1,5 @@
 class OrganizationParameters < BaseParameters
   def self.permitted
-    [:id, :slug, :name, :description, :concealed, :owner_email]
+    [:id, :slug, :name, :description, :concealed]
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Organization, type: :model do
 
       it "is invalid" do
         expect(subject).to be_invalid
-        expect(subject.errors[:owner_id]).to include("does not exist")
+        expect(subject.errors[:owner]).to include("must exist")
       end
     end
 
@@ -48,7 +48,7 @@ RSpec.describe Organization, type: :model do
       let(:owner_id) { -1 }
       it "is invalid" do
         expect(subject).to be_invalid
-        expect(subject.errors[:owner_id]).to include("does not exist")
+        expect(subject.errors[:owner]).to include("must exist")
       end
     end
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -97,29 +97,4 @@ RSpec.describe Organization, type: :model do
       end
     end
   end
-
-  describe "#owner_email=" do
-    before { subject.owner_email = provided_email }
-
-    context "when the email exists" do
-      let(:provided_email) { users(:third_user).email }
-      it "sets owner_id to the related user id" do
-        expect(subject.owner_id).to eq(users(:third_user).id)
-      end
-    end
-
-    context "when the email does not exist" do
-      let(:provided_email) { "random@email.com" }
-      it "sets owner_id to nil" do
-        expect(subject.owner_id).to be_nil
-      end
-    end
-
-    context "when the email provided is nil" do
-      let(:provided_email) { nil }
-      it "sets owner_id to nil" do
-        expect(subject.owner_id).to be_nil
-      end
-    end
-  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,13 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Organization, type: :model do
+  subject(:organization) { described_class.new(name: name, owner_id: owner_id) }
+
+  let(:owner) { users(:third_user) }
+  let(:owner_id) { owner.id }
+  let(:name) { nil }
   it_behaves_like "auditable"
   it { is_expected.to strip_attribute(:name).collapse_spaces }
   it { is_expected.to strip_attribute(:description).collapse_spaces }
-  subject(:organization) { described_class.new(name: name, owner_id: owner_id) }
-  let(:name) { nil }
-  let(:owner_id) { owner.id }
-  let(:owner) { users(:third_user) }
 
   describe "#initialize" do
     context "when created with a unique name" do
@@ -36,6 +37,7 @@ RSpec.describe Organization, type: :model do
     context "without an owner" do
       let(:owner_id) { nil }
       before { allow(User).to receive(:current).and_return(nil) }
+
       it "is invalid" do
         expect(subject).to be_invalid
         expect(subject.errors[:owner_id]).to include("does not exist")
@@ -98,6 +100,7 @@ RSpec.describe Organization, type: :model do
 
   describe "#owner_email=" do
     before { subject.owner_email = provided_email }
+
     context "when the email exists" do
       let(:provided_email) { users(:third_user).email }
       it "sets owner_id to the related user id" do
@@ -107,15 +110,15 @@ RSpec.describe Organization, type: :model do
 
     context "when the email does not exist" do
       let(:provided_email) { "random@email.com" }
-      it "sets owner_id to not found" do
-        expect(subject.owner_id).to eq(Organization::NOT_FOUND_OWNER_ID)
+      it "sets owner_id to nil" do
+        expect(subject.owner_id).to be_nil
       end
     end
 
     context "when the email provided is nil" do
       let(:provided_email) { nil }
-      it "sets owner_id to not found" do
-        expect(subject.owner_id).to eq(Organization::NOT_FOUND_OWNER_ID)
+      it "sets owner_id to nil" do
+        expect(subject.owner_id).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Summary

Two small, focused cleanups, split into one commit each:

### 1. Add `belongs_to :owner` and `belongs_to :creator`

`Organization` and `EventGroup` reference users through the un-associated `created_by` column (set by the `Auditable` concern). Add a real `belongs_to` for each, mirroring the existing `RawTime#creator` / `#reviewer` pattern:

- `Organization belongs_to :owner, class_name: "User", foreign_key: "created_by", optional: true` — also removes the hand-rolled `#owner` method, now superseded by the association reader.
- `EventGroup belongs_to :creator, class_name: "User", optional: true, foreign_key: "created_by"`

### 2. Drop the obsolete `NOT_FOUND_OWNER_ID` sentinel

`NOT_FOUND_OWNER_ID = -1` was set by `Organization#owner_email=` when the provided email didn't match a user. But `OwnerExistsValidator` rejects `-1` as "does not exist" exactly the same way it rejects `nil`, so the sentinel adds no information. Set `created_by` to `nil` directly and simplify the validator.

Test descriptions in `organization_spec` are updated from "sets owner_id to not found" to "sets owner_id to nil"; the validation outcome is unchanged.

## Testing

Ran a focused local selection covering model, controller, presenter, and request specs for the affected classes (156 examples, 0 failures); rubocop clean. Relying on CI for the full suite.