### PR TITLE
Make event_groups a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -40,6 +40,7 @@ module FixtureHelper
   PORTABLE_FIXTURE_TABLES = [
     :course_groups,
     :credentials,
+    :event_groups,
     :historical_facts,
     :lotteries,
     :organizations,

--- a/spec/fixtures/connections.yml
+++ b/spec/fixtures/connections.yml
@@ -1,8 +1,7 @@
 ---
 connection_0001:
+  destination: rufa_2017 (EventGroup)
   id: 1
-  destination_id: 59
-  destination_type: EventGroup
   service_identifier: runsignup
   source_id: '123'
   source_type: Race

--- a/spec/fixtures/event_groups.yml
+++ b/spec/fixtures/event_groups.yml
@@ -1,20 +1,18 @@
 ---
-ramble:
-  organization: rattlesnake_ramble
+dirty_30:
+  organization: dirty_30_running
   creator: admin_user
-  id: 4
-  available_live: false
+  available_live: true
   concealed: false
-  data_entry_grouping_strategy: 0
+  data_entry_grouping_strategy: 1
   home_time_zone: Mountain Time (US & Canada)
   monitor_pacers: false
-  name: Ramble
-  slug: ramble
+  name: Dirty 30
+  slug: dirty-30
   webhook_token:
 hardrock_2014:
   organization: hardrock
   creator: admin_user
-  id: 7
   available_live: false
   concealed: false
   data_entry_grouping_strategy: 0
@@ -26,7 +24,6 @@ hardrock_2014:
 hardrock_2015:
   organization: hardrock
   creator: admin_user
-  id: 17
   available_live: true
   concealed: false
   data_entry_grouping_strategy: 0
@@ -35,34 +32,9 @@ hardrock_2015:
   name: Hardrock 2015
   slug: hardrock-2015
   webhook_token:
-rufa_2016:
-  organization: running_up_for_air
-  creator: admin_user
-  id: 25
-  available_live: false
-  concealed: false
-  data_entry_grouping_strategy: 0
-  home_time_zone: Mountain Time (US & Canada)
-  monitor_pacers: false
-  name: RUFA 2016
-  slug: rufa-2016
-  webhook_token:
-dirty_30:
-  organization: dirty_30_running
-  creator: admin_user
-  id: 27
-  available_live: true
-  concealed: false
-  data_entry_grouping_strategy: 1
-  home_time_zone: Mountain Time (US & Canada)
-  monitor_pacers: false
-  name: Dirty 30
-  slug: dirty-30
-  webhook_token:
 hardrock_2016:
   organization: hardrock
   creator: admin_user
-  id: 28
   available_live: true
   concealed: false
   data_entry_grouping_strategy: 0
@@ -71,22 +43,31 @@ hardrock_2016:
   name: Hardrock 2016
   slug: hardrock-2016
   webhook_token:
-sum:
-  organization: dirty_30_running
+ramble:
+  organization: rattlesnake_ramble
   creator: admin_user
-  id: 32
-  available_live: true
+  available_live: false
   concealed: false
   data_entry_grouping_strategy: 0
   home_time_zone: Mountain Time (US & Canada)
   monitor_pacers: false
-  name: SUM
-  slug: sum
+  name: Ramble
+  slug: ramble
+  webhook_token:
+rufa_2016:
+  organization: running_up_for_air
+  creator: admin_user
+  available_live: false
+  concealed: false
+  data_entry_grouping_strategy: 0
+  home_time_zone: Mountain Time (US & Canada)
+  monitor_pacers: false
+  name: RUFA 2016
+  slug: rufa-2016
   webhook_token:
 rufa_2017:
   organization: running_up_for_air
   creator: admin_user
-  id: 59
   available_live: true
   concealed: false
   data_entry_grouping_strategy: 0
@@ -94,4 +75,15 @@ rufa_2017:
   monitor_pacers: false
   name: RUFA 2017
   slug: rufa-2017
+  webhook_token:
+sum:
+  organization: dirty_30_running
+  creator: admin_user
+  available_live: true
+  concealed: false
+  data_entry_grouping_strategy: 0
+  home_time_zone: Mountain Time (US & Canada)
+  monitor_pacers: false
+  name: SUM
+  slug: sum
   webhook_token:

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -1,11 +1,11 @@
 ---
 hardrock_2015:
+  event_group: hardrock_2015
   results_template: simple
   id: 4
   beacon_url:
   course_id: 4
   efforts_count: 30
-  event_group_id: 17
   historical_name: Hardrock 2015
   laps_required: 1
   notice_text:
@@ -14,12 +14,12 @@ hardrock_2015:
   slug: hardrock-2015
   topic_resource_key:
 ramble:
+  event_group: ramble
   results_template: simple
   id: 14
   beacon_url:
   course_id: 9
   efforts_count: 4
-  event_group_id: 4
   historical_name: Ramble
   laps_required: 1
   notice_text:
@@ -28,12 +28,12 @@ ramble:
   slug: ramble
   topic_resource_key:
 hardrock_2014:
+  event_group: hardrock_2014
   results_template: simple
   id: 17
   beacon_url:
   course_id: 12
   efforts_count: 19
-  event_group_id: 7
   historical_name: Hardrock 2014
   laps_required: 1
   notice_text:
@@ -42,12 +42,12 @@ hardrock_2014:
   slug: hardrock-2014
   topic_resource_key:
 rufa_2016:
+  event_group: rufa_2016
   results_template: simple
   id: 34
   beacon_url:
   course_id: 20
   efforts_count: 4
-  event_group_id: 25
   historical_name: RUFA 2016
   laps_required: 0
   notice_text:
@@ -56,12 +56,12 @@ rufa_2016:
   slug: rufa-2016
   topic_resource_key:
 rufa_2017_24h:
+  event_group: rufa_2017
   results_template: simple
   id: 36
   beacon_url:
   course_id: 20
   efforts_count: 6
-  event_group_id: 59
   historical_name: RUFA 2017 24H
   laps_required: 0
   notice_text:
@@ -70,12 +70,12 @@ rufa_2017_24h:
   slug: rufa-2017-24h
   topic_resource_key:
 hardrock_2016:
+  event_group: hardrock_2016
   results_template: simple
   id: 37
   beacon_url: http://trackleaders.com/hardrock16
   course_id: 12
   efforts_count: 19
-  event_group_id: 28
   historical_name: Hardrock 2016
   laps_required: 1
   notice_text:
@@ -84,12 +84,12 @@ hardrock_2016:
   slug: hardrock-2016
   topic_resource_key:
 ggd30_50k:
+  event_group: dirty_30
   results_template: simple
   id: 48
   beacon_url: https://goldengatedirty30.maprogress.com
   course_id: 26
   efforts_count: 8
-  event_group_id: 27
   historical_name: GGD30 50K
   laps_required: 1
   notice_text:
@@ -98,12 +98,12 @@ ggd30_50k:
   slug: ggd30-50k
   topic_resource_key:
 ggd30_12m:
+  event_group: dirty_30
   results_template: simple
   id: 49
   beacon_url:
   course_id: 27
   efforts_count: 6
-  event_group_id: 27
   historical_name: GGD30 12M
   laps_required: 1
   notice_text:
@@ -112,12 +112,12 @@ ggd30_12m:
   slug: ggd30-12m
   topic_resource_key:
 sum_100k:
+  event_group: sum
   results_template: simple
   id: 56
   beacon_url:
   course_id: 31
   efforts_count: 5
-  event_group_id: 32
   historical_name: SUM 100K
   laps_required: 1
   notice_text:
@@ -126,12 +126,12 @@ sum_100k:
   slug: sum-100k
   topic_resource_key:
 sum_55k:
+  event_group: sum
   results_template: sub_masters_masters_and_grandmasters
   id: 57
   beacon_url:
   course_id: 32
   efforts_count: 8
-  event_group_id: 32
   historical_name: SUM 55K
   laps_required: 1
   notice_text:
@@ -140,12 +140,12 @@ sum_55k:
   slug: sum-55k
   topic_resource_key:
 rufa_2017_12h:
+  event_group: rufa_2017
   results_template: simple
   id: 70
   beacon_url:
   course_id: 20
   efforts_count: 6
-  event_group_id: 59
   historical_name: RUFA 2017 12H
   laps_required: 0
   notice_text:

--- a/spec/fixtures/partners.yml
+++ b/spec/fixtures/partners.yml
@@ -1,13 +1,11 @@
 ---
 partner_0001:
+  partnerable: dirty_30 (EventGroup)
   banner_link: www.blackdiamondequipment.com
   name: Black Diamond Equipment
-  partnerable_id: 27
-  partnerable_type: EventGroup
   weight: 1
 partner_0002:
+  partnerable: sum (EventGroup)
   banner_link: blackdiamondequipment.com
   name: BD
-  partnerable_id: 32
-  partnerable_type: EventGroup
   weight: 100

--- a/spec/fixtures/raw_times.yml
+++ b/spec/fixtures/raw_times.yml
@@ -1,5 +1,6 @@
 ---
 raw_time_0001:
+  event_group: hardrock_2015
   creator: admin_user
   reviewer: admin_user
   id: 49
@@ -10,7 +11,6 @@ raw_time_0001:
   disassociated_from_effort:
   entered_lap:
   entered_time: '16:31:00'
-  event_group_id: 17
   matchable_bib_number: 102
   parameterized_split_name: pole-creek
   remarks:
@@ -22,6 +22,7 @@ raw_time_0001:
   stopped_here:
   with_pacer:
 raw_time_0002:
+  event_group: hardrock_2015
   creator: admin_user
   reviewer: admin_user
   id: 50
@@ -32,7 +33,6 @@ raw_time_0002:
   disassociated_from_effort:
   entered_lap:
   entered_time: '20:20:00'
-  event_group_id: 17
   matchable_bib_number: 103
   parameterized_split_name: pole-creek
   remarks:
@@ -44,6 +44,7 @@ raw_time_0002:
   stopped_here:
   with_pacer:
 raw_time_0003:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 67
@@ -54,7 +55,6 @@ raw_time_0003:
   disassociated_from_effort:
   entered_lap:
   entered_time: '12:34:00'
-  event_group_id: 32
   matchable_bib_number: 130
   parameterized_split_name: molas-pass-aid1
   remarks:
@@ -66,6 +66,7 @@ raw_time_0003:
   stopped_here:
   with_pacer: false
 raw_time_0004:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 68
@@ -76,7 +77,6 @@ raw_time_0004:
   disassociated_from_effort:
   entered_lap:
   entered_time: '12:44:00'
-  event_group_id: 32
   matchable_bib_number: 130
   parameterized_split_name: molas-pass-aid1
   remarks:
@@ -88,6 +88,7 @@ raw_time_0004:
   stopped_here:
   with_pacer: false
 raw_time_0005:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 69
@@ -98,7 +99,6 @@ raw_time_0005:
   disassociated_from_effort:
   entered_lap:
   entered_time: '21:11:00'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: anvil-cg-aid6
   remarks:
@@ -110,6 +110,7 @@ raw_time_0005:
   stopped_here:
   with_pacer: false
 raw_time_0006:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 70
@@ -120,7 +121,6 @@ raw_time_0006:
   disassociated_from_effort:
   entered_lap:
   entered_time: '21:21:00'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: anvil-cg-aid6
   remarks:
@@ -132,6 +132,7 @@ raw_time_0006:
   stopped_here:
   with_pacer: false
 raw_time_0007:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 73
@@ -142,7 +143,6 @@ raw_time_0007:
   disassociated_from_effort:
   entered_lap:
   entered_time: '09:09:00'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -154,6 +154,7 @@ raw_time_0007:
   stopped_here:
   with_pacer: false
 raw_time_0008:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 74
@@ -164,7 +165,6 @@ raw_time_0008:
   disassociated_from_effort:
   entered_lap:
   entered_time: '09:10:00'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -176,6 +176,7 @@ raw_time_0008:
   stopped_here:
   with_pacer: false
 raw_time_0009:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 75
@@ -186,7 +187,6 @@ raw_time_0009:
   disassociated_from_effort:
   entered_lap:
   entered_time: '13:13:00'
-  event_group_id: 32
   matchable_bib_number: 130
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -198,6 +198,7 @@ raw_time_0009:
   stopped_here:
   with_pacer: false
 raw_time_0010:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 76
@@ -208,7 +209,6 @@ raw_time_0010:
   disassociated_from_effort:
   entered_lap:
   entered_time: '13:14:00'
-  event_group_id: 32
   matchable_bib_number: 130
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -220,6 +220,7 @@ raw_time_0010:
   stopped_here:
   with_pacer: false
 raw_time_0011:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 77
@@ -230,7 +231,6 @@ raw_time_0011:
   disassociated_from_effort:
   entered_lap:
   entered_time: '07:00:00'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: start
   remarks:
@@ -242,6 +242,7 @@ raw_time_0011:
   stopped_here:
   with_pacer: false
 raw_time_0012:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 78
@@ -252,7 +253,6 @@ raw_time_0012:
   disassociated_from_effort:
   entered_lap:
   entered_time: '08:30:00'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: molas-pass-aid1
   remarks:
@@ -264,6 +264,7 @@ raw_time_0012:
   stopped_here:
   with_pacer: false
 raw_time_0013:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 79
@@ -274,7 +275,6 @@ raw_time_0013:
   disassociated_from_effort:
   entered_lap:
   entered_time: '08:32:00'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: molas-pass-aid1
   remarks:
@@ -286,6 +286,7 @@ raw_time_0013:
   stopped_here:
   with_pacer: false
 raw_time_0014:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 80
@@ -296,7 +297,6 @@ raw_time_0014:
   disassociated_from_effort:
   entered_lap:
   entered_time: '01:24:00'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: cascade-creek-rd-aid3
   remarks:
@@ -308,6 +308,7 @@ raw_time_0014:
   stopped_here:
   with_pacer: false
 raw_time_0015:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 81
@@ -318,7 +319,6 @@ raw_time_0015:
   disassociated_from_effort:
   entered_lap:
   entered_time: '01:28:00'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: cascade-creek-rd-aid3
   remarks:
@@ -330,6 +330,7 @@ raw_time_0015:
   stopped_here:
   with_pacer: false
 raw_time_0016:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 82
@@ -340,7 +341,6 @@ raw_time_0016:
   disassociated_from_effort:
   entered_lap:
   entered_time: '09:09:00'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: engineer-mtn-th-aid4
   remarks:
@@ -352,6 +352,7 @@ raw_time_0016:
   stopped_here:
   with_pacer: false
 raw_time_0017:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 83
@@ -362,7 +363,6 @@ raw_time_0017:
   disassociated_from_effort:
   entered_lap:
   entered_time: '09:09:09'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: engineer-mtn-th-aid4
   remarks:
@@ -374,6 +374,7 @@ raw_time_0017:
   stopped_here:
   with_pacer: false
 raw_time_0018:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 84
@@ -384,7 +385,6 @@ raw_time_0018:
   disassociated_from_effort:
   entered_lap:
   entered_time: '22:22:00'
-  event_group_id: 32
   matchable_bib_number: 101
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -396,6 +396,7 @@ raw_time_0018:
   stopped_here:
   with_pacer: false
 raw_time_0019:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 85
@@ -406,7 +407,6 @@ raw_time_0019:
   disassociated_from_effort:
   entered_lap:
   entered_time: '23:23:00'
-  event_group_id: 32
   matchable_bib_number: 101
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -418,6 +418,7 @@ raw_time_0019:
   stopped_here:
   with_pacer: false
 raw_time_0020:
+  event_group: sum
   creator:
   reviewer: admin_user
   id: 86
@@ -428,7 +429,6 @@ raw_time_0020:
   disassociated_from_effort:
   entered_lap:
   entered_time: '01:02:03'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -440,6 +440,7 @@ raw_time_0020:
   stopped_here:
   with_pacer:
 raw_time_0021:
+  event_group: sum
   creator:
   reviewer: admin_user
   id: 87
@@ -450,7 +451,6 @@ raw_time_0021:
   disassociated_from_effort:
   entered_lap:
   entered_time: '01:03:04'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -462,6 +462,7 @@ raw_time_0021:
   stopped_here:
   with_pacer:
 raw_time_0022:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 88
@@ -472,7 +473,6 @@ raw_time_0022:
   disassociated_from_effort:
   entered_lap:
   entered_time: '01:03:05'
-  event_group_id: 32
   matchable_bib_number: 999
   parameterized_split_name: rolling-pass-aid2
   remarks: ''
@@ -484,6 +484,7 @@ raw_time_0022:
   stopped_here:
   with_pacer:
 raw_time_0023:
+  event_group: sum
   creator: admin_user
   reviewer:
   id: 89
@@ -494,7 +495,6 @@ raw_time_0023:
   disassociated_from_effort:
   entered_lap:
   entered_time: '13:14:00'
-  event_group_id: 32
   matchable_bib_number: 130
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -506,6 +506,7 @@ raw_time_0023:
   stopped_here: false
   with_pacer: false
 raw_time_0024:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 91
@@ -516,7 +517,6 @@ raw_time_0024:
   disassociated_from_effort:
   entered_lap:
   entered_time: '07:00:00'
-  event_group_id: 32
   matchable_bib_number: 777
   parameterized_split_name: start
   remarks: ''
@@ -528,6 +528,7 @@ raw_time_0024:
   stopped_here: false
   with_pacer: false
 raw_time_0025:
+  event_group: sum
   creator:
   reviewer: admin_user
   id: 92
@@ -538,7 +539,6 @@ raw_time_0025:
   disassociated_from_effort:
   entered_lap:
   entered_time: '09:mm:ss'
-  event_group_id: 32
   matchable_bib_number: 777
   parameterized_split_name: start
   remarks:
@@ -550,6 +550,7 @@ raw_time_0025:
   stopped_here: false
   with_pacer: false
 raw_time_0026:
+  event_group: sum
   creator:
   reviewer: admin_user
   id: 176
@@ -560,7 +561,6 @@ raw_time_0026:
   disassociated_from_effort:
   entered_lap:
   entered_time: '13:13:13'
-  event_group_id: 32
   matchable_bib_number: 130
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -572,6 +572,7 @@ raw_time_0026:
   stopped_here: false
   with_pacer: false
 raw_time_0027:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 177
@@ -582,7 +583,6 @@ raw_time_0027:
   disassociated_from_effort:
   entered_lap:
   entered_time: '13:13:15'
-  event_group_id: 32
   matchable_bib_number: 130
   parameterized_split_name: rolling-pass-aid2
   remarks: ''
@@ -594,6 +594,7 @@ raw_time_0027:
   stopped_here: false
   with_pacer: false
 raw_time_0028:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 178
@@ -604,7 +605,6 @@ raw_time_0028:
   disassociated_from_effort:
   entered_lap:
   entered_time: '13:13:11'
-  event_group_id: 32
   matchable_bib_number: 130
   parameterized_split_name: rolling-pass-aid2
   remarks: ''
@@ -616,6 +616,7 @@ raw_time_0028:
   stopped_here: false
   with_pacer: false
 raw_time_0029:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 1100
@@ -626,7 +627,6 @@ raw_time_0029:
   disassociated_from_effort:
   entered_lap:
   entered_time: '13:13:13'
-  event_group_id: 32
   matchable_bib_number: 130
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -638,6 +638,7 @@ raw_time_0029:
   stopped_here: false
   with_pacer: false
 raw_time_0030:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 1106
@@ -648,7 +649,6 @@ raw_time_0030:
   disassociated_from_effort:
   entered_lap:
   entered_time: '23:41:00'
-  event_group_id: 32
   matchable_bib_number: 103
   parameterized_split_name: bandera-mine-aid5
   remarks:
@@ -660,6 +660,7 @@ raw_time_0030:
   stopped_here: false
   with_pacer: false
 raw_time_0031:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 1110
@@ -670,7 +671,6 @@ raw_time_0031:
   disassociated_from_effort:
   entered_lap:
   entered_time: '01:00:00'
-  event_group_id: 32
   matchable_bib_number: 103
   parameterized_split_name: anvil-cg-aid6
   remarks:
@@ -682,6 +682,7 @@ raw_time_0031:
   stopped_here: false
   with_pacer: false
 raw_time_0032:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 1111
@@ -692,7 +693,6 @@ raw_time_0032:
   disassociated_from_effort:
   entered_lap:
   entered_time: '01:05:00'
-  event_group_id: 32
   matchable_bib_number: 103
   parameterized_split_name: anvil-cg-aid6
   remarks:
@@ -704,6 +704,7 @@ raw_time_0032:
   stopped_here: true
   with_pacer: false
 raw_time_0033:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 1117
@@ -714,7 +715,6 @@ raw_time_0033:
   disassociated_from_effort:
   entered_lap:
   entered_time: '01:40:00'
-  event_group_id: 32
   matchable_bib_number: 103
   parameterized_split_name: anvil-cg-aid6
   remarks:
@@ -726,6 +726,7 @@ raw_time_0033:
   stopped_here: true
   with_pacer: false
 raw_time_0034:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 1122
@@ -736,7 +737,6 @@ raw_time_0034:
   disassociated_from_effort:
   entered_lap:
   entered_time: '21:30:00'
-  event_group_id: 32
   matchable_bib_number: 101
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -748,6 +748,7 @@ raw_time_0034:
   stopped_here: false
   with_pacer: false
 raw_time_0035:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 1123
@@ -758,7 +759,6 @@ raw_time_0035:
   disassociated_from_effort:
   entered_lap:
   entered_time: '21:40:00'
-  event_group_id: 32
   matchable_bib_number: 101
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -770,6 +770,7 @@ raw_time_0035:
   stopped_here: false
   with_pacer: false
 raw_time_0036:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 1124
@@ -780,7 +781,6 @@ raw_time_0036:
   disassociated_from_effort:
   entered_lap:
   entered_time: '22:30:00'
-  event_group_id: 32
   matchable_bib_number: 101
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -792,6 +792,7 @@ raw_time_0036:
   stopped_here: false
   with_pacer: false
 raw_time_0037:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 1125
@@ -802,7 +803,6 @@ raw_time_0037:
   disassociated_from_effort:
   entered_lap:
   entered_time: '22:35:00'
-  event_group_id: 32
   matchable_bib_number: 101
   parameterized_split_name: rolling-pass-aid2
   remarks:
@@ -814,6 +814,7 @@ raw_time_0037:
   stopped_here: false
   with_pacer: false
 raw_time_0038:
+  event_group: sum
   creator: admin_user
   reviewer: admin_user
   id: 1126
@@ -824,7 +825,6 @@ raw_time_0038:
   disassociated_from_effort:
   entered_lap:
   entered_time: '10:00:00'
-  event_group_id: 32
   matchable_bib_number: 114
   parameterized_split_name: start
   remarks:

--- a/spec/support/user_current_reset.rb
+++ b/spec/support/user_current_reset.rb
@@ -1,0 +1,8 @@
+# Reset User.current between examples. ApplicationController assigns
+# User.current = current_user on every request, so controller/request specs
+# that log in leave that thread-local pointing at a now-rolled-back user when
+# the example ends. Auditable's before_validation then sets created_by from
+# the stale User.current.id, causing FK violations in subsequent examples.
+RSpec.configure do |config|
+  config.before { User.current = nil }
+end

--- a/spec/system/event_groups/search_event_group_index_spec.rb
+++ b/spec/system/event_groups/search_event_group_index_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe "search the event group index", :js, type: :system do
 
   let(:concealed_event_group) { event_groups(:rufa_2017) }
   let(:concealed_event) { concealed_event_group.events.first }
-  let(:visible_event_groups) { event_groups - [concealed_event_group].sort_by(&:name) }
-  let(:visible_event_group_1) { visible_event_groups.first }
-  let(:visible_event_group_2) { visible_event_groups.second }
+  let(:visible_event_group_1) { event_groups(:ramble) }
+  let(:visible_event_group_2) { event_groups(:hardrock_2014) }
   let(:visible_event_1) { visible_event_group_1.events.first }
   let(:visible_event_2) { visible_event_group_2.events.first }
 


### PR DESCRIPTION
## Summary

Continues the "Make X a portable fixture table" series. event_groups now use Rails-assigned (label-hashed) ids; other fixtures reference them by label.

### Changes
- Add `:event_groups` to `PORTABLE_FIXTURE_TABLES`. event_groups is slugged, so no `ORDER_BY_MAP` entry is needed.
- `spec/fixtures/event_groups.yml`: drop the explicit `id:` from every entry; reorder entries by slug (matches what the dump task produces).
- `spec/fixtures/events.yml`: replace `event_group_id: <int>` with `event_group: <label>` on all 11 rows. `Event belongs_to :event_group` already existed, so the dump converts the FK automatically.
- `spec/fixtures/raw_times.yml`: same treatment for all 38 rows. `RawTime belongs_to :event_group` already existed.

No referencing specs hardcoded an event_group id (the `event_group_id: 100` references in `verify_raw_time_row_spec` are `build_stubbed` values with no DB interaction, so they're unaffected). Schema confirmation: only `events` and `raw_times` carry an `event_group_id` FK.

## Testing

Ran a focused local selection (~410 examples covering EventGroup, Event, RawTime, Effort, ownership/concealment, the AidStations factory-cascade canary, drop-list request spec, and the rest of the portable-table specs) — all green, rubocop clean. Relying on CI for the full suite.

There is a pre-existing `User.current` thread-local leak from auth-using controller specs (`aid_stations_controller_spec`, `events_controller_spec`) introduced by the users-portable work — it's invisible to CI because the unit shard's pollution doesn't cross-contaminate sequentially, but visible when running those specs alongside `submit_raw_time_rows_spec` locally. Verified identical failure sets on master and this branch, so this PR adds no regression. Worth fixing separately with a `before(:each) { User.current = nil }` somewhere in spec support, but out of scope here.

Part of #2065
