### PR TITLE
Make events a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -42,6 +42,7 @@ module FixtureHelper
     :courses,
     :credentials,
     :event_groups,
+    :events,
     :historical_facts,
     :lotteries,
     :organizations,

--- a/spec/fixtures/aid_stations.yml
+++ b/spec/fixtures/aid_stations.yml
@@ -1,225 +1,225 @@
 ---
 aid_station_0001:
+  event: hardrock_2015
   id: 5
-  event_id: 4
   split_id: 5
 aid_station_0002:
+  event: hardrock_2015
   id: 6
-  event_id: 4
   split_id: 6
 aid_station_0003:
+  event: hardrock_2015
   id: 12
-  event_id: 4
   split_id: 12
 aid_station_0004:
+  event: hardrock_2015
   id: 16
-  event_id: 4
   split_id: 16
 aid_station_0005:
+  event: hardrock_2015
   id: 26
-  event_id: 4
   split_id: 26
 aid_station_0006:
+  event: hardrock_2015
   id: 32
-  event_id: 4
   split_id: 32
 aid_station_0007:
+  event: hardrock_2015
   id: 34
-  event_id: 4
   split_id: 34
 aid_station_0008:
+  event: ramble
   id: 140
-  event_id: 14
   split_id: 46
 aid_station_0009:
+  event: ramble
   id: 141
-  event_id: 14
   split_id: 47
 aid_station_0010:
+  event: hardrock_2014
   id: 202
-  event_id: 17
   split_id: 81
 aid_station_0011:
+  event: hardrock_2014
   id: 203
-  event_id: 17
   split_id: 82
 aid_station_0012:
+  event: hardrock_2014
   id: 208
-  event_id: 17
   split_id: 87
 aid_station_0013:
+  event: hardrock_2014
   id: 214
-  event_id: 17
   split_id: 93
 aid_station_0014:
+  event: hardrock_2014
   id: 218
-  event_id: 17
   split_id: 97
 aid_station_0015:
+  event: hardrock_2014
   id: 222
-  event_id: 17
   split_id: 101
 aid_station_0016:
+  event: hardrock_2014
   id: 228
-  event_id: 17
   split_id: 107
 aid_station_0017:
+  event: rufa_2016
   id: 458
-  event_id: 34
   split_id: 135
 aid_station_0018:
+  event: rufa_2016
   id: 459
-  event_id: 34
   split_id: 136
 aid_station_0019:
+  event: rufa_2016
   id: 460
-  event_id: 34
   split_id: 137
 aid_station_0020:
+  event: rufa_2017_24h
   id: 476
-  event_id: 36
   split_id: 137
 aid_station_0021:
+  event: rufa_2017_24h
   id: 477
-  event_id: 36
   split_id: 135
 aid_station_0022:
+  event: rufa_2017_24h
   id: 478
-  event_id: 36
   split_id: 136
 aid_station_0023:
+  event: hardrock_2016
   id: 479
-  event_id: 37
   split_id: 81
 aid_station_0024:
+  event: hardrock_2016
   id: 482
-  event_id: 37
   split_id: 87
 aid_station_0025:
+  event: hardrock_2016
   id: 485
-  event_id: 37
   split_id: 93
 aid_station_0026:
+  event: hardrock_2016
   id: 487
-  event_id: 37
   split_id: 97
 aid_station_0027:
+  event: hardrock_2016
   id: 489
-  event_id: 37
   split_id: 101
 aid_station_0028:
+  event: hardrock_2016
   id: 492
-  event_id: 37
   split_id: 107
 aid_station_0029:
+  event: hardrock_2016
   id: 493
-  event_id: 37
   split_id: 82
 aid_station_0030:
+  event: hardrock_2015
   id: 513
-  event_id: 4
   split_id: 20
 aid_station_0031:
+  event: ggd30_50k
   id: 570
-  event_id: 48
   split_id: 164
 aid_station_0032:
+  event: ggd30_50k
   id: 571
-  event_id: 48
   split_id: 165
 aid_station_0033:
+  event: ggd30_50k
   id: 572
-  event_id: 48
   split_id: 167
 aid_station_0034:
+  event: ggd30_50k
   id: 574
-  event_id: 48
   split_id: 170
 aid_station_0035:
+  event: ggd30_50k
   id: 575
-  event_id: 48
   split_id: 168
 aid_station_0036:
+  event: ggd30_50k
   id: 576
-  event_id: 48
   split_id: 166
 aid_station_0037:
+  event: ggd30_50k
   id: 577
-  event_id: 48
   split_id: 171
 aid_station_0038:
+  event: ggd30_12m
   id: 578
-  event_id: 49
   split_id: 173
 aid_station_0039:
+  event: ggd30_12m
   id: 579
-  event_id: 49
   split_id: 172
 aid_station_0040:
+  event: sum_100k
   id: 626
-  event_id: 56
   split_id: 205
 aid_station_0041:
+  event: sum_100k
   id: 627
-  event_id: 56
   split_id: 204
 aid_station_0042:
+  event: sum_100k
   id: 629
-  event_id: 56
   split_id: 207
 aid_station_0043:
+  event: sum_100k
   id: 630
-  event_id: 56
   split_id: 208
 aid_station_0044:
+  event: sum_100k
   id: 631
-  event_id: 56
   split_id: 209
 aid_station_0045:
+  event: sum_100k
   id: 632
-  event_id: 56
   split_id: 210
 aid_station_0046:
+  event: sum_55k
   id: 634
-  event_id: 57
   split_id: 213
 aid_station_0047:
+  event: sum_55k
   id: 635
-  event_id: 57
   split_id: 212
 aid_station_0048:
+  event: sum_55k
   id: 636
-  event_id: 57
   split_id: 218
 aid_station_0049:
+  event: sum_55k
   id: 637
-  event_id: 57
   split_id: 219
 aid_station_0050:
+  event: sum_55k
   id: 638
-  event_id: 57
   split_id: 220
 aid_station_0051:
+  event: sum_55k
   id: 639
-  event_id: 57
   split_id: 221
 aid_station_0052:
+  event: sum_100k
   id: 725
-  event_id: 56
   split_id: 206
 aid_station_0053:
+  event: sum_100k
   id: 726
-  event_id: 56
   split_id: 211
 aid_station_0054:
+  event: rufa_2017_12h
   id: 753
-  event_id: 70
   split_id: 137
 aid_station_0055:
+  event: rufa_2017_12h
   id: 754
-  event_id: 70
   split_id: 136
 aid_station_0056:
+  event: rufa_2017_12h
   id: 755
-  event_id: 70
   split_id: 135

--- a/spec/fixtures/connections.yml
+++ b/spec/fixtures/connections.yml
@@ -7,17 +7,15 @@ connection_0001:
   source_type: Race
   field_mappings: []
 connection_0002:
+  destination: rufa_2017_24h (Event)
   id: 2
-  destination_id: 36
-  destination_type: Event
   service_identifier: runsignup
   source_id: '24'
   source_type: Event
   field_mappings: []
 connection_0003:
+  destination: rufa_2017_12h (Event)
   id: 3
-  destination_id: 70
-  destination_type: Event
   service_identifier: runsignup
   source_id: '12'
   source_type: Event

--- a/spec/fixtures/efforts.yml
+++ b/spec/fixtures/efforts.yml
@@ -1,5 +1,6 @@
 ---
 hardrock_2015_tuan_jacobs:
+  event: hardrock_2015
   person: tuan_jacobs
   id: 7
   age: 17
@@ -19,7 +20,6 @@ hardrock_2015_tuan_jacobs:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 42
   finished: true
   first_name: Tuan
@@ -39,6 +39,7 @@ hardrock_2015_tuan_jacobs:
   topic_resource_key:
   wave:
 hardrock_2015_erich_larson:
+  event: hardrock_2015
   person: erich_larson
   id: 8
   age: 36
@@ -58,7 +59,6 @@ hardrock_2015_erich_larson:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 72
   finished: true
   first_name: Erich
@@ -78,6 +78,7 @@ hardrock_2015_erich_larson:
   topic_resource_key:
   wave:
 hardrock_2015_leif_carter:
+  event: hardrock_2015
   person: leif_carter
   id: 15
   age: 55
@@ -97,7 +98,6 @@ hardrock_2015_leif_carter:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 282
   finished: true
   first_name: Leif
@@ -117,6 +117,7 @@ hardrock_2015_leif_carter:
   topic_resource_key:
   wave:
 hardrock_2015_carmine_adams:
+  event: hardrock_2015
   person: carmine_adams
   id: 20
   age: 18
@@ -136,7 +137,6 @@ hardrock_2015_carmine_adams:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 432
   finished: true
   first_name: Carmine
@@ -156,6 +156,7 @@ hardrock_2015_carmine_adams:
   topic_resource_key:
   wave:
 hardrock_2015_garry_kuhlman:
+  event: hardrock_2015
   person: garry_kuhlman
   id: 24
   age: 45
@@ -175,7 +176,6 @@ hardrock_2015_garry_kuhlman:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 552
   finished: true
   first_name: Garry
@@ -195,6 +195,7 @@ hardrock_2015_garry_kuhlman:
   topic_resource_key:
   wave:
 hardrock_2015_darius_jacobson:
+  event: hardrock_2015
   person: darius_jacobson
   id: 25
   age: 30
@@ -214,7 +215,6 @@ hardrock_2015_darius_jacobson:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 582
   finished: true
   first_name: Darius
@@ -234,6 +234,7 @@ hardrock_2015_darius_jacobson:
   topic_resource_key:
   wave:
 hardrock_2015_santa_green:
+  event: hardrock_2015
   person: santa_green
   id: 29
   age: 37
@@ -253,7 +254,6 @@ hardrock_2015_santa_green:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 702
   finished: true
   first_name: Santa
@@ -273,6 +273,7 @@ hardrock_2015_santa_green:
   topic_resource_key:
   wave:
 hardrock_2015_gilberto_mckenzie:
+  event: hardrock_2015
   person: gilberto_mckenzie
   id: 31
   age: 45
@@ -292,7 +293,6 @@ hardrock_2015_gilberto_mckenzie:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 762
   finished: true
   first_name: Gilberto
@@ -312,6 +312,7 @@ hardrock_2015_gilberto_mckenzie:
   topic_resource_key:
   wave:
 hardrock_2015_vince_willms:
+  event: hardrock_2015
   person: vince_willms
   id: 47
   age: 50
@@ -331,7 +332,6 @@ hardrock_2015_vince_willms:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 1242
   finished: true
   first_name: Vince
@@ -351,6 +351,7 @@ hardrock_2015_vince_willms:
   topic_resource_key:
   wave:
 hardrock_2015_cedric_windler:
+  event: hardrock_2015
   person: cedric_windler
   id: 50
   age: 36
@@ -370,7 +371,6 @@ hardrock_2015_cedric_windler:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 1332
   finished: true
   first_name: Cedric
@@ -390,6 +390,7 @@ hardrock_2015_cedric_windler:
   topic_resource_key:
   wave:
 hardrock_2015_chris_rempel:
+  event: hardrock_2015
   person: chris_rempel
   id: 56
   age: 26
@@ -409,7 +410,6 @@ hardrock_2015_chris_rempel:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 1512
   finished: true
   first_name: Chris
@@ -429,6 +429,7 @@ hardrock_2015_chris_rempel:
   topic_resource_key:
   wave:
 hardrock_2015_robby_gerlach:
+  event: hardrock_2015
   person: robby_gerlach
   id: 57
   age: 45
@@ -448,7 +449,6 @@ hardrock_2015_robby_gerlach:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 1542
   finished: true
   first_name: Robby
@@ -468,6 +468,7 @@ hardrock_2015_robby_gerlach:
   topic_resource_key:
   wave:
 hardrock_2015_rachelle_eichmann:
+  event: hardrock_2015
   person: rachelle_eichmann
   id: 59
   age: 23
@@ -487,7 +488,6 @@ hardrock_2015_rachelle_eichmann:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 1602
   finished: true
   first_name: Rachelle
@@ -507,6 +507,7 @@ hardrock_2015_rachelle_eichmann:
   topic_resource_key:
   wave:
 hardrock_2015_elden_morissette:
+  event: hardrock_2015
   person: elden_morissette
   id: 61
   age: 42
@@ -526,7 +527,6 @@ hardrock_2015_elden_morissette:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 1662
   finished: true
   first_name: Elden
@@ -546,6 +546,7 @@ hardrock_2015_elden_morissette:
   topic_resource_key:
   wave:
 hardrock_2015_leroy_leffler:
+  event: hardrock_2015
   person: leroy_leffler
   id: 63
   age: 48
@@ -565,7 +566,6 @@ hardrock_2015_leroy_leffler:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 1722
   finished: true
   first_name: Leroy
@@ -585,6 +585,7 @@ hardrock_2015_leroy_leffler:
   topic_resource_key:
   wave:
 hardrock_2015_samara_vandervort:
+  event: hardrock_2015
   person: samara_vandervort
   id: 73
   age: 22
@@ -604,7 +605,6 @@ hardrock_2015_samara_vandervort:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 2022
   finished: true
   first_name: Samara
@@ -624,6 +624,7 @@ hardrock_2015_samara_vandervort:
   topic_resource_key:
   wave:
 hardrock_2015_robt_wintheiser:
+  event: hardrock_2015
   person: robt_wintheiser
   id: 94
   age: 57
@@ -643,7 +644,6 @@ hardrock_2015_robt_wintheiser:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 2652
   finished: true
   first_name: Robt
@@ -663,6 +663,7 @@ hardrock_2015_robt_wintheiser:
   topic_resource_key:
   wave:
 hardrock_2015_demetrius_moen:
+  event: hardrock_2015
   person: demetrius_moen
   id: 96
   age: 40
@@ -682,7 +683,6 @@ hardrock_2015_demetrius_moen:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 2712
   finished: true
   first_name: Demetrius
@@ -702,6 +702,7 @@ hardrock_2015_demetrius_moen:
   topic_resource_key:
   wave:
 hardrock_2015_vern_buckridge:
+  event: hardrock_2015
   person: vern_buckridge
   id: 105
   age: 33
@@ -721,7 +722,6 @@ hardrock_2015_vern_buckridge:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 2982
   finished: true
   first_name: Vern
@@ -741,6 +741,7 @@ hardrock_2015_vern_buckridge:
   topic_resource_key:
   wave:
 hardrock_2015_donte_spencer:
+  event: hardrock_2015
   person: donte_spencer
   id: 112
   age: 30
@@ -760,7 +761,6 @@ hardrock_2015_donte_spencer:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 3192
   finished: true
   first_name: Donte
@@ -780,6 +780,7 @@ hardrock_2015_donte_spencer:
   topic_resource_key:
   wave:
 hardrock_2015_bruno_fadel:
+  event: hardrock_2015
   person: bruno_fadel
   id: 116
   age: 27
@@ -799,7 +800,6 @@ hardrock_2015_bruno_fadel:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 3312
   finished: true
   first_name: Bruno
@@ -819,6 +819,7 @@ hardrock_2015_bruno_fadel:
   topic_resource_key:
   wave:
 hardrock_2015_gus_walker:
+  event: hardrock_2015
   person: gus_walker
   id: 117
   age: 54
@@ -838,7 +839,6 @@ hardrock_2015_gus_walker:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 3342
   finished: true
   first_name: Gus
@@ -858,6 +858,7 @@ hardrock_2015_gus_walker:
   topic_resource_key:
   wave:
 hardrock_2015_susanna_abshire:
+  event: hardrock_2015
   person: susanna_abshire
   id: 121
   age: 34
@@ -877,7 +878,6 @@ hardrock_2015_susanna_abshire:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 3462
   finished: true
   first_name: Susanna
@@ -897,6 +897,7 @@ hardrock_2015_susanna_abshire:
   topic_resource_key:
   wave:
 hardrock_2015_leandro_cole:
+  event: hardrock_2015
   person: leandro_cole
   id: 125
   age: 45
@@ -916,7 +917,6 @@ hardrock_2015_leandro_cole:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 3582
   finished: true
   first_name: Leandro
@@ -936,6 +936,7 @@ hardrock_2015_leandro_cole:
   topic_resource_key:
   wave:
 hardrock_2015_benedict_davis:
+  event: hardrock_2015
   person: benedict_davis
   id: 129
   age: 32
@@ -955,7 +956,6 @@ hardrock_2015_benedict_davis:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 3702
   finished: true
   first_name: Benedict
@@ -975,6 +975,7 @@ hardrock_2015_benedict_davis:
   topic_resource_key:
   wave:
 hardrock_2015_raphael_swift:
+  event: hardrock_2015
   person: raphael_swift
   id: 136
   age: 40
@@ -994,7 +995,6 @@ hardrock_2015_raphael_swift:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 3891
   finished: false
   first_name: Raphael
@@ -1014,6 +1014,7 @@ hardrock_2015_raphael_swift:
   topic_resource_key:
   wave:
 hardrock_2015_bad_status:
+  event: hardrock_2015
   person: bad_status
   id: 138
   age: 21
@@ -1033,7 +1034,6 @@ hardrock_2015_bad_status:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 101556
   finished: false
   first_name: Bad
@@ -1053,6 +1053,7 @@ hardrock_2015_bad_status:
   topic_resource_key:
   wave:
 hardrock_2015_irvin_harber:
+  event: hardrock_2015
   person: irvin_harber
   id: 141
   age: 19
@@ -1072,7 +1073,6 @@ hardrock_2015_irvin_harber:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 101541
   finished: false
   first_name: Irvin
@@ -1092,6 +1092,7 @@ hardrock_2015_irvin_harber:
   topic_resource_key:
   wave:
 hardrock_2015_cassondra_nienow:
+  event: hardrock_2015
   person: cassondra_nienow
   id: 155
   age: 56
@@ -1111,7 +1112,6 @@ hardrock_2015_cassondra_nienow:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 4198
   finished: false
   first_name: Cassondra
@@ -1131,6 +1131,7 @@ hardrock_2015_cassondra_nienow:
   topic_resource_key:
   wave:
 hardrock_2015_donn_mckenzie:
+  event: hardrock_2015
   person: donn_mckenzie
   id: 158
   age: 16
@@ -1150,7 +1151,6 @@ hardrock_2015_donn_mckenzie:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 4
   final_split_time_id: 4219
   finished: false
   first_name: Donn
@@ -1170,6 +1170,7 @@ hardrock_2015_donn_mckenzie:
   topic_resource_key:
   wave:
 ramble_finished_first:
+  event: ramble
   person: finished_first_2019_02_01
   id: 1040
   age: 49
@@ -1189,7 +1190,6 @@ ramble_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 14
   final_split_time_id: 15145
   finished: true
   first_name: Finished
@@ -1209,6 +1209,7 @@ ramble_finished_first:
   topic_resource_key:
   wave:
 ramble_finished_second:
+  event: ramble
   person: finished_second_montana_us
   id: 1048
   age: 12
@@ -1228,7 +1229,6 @@ ramble_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 14
   final_split_time_id: 15161
   finished: true
   first_name: Finished
@@ -1248,6 +1248,7 @@ ramble_finished_second:
   topic_resource_key:
   wave:
 ramble_start_only:
+  event: ramble
   person: start_only_2019_02_01
   id: 1051
   age: 38
@@ -1267,7 +1268,6 @@ ramble_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 14
   final_split_time_id: 15166
   finished: false
   first_name: Start
@@ -1287,6 +1287,7 @@ ramble_start_only:
   topic_resource_key:
   wave:
 ramble_not_started:
+  event: ramble
   person: not_started_2019_02_01
   id: 1061
   age: 17
@@ -1306,7 +1307,6 @@ ramble_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 14
   final_split_time_id:
   finished: false
   first_name: Not
@@ -1326,6 +1326,7 @@ ramble_not_started:
   topic_resource_key:
   wave:
 hardrock_2014_finished_first:
+  event: hardrock_2014
   person: finished_first_japan
   id: 4172
   age: 19
@@ -1345,7 +1346,6 @@ hardrock_2014_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 91286
   finished: true
   first_name: Finished
@@ -1365,6 +1365,7 @@ hardrock_2014_finished_first:
   topic_resource_key:
   wave:
 hardrock_2014_finished_with_stop:
+  event: hardrock_2014
   person: finished_with_stop
   id: 4173
   age: 40
@@ -1384,7 +1385,6 @@ hardrock_2014_finished_with_stop:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 91314
   finished: true
   first_name: Finished
@@ -1404,6 +1404,7 @@ hardrock_2014_finished_with_stop:
   topic_resource_key:
   wave:
 hardrock_2014_finished_without_stop:
+  event: hardrock_2014
   person: finished_without_stop
   id: 4174
   age: 25
@@ -1423,7 +1424,6 @@ hardrock_2014_finished_without_stop:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 91342
   finished: true
   first_name: Finished
@@ -1443,6 +1443,7 @@ hardrock_2014_finished_without_stop:
   topic_resource_key:
   wave:
 hardrock_2014_claudio_wunsch:
+  event: hardrock_2014
   person: claudio_wunsch
   id: 4192
   age: 33
@@ -1462,7 +1463,6 @@ hardrock_2014_claudio_wunsch:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 91846
   finished: true
   first_name: Claudio
@@ -1482,6 +1482,7 @@ hardrock_2014_claudio_wunsch:
   topic_resource_key:
   wave:
 hardrock_2014_rachelle_eichmann:
+  event: hardrock_2014
   person: rachelle_eichmann
   id: 4199
   age: 22
@@ -1501,7 +1502,6 @@ hardrock_2014_rachelle_eichmann:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 92042
   finished: true
   first_name: Rachelle
@@ -1521,6 +1521,7 @@ hardrock_2014_rachelle_eichmann:
   topic_resource_key:
   wave:
 hardrock_2014_keith_metz:
+  event: hardrock_2014
   person: keith_metz
   id: 4206
   age: 42
@@ -1540,7 +1541,6 @@ hardrock_2014_keith_metz:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 92238
   finished: true
   first_name: Keith
@@ -1560,6 +1560,7 @@ hardrock_2014_keith_metz:
   topic_resource_key:
   wave:
 hardrock_2014_major_green:
+  event: hardrock_2014
   person: major_green
   id: 4207
   age: 58
@@ -1579,7 +1580,6 @@ hardrock_2014_major_green:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 92266
   finished: true
   first_name: Major
@@ -1599,6 +1599,7 @@ hardrock_2014_major_green:
   topic_resource_key:
   wave:
 hardrock_2014_humberto_adams:
+  event: hardrock_2014
   person: humberto_adams
   id: 4221
   age: 24
@@ -1618,7 +1619,6 @@ hardrock_2014_humberto_adams:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 92658
   finished: true
   first_name: Humberto
@@ -1638,6 +1638,7 @@ hardrock_2014_humberto_adams:
   topic_resource_key:
   wave:
 hardrock_2014_omer_yundt:
+  event: hardrock_2014
   person: omer_yundt
   id: 4246
   age: 40
@@ -1657,7 +1658,6 @@ hardrock_2014_omer_yundt:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 93358
   finished: true
   first_name: Omer
@@ -1677,6 +1677,7 @@ hardrock_2014_omer_yundt:
   topic_resource_key:
   wave:
 hardrock_2014_pat_schaden:
+  event: hardrock_2014
   person: pat_schaden
   id: 4247
   age: 53
@@ -1696,7 +1697,6 @@ hardrock_2014_pat_schaden:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 93384
   finished: false
   first_name: Pat
@@ -1716,6 +1716,7 @@ hardrock_2014_pat_schaden:
   topic_resource_key:
   wave:
 hardrock_2014_clarence_goyette:
+  event: hardrock_2014
   person: clarence_goyette
   id: 4249
   age: 52
@@ -1735,7 +1736,6 @@ hardrock_2014_clarence_goyette:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 93442
   finished: true
   first_name: Clarence
@@ -1755,6 +1755,7 @@ hardrock_2014_clarence_goyette:
   topic_resource_key:
   wave:
 hardrock_2014_irvin_corkery:
+  event: hardrock_2014
   person: irvin_corkery
   id: 4251
   age: 22
@@ -1774,7 +1775,6 @@ hardrock_2014_irvin_corkery:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 93498
   finished: true
   first_name: Irvin
@@ -1794,6 +1794,7 @@ hardrock_2014_irvin_corkery:
   topic_resource_key:
   wave:
 hardrock_2014_willis_murray:
+  event: hardrock_2014
   person: willis_murray
   id: 4253
   age: 16
@@ -1813,7 +1814,6 @@ hardrock_2014_willis_murray:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 93554
   finished: true
   first_name: Willis
@@ -1833,6 +1833,7 @@ hardrock_2014_willis_murray:
   topic_resource_key:
   wave:
 hardrock_2014_ken_bradtke:
+  event: hardrock_2014
   person: ken_bradtke
   id: 4256
   age: 47
@@ -1852,7 +1853,6 @@ hardrock_2014_ken_bradtke:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 93638
   finished: true
   first_name: Ken
@@ -1872,6 +1872,7 @@ hardrock_2014_ken_bradtke:
   topic_resource_key:
   wave:
 hardrock_2014_progress_sherman:
+  event: hardrock_2014
   person: progress_sherman_colorado_us
   id: 4277
   age: 36
@@ -1891,7 +1892,6 @@ hardrock_2014_progress_sherman:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 94175
   finished: false
   first_name: Progress
@@ -1911,6 +1911,7 @@ hardrock_2014_progress_sherman:
   topic_resource_key:
   wave:
 hardrock_2014_multiple_stops:
+  event: hardrock_2014
   person: multiple_stops
   id: 4293
   age: 60
@@ -1930,7 +1931,6 @@ hardrock_2014_multiple_stops:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 94453
   finished: false
   first_name: Multiple
@@ -1950,6 +1950,7 @@ hardrock_2014_multiple_stops:
   topic_resource_key:
   wave:
 hardrock_2014_without_start:
+  event: hardrock_2014
   person: without_start
   id: 4294
   age: 49
@@ -1969,7 +1970,6 @@ hardrock_2014_without_start:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 94470
   finished: false
   first_name: Without
@@ -1989,6 +1989,7 @@ hardrock_2014_without_start:
   topic_resource_key:
   wave:
 hardrock_2014_drop_ouray:
+  event: hardrock_2014
   person: drop_ouray
   id: 4295
   age: 40
@@ -2008,7 +2009,6 @@ hardrock_2014_drop_ouray:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id: 94483
   finished: false
   first_name: Drop
@@ -2028,6 +2028,7 @@ hardrock_2014_drop_ouray:
   topic_resource_key:
   wave:
 hardrock_2014_not_started:
+  event: hardrock_2014
   person: not_started
   id: 4302
   age: 28
@@ -2047,7 +2048,6 @@ hardrock_2014_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 17
   final_split_time_id:
   finished: false
   first_name: Not
@@ -2067,6 +2067,7 @@ hardrock_2014_not_started:
   topic_resource_key:
   wave:
 rufa_2016_finished_first:
+  event: rufa_2016
   person:
   id: 6518
   age: 35
@@ -2086,7 +2087,6 @@ rufa_2016_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 34
   final_split_time_id: 132059
   finished: true
   first_name: Finished
@@ -2106,6 +2106,7 @@ rufa_2016_finished_first:
   topic_resource_key:
   wave:
 rufa_2016_finished_second:
+  event: rufa_2016
   person:
   id: 6520
   age: 32
@@ -2125,7 +2126,6 @@ rufa_2016_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 34
   final_split_time_id: 132090
   finished: true
   first_name: Finished
@@ -2145,6 +2145,7 @@ rufa_2016_finished_second:
   topic_resource_key:
   wave:
 rufa_2016_progress_lap1:
+  event: rufa_2016
   person:
   id: 6560
   age: 25
@@ -2164,7 +2165,6 @@ rufa_2016_progress_lap1:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 34
   final_split_time_id: 132439
   finished: false
   first_name: Progress
@@ -2184,6 +2184,7 @@ rufa_2016_progress_lap1:
   topic_resource_key:
   wave:
 rufa_2016_not_started:
+  event: rufa_2016
   person:
   id: 6561
   age: 57
@@ -2203,7 +2204,6 @@ rufa_2016_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 34
   final_split_time_id:
   finished: false
   first_name: Not
@@ -2223,6 +2223,7 @@ rufa_2016_not_started:
   topic_resource_key:
   wave:
 rufa_2017_24h_finished_first:
+  event: rufa_2017_24h
   person: finished_first_utah_us
   id: 6693
   age: 47
@@ -2242,7 +2243,6 @@ rufa_2017_24h_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 36
   final_split_time_id: 133983
   finished: true
   first_name: Finished
@@ -2262,6 +2262,7 @@ rufa_2017_24h_finished_first:
   topic_resource_key:
   wave:
 rufa_2017_24h_progress_lap6:
+  event: rufa_2017_24h
   person: progress_lap6
   id: 6695
   age: 33
@@ -2281,7 +2282,6 @@ rufa_2017_24h_progress_lap6:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 36
   final_split_time_id: 134018
   finished: false
   first_name: Progress
@@ -2301,6 +2301,7 @@ rufa_2017_24h_progress_lap6:
   topic_resource_key:
   wave:
 rufa_2017_24h_multiple_stops:
+  event: rufa_2017_24h
   person: multiple_stops_utah_us
   id: 6756
   age: 43
@@ -2320,7 +2321,6 @@ rufa_2017_24h_multiple_stops:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 36
   final_split_time_id: 134812
   finished: true
   first_name: Multiple
@@ -2340,6 +2340,7 @@ rufa_2017_24h_multiple_stops:
   topic_resource_key:
   wave:
 rufa_2017_24h_finished_last:
+  event: rufa_2017_24h
   person: finished_last
   id: 6780
   age: 40
@@ -2359,7 +2360,6 @@ rufa_2017_24h_finished_last:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 36
   final_split_time_id: 135012
   finished: true
   first_name: Finished
@@ -2379,6 +2379,7 @@ rufa_2017_24h_finished_last:
   topic_resource_key:
   wave:
 rufa_2017_24h_not_started:
+  event: rufa_2017_24h
   person: not_started
   id: 6782
   age: 30
@@ -2398,7 +2399,6 @@ rufa_2017_24h_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 36
   final_split_time_id:
   finished: false
   first_name: Not
@@ -2418,6 +2418,7 @@ rufa_2017_24h_not_started:
   topic_resource_key:
   wave:
 rufa_2017_24h_progress_lap1:
+  event: rufa_2017_24h
   person: progress_lap1
   id: 6805
   age: 49
@@ -2437,7 +2438,6 @@ rufa_2017_24h_progress_lap1:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 36
   final_split_time_id: 135134
   finished: false
   first_name: Progress
@@ -2457,6 +2457,7 @@ rufa_2017_24h_progress_lap1:
   topic_resource_key:
   wave:
 hardrock_2016_lavon_paucek:
+  event: hardrock_2016
   person: lavon_paucek
   id: 7270
   age: 41
@@ -2476,7 +2477,6 @@ hardrock_2016_lavon_paucek:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 146950
   finished: true
   first_name: Lavon
@@ -2496,6 +2496,7 @@ hardrock_2016_lavon_paucek:
   topic_resource_key:
   wave:
 hardrock_2016_vesta_borer:
+  event: hardrock_2016
   person: vesta_borer
   id: 7284
   age: 21
@@ -2515,7 +2516,6 @@ hardrock_2016_vesta_borer:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 147341
   finished: false
   first_name: Vesta
@@ -2535,6 +2535,7 @@ hardrock_2016_vesta_borer:
   topic_resource_key:
   wave:
 hardrock_2016_kory_kulas:
+  event: hardrock_2016
   person: kory_kulas
   id: 7289
   age: 42
@@ -2554,7 +2555,6 @@ hardrock_2016_kory_kulas:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 147481
   finished: false
   first_name: Kory
@@ -2574,6 +2574,7 @@ hardrock_2016_kory_kulas:
   topic_resource_key:
   wave:
 hardrock_2016_shad_hirthe:
+  event: hardrock_2016
   person: shad_hirthe
   id: 7297
   age: 40
@@ -2593,7 +2594,6 @@ hardrock_2016_shad_hirthe:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 147699
   finished: false
   first_name: Shad
@@ -2613,6 +2613,7 @@ hardrock_2016_shad_hirthe:
   topic_resource_key:
   wave:
 hardrock_2016_douglas_vandervort:
+  event: hardrock_2016
   person: douglas_vandervort
   id: 7302
   age: 52
@@ -2632,7 +2633,6 @@ hardrock_2016_douglas_vandervort:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 147839
   finished: false
   first_name: Douglas
@@ -2652,6 +2652,7 @@ hardrock_2016_douglas_vandervort:
   topic_resource_key:
   wave:
 hardrock_2016_missing_telluride_out:
+  event: hardrock_2016
   person:
   id: 7308
   age: 20
@@ -2671,7 +2672,6 @@ hardrock_2016_missing_telluride_out:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 148007
   finished: false
   first_name: Missing
@@ -2691,6 +2691,7 @@ hardrock_2016_missing_telluride_out:
   topic_resource_key:
   wave:
 hardrock_2016_junior_lesch:
+  event: hardrock_2016
   person: junior_lesch
   id: 7311
   age: 49
@@ -2710,7 +2711,6 @@ hardrock_2016_junior_lesch:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 148091
   finished: false
   first_name: Junior
@@ -2730,6 +2730,7 @@ hardrock_2016_junior_lesch:
   topic_resource_key:
   wave:
 hardrock_2016_eddy_goldner:
+  event: hardrock_2016
   person: eddy_goldner
   id: 7315
   age: 18
@@ -2749,7 +2750,6 @@ hardrock_2016_eddy_goldner:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 148203
   finished: false
   first_name: Eddy
@@ -2769,6 +2769,7 @@ hardrock_2016_eddy_goldner:
   topic_resource_key:
   wave:
 hardrock_2016_progress_sherman:
+  event: hardrock_2016
   person: progress_sherman
   id: 7328
   age: 33
@@ -2788,7 +2789,6 @@ hardrock_2016_progress_sherman:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 148567
   finished: false
   first_name: Progress
@@ -2808,6 +2808,7 @@ hardrock_2016_progress_sherman:
   topic_resource_key:
   wave:
 hardrock_2016_benito_moen:
+  event: hardrock_2016
   person: benito_moen
   id: 7337
   age: 52
@@ -2827,7 +2828,6 @@ hardrock_2016_benito_moen:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 148819
   finished: false
   first_name: Benito
@@ -2847,6 +2847,7 @@ hardrock_2016_benito_moen:
   topic_resource_key:
   wave:
 hardrock_2016_kendall_koch:
+  event: hardrock_2016
   person: kendall_koch
   id: 7340
   age: 40
@@ -2866,7 +2867,6 @@ hardrock_2016_kendall_koch:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 148903
   finished: false
   first_name: Kendall
@@ -2886,6 +2886,7 @@ hardrock_2016_kendall_koch:
   topic_resource_key:
   wave:
 hardrock_2016_charlie_mueller:
+  event: hardrock_2016
   person: charlie_mueller
   id: 7343
   age: 27
@@ -2905,7 +2906,6 @@ hardrock_2016_charlie_mueller:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 148987
   finished: false
   first_name: Charlie
@@ -2925,6 +2925,7 @@ hardrock_2016_charlie_mueller:
   topic_resource_key:
   wave:
 hardrock_2016_brinda_fisher:
+  event: hardrock_2016
   person: brinda_fisher
   id: 7376
   age: 22
@@ -2944,7 +2945,6 @@ hardrock_2016_brinda_fisher:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 149907
   finished: false
   first_name: Brinda
@@ -2964,6 +2964,7 @@ hardrock_2016_brinda_fisher:
   topic_resource_key:
   wave:
 hardrock_2016_rene_mclaughlin:
+  event: hardrock_2016
   person: rene_mclaughlin
   id: 7380
   age: 32
@@ -2983,7 +2984,6 @@ hardrock_2016_rene_mclaughlin:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 150016
   finished: false
   first_name: Rene
@@ -3003,6 +3003,7 @@ hardrock_2016_rene_mclaughlin:
   topic_resource_key:
   wave:
 hardrock_2016_dropped_grouse:
+  event: hardrock_2016
   person: dropped_grouse
   id: 7396
   age: 47
@@ -3022,7 +3023,6 @@ hardrock_2016_dropped_grouse:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 150335
   finished: false
   first_name: Dropped
@@ -3042,6 +3042,7 @@ hardrock_2016_dropped_grouse:
   topic_resource_key:
   wave:
 hardrock_2016_mervin_smitham:
+  event: hardrock_2016
   person: mervin_smitham
   id: 7400
   age: 24
@@ -3061,7 +3062,6 @@ hardrock_2016_mervin_smitham:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 150403
   finished: false
   first_name: Mervin
@@ -3081,6 +3081,7 @@ hardrock_2016_mervin_smitham:
   topic_resource_key:
   wave:
 hardrock_2016_rhett_auer:
+  event: hardrock_2016
   person:
   id: 7404
   age: 41
@@ -3100,7 +3101,6 @@ hardrock_2016_rhett_auer:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 150467
   finished: false
   first_name: Rhett
@@ -3120,6 +3120,7 @@ hardrock_2016_rhett_auer:
   topic_resource_key:
   wave:
 hardrock_2016_hoyt_macejkovic:
+  event: hardrock_2016
   person: hoyt_macejkovic
   id: 7407
   age: 55
@@ -3139,7 +3140,6 @@ hardrock_2016_hoyt_macejkovic:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 150506
   finished: false
   first_name: Hoyt
@@ -3159,6 +3159,7 @@ hardrock_2016_hoyt_macejkovic:
   topic_resource_key:
   wave:
 hardrock_2016_start_only:
+  event: hardrock_2016
   person: start_only_maine_us
   id: 7411
   age: 26
@@ -3178,7 +3179,6 @@ hardrock_2016_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 37
   final_split_time_id: 192705
   finished: false
   first_name: Start
@@ -3198,6 +3198,7 @@ hardrock_2016_start_only:
   topic_resource_key:
   wave:
 ggd30_50k_finished_first:
+  event: ggd30_50k
   person: finished_first_colorado_us
   id: 15626
   age: 44
@@ -3217,7 +3218,6 @@ ggd30_50k_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 48
   final_split_time_id: 188951
   finished: true
   first_name: Finished
@@ -3237,6 +3237,7 @@ ggd30_50k_finished_first:
   topic_resource_key:
   wave:
 ggd30_50k_bad_finish:
+  event: ggd30_50k
   person: bad_finish
   id: 15664
   age: 21
@@ -3256,7 +3257,6 @@ ggd30_50k_bad_finish:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 48
   final_split_time_id: 189055
   finished: true
   first_name: Bad
@@ -3276,6 +3276,7 @@ ggd30_50k_bad_finish:
   topic_resource_key:
   wave:
 ggd30_50k_progress_aid4:
+  event: ggd30_50k
   person: progress_aid4
   id: 15891
   age: 35
@@ -3295,7 +3296,6 @@ ggd30_50k_progress_aid4:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 48
   final_split_time_id: 189814
   finished: false
   first_name: Progress
@@ -3315,6 +3315,7 @@ ggd30_50k_progress_aid4:
   topic_resource_key:
   wave:
 ggd30_50k_progress_aid3:
+  event: ggd30_50k
   person: progress_aid3
   id: 15901
   age: 31
@@ -3334,7 +3335,6 @@ ggd30_50k_progress_aid3:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 48
   final_split_time_id: 189850
   finished: false
   first_name: Progress
@@ -3354,6 +3354,7 @@ ggd30_50k_progress_aid3:
   topic_resource_key:
   wave:
 ggd30_50k_drop_aid4:
+  event: ggd30_50k
   person: drop_aid4
   id: 15931
   age: 18
@@ -3373,7 +3374,6 @@ ggd30_50k_drop_aid4:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 48
   final_split_time_id: 189952
   finished: false
   first_name: Drop
@@ -3393,6 +3393,7 @@ ggd30_50k_drop_aid4:
   topic_resource_key:
   wave:
 ggd30_50k_start_only:
+  event: ggd30_50k
   person: start_only_2019_02_01_07_19_53
   id: 16023
   age: 31
@@ -3412,7 +3413,6 @@ ggd30_50k_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 48
   final_split_time_id: 190761
   finished: false
   first_name: Start
@@ -3432,6 +3432,7 @@ ggd30_50k_start_only:
   topic_resource_key:
   wave:
 ggd30_50k_not_started:
+  event: ggd30_50k
   person: not_started
   id: 16032
   age: 31
@@ -3451,7 +3452,6 @@ ggd30_50k_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 48
   final_split_time_id:
   finished: false
   first_name: Not
@@ -3471,6 +3471,7 @@ ggd30_50k_not_started:
   topic_resource_key:
   wave:
 ggd30_12m_start_only:
+  event: ggd30_12m
   person: start_only_colorado_us
   id: 16094
   age: 27
@@ -3490,7 +3491,6 @@ ggd30_12m_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 49
   final_split_time_id: 190731
   finished: false
   first_name: Start
@@ -3510,6 +3510,7 @@ ggd30_12m_start_only:
   topic_resource_key:
   wave:
 ggd30_12m_finished_second:
+  event: ggd30_12m
   person: finished_second_colorado_us
   id: 16107
   age: 43
@@ -3529,7 +3530,6 @@ ggd30_12m_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 49
   final_split_time_id: 190273
   finished: true
   first_name: Finished
@@ -3549,6 +3549,7 @@ ggd30_12m_finished_second:
   topic_resource_key:
   wave:
 ggd30_12m_finished_first:
+  event: ggd30_12m
   person: finished_first_france
   id: 16173
   age: 23
@@ -3568,7 +3569,6 @@ ggd30_12m_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 49
   final_split_time_id: 190117
   finished: true
   first_name: Finished
@@ -3588,6 +3588,7 @@ ggd30_12m_finished_first:
   topic_resource_key:
   wave:
 ggd30_12m_not_started:
+  event: ggd30_12m
   person: not_started_colorado_us
   id: 16209
   age: 22
@@ -3607,7 +3608,6 @@ ggd30_12m_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 49
   final_split_time_id:
   finished: false
   first_name: Not
@@ -3627,6 +3627,7 @@ ggd30_12m_not_started:
   topic_resource_key:
   wave:
 sum_55k_finished_first:
+  event: sum_55k
   person: finished_first_colorado_us
   id: 16227
   age: 44
@@ -3646,7 +3647,6 @@ sum_55k_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 57
   final_split_time_id: 190508
   finished: true
   first_name: Finished
@@ -3666,6 +3666,7 @@ sum_55k_finished_first:
   topic_resource_key:
   wave:
 sum_55k_finished_second:
+  event: sum_55k
   person: finished_second_colorado_us
   id: 16229
   age: 44
@@ -3685,7 +3686,6 @@ sum_55k_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 57
   final_split_time_id: 190528
   finished: true
   first_name: Finished
@@ -3705,6 +3705,7 @@ sum_55k_finished_second:
   topic_resource_key:
   wave:
 sum_55k_not_started:
+  event: sum_55k
   person: not_started_colorado_us_2019_02_01
   id: 16242
   age: 36
@@ -3724,7 +3725,6 @@ sum_55k_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 57
   final_split_time_id:
   finished: false
   first_name: Not
@@ -3744,6 +3744,7 @@ sum_55k_not_started:
   topic_resource_key:
   wave:
 sum_55k_progress_rolling:
+  event: sum_55k
   person: progress_rolling
   id: 16244
   age: 55
@@ -3763,7 +3764,6 @@ sum_55k_progress_rolling:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 57
   final_split_time_id: 190672
   finished: false
   first_name: Progress
@@ -3783,6 +3783,7 @@ sum_55k_progress_rolling:
   topic_resource_key:
   wave:
 sum_55k_drop_bandera:
+  event: sum_55k
   person: drop_bandera
   id: 16245
   age: 19
@@ -3802,7 +3803,6 @@ sum_55k_drop_bandera:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 57
   final_split_time_id: 190683
   finished: false
   first_name: Drop
@@ -3822,6 +3822,7 @@ sum_55k_drop_bandera:
   topic_resource_key:
   wave:
 sum_55k_start_only:
+  event: sum_55k
   person: start_only_colorado_us_2019_02_01
   id: 16246
   age: 49
@@ -3841,7 +3842,6 @@ sum_55k_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 57
   final_split_time_id: 190816
   finished: false
   first_name: Start
@@ -3861,6 +3861,7 @@ sum_55k_start_only:
   topic_resource_key:
   wave:
 sum_100k_drop_anvil:
+  event: sum_100k
   person: drop_anvil
   id: 16247
   age: 28
@@ -3880,7 +3881,6 @@ sum_100k_drop_anvil:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 56
   final_split_time_id: 190695
   finished: false
   first_name: Drop
@@ -3900,6 +3900,7 @@ sum_100k_drop_anvil:
   topic_resource_key:
   wave:
 sum_100k_progress_cascade:
+  event: sum_100k
   person: progress_cascade
   id: 16248
   age: 20
@@ -3919,7 +3920,6 @@ sum_100k_progress_cascade:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 56
   final_split_time_id: 192704
   finished: false
   first_name: Progress
@@ -3939,6 +3939,7 @@ sum_100k_progress_cascade:
   topic_resource_key:
   wave:
 rufa_2017_12h_finished_first:
+  event: rufa_2017_12h
   person: finished_first
   id: 16643
   age: 20
@@ -3958,7 +3959,6 @@ rufa_2017_12h_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 70
   final_split_time_id: 192201
   finished: true
   first_name: Finished
@@ -3978,6 +3978,7 @@ rufa_2017_12h_finished_first:
   topic_resource_key:
   wave:
 rufa_2017_12h_finished_lap6:
+  event: rufa_2017_12h
   person: finished_lap6
   id: 16648
   age: 53
@@ -3997,7 +3998,6 @@ rufa_2017_12h_finished_lap6:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 70
   final_split_time_id: 192295
   finished: true
   first_name: Finished
@@ -4017,6 +4017,7 @@ rufa_2017_12h_finished_lap6:
   topic_resource_key:
   wave:
 rufa_2017_12h_progress_lap5_partial:
+  event: rufa_2017_12h
   person: progress_lap5_partial
   id: 16657
   age: 28
@@ -4036,7 +4037,6 @@ rufa_2017_12h_progress_lap5_partial:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 70
   final_split_time_id: 192433
   finished: false
   first_name: Progress
@@ -4056,6 +4056,7 @@ rufa_2017_12h_progress_lap5_partial:
   topic_resource_key:
   wave:
 rufa_2017_12h_progress_lap2:
+  event: rufa_2017_12h
   person: progress_lap2
   id: 16663
   age: 24
@@ -4075,7 +4076,6 @@ rufa_2017_12h_progress_lap2:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 70
   final_split_time_id: 192502
   finished: false
   first_name: Progress
@@ -4095,6 +4095,7 @@ rufa_2017_12h_progress_lap2:
   topic_resource_key:
   wave:
 rufa_2017_12h_start_only:
+  event: rufa_2017_12h
   person: start_only
   id: 16667
   age: 44
@@ -4114,7 +4115,6 @@ rufa_2017_12h_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 70
   final_split_time_id: 192542
   finished: false
   first_name: Start
@@ -4134,6 +4134,7 @@ rufa_2017_12h_start_only:
   topic_resource_key:
   wave:
 rufa_2017_12h_not_started:
+  event: rufa_2017_12h
   person: not_started_utah_us
   id: 16673
   age: 49
@@ -4153,7 +4154,6 @@ rufa_2017_12h_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 70
   final_split_time_id:
   finished: false
   first_name: Not
@@ -4173,6 +4173,7 @@ rufa_2017_12h_not_started:
   topic_resource_key:
   wave:
 sum_100k_un_started:
+  event: sum_100k
   person: un_started
   id: 16683
   age: 29
@@ -4192,7 +4193,6 @@ sum_100k_un_started:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 56
   final_split_time_id:
   finished: false
   first_name: Un
@@ -4212,6 +4212,7 @@ sum_100k_un_started:
   topic_resource_key:
   wave:
 sum_100k_on_dst_change:
+  event: sum_100k
   person: on_dst_change
   id: 16684
   age:
@@ -4231,7 +4232,6 @@ sum_100k_on_dst_change:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 56
   final_split_time_id: 192715
   finished: false
   first_name: 'On'
@@ -4251,6 +4251,7 @@ sum_100k_on_dst_change:
   topic_resource_key:
   wave:
 sum_100k_across_dst_change:
+  event: sum_100k
   person: across_dst_change
   id: 16685
   age:
@@ -4270,7 +4271,6 @@ sum_100k_across_dst_change:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 56
   final_split_time_id: 192710
   finished: false
   first_name: Across
@@ -4290,6 +4290,7 @@ sum_100k_across_dst_change:
   topic_resource_key:
   wave:
 ggd30_50k_finished_second:
+  event: ggd30_50k
   person:
   id: 16686
   age: 43
@@ -4309,7 +4310,6 @@ ggd30_50k_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 48
   final_split_time_id: 192722
   finished: true
   first_name: Finished
@@ -4329,6 +4329,7 @@ ggd30_50k_finished_second:
   topic_resource_key:
   wave:
 ggd30_12m_series_finisher:
+  event: ggd30_12m
   person: series_finisher
   id: 16687
   age: 34
@@ -4348,7 +4349,6 @@ ggd30_12m_series_finisher:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 49
   final_split_time_id: 192724
   finished: true
   first_name: Series
@@ -4368,6 +4368,7 @@ ggd30_12m_series_finisher:
   topic_resource_key:
   wave:
 sum_55k_series_finisher:
+  event: sum_55k
   person: series_finisher
   id: 16688
   age: 34
@@ -4387,7 +4388,6 @@ sum_55k_series_finisher:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 57
   final_split_time_id: 192734
   finished: true
   first_name: Series
@@ -4407,6 +4407,7 @@ sum_55k_series_finisher:
   topic_resource_key:
   wave:
 sum_55k_slow_finisher:
+  event: sum_55k
   person: slow_finisher
   id: 16689
   age: 64
@@ -4426,7 +4427,6 @@ sum_55k_slow_finisher:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 57
   final_split_time_id: 192744
   finished: true
   first_name: Slow
@@ -4446,6 +4446,7 @@ sum_55k_slow_finisher:
   topic_resource_key:
   wave:
 ggd30_12m_slow_finisher:
+  event: ggd30_12m
   person: slow_finisher
   id: 16690
   age: 64
@@ -4465,7 +4466,6 @@ ggd30_12m_slow_finisher:
   email:
   emergency_contact:
   emergency_phone:
-  event_id: 49
   final_split_time_id: 192746
   finished: true
   first_name: Slow

--- a/spec/fixtures/event_series_events.yml
+++ b/spec/fixtures/event_series_events.yml
@@ -1,17 +1,17 @@
 ---
 event_series_event_0001:
+  event: ggd30_50k
   id: 1
-  event_id: 48
   event_series_id: 1
 event_series_event_0002:
+  event: sum_55k
   id: 2
-  event_id: 57
   event_series_id: 1
 event_series_event_0003:
+  event: ggd30_12m
   id: 3
-  event_id: 49
   event_series_id: 2
 event_series_event_0004:
+  event: sum_55k
   id: 4
-  event_id: 57
   event_series_id: 2

--- a/spec/fixtures/events.yml
+++ b/spec/fixtures/events.yml
@@ -1,107 +1,8 @@
 ---
-hardrock_2015:
-  course: hardrock_ccw
-  event_group: hardrock_2015
-  results_template: simple
-  id: 4
-  beacon_url:
-  efforts_count: 30
-  historical_name: Hardrock 2015
-  laps_required: 1
-  notice_text:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  short_name:
-  slug: hardrock-2015
-  topic_resource_key:
-ramble:
-  course: ramble_even_course
-  event_group: ramble
-  results_template: simple
-  id: 14
-  beacon_url:
-  efforts_count: 4
-  historical_name: Ramble
-  laps_required: 1
-  notice_text:
-  scheduled_start_time: 2006-09-16 14:00:00.000000000 Z
-  short_name:
-  slug: ramble
-  topic_resource_key:
-hardrock_2014:
-  course: hardrock_cw
-  event_group: hardrock_2014
-  results_template: simple
-  id: 17
-  beacon_url:
-  efforts_count: 19
-  historical_name: Hardrock 2014
-  laps_required: 1
-  notice_text:
-  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  short_name:
-  slug: hardrock-2014
-  topic_resource_key:
-rufa_2016:
-  course: rufa_course
-  event_group: rufa_2016
-  results_template: simple
-  id: 34
-  beacon_url:
-  efforts_count: 4
-  historical_name: RUFA 2016
-  laps_required: 0
-  notice_text:
-  scheduled_start_time: 2016-02-13 13:00:00.000000000 Z
-  short_name:
-  slug: rufa-2016
-  topic_resource_key:
-rufa_2017_24h:
-  course: rufa_course
-  event_group: rufa_2017
-  results_template: simple
-  id: 36
-  beacon_url:
-  efforts_count: 6
-  historical_name: RUFA 2017 24H
-  laps_required: 0
-  notice_text:
-  scheduled_start_time: 2017-02-11 13:00:00.000000000 Z
-  short_name: 24H
-  slug: rufa-2017-24h
-  topic_resource_key:
-hardrock_2016:
-  course: hardrock_cw
-  event_group: hardrock_2016
-  results_template: simple
-  id: 37
-  beacon_url: http://trackleaders.com/hardrock16
-  efforts_count: 19
-  historical_name: Hardrock 2016
-  laps_required: 1
-  notice_text:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  short_name:
-  slug: hardrock-2016
-  topic_resource_key:
-ggd30_50k:
-  course: d30_50k_course
-  event_group: dirty_30
-  results_template: simple
-  id: 48
-  beacon_url: https://goldengatedirty30.maprogress.com
-  efforts_count: 8
-  historical_name: GGD30 50K
-  laps_required: 1
-  notice_text:
-  scheduled_start_time: 2017-06-04 01:00:00.000000000 Z
-  short_name: 50K
-  slug: ggd30-50k
-  topic_resource_key:
 ggd30_12m:
   course: d30_12m_course
   event_group: dirty_30
   results_template: simple
-  id: 49
   beacon_url:
   efforts_count: 6
   historical_name: GGD30 12M
@@ -111,11 +12,114 @@ ggd30_12m:
   short_name: 12-miler
   slug: ggd30-12m
   topic_resource_key:
+ggd30_50k:
+  course: d30_50k_course
+  event_group: dirty_30
+  results_template: simple
+  beacon_url: https://goldengatedirty30.maprogress.com
+  efforts_count: 8
+  historical_name: GGD30 50K
+  laps_required: 1
+  notice_text:
+  scheduled_start_time: 2017-06-04 01:00:00.000000000 Z
+  short_name: 50K
+  slug: ggd30-50k
+  topic_resource_key:
+hardrock_2014:
+  course: hardrock_cw
+  event_group: hardrock_2014
+  results_template: simple
+  beacon_url:
+  efforts_count: 19
+  historical_name: Hardrock 2014
+  laps_required: 1
+  notice_text:
+  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
+  short_name:
+  slug: hardrock-2014
+  topic_resource_key:
+hardrock_2015:
+  course: hardrock_ccw
+  event_group: hardrock_2015
+  results_template: simple
+  beacon_url:
+  efforts_count: 30
+  historical_name: Hardrock 2015
+  laps_required: 1
+  notice_text:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  short_name:
+  slug: hardrock-2015
+  topic_resource_key:
+hardrock_2016:
+  course: hardrock_cw
+  event_group: hardrock_2016
+  results_template: simple
+  beacon_url: http://trackleaders.com/hardrock16
+  efforts_count: 19
+  historical_name: Hardrock 2016
+  laps_required: 1
+  notice_text:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  short_name:
+  slug: hardrock-2016
+  topic_resource_key:
+ramble:
+  course: ramble_even_course
+  event_group: ramble
+  results_template: simple
+  beacon_url:
+  efforts_count: 4
+  historical_name: Ramble
+  laps_required: 1
+  notice_text:
+  scheduled_start_time: 2006-09-16 14:00:00.000000000 Z
+  short_name:
+  slug: ramble
+  topic_resource_key:
+rufa_2016:
+  course: rufa_course
+  event_group: rufa_2016
+  results_template: simple
+  beacon_url:
+  efforts_count: 4
+  historical_name: RUFA 2016
+  laps_required: 0
+  notice_text:
+  scheduled_start_time: 2016-02-13 13:00:00.000000000 Z
+  short_name:
+  slug: rufa-2016
+  topic_resource_key:
+rufa_2017_12h:
+  course: rufa_course
+  event_group: rufa_2017
+  results_template: simple
+  beacon_url:
+  efforts_count: 6
+  historical_name: RUFA 2017 12H
+  laps_required: 0
+  notice_text:
+  scheduled_start_time: 2017-02-11 14:00:00.000000000 Z
+  short_name: 12H
+  slug: rufa-2017-12h
+  topic_resource_key:
+rufa_2017_24h:
+  course: rufa_course
+  event_group: rufa_2017
+  results_template: simple
+  beacon_url:
+  efforts_count: 6
+  historical_name: RUFA 2017 24H
+  laps_required: 0
+  notice_text:
+  scheduled_start_time: 2017-02-11 13:00:00.000000000 Z
+  short_name: 24H
+  slug: rufa-2017-24h
+  topic_resource_key:
 sum_100k:
   course: sum_100k_course
   event_group: sum
   results_template: simple
-  id: 56
   beacon_url:
   efforts_count: 5
   historical_name: SUM 100K
@@ -129,7 +133,6 @@ sum_55k:
   course: sum_55k_course
   event_group: sum
   results_template: sub_masters_masters_and_grandmasters
-  id: 57
   beacon_url:
   efforts_count: 8
   historical_name: SUM 55K
@@ -138,18 +141,4 @@ sum_55k:
   scheduled_start_time: 2017-09-23 15:00:00.000000000 Z
   short_name: 55K
   slug: sum-55k
-  topic_resource_key:
-rufa_2017_12h:
-  course: rufa_course
-  event_group: rufa_2017
-  results_template: simple
-  id: 70
-  beacon_url:
-  efforts_count: 6
-  historical_name: RUFA 2017 12H
-  laps_required: 0
-  notice_text:
-  scheduled_start_time: 2017-02-11 14:00:00.000000000 Z
-  short_name: 12H
-  slug: rufa-2017-12h
   topic_resource_key:

--- a/spec/fixtures/projection_assessment_runs.yml
+++ b/spec/fixtures/projection_assessment_runs.yml
@@ -1,12 +1,12 @@
 ---
 projection_assessment_run_0001:
+  event: ramble
   id: 269964004
   completed_bitkey: 1
   completed_lap: 1
   completed_split_id: 46
   elapsed_time:
   error_message:
-  event_id: 14
   failure_count:
   projected_bitkey: 1
   projected_lap: 1

--- a/spec/models/interval_split_traffic_spec.rb
+++ b/spec/models/interval_split_traffic_spec.rb
@@ -3,10 +3,11 @@ require "rails_helper"
 RSpec.describe IntervalSplitTraffic, type: :model do
   describe ".execute_query" do
     subject { described_class.execute_query(event_group: event_group, split_name: split_name, band_width: band_width) }
+
     let(:event_group) { event_groups(:hardrock_2015) }
     let(:band_width) { 1.hour }
 
-    context "for a split close to the start" do
+    context "when the split is close to the start" do
       let(:split_name) { "Cunningham" }
 
       it "returns an array of IntervalSplitTraffic objects" do
@@ -18,7 +19,7 @@ RSpec.describe IntervalSplitTraffic, type: :model do
       end
     end
 
-    context "for a split extending over multiple days" do
+    context "when the split extends over multiple days" do
       let(:split_name) { "Telluride" }
 
       it "returns an array of IntervalSplitTraffic objects reflecting multiple days" do
@@ -34,7 +35,7 @@ RSpec.describe IntervalSplitTraffic, type: :model do
       end
     end
 
-    context "for an event group with multiple events" do
+    context "when the event group has multiple events" do
       let(:event_group) { event_groups(:sum) }
       let(:split_name) { "Start" }
       let(:band_width) { 1.day }
@@ -46,7 +47,7 @@ RSpec.describe IntervalSplitTraffic, type: :model do
         expect(subject_ist.start_time).to eq("2017-09-23 00:00:00")
         expect(subject_ist.end_time).to eq("2017-09-24 00:00:00")
         expect(subject_ist.short_names).to eq(%w[100K 55K])
-        expect(subject_ist.event_ids).to eq([56, 57])
+        expect(subject_ist.event_ids).to eq([events(:sum_100k).id, events(:sum_55k).id])
         expect(subject_ist.in_counts).to eq([2, 2])
         expect(subject_ist.out_counts).to eq([0, 0])
         expect(subject_ist.finished_in_counts).to eq([0, 2])
@@ -63,11 +64,11 @@ RSpec.describe IntervalSplitTraffic, type: :model do
       end
     end
 
-    context "for a split that has not yet seen any traffic" do
+    context "when the split has not yet seen any traffic" do
       let(:event_group) { event_groups(:hardrock_2016) }
       let(:split_name) { "Finish" }
       let(:split) { event_group.events.first.course.finish_split }
-      before { event_group.split_times.where(split: split).each(&:destroy) }
+      before { event_group.split_times.where(split: split).find_each(&:destroy) }
 
       it "returns an empty array" do
         expect(subject).to eq([])
@@ -93,17 +94,17 @@ RSpec.describe IntervalSplitTraffic, type: :model do
 
     let(:result) { subject.counts_for_event(event_id) }
 
-    context "for the first event" do
+    context "when event_id matches the first event" do
       let(:event_id) { 1 }
       it { expect(result).to eq(described_class::Counts.new(1, "First Event", 3, 3, 2, 2)) }
     end
 
-    context "for the second event" do
+    context "when event_id matches the second event" do
       let(:event_id) { 2 }
       it { expect(result).to eq(described_class::Counts.new(2, "Second Event", 4, 3, 3, 2)) }
     end
 
-    context "for the overall event group" do
+    context "when event_id is nil for the overall event group" do
       let(:event_id) { nil }
       it { expect(result).to eq(described_class::Counts.new(nil, nil, 7, 6, 5, 4)) }
     end

--- a/spec/models/interval_split_traffic_spec.rb
+++ b/spec/models/interval_split_traffic_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe IntervalSplitTraffic, type: :model do
     subject do
       described_class.new(
         short_names: ["First Event", "Second Event"],
-        event_ids: [1, 2],
+        event_ids: [first_event.id, second_event.id],
         in_counts: [3, 4],
         out_counts: [3, 3],
         finished_in_counts: [2, 3],
@@ -92,16 +92,18 @@ RSpec.describe IntervalSplitTraffic, type: :model do
       )
     end
 
+    let(:first_event) { events(:sum_100k) }
+    let(:second_event) { events(:sum_55k) }
     let(:result) { subject.counts_for_event(event_id) }
 
     context "when event_id matches the first event" do
-      let(:event_id) { 1 }
-      it { expect(result).to eq(described_class::Counts.new(1, "First Event", 3, 3, 2, 2)) }
+      let(:event_id) { first_event.id }
+      it { expect(result).to eq(described_class::Counts.new(first_event.id, "First Event", 3, 3, 2, 2)) }
     end
 
     context "when event_id matches the second event" do
-      let(:event_id) { 2 }
-      it { expect(result).to eq(described_class::Counts.new(2, "Second Event", 4, 3, 3, 2)) }
+      let(:event_id) { second_event.id }
+      it { expect(result).to eq(described_class::Counts.new(second_event.id, "Second Event", 4, 3, 3, 2)) }
     end
 
     context "when event_id is nil for the overall event group" do


### PR DESCRIPTION
## Summary

Continues the "Make X a portable fixture table" series. Events now use Rails-assigned (label-hashed) ids; other fixtures reference them by label.

### Changes
- Add `:events` to `PORTABLE_FIXTURE_TABLES`. events is slugged, so no `ORDER_BY_MAP` entry is needed.
- `spec/fixtures/events.yml`: drop the explicit `id:` from every entry; reorder by slug (matches the dump task's output).
- Replace `event_id: <int>` with `event: <label>` in four referencing fixtures (Event is already a `belongs_to` on each, so the dump converts them automatically):
  - `aid_stations.yml` (56 rows) — inserted at top (AidStation declares `:event` first).
  - `efforts.yml` (115 rows) — inserted before `person:` (Effort declares `:event` before `:person`).
  - `event_series_events.yml` (4 rows) — inserted at top.
  - `projection_assessment_runs.yml` (1 row) — inserted at top.
- `connections.yml`: rewrite the two polymorphic `Event` refs (`connection_0002`, `connection_0003`) as `destination: <label> (Event)`.

Event has no `Auditable` `created_by` and (aside from connections, fixed here) no other polymorphic refs, so this conversion needs no model changes. The two specs that mention `event_id: 10` (`spec/queries/base_query_spec.rb`) use in-memory hash arguments, not DB records, so they're unaffected.

## Testing

Ran a focused local selection (~620 examples across Event, EventGroup, Course, Effort, RawTime, Split, AidStation, the AidStations/Events/Courses/Splits/Efforts API controllers, presenter specs, ETL/sync interactor specs, request specs, and the search system spec) — all green. Relying on CI for the full suite.

Part of #2065
