### PR TITLE
Add belongs_to :completed_split and :projected_split on ProjectionAssessmentRun

### DIFF
--- a/app/models/projection_assessment_run.rb
+++ b/app/models/projection_assessment_run.rb
@@ -1,5 +1,7 @@
 class ProjectionAssessmentRun < ApplicationRecord
   belongs_to :event
+  belongs_to :completed_split, class_name: "Split"
+  belongs_to :projected_split, class_name: "Split"
   has_many :assessments, class_name: "ProjectionAssessment", dependent: :destroy
 
   after_update :broadcast_projection_assessment_run
@@ -35,6 +37,6 @@ class ProjectionAssessmentRun < ApplicationRecord
     broadcast_replace_to event,
                          :projection_assessment_runs,
                          partial: "projection_assessment_runs/projection_assessment_run",
-                         locals: { organization: self.organization, event: self.event, projection_assessment_run: self }
+                         locals: { organization: organization, event: event, projection_assessment_run: self }
   end
 end


### PR DESCRIPTION
## Summary

Preparatory model change for the upcoming `splits` portability PR.

`ProjectionAssessmentRun#completed_split_id` and `#projected_split_id` are plain integer columns with no association — same pattern as `created_by` on `Organization` / `EventGroup` before #2081. With splits as a non-portable fixture today, the literal ids in `projection_assessment_runs.yml` (46, 47) line up with real seeded splits. But making splits portable would leave those values dangling, because the dump task only rewrites a column to a label reference when the model has a `belongs_to` pointing at the (newly-portable) table.

Add the two associations now, in a dedicated PR, so the splits portability PR can convert the fixture references automatically:

- `belongs_to :completed_split, class_name: "Split"`
- `belongs_to :projected_split, class_name: "Split"`

Both are required — the columns are `null: false` in the schema (lines 560 and 568).

The only existing caller (`runner_spec.rb`) already builds records with `completed_split_id: completed_split.id` / `projected_split_id: projected_split.id`, so the new associations are transparent. No behavior change.

Also auto-fixes two pre-existing `Style/RedundantSelf` offenses in the touched file (`self.organization` / `self.event` → `organization` / `event` in `broadcast_projection_assessment_run`).

## Testing

`spec/lib/projection_assessments/runner_spec.rb` (4 examples, 0 failures); rubocop clean. The full suite belongs to CI.

Part of #2065
