### PR TITLE
Make splits a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -51,6 +51,7 @@ module FixtureHelper
     :results_categories,
     :results_templates,
     :results_template_categories,
+    :splits,
     :users,
   ].freeze
 

--- a/spec/fixtures/aid_stations.yml
+++ b/spec/fixtures/aid_stations.yml
@@ -1,225 +1,225 @@
 ---
 aid_station_0001:
   event: hardrock_2015
+  split: hardrock_ccw_start
   id: 5
-  split_id: 5
 aid_station_0002:
   event: hardrock_2015
+  split: hardrock_ccw_cunningham
   id: 6
-  split_id: 6
 aid_station_0003:
   event: hardrock_2015
+  split: hardrock_ccw_sherman
   id: 12
-  split_id: 12
 aid_station_0004:
   event: hardrock_2015
+  split: hardrock_ccw_grouse
   id: 16
-  split_id: 16
 aid_station_0005:
   event: hardrock_2015
+  split: hardrock_ccw_telluride
   id: 26
-  split_id: 26
 aid_station_0006:
   event: hardrock_2015
+  split: hardrock_ccw_putnam
   id: 32
-  split_id: 32
 aid_station_0007:
   event: hardrock_2015
+  split: hardrock_ccw_finish
   id: 34
-  split_id: 34
 aid_station_0008:
   event: ramble
+  split: ramble_even_course_start
   id: 140
-  split_id: 46
 aid_station_0009:
   event: ramble
+  split: ramble_even_course_finish
   id: 141
-  split_id: 47
 aid_station_0010:
   event: hardrock_2014
+  split: hardrock_cw_start
   id: 202
-  split_id: 81
 aid_station_0011:
   event: hardrock_2014
+  split: hardrock_cw_finish
   id: 203
-  split_id: 82
 aid_station_0012:
   event: hardrock_2014
+  split: hardrock_cw_telluride
   id: 208
-  split_id: 87
 aid_station_0013:
   event: hardrock_2014
+  split: hardrock_cw_ouray
   id: 214
-  split_id: 93
 aid_station_0014:
   event: hardrock_2014
+  split: hardrock_cw_grouse
   id: 218
-  split_id: 97
 aid_station_0015:
   event: hardrock_2014
+  split: hardrock_cw_sherman
   id: 222
-  split_id: 101
 aid_station_0016:
   event: hardrock_2014
+  split: hardrock_cw_cunningham
   id: 228
-  split_id: 107
 aid_station_0017:
   event: rufa_2016
+  split: rufa_course_start
   id: 458
-  split_id: 135
 aid_station_0018:
   event: rufa_2016
+  split: rufa_course_finish
   id: 459
-  split_id: 136
 aid_station_0019:
   event: rufa_2016
+  split: rufa_course_grandeur_peak
   id: 460
-  split_id: 137
 aid_station_0020:
   event: rufa_2017_24h
+  split: rufa_course_grandeur_peak
   id: 476
-  split_id: 137
 aid_station_0021:
   event: rufa_2017_24h
+  split: rufa_course_start
   id: 477
-  split_id: 135
 aid_station_0022:
   event: rufa_2017_24h
+  split: rufa_course_finish
   id: 478
-  split_id: 136
 aid_station_0023:
   event: hardrock_2016
+  split: hardrock_cw_start
   id: 479
-  split_id: 81
 aid_station_0024:
   event: hardrock_2016
+  split: hardrock_cw_telluride
   id: 482
-  split_id: 87
 aid_station_0025:
   event: hardrock_2016
+  split: hardrock_cw_ouray
   id: 485
-  split_id: 93
 aid_station_0026:
   event: hardrock_2016
+  split: hardrock_cw_grouse
   id: 487
-  split_id: 97
 aid_station_0027:
   event: hardrock_2016
+  split: hardrock_cw_sherman
   id: 489
-  split_id: 101
 aid_station_0028:
   event: hardrock_2016
+  split: hardrock_cw_cunningham
   id: 492
-  split_id: 107
 aid_station_0029:
   event: hardrock_2016
+  split: hardrock_cw_finish
   id: 493
-  split_id: 82
 aid_station_0030:
   event: hardrock_2015
+  split: hardrock_ccw_ouray
   id: 513
-  split_id: 20
 aid_station_0031:
   event: ggd30_50k
+  split: d30_50k_course_start
   id: 570
-  split_id: 164
 aid_station_0032:
   event: ggd30_50k
+  split: d30_50k_course_finish
   id: 571
-  split_id: 165
 aid_station_0033:
   event: ggd30_50k
+  split: d30_50k_course_aid_1
   id: 572
-  split_id: 167
 aid_station_0034:
   event: ggd30_50k
+  split: d30_50k_course_aid_3
   id: 574
-  split_id: 170
 aid_station_0035:
   event: ggd30_50k
+  split: d30_50k_course_aid_4
   id: 575
-  split_id: 168
 aid_station_0036:
   event: ggd30_50k
+  split: d30_50k_course_aid_5
   id: 576
-  split_id: 166
 aid_station_0037:
   event: ggd30_50k
+  split: d30_50k_course_aid_2
   id: 577
-  split_id: 171
 aid_station_0038:
   event: ggd30_12m
+  split: d30_12m_course_finish
   id: 578
-  split_id: 173
 aid_station_0039:
   event: ggd30_12m
+  split: d30_12m_course_start
   id: 579
-  split_id: 172
 aid_station_0040:
   event: sum_100k
+  split: sum_100k_course_finish
   id: 626
-  split_id: 205
 aid_station_0041:
   event: sum_100k
+  split: sum_100k_course_start
   id: 627
-  split_id: 204
 aid_station_0042:
   event: sum_100k
+  split: sum_100k_course_rolling_pass_aid2
   id: 629
-  split_id: 207
 aid_station_0043:
   event: sum_100k
+  split: sum_100k_course_cascade_creek_rd_aid3
   id: 630
-  split_id: 208
 aid_station_0044:
   event: sum_100k
+  split: sum_100k_course_engineer_mtn_th_aid4
   id: 631
-  split_id: 209
 aid_station_0045:
   event: sum_100k
+  split: sum_100k_course_bandera_mine_aid5
   id: 632
-  split_id: 210
 aid_station_0046:
   event: sum_55k
+  split: sum_55k_course_finish
   id: 634
-  split_id: 213
 aid_station_0047:
   event: sum_55k
+  split: sum_55k_course_start
   id: 635
-  split_id: 212
 aid_station_0048:
   event: sum_55k
+  split: sum_55k_course_molas_pass_aid1
   id: 636
-  split_id: 218
 aid_station_0049:
   event: sum_55k
+  split: sum_55k_course_rolling_pass_aid2
   id: 637
-  split_id: 219
 aid_station_0050:
   event: sum_55k
+  split: sum_55k_course_bandera_mine_aid5
   id: 638
-  split_id: 220
 aid_station_0051:
   event: sum_55k
+  split: sum_55k_course_anvil_cg_aid6
   id: 639
-  split_id: 221
 aid_station_0052:
   event: sum_100k
+  split: sum_100k_course_molas_pass_aid1
   id: 725
-  split_id: 206
 aid_station_0053:
   event: sum_100k
+  split: sum_100k_course_anvil_cg_aid6
   id: 726
-  split_id: 211
 aid_station_0054:
   event: rufa_2017_12h
+  split: rufa_course_grandeur_peak
   id: 753
-  split_id: 137
 aid_station_0055:
   event: rufa_2017_12h
+  split: rufa_course_finish
   id: 754
-  split_id: 136
 aid_station_0056:
   event: rufa_2017_12h
+  split: rufa_course_start
   id: 755
-  split_id: 135

--- a/spec/fixtures/projection_assessment_runs.yml
+++ b/spec/fixtures/projection_assessment_runs.yml
@@ -1,16 +1,16 @@
 ---
 projection_assessment_run_0001:
   event: ramble
+  completed_split: ramble_even_course_start
+  projected_split: ramble_even_course_finish
   id: 269964004
   completed_bitkey: 1
   completed_lap: 1
-  completed_split_id: 46
   elapsed_time:
   error_message:
   failure_count:
   projected_bitkey: 1
   projected_lap: 1
-  projected_split_id: 47
   started_at:
   status: 0
   success_count:

--- a/spec/fixtures/split_times.yml
+++ b/spec/fixtures/split_times.yml
@@ -1,5 +1,6 @@
 ---
 hardrock_2015_tuan_jacobs_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 14
   absolute_time: 2015-07-10 13:38:00.000000000 Z
   data_status: 2
@@ -8,11 +9,11 @@ hardrock_2015_tuan_jacobs_cunningham_in_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 15
   absolute_time: 2015-07-10 13:38:00.000000000 Z
   data_status: 2
@@ -21,11 +22,11 @@ hardrock_2015_tuan_jacobs_cunningham_out_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 20
   absolute_time: 2015-07-10 17:38:00.000000000 Z
   data_status: 2
@@ -34,11 +35,11 @@ hardrock_2015_tuan_jacobs_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 21
   absolute_time: 2015-07-10 17:39:00.000000000 Z
   data_status: 2
@@ -47,11 +48,11 @@ hardrock_2015_tuan_jacobs_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 24
   absolute_time: 2015-07-10 20:52:00.000000000 Z
   data_status: 2
@@ -60,11 +61,11 @@ hardrock_2015_tuan_jacobs_grouse_in_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 25
   absolute_time: 2015-07-10 20:57:00.000000000 Z
   data_status: 2
@@ -73,11 +74,11 @@ hardrock_2015_tuan_jacobs_grouse_out_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 28
   absolute_time: 2015-07-10 23:39:00.000000000 Z
   data_status: 2
@@ -86,11 +87,11 @@ hardrock_2015_tuan_jacobs_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 29
   absolute_time: 2015-07-10 23:45:00.000000000 Z
   data_status: 2
@@ -99,11 +100,11 @@ hardrock_2015_tuan_jacobs_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 34
   absolute_time: 2015-07-11 03:12:00.000000000 Z
   data_status: 2
@@ -112,11 +113,11 @@ hardrock_2015_tuan_jacobs_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 35
   absolute_time: 2015-07-11 03:22:00.000000000 Z
   data_status: 2
@@ -125,11 +126,11 @@ hardrock_2015_tuan_jacobs_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 40
   absolute_time: 2015-07-11 10:06:00.000000000 Z
   data_status: 2
@@ -138,11 +139,11 @@ hardrock_2015_tuan_jacobs_putnam_in_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 41
   absolute_time: 2015-07-11 10:06:00.000000000 Z
   data_status: 2
@@ -151,11 +152,11 @@ hardrock_2015_tuan_jacobs_putnam_out_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_finish_1:
+  split: hardrock_ccw_finish
   id: 42
   absolute_time: 2015-07-11 11:13:00.000000000 Z
   data_status: 2
@@ -164,11 +165,11 @@ hardrock_2015_tuan_jacobs_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_start_1:
+  split: hardrock_ccw_start
   id: 43
   absolute_time: 2015-07-10 12:00:11.000000000 Z
   data_status: 2
@@ -177,11 +178,11 @@ hardrock_2015_erich_larson_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 44
   absolute_time: 2015-07-10 14:00:22.000000000 Z
   data_status: 2
@@ -190,11 +191,11 @@ hardrock_2015_erich_larson_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 45
   absolute_time: 2015-07-10 14:01:33.000000000 Z
   data_status: 2
@@ -203,11 +204,11 @@ hardrock_2015_erich_larson_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 50
   absolute_time: 2015-07-10 18:06:50.000000000 Z
   data_status: 2
@@ -216,11 +217,11 @@ hardrock_2015_erich_larson_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 51
   absolute_time: 2015-07-10 18:07:00.000000000 Z
   data_status: 2
@@ -229,11 +230,11 @@ hardrock_2015_erich_larson_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 54
   absolute_time: 2015-07-10 21:21:00.000000000 Z
   data_status: 2
@@ -242,11 +243,11 @@ hardrock_2015_erich_larson_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 55
   absolute_time: 2015-07-10 21:24:59.000000000 Z
   data_status: 2
@@ -255,11 +256,11 @@ hardrock_2015_erich_larson_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 58
   absolute_time: 2015-07-11 00:20:00.000000000 Z
   data_status: 2
@@ -268,11 +269,11 @@ hardrock_2015_erich_larson_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 59
   absolute_time: 2015-07-11 00:24:00.000000000 Z
   data_status: 2
@@ -281,11 +282,11 @@ hardrock_2015_erich_larson_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 64
   absolute_time: 2015-07-11 04:29:00.000000000 Z
   data_status: 2
@@ -294,11 +295,11 @@ hardrock_2015_erich_larson_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 65
   absolute_time: 2015-07-11 04:33:03.000000000 Z
   data_status: 2
@@ -307,11 +308,11 @@ hardrock_2015_erich_larson_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 70
   absolute_time: 2015-07-11 12:39:05.000000000 Z
   data_status: 2
@@ -320,11 +321,11 @@ hardrock_2015_erich_larson_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 71
   absolute_time: 2015-07-11 12:39:07.000000000 Z
   data_status: 2
@@ -333,11 +334,11 @@ hardrock_2015_erich_larson_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_finish_1:
+  split: hardrock_ccw_finish
   id: 72
   absolute_time: 2015-07-11 13:45:09.000000000 Z
   data_status: 2
@@ -346,11 +347,11 @@ hardrock_2015_erich_larson_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_start_1:
+  split: hardrock_ccw_start
   id: 253
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -359,11 +360,11 @@ hardrock_2015_leif_carter_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 254
   absolute_time: 2015-07-10 13:53:00.000000000 Z
   data_status: 2
@@ -372,11 +373,11 @@ hardrock_2015_leif_carter_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 255
   absolute_time: 2015-07-10 13:53:00.000000000 Z
   data_status: 2
@@ -385,11 +386,11 @@ hardrock_2015_leif_carter_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 260
   absolute_time: 2015-07-10 18:06:00.000000000 Z
   data_status: 2
@@ -398,11 +399,11 @@ hardrock_2015_leif_carter_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 261
   absolute_time: 2015-07-10 18:08:00.000000000 Z
   data_status: 2
@@ -411,11 +412,11 @@ hardrock_2015_leif_carter_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 264
   absolute_time: 2015-07-10 21:30:00.000000000 Z
   data_status: 2
@@ -424,11 +425,11 @@ hardrock_2015_leif_carter_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 265
   absolute_time: 2015-07-10 21:36:00.000000000 Z
   data_status: 2
@@ -437,11 +438,11 @@ hardrock_2015_leif_carter_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 268
   absolute_time: 2015-07-11 00:46:00.000000000 Z
   data_status: 2
@@ -450,11 +451,11 @@ hardrock_2015_leif_carter_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 269
   absolute_time: 2015-07-11 00:46:00.000000000 Z
   data_status: 2
@@ -463,11 +464,11 @@ hardrock_2015_leif_carter_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 274
   absolute_time: 2015-07-11 05:18:00.000000000 Z
   data_status: 2
@@ -476,11 +477,11 @@ hardrock_2015_leif_carter_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 275
   absolute_time: 2015-07-11 05:24:00.000000000 Z
   data_status: 2
@@ -489,11 +490,11 @@ hardrock_2015_leif_carter_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 280
   absolute_time: 2015-07-11 15:02:00.000000000 Z
   data_status: 2
@@ -502,11 +503,11 @@ hardrock_2015_leif_carter_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 281
   absolute_time: 2015-07-11 15:06:00.000000000 Z
   data_status: 2
@@ -515,11 +516,11 @@ hardrock_2015_leif_carter_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_finish_1:
+  split: hardrock_ccw_finish
   id: 282
   absolute_time: 2015-07-11 16:54:00.000000000 Z
   data_status: 2
@@ -528,11 +529,11 @@ hardrock_2015_leif_carter_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_start_1:
+  split: hardrock_ccw_start
   id: 403
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -541,11 +542,11 @@ hardrock_2015_carmine_adams_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 404
   absolute_time: 2015-07-10 14:22:00.000000000 Z
   data_status: 2
@@ -554,11 +555,11 @@ hardrock_2015_carmine_adams_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 405
   absolute_time: 2015-07-10 14:22:00.000000000 Z
   data_status: 2
@@ -567,11 +568,11 @@ hardrock_2015_carmine_adams_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 410
   absolute_time: 2015-07-10 19:34:00.000000000 Z
   data_status: 2
@@ -580,11 +581,11 @@ hardrock_2015_carmine_adams_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 411
   absolute_time: 2015-07-10 19:40:00.000000000 Z
   data_status: 2
@@ -593,11 +594,11 @@ hardrock_2015_carmine_adams_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 414
   absolute_time: 2015-07-10 23:55:00.000000000 Z
   data_status: 2
@@ -606,11 +607,11 @@ hardrock_2015_carmine_adams_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 415
   absolute_time: 2015-07-11 00:00:00.000000000 Z
   data_status: 2
@@ -619,11 +620,11 @@ hardrock_2015_carmine_adams_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 418
   absolute_time: 2015-07-11 03:51:00.000000000 Z
   data_status: 2
@@ -632,11 +633,11 @@ hardrock_2015_carmine_adams_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 419
   absolute_time: 2015-07-11 04:00:00.000000000 Z
   data_status: 2
@@ -645,11 +646,11 @@ hardrock_2015_carmine_adams_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 424
   absolute_time: 2015-07-11 08:59:00.000000000 Z
   data_status: 2
@@ -658,11 +659,11 @@ hardrock_2015_carmine_adams_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 425
   absolute_time: 2015-07-11 09:09:00.000000000 Z
   data_status: 2
@@ -671,11 +672,11 @@ hardrock_2015_carmine_adams_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 430
   absolute_time: 2015-07-11 17:40:00.000000000 Z
   data_status: 2
@@ -684,11 +685,11 @@ hardrock_2015_carmine_adams_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 431
   absolute_time: 2015-07-11 17:40:00.000000000 Z
   data_status: 2
@@ -697,11 +698,11 @@ hardrock_2015_carmine_adams_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_finish_1:
+  split: hardrock_ccw_finish
   id: 432
   absolute_time: 2015-07-11 18:57:00.000000000 Z
   data_status: 2
@@ -710,11 +711,11 @@ hardrock_2015_carmine_adams_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_start_1:
+  split: hardrock_ccw_start
   id: 523
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -723,11 +724,11 @@ hardrock_2015_garry_kuhlman_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 524
   absolute_time: 2015-07-10 14:30:00.000000000 Z
   data_status: 2
@@ -736,11 +737,11 @@ hardrock_2015_garry_kuhlman_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 525
   absolute_time: 2015-07-10 14:30:00.000000000 Z
   data_status: 2
@@ -749,11 +750,11 @@ hardrock_2015_garry_kuhlman_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 530
   absolute_time: 2015-07-10 19:52:00.000000000 Z
   data_status: 2
@@ -762,11 +763,11 @@ hardrock_2015_garry_kuhlman_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 531
   absolute_time: 2015-07-10 19:58:00.000000000 Z
   data_status: 2
@@ -775,11 +776,11 @@ hardrock_2015_garry_kuhlman_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 534
   absolute_time: 2015-07-10 23:53:00.000000000 Z
   data_status: 2
@@ -788,11 +789,11 @@ hardrock_2015_garry_kuhlman_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 535
   absolute_time: 2015-07-10 23:56:00.000000000 Z
   data_status: 2
@@ -801,11 +802,11 @@ hardrock_2015_garry_kuhlman_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 538
   absolute_time: 2015-07-11 03:42:00.000000000 Z
   data_status: 2
@@ -814,11 +815,11 @@ hardrock_2015_garry_kuhlman_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 539
   absolute_time: 2015-07-11 03:51:00.000000000 Z
   data_status: 2
@@ -827,11 +828,11 @@ hardrock_2015_garry_kuhlman_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 544
   absolute_time: 2015-07-11 08:59:00.000000000 Z
   data_status: 2
@@ -840,11 +841,11 @@ hardrock_2015_garry_kuhlman_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 545
   absolute_time: 2015-07-11 09:04:00.000000000 Z
   data_status: 2
@@ -853,11 +854,11 @@ hardrock_2015_garry_kuhlman_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 550
   absolute_time: 2015-07-11 18:11:00.000000000 Z
   data_status: 2
@@ -866,11 +867,11 @@ hardrock_2015_garry_kuhlman_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 551
   absolute_time: 2015-07-11 18:11:00.000000000 Z
   data_status: 2
@@ -879,11 +880,11 @@ hardrock_2015_garry_kuhlman_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_finish_1:
+  split: hardrock_ccw_finish
   id: 552
   absolute_time: 2015-07-11 19:39:00.000000000 Z
   data_status: 2
@@ -892,11 +893,11 @@ hardrock_2015_garry_kuhlman_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_start_1:
+  split: hardrock_ccw_start
   id: 553
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -905,11 +906,11 @@ hardrock_2015_darius_jacobson_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 554
   absolute_time: 2015-07-10 14:18:00.000000000 Z
   data_status: 2
@@ -918,11 +919,11 @@ hardrock_2015_darius_jacobson_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 555
   absolute_time: 2015-07-10 14:18:00.000000000 Z
   data_status: 2
@@ -931,11 +932,11 @@ hardrock_2015_darius_jacobson_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_darius_jacobson_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 560
   absolute_time: 2015-07-10 19:09:00.000000000 Z
   data_status: 2
@@ -944,11 +945,11 @@ hardrock_2015_darius_jacobson_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 561
   absolute_time: 2015-07-10 19:18:00.000000000 Z
   data_status: 2
@@ -957,11 +958,11 @@ hardrock_2015_darius_jacobson_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_darius_jacobson_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 564
   absolute_time: 2015-07-10 23:17:00.000000000 Z
   data_status: 2
@@ -970,11 +971,11 @@ hardrock_2015_darius_jacobson_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 565
   absolute_time: 2015-07-10 23:34:00.000000000 Z
   data_status: 2
@@ -983,11 +984,11 @@ hardrock_2015_darius_jacobson_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_darius_jacobson_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 574
   absolute_time: 2015-07-11 08:40:00.000000000 Z
   data_status: 2
@@ -996,11 +997,11 @@ hardrock_2015_darius_jacobson_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 575
   absolute_time: 2015-07-11 08:54:00.000000000 Z
   data_status: 2
@@ -1009,11 +1010,11 @@ hardrock_2015_darius_jacobson_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_darius_jacobson_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 580
   absolute_time: 2015-07-11 18:26:00.000000000 Z
   data_status: 2
@@ -1022,11 +1023,11 @@ hardrock_2015_darius_jacobson_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 581
   absolute_time: 2015-07-11 18:27:00.000000000 Z
   data_status: 2
@@ -1035,11 +1036,11 @@ hardrock_2015_darius_jacobson_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_darius_jacobson_finish_1:
+  split: hardrock_ccw_finish
   id: 582
   absolute_time: 2015-07-11 19:43:00.000000000 Z
   data_status: 2
@@ -1048,11 +1049,11 @@ hardrock_2015_darius_jacobson_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_start_1:
+  split: hardrock_ccw_start
   id: 673
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -1061,11 +1062,11 @@ hardrock_2015_santa_green_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 674
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
@@ -1074,11 +1075,11 @@ hardrock_2015_santa_green_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 675
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
@@ -1087,11 +1088,11 @@ hardrock_2015_santa_green_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 680
   absolute_time: 2015-07-10 19:36:00.000000000 Z
   data_status: 2
@@ -1100,11 +1101,11 @@ hardrock_2015_santa_green_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 681
   absolute_time: 2015-07-10 19:42:00.000000000 Z
   data_status: 2
@@ -1113,11 +1114,11 @@ hardrock_2015_santa_green_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 684
   absolute_time: 2015-07-10 23:52:00.000000000 Z
   data_status: 2
@@ -1126,11 +1127,11 @@ hardrock_2015_santa_green_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 685
   absolute_time: 2015-07-10 23:52:00.000000000 Z
   data_status: 2
@@ -1139,11 +1140,11 @@ hardrock_2015_santa_green_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 688
   absolute_time: 2015-07-11 04:14:00.000000000 Z
   data_status: 2
@@ -1152,11 +1153,11 @@ hardrock_2015_santa_green_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 689
   absolute_time: 2015-07-11 04:27:00.000000000 Z
   data_status: 2
@@ -1165,11 +1166,11 @@ hardrock_2015_santa_green_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 694
   absolute_time: 2015-07-11 10:05:00.000000000 Z
   data_status: 2
@@ -1178,11 +1179,11 @@ hardrock_2015_santa_green_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 695
   absolute_time: 2015-07-11 10:14:00.000000000 Z
   data_status: 2
@@ -1191,11 +1192,11 @@ hardrock_2015_santa_green_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 700
   absolute_time: 2015-07-11 19:38:00.000000000 Z
   data_status: 2
@@ -1204,11 +1205,11 @@ hardrock_2015_santa_green_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 701
   absolute_time: 2015-07-11 19:43:00.000000000 Z
   data_status: 2
@@ -1217,11 +1218,11 @@ hardrock_2015_santa_green_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_finish_1:
+  split: hardrock_ccw_finish
   id: 702
   absolute_time: 2015-07-11 21:22:00.000000000 Z
   data_status: 2
@@ -1230,11 +1231,11 @@ hardrock_2015_santa_green_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_start_1:
+  split: hardrock_ccw_start
   id: 733
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -1243,11 +1244,11 @@ hardrock_2015_gilberto_mckenzie_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 734
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
@@ -1256,11 +1257,11 @@ hardrock_2015_gilberto_mckenzie_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 735
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
@@ -1269,11 +1270,11 @@ hardrock_2015_gilberto_mckenzie_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 740
   absolute_time: 2015-07-10 19:56:00.000000000 Z
   data_status: 2
@@ -1282,11 +1283,11 @@ hardrock_2015_gilberto_mckenzie_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 741
   absolute_time: 2015-07-10 20:02:00.000000000 Z
   data_status: 2
@@ -1295,11 +1296,11 @@ hardrock_2015_gilberto_mckenzie_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 744
   absolute_time: 2015-07-11 00:58:00.000000000 Z
   data_status: 2
@@ -1308,11 +1309,11 @@ hardrock_2015_gilberto_mckenzie_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 745
   absolute_time: 2015-07-11 01:12:00.000000000 Z
   data_status: 2
@@ -1321,11 +1322,11 @@ hardrock_2015_gilberto_mckenzie_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 748
   absolute_time: 2015-07-11 05:59:00.000000000 Z
   data_status: 2
@@ -1334,11 +1335,11 @@ hardrock_2015_gilberto_mckenzie_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 749
   absolute_time: 2015-07-11 06:09:00.000000000 Z
   data_status: 2
@@ -1347,11 +1348,11 @@ hardrock_2015_gilberto_mckenzie_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 754
   absolute_time: 2015-07-11 11:33:00.000000000 Z
   data_status: 2
@@ -1360,11 +1361,11 @@ hardrock_2015_gilberto_mckenzie_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 755
   absolute_time: 2015-07-11 11:45:00.000000000 Z
   data_status: 2
@@ -1373,11 +1374,11 @@ hardrock_2015_gilberto_mckenzie_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 760
   absolute_time: 2015-07-11 21:46:00.000000000 Z
   data_status: 2
@@ -1386,11 +1387,11 @@ hardrock_2015_gilberto_mckenzie_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 761
   absolute_time: 2015-07-11 21:46:00.000000000 Z
   data_status: 2
@@ -1399,11 +1400,11 @@ hardrock_2015_gilberto_mckenzie_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_finish_1:
+  split: hardrock_ccw_finish
   id: 762
   absolute_time: 2015-07-11 23:18:00.000000000 Z
   data_status: 2
@@ -1412,11 +1413,11 @@ hardrock_2015_gilberto_mckenzie_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_start_1:
+  split: hardrock_ccw_start
   id: 1213
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -1425,11 +1426,11 @@ hardrock_2015_vince_willms_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 1214
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
@@ -1438,11 +1439,11 @@ hardrock_2015_vince_willms_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 1215
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
@@ -1451,11 +1452,11 @@ hardrock_2015_vince_willms_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 1220
   absolute_time: 2015-07-10 19:47:00.000000000 Z
   data_status: 2
@@ -1464,11 +1465,11 @@ hardrock_2015_vince_willms_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 1221
   absolute_time: 2015-07-10 19:59:00.000000000 Z
   data_status: 2
@@ -1477,11 +1478,11 @@ hardrock_2015_vince_willms_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 1224
   absolute_time: 2015-07-10 23:58:00.000000000 Z
   data_status: 2
@@ -1490,11 +1491,11 @@ hardrock_2015_vince_willms_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 1225
   absolute_time: 2015-07-11 00:06:00.000000000 Z
   data_status: 2
@@ -1503,11 +1504,11 @@ hardrock_2015_vince_willms_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 1228
   absolute_time: 2015-07-11 04:34:00.000000000 Z
   data_status: 2
@@ -1516,11 +1517,11 @@ hardrock_2015_vince_willms_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 1229
   absolute_time: 2015-07-11 04:58:00.000000000 Z
   data_status: 2
@@ -1529,11 +1530,11 @@ hardrock_2015_vince_willms_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 1234
   absolute_time: 2015-07-11 11:40:00.000000000 Z
   data_status: 2
@@ -1542,11 +1543,11 @@ hardrock_2015_vince_willms_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 1235
   absolute_time: 2015-07-11 12:53:00.000000000 Z
   data_status: 2
@@ -1555,11 +1556,11 @@ hardrock_2015_vince_willms_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 1240
   absolute_time: 2015-07-11 23:23:00.000000000 Z
   data_status: 2
@@ -1568,11 +1569,11 @@ hardrock_2015_vince_willms_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 1241
   absolute_time: 2015-07-11 23:25:00.000000000 Z
   data_status: 2
@@ -1581,11 +1582,11 @@ hardrock_2015_vince_willms_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_finish_1:
+  split: hardrock_ccw_finish
   id: 1242
   absolute_time: 2015-07-12 00:58:00.000000000 Z
   data_status: 2
@@ -1594,11 +1595,11 @@ hardrock_2015_vince_willms_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 1304
   absolute_time: 2015-07-10 14:32:00.000000000 Z
   data_status: 2
@@ -1607,11 +1608,11 @@ hardrock_2015_cedric_windler_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 1305
   absolute_time: 2015-07-10 14:32:00.000000000 Z
   data_status: 2
@@ -1620,11 +1621,11 @@ hardrock_2015_cedric_windler_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 1310
   absolute_time: 2015-07-10 19:52:00.000000000 Z
   data_status: 2
@@ -1633,11 +1634,11 @@ hardrock_2015_cedric_windler_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 1311
   absolute_time: 2015-07-10 19:59:00.000000000 Z
   data_status: 2
@@ -1646,11 +1647,11 @@ hardrock_2015_cedric_windler_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 1314
   absolute_time: 2015-07-11 00:51:00.000000000 Z
   data_status: 2
@@ -1659,11 +1660,11 @@ hardrock_2015_cedric_windler_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 1315
   absolute_time: 2015-07-11 01:02:00.000000000 Z
   data_status: 2
@@ -1672,11 +1673,11 @@ hardrock_2015_cedric_windler_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 1318
   absolute_time: 2015-07-11 06:06:00.000000000 Z
   data_status: 2
@@ -1685,11 +1686,11 @@ hardrock_2015_cedric_windler_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 1319
   absolute_time: 2015-07-11 06:53:00.000000000 Z
   data_status: 2
@@ -1698,11 +1699,11 @@ hardrock_2015_cedric_windler_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 1324
   absolute_time: 2015-07-11 13:10:00.000000000 Z
   data_status: 2
@@ -1711,11 +1712,11 @@ hardrock_2015_cedric_windler_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 1325
   absolute_time: 2015-07-11 13:20:00.000000000 Z
   data_status: 2
@@ -1724,11 +1725,11 @@ hardrock_2015_cedric_windler_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 1330
   absolute_time: 2015-07-11 23:39:00.000000000 Z
   data_status: 2
@@ -1737,11 +1738,11 @@ hardrock_2015_cedric_windler_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 1331
   absolute_time: 2015-07-11 23:39:00.000000000 Z
   data_status: 2
@@ -1750,11 +1751,11 @@ hardrock_2015_cedric_windler_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_finish_1:
+  split: hardrock_ccw_finish
   id: 1332
   absolute_time: 2015-07-12 01:19:00.000000000 Z
   data_status: 2
@@ -1763,11 +1764,11 @@ hardrock_2015_cedric_windler_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_start_1:
+  split: hardrock_ccw_start
   id: 1483
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -1776,11 +1777,11 @@ hardrock_2015_chris_rempel_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 1484
   absolute_time: 2015-07-10 14:36:00.000000000 Z
   data_status: 2
@@ -1789,11 +1790,11 @@ hardrock_2015_chris_rempel_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 1485
   absolute_time: 2015-07-10 14:36:00.000000000 Z
   data_status: 2
@@ -1802,11 +1803,11 @@ hardrock_2015_chris_rempel_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 1490
   absolute_time: 2015-07-10 20:12:00.000000000 Z
   data_status: 2
@@ -1815,11 +1816,11 @@ hardrock_2015_chris_rempel_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 1491
   absolute_time: 2015-07-10 20:23:00.000000000 Z
   data_status: 2
@@ -1828,11 +1829,11 @@ hardrock_2015_chris_rempel_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 1494
   absolute_time: 2015-07-11 00:57:00.000000000 Z
   data_status: 2
@@ -1841,11 +1842,11 @@ hardrock_2015_chris_rempel_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 1495
   absolute_time: 2015-07-11 01:09:00.000000000 Z
   data_status: 2
@@ -1854,11 +1855,11 @@ hardrock_2015_chris_rempel_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 1498
   absolute_time: 2015-07-11 06:05:00.000000000 Z
   data_status: 2
@@ -1867,11 +1868,11 @@ hardrock_2015_chris_rempel_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 1499
   absolute_time: 2015-07-11 06:23:00.000000000 Z
   data_status: 2
@@ -1880,11 +1881,11 @@ hardrock_2015_chris_rempel_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 1504
   absolute_time: 2015-07-11 12:40:00.000000000 Z
   data_status: 2
@@ -1893,11 +1894,11 @@ hardrock_2015_chris_rempel_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 1505
   absolute_time: 2015-07-11 13:00:00.000000000 Z
   data_status: 2
@@ -1906,11 +1907,11 @@ hardrock_2015_chris_rempel_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 1510
   absolute_time: 2015-07-12 00:03:00.000000000 Z
   data_status: 2
@@ -1919,11 +1920,11 @@ hardrock_2015_chris_rempel_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 1511
   absolute_time: 2015-07-12 00:04:00.000000000 Z
   data_status: 2
@@ -1932,11 +1933,11 @@ hardrock_2015_chris_rempel_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_finish_1:
+  split: hardrock_ccw_finish
   id: 1512
   absolute_time: 2015-07-12 01:54:00.000000000 Z
   data_status: 2
@@ -1945,11 +1946,11 @@ hardrock_2015_chris_rempel_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_start_1:
+  split: hardrock_ccw_start
   id: 1513
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -1958,11 +1959,11 @@ hardrock_2015_robby_gerlach_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 1514
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
@@ -1971,11 +1972,11 @@ hardrock_2015_robby_gerlach_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 1515
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
@@ -1984,11 +1985,11 @@ hardrock_2015_robby_gerlach_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 1520
   absolute_time: 2015-07-10 20:51:00.000000000 Z
   data_status: 2
@@ -1997,11 +1998,11 @@ hardrock_2015_robby_gerlach_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 1521
   absolute_time: 2015-07-10 21:03:00.000000000 Z
   data_status: 2
@@ -2010,11 +2011,11 @@ hardrock_2015_robby_gerlach_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 1524
   absolute_time: 2015-07-11 01:51:00.000000000 Z
   data_status: 2
@@ -2023,11 +2024,11 @@ hardrock_2015_robby_gerlach_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 1525
   absolute_time: 2015-07-11 02:08:00.000000000 Z
   data_status: 2
@@ -2036,11 +2037,11 @@ hardrock_2015_robby_gerlach_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 1528
   absolute_time: 2015-07-11 07:15:00.000000000 Z
   data_status: 2
@@ -2049,11 +2050,11 @@ hardrock_2015_robby_gerlach_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 1529
   absolute_time: 2015-07-11 07:32:00.000000000 Z
   data_status: 2
@@ -2062,11 +2063,11 @@ hardrock_2015_robby_gerlach_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 1534
   absolute_time: 2015-07-11 13:29:00.000000000 Z
   data_status: 2
@@ -2075,11 +2076,11 @@ hardrock_2015_robby_gerlach_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 1535
   absolute_time: 2015-07-11 14:44:00.000000000 Z
   data_status: 2
@@ -2088,11 +2089,11 @@ hardrock_2015_robby_gerlach_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 1540
   absolute_time: 2015-07-12 00:14:00.000000000 Z
   data_status: 2
@@ -2101,11 +2102,11 @@ hardrock_2015_robby_gerlach_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 1541
   absolute_time: 2015-07-12 00:14:00.000000000 Z
   data_status: 2
@@ -2114,11 +2115,11 @@ hardrock_2015_robby_gerlach_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_finish_1:
+  split: hardrock_ccw_finish
   id: 1542
   absolute_time: 2015-07-12 01:56:00.000000000 Z
   data_status: 2
@@ -2127,11 +2128,11 @@ hardrock_2015_robby_gerlach_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_start_1:
+  split: hardrock_ccw_start
   id: 1573
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -2140,11 +2141,11 @@ hardrock_2015_rachelle_eichmann_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 1574
   absolute_time: 2015-07-10 14:28:00.000000000 Z
   data_status: 2
@@ -2153,11 +2154,11 @@ hardrock_2015_rachelle_eichmann_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 1575
   absolute_time: 2015-07-10 14:28:00.000000000 Z
   data_status: 2
@@ -2166,11 +2167,11 @@ hardrock_2015_rachelle_eichmann_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 1580
   absolute_time: 2015-07-10 20:11:00.000000000 Z
   data_status: 2
@@ -2179,11 +2180,11 @@ hardrock_2015_rachelle_eichmann_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 1581
   absolute_time: 2015-07-10 20:24:00.000000000 Z
   data_status: 2
@@ -2192,11 +2193,11 @@ hardrock_2015_rachelle_eichmann_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 1584
   absolute_time: 2015-07-11 00:53:00.000000000 Z
   data_status: 2
@@ -2205,11 +2206,11 @@ hardrock_2015_rachelle_eichmann_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 1585
   absolute_time: 2015-07-11 01:10:00.000000000 Z
   data_status: 2
@@ -2218,11 +2219,11 @@ hardrock_2015_rachelle_eichmann_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 1588
   absolute_time: 2015-07-11 06:30:00.000000000 Z
   data_status: 2
@@ -2231,11 +2232,11 @@ hardrock_2015_rachelle_eichmann_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 1589
   absolute_time: 2015-07-11 06:40:00.000000000 Z
   data_status: 2
@@ -2244,11 +2245,11 @@ hardrock_2015_rachelle_eichmann_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 1594
   absolute_time: 2015-07-11 13:45:00.000000000 Z
   data_status: 2
@@ -2257,11 +2258,11 @@ hardrock_2015_rachelle_eichmann_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 1595
   absolute_time: 2015-07-11 14:05:00.000000000 Z
   data_status: 2
@@ -2270,11 +2271,11 @@ hardrock_2015_rachelle_eichmann_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 1600
   absolute_time: 2015-07-12 01:05:00.000000000 Z
   data_status: 2
@@ -2283,11 +2284,11 @@ hardrock_2015_rachelle_eichmann_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 1601
   absolute_time: 2015-07-12 01:05:00.000000000 Z
   data_status: 2
@@ -2296,11 +2297,11 @@ hardrock_2015_rachelle_eichmann_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_finish_1:
+  split: hardrock_ccw_finish
   id: 1602
   absolute_time: 2015-07-12 02:36:00.000000000 Z
   data_status: 2
@@ -2309,11 +2310,11 @@ hardrock_2015_rachelle_eichmann_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_start_1:
+  split: hardrock_ccw_start
   id: 1633
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -2322,11 +2323,11 @@ hardrock_2015_elden_morissette_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 1634
   absolute_time: 2015-07-10 14:33:00.000000000 Z
   data_status: 2
@@ -2335,11 +2336,11 @@ hardrock_2015_elden_morissette_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 1635
   absolute_time: 2015-07-10 14:33:00.000000000 Z
   data_status: 2
@@ -2348,11 +2349,11 @@ hardrock_2015_elden_morissette_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 1640
   absolute_time: 2015-07-10 20:20:00.000000000 Z
   data_status: 2
@@ -2361,11 +2362,11 @@ hardrock_2015_elden_morissette_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 1641
   absolute_time: 2015-07-10 20:38:00.000000000 Z
   data_status: 2
@@ -2374,11 +2375,11 @@ hardrock_2015_elden_morissette_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 1644
   absolute_time: 2015-07-11 01:24:00.000000000 Z
   data_status: 2
@@ -2387,11 +2388,11 @@ hardrock_2015_elden_morissette_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 1645
   absolute_time: 2015-07-11 01:50:00.000000000 Z
   data_status: 2
@@ -2400,11 +2401,11 @@ hardrock_2015_elden_morissette_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 1648
   absolute_time: 2015-07-11 06:15:00.000000000 Z
   data_status: 2
@@ -2413,11 +2414,11 @@ hardrock_2015_elden_morissette_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 1649
   absolute_time: 2015-07-11 06:59:00.000000000 Z
   data_status: 2
@@ -2426,11 +2427,11 @@ hardrock_2015_elden_morissette_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 1654
   absolute_time: 2015-07-11 13:08:00.000000000 Z
   data_status: 2
@@ -2439,11 +2440,11 @@ hardrock_2015_elden_morissette_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 1655
   absolute_time: 2015-07-11 13:33:00.000000000 Z
   data_status: 2
@@ -2452,11 +2453,11 @@ hardrock_2015_elden_morissette_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 1660
   absolute_time: 2015-07-12 00:48:00.000000000 Z
   data_status: 2
@@ -2465,11 +2466,11 @@ hardrock_2015_elden_morissette_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 1661
   absolute_time: 2015-07-12 00:53:00.000000000 Z
   data_status: 2
@@ -2478,11 +2479,11 @@ hardrock_2015_elden_morissette_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_finish_1:
+  split: hardrock_ccw_finish
   id: 1662
   absolute_time: 2015-07-12 02:41:00.000000000 Z
   data_status: 2
@@ -2491,11 +2492,11 @@ hardrock_2015_elden_morissette_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_start_1:
+  split: hardrock_ccw_start
   id: 1693
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -2504,11 +2505,11 @@ hardrock_2015_leroy_leffler_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 1694
   absolute_time: 2015-07-10 14:38:00.000000000 Z
   data_status: 2
@@ -2517,11 +2518,11 @@ hardrock_2015_leroy_leffler_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 1695
   absolute_time: 2015-07-10 14:38:00.000000000 Z
   data_status: 2
@@ -2530,11 +2531,11 @@ hardrock_2015_leroy_leffler_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 1700
   absolute_time: 2015-07-10 20:22:00.000000000 Z
   data_status: 2
@@ -2543,11 +2544,11 @@ hardrock_2015_leroy_leffler_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 1701
   absolute_time: 2015-07-10 20:38:00.000000000 Z
   data_status: 2
@@ -2556,11 +2557,11 @@ hardrock_2015_leroy_leffler_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 1704
   absolute_time: 2015-07-11 01:21:00.000000000 Z
   data_status: 2
@@ -2569,11 +2570,11 @@ hardrock_2015_leroy_leffler_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 1705
   absolute_time: 2015-07-11 01:38:00.000000000 Z
   data_status: 2
@@ -2582,11 +2583,11 @@ hardrock_2015_leroy_leffler_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 1708
   absolute_time: 2015-07-11 06:32:00.000000000 Z
   data_status: 2
@@ -2595,11 +2596,11 @@ hardrock_2015_leroy_leffler_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 1709
   absolute_time: 2015-07-11 07:21:00.000000000 Z
   data_status: 2
@@ -2608,11 +2609,11 @@ hardrock_2015_leroy_leffler_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 1714
   absolute_time: 2015-07-11 13:07:00.000000000 Z
   data_status: 2
@@ -2621,11 +2622,11 @@ hardrock_2015_leroy_leffler_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 1715
   absolute_time: 2015-07-11 13:43:00.000000000 Z
   data_status: 2
@@ -2634,11 +2635,11 @@ hardrock_2015_leroy_leffler_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 1720
   absolute_time: 2015-07-12 01:15:00.000000000 Z
   data_status: 2
@@ -2647,11 +2648,11 @@ hardrock_2015_leroy_leffler_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 1721
   absolute_time: 2015-07-12 01:15:00.000000000 Z
   data_status: 2
@@ -2660,11 +2661,11 @@ hardrock_2015_leroy_leffler_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_finish_1:
+  split: hardrock_ccw_finish
   id: 1722
   absolute_time: 2015-07-12 03:11:00.000000000 Z
   data_status: 2
@@ -2673,11 +2674,11 @@ hardrock_2015_leroy_leffler_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_start_1:
+  split: hardrock_ccw_start
   id: 1993
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -2686,11 +2687,11 @@ hardrock_2015_samara_vandervort_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 1994
   absolute_time: 2015-07-10 14:35:00.000000000 Z
   data_status: 2
@@ -2699,11 +2700,11 @@ hardrock_2015_samara_vandervort_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 1995
   absolute_time: 2015-07-10 14:35:00.000000000 Z
   data_status: 2
@@ -2712,11 +2713,11 @@ hardrock_2015_samara_vandervort_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 2000
   absolute_time: 2015-07-10 20:28:00.000000000 Z
   data_status: 2
@@ -2725,11 +2726,11 @@ hardrock_2015_samara_vandervort_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 2001
   absolute_time: 2015-07-10 20:42:00.000000000 Z
   data_status: 2
@@ -2738,11 +2739,11 @@ hardrock_2015_samara_vandervort_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 2004
   absolute_time: 2015-07-11 01:50:00.000000000 Z
   data_status: 2
@@ -2751,11 +2752,11 @@ hardrock_2015_samara_vandervort_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 2005
   absolute_time: 2015-07-11 02:03:00.000000000 Z
   data_status: 2
@@ -2764,11 +2765,11 @@ hardrock_2015_samara_vandervort_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 2008
   absolute_time: 2015-07-11 07:06:00.000000000 Z
   data_status: 2
@@ -2777,11 +2778,11 @@ hardrock_2015_samara_vandervort_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 2009
   absolute_time: 2015-07-11 07:20:00.000000000 Z
   data_status: 2
@@ -2790,11 +2791,11 @@ hardrock_2015_samara_vandervort_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 2014
   absolute_time: 2015-07-11 14:11:00.000000000 Z
   data_status: 0
@@ -2803,11 +2804,11 @@ hardrock_2015_samara_vandervort_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 2015
   absolute_time: 2015-07-11 14:29:00.000000000 Z
   data_status: 0
@@ -2816,11 +2817,11 @@ hardrock_2015_samara_vandervort_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 2020
   absolute_time: 2015-07-12 01:58:00.000000000 Z
   data_status: 2
@@ -2829,11 +2830,11 @@ hardrock_2015_samara_vandervort_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 2021
   absolute_time: 2015-07-12 02:04:00.000000000 Z
   data_status: 2
@@ -2842,11 +2843,11 @@ hardrock_2015_samara_vandervort_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_finish_1:
+  split: hardrock_ccw_finish
   id: 2022
   absolute_time: 2015-07-12 04:16:00.000000000 Z
   data_status: 2
@@ -2855,11 +2856,11 @@ hardrock_2015_samara_vandervort_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_start_1:
+  split: hardrock_ccw_start
   id: 2623
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -2868,11 +2869,11 @@ hardrock_2015_robt_wintheiser_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 2624
   absolute_time: 2015-07-10 14:52:00.000000000 Z
   data_status: 2
@@ -2881,11 +2882,11 @@ hardrock_2015_robt_wintheiser_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 2625
   absolute_time: 2015-07-10 14:52:00.000000000 Z
   data_status: 2
@@ -2894,11 +2895,11 @@ hardrock_2015_robt_wintheiser_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 2630
   absolute_time: 2015-07-10 21:10:00.000000000 Z
   data_status: 2
@@ -2907,11 +2908,11 @@ hardrock_2015_robt_wintheiser_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 2631
   absolute_time: 2015-07-10 21:27:00.000000000 Z
   data_status: 2
@@ -2920,11 +2921,11 @@ hardrock_2015_robt_wintheiser_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 2634
   absolute_time: 2015-07-11 02:37:00.000000000 Z
   data_status: 2
@@ -2933,11 +2934,11 @@ hardrock_2015_robt_wintheiser_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 2635
   absolute_time: 2015-07-11 03:00:00.000000000 Z
   data_status: 2
@@ -2946,11 +2947,11 @@ hardrock_2015_robt_wintheiser_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 2638
   absolute_time: 2015-07-11 08:24:00.000000000 Z
   data_status: 2
@@ -2959,11 +2960,11 @@ hardrock_2015_robt_wintheiser_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 2639
   absolute_time: 2015-07-11 08:27:00.000000000 Z
   data_status: 2
@@ -2972,11 +2973,11 @@ hardrock_2015_robt_wintheiser_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 2644
   absolute_time: 2015-07-11 15:34:00.000000000 Z
   data_status: 2
@@ -2985,11 +2986,11 @@ hardrock_2015_robt_wintheiser_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 2645
   absolute_time: 2015-07-11 16:34:00.000000000 Z
   data_status: 2
@@ -2998,11 +2999,11 @@ hardrock_2015_robt_wintheiser_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 2650
   absolute_time: 2015-07-12 05:22:00.000000000 Z
   data_status: 2
@@ -3011,11 +3012,11 @@ hardrock_2015_robt_wintheiser_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 2651
   absolute_time: 2015-07-12 05:33:00.000000000 Z
   data_status: 2
@@ -3024,11 +3025,11 @@ hardrock_2015_robt_wintheiser_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_finish_1:
+  split: hardrock_ccw_finish
   id: 2652
   absolute_time: 2015-07-12 07:56:00.000000000 Z
   data_status: 2
@@ -3037,11 +3038,11 @@ hardrock_2015_robt_wintheiser_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_start_1:
+  split: hardrock_ccw_start
   id: 2683
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -3050,11 +3051,11 @@ hardrock_2015_demetrius_moen_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 2684
   absolute_time: 2015-07-10 14:45:00.000000000 Z
   data_status: 2
@@ -3063,11 +3064,11 @@ hardrock_2015_demetrius_moen_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 2685
   absolute_time: 2015-07-10 14:45:00.000000000 Z
   data_status: 2
@@ -3076,11 +3077,11 @@ hardrock_2015_demetrius_moen_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 2690
   absolute_time: 2015-07-10 21:21:00.000000000 Z
   data_status: 2
@@ -3089,11 +3090,11 @@ hardrock_2015_demetrius_moen_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 2691
   absolute_time: 2015-07-10 21:36:00.000000000 Z
   data_status: 2
@@ -3102,11 +3103,11 @@ hardrock_2015_demetrius_moen_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 2694
   absolute_time: 2015-07-11 03:07:00.000000000 Z
   data_status: 2
@@ -3115,11 +3116,11 @@ hardrock_2015_demetrius_moen_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 2695
   absolute_time: 2015-07-11 03:27:00.000000000 Z
   data_status: 2
@@ -3128,11 +3129,11 @@ hardrock_2015_demetrius_moen_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 2698
   absolute_time: 2015-07-11 08:53:00.000000000 Z
   data_status: 2
@@ -3141,11 +3142,11 @@ hardrock_2015_demetrius_moen_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 2699
   absolute_time: 2015-07-11 09:15:00.000000000 Z
   data_status: 2
@@ -3154,11 +3155,11 @@ hardrock_2015_demetrius_moen_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 2704
   absolute_time: 2015-07-11 15:43:00.000000000 Z
   data_status: 2
@@ -3167,11 +3168,11 @@ hardrock_2015_demetrius_moen_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 2705
   absolute_time: 2015-07-11 16:02:00.000000000 Z
   data_status: 2
@@ -3180,11 +3181,11 @@ hardrock_2015_demetrius_moen_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 2710
   absolute_time: 2015-07-12 05:27:00.000000000 Z
   data_status: 2
@@ -3193,11 +3194,11 @@ hardrock_2015_demetrius_moen_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 2711
   absolute_time: 2015-07-12 05:36:00.000000000 Z
   data_status: 2
@@ -3206,11 +3207,11 @@ hardrock_2015_demetrius_moen_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_finish_1:
+  split: hardrock_ccw_finish
   id: 2712
   absolute_time: 2015-07-12 08:01:00.000000000 Z
   data_status: 2
@@ -3219,11 +3220,11 @@ hardrock_2015_demetrius_moen_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_start_1:
+  split: hardrock_ccw_start
   id: 2953
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -3232,11 +3233,11 @@ hardrock_2015_vern_buckridge_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 2954
   absolute_time: 2015-07-10 14:46:00.000000000 Z
   data_status: 2
@@ -3245,11 +3246,11 @@ hardrock_2015_vern_buckridge_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 2955
   absolute_time: 2015-07-10 14:46:00.000000000 Z
   data_status: 2
@@ -3258,11 +3259,11 @@ hardrock_2015_vern_buckridge_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 2960
   absolute_time: 2015-07-10 21:45:00.000000000 Z
   data_status: 2
@@ -3271,11 +3272,11 @@ hardrock_2015_vern_buckridge_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 2961
   absolute_time: 2015-07-10 22:09:00.000000000 Z
   data_status: 2
@@ -3284,11 +3285,11 @@ hardrock_2015_vern_buckridge_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 2964
   absolute_time: 2015-07-11 04:04:00.000000000 Z
   data_status: 2
@@ -3297,11 +3298,11 @@ hardrock_2015_vern_buckridge_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 2965
   absolute_time: 2015-07-11 04:21:00.000000000 Z
   data_status: 2
@@ -3310,11 +3311,11 @@ hardrock_2015_vern_buckridge_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 2968
   absolute_time: 2015-07-11 09:48:00.000000000 Z
   data_status: 2
@@ -3323,11 +3324,11 @@ hardrock_2015_vern_buckridge_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 2969
   absolute_time: 2015-07-11 10:15:00.000000000 Z
   data_status: 2
@@ -3336,11 +3337,11 @@ hardrock_2015_vern_buckridge_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 2974
   absolute_time: 2015-07-11 17:08:00.000000000 Z
   data_status: 2
@@ -3349,11 +3350,11 @@ hardrock_2015_vern_buckridge_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 2975
   absolute_time: 2015-07-11 17:29:00.000000000 Z
   data_status: 2
@@ -3362,11 +3363,11 @@ hardrock_2015_vern_buckridge_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 2980
   absolute_time: 2015-07-12 06:54:00.000000000 Z
   data_status: 2
@@ -3375,11 +3376,11 @@ hardrock_2015_vern_buckridge_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 2981
   absolute_time: 2015-07-12 07:00:00.000000000 Z
   data_status: 2
@@ -3388,11 +3389,11 @@ hardrock_2015_vern_buckridge_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_finish_1:
+  split: hardrock_ccw_finish
   id: 2982
   absolute_time: 2015-07-12 09:20:00.000000000 Z
   data_status: 2
@@ -3401,11 +3402,11 @@ hardrock_2015_vern_buckridge_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_start_1:
+  split: hardrock_ccw_start
   id: 3163
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -3414,11 +3415,11 @@ hardrock_2015_donte_spencer_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 3164
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
@@ -3427,11 +3428,11 @@ hardrock_2015_donte_spencer_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 3165
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
@@ -3440,11 +3441,11 @@ hardrock_2015_donte_spencer_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 3170
   absolute_time: 2015-07-10 20:54:00.000000000 Z
   data_status: 2
@@ -3453,11 +3454,11 @@ hardrock_2015_donte_spencer_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 3171
   absolute_time: 2015-07-10 21:17:00.000000000 Z
   data_status: 2
@@ -3466,11 +3467,11 @@ hardrock_2015_donte_spencer_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 3174
   absolute_time: 2015-07-11 02:11:00.000000000 Z
   data_status: 2
@@ -3479,11 +3480,11 @@ hardrock_2015_donte_spencer_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 3175
   absolute_time: 2015-07-11 02:43:00.000000000 Z
   data_status: 2
@@ -3492,11 +3493,11 @@ hardrock_2015_donte_spencer_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 3178
   absolute_time: 2015-07-11 09:34:00.000000000 Z
   data_status: 2
@@ -3505,11 +3506,11 @@ hardrock_2015_donte_spencer_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 3179
   absolute_time: 2015-07-11 11:19:00.000000000 Z
   data_status: 2
@@ -3518,11 +3519,11 @@ hardrock_2015_donte_spencer_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 3184
   absolute_time: 2015-07-11 17:44:00.000000000 Z
   data_status: 2
@@ -3531,11 +3532,11 @@ hardrock_2015_donte_spencer_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 3185
   absolute_time: 2015-07-11 17:56:00.000000000 Z
   data_status: 2
@@ -3544,11 +3545,11 @@ hardrock_2015_donte_spencer_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 3190
   absolute_time: 2015-07-12 07:24:00.000000000 Z
   data_status: 2
@@ -3557,11 +3558,11 @@ hardrock_2015_donte_spencer_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 3191
   absolute_time: 2015-07-12 08:48:00.000000000 Z
   data_status: 2
@@ -3570,11 +3571,11 @@ hardrock_2015_donte_spencer_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_finish_1:
+  split: hardrock_ccw_finish
   id: 3192
   absolute_time: 2015-07-12 10:48:00.000000000 Z
   data_status: 2
@@ -3583,11 +3584,11 @@ hardrock_2015_donte_spencer_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_start_1:
+  split: hardrock_ccw_start
   id: 3283
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -3596,11 +3597,11 @@ hardrock_2015_bruno_fadel_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 3284
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
@@ -3609,11 +3610,11 @@ hardrock_2015_bruno_fadel_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 3285
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
@@ -3622,11 +3623,11 @@ hardrock_2015_bruno_fadel_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 3290
   absolute_time: 2015-07-10 22:10:00.000000000 Z
   data_status: 2
@@ -3635,11 +3636,11 @@ hardrock_2015_bruno_fadel_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 3291
   absolute_time: 2015-07-10 22:20:00.000000000 Z
   data_status: 2
@@ -3648,11 +3649,11 @@ hardrock_2015_bruno_fadel_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 3294
   absolute_time: 2015-07-11 04:15:00.000000000 Z
   data_status: 2
@@ -3661,11 +3662,11 @@ hardrock_2015_bruno_fadel_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 3295
   absolute_time: 2015-07-11 04:32:00.000000000 Z
   data_status: 2
@@ -3674,11 +3675,11 @@ hardrock_2015_bruno_fadel_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 3298
   absolute_time: 2015-07-11 10:13:00.000000000 Z
   data_status: 2
@@ -3687,11 +3688,11 @@ hardrock_2015_bruno_fadel_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 3299
   absolute_time: 2015-07-11 10:35:00.000000000 Z
   data_status: 2
@@ -3700,11 +3701,11 @@ hardrock_2015_bruno_fadel_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 3304
   absolute_time: 2015-07-11 17:18:00.000000000 Z
   data_status: 2
@@ -3713,11 +3714,11 @@ hardrock_2015_bruno_fadel_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 3305
   absolute_time: 2015-07-11 17:37:00.000000000 Z
   data_status: 2
@@ -3726,11 +3727,11 @@ hardrock_2015_bruno_fadel_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 3310
   absolute_time: 2015-07-12 08:22:00.000000000 Z
   data_status: 2
@@ -3739,11 +3740,11 @@ hardrock_2015_bruno_fadel_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 3311
   absolute_time: 2015-07-12 08:28:00.000000000 Z
   data_status: 2
@@ -3752,11 +3753,11 @@ hardrock_2015_bruno_fadel_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_finish_1:
+  split: hardrock_ccw_finish
   id: 3312
   absolute_time: 2015-07-12 11:17:00.000000000 Z
   data_status: 2
@@ -3765,11 +3766,11 @@ hardrock_2015_bruno_fadel_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_start_1:
+  split: hardrock_ccw_start
   id: 3313
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -3778,11 +3779,11 @@ hardrock_2015_gus_walker_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 3314
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
@@ -3791,11 +3792,11 @@ hardrock_2015_gus_walker_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 3315
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
@@ -3804,11 +3805,11 @@ hardrock_2015_gus_walker_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 3320
   absolute_time: 2015-07-10 22:26:00.000000000 Z
   data_status: 2
@@ -3817,11 +3818,11 @@ hardrock_2015_gus_walker_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 3321
   absolute_time: 2015-07-10 22:46:00.000000000 Z
   data_status: 2
@@ -3830,11 +3831,11 @@ hardrock_2015_gus_walker_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 3324
   absolute_time: 2015-07-11 05:05:00.000000000 Z
   data_status: 2
@@ -3843,11 +3844,11 @@ hardrock_2015_gus_walker_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 3325
   absolute_time: 2015-07-11 05:09:00.000000000 Z
   data_status: 2
@@ -3856,11 +3857,11 @@ hardrock_2015_gus_walker_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 3328
   absolute_time: 2015-07-11 09:04:00.000000000 Z
   data_status: 2
@@ -3869,11 +3870,11 @@ hardrock_2015_gus_walker_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 3329
   absolute_time: 2015-07-11 09:16:00.000000000 Z
   data_status: 2
@@ -3882,11 +3883,11 @@ hardrock_2015_gus_walker_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 3334
   absolute_time: 2015-07-11 18:49:00.000000000 Z
   data_status: 1
@@ -3895,11 +3896,11 @@ hardrock_2015_gus_walker_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 3335
   absolute_time: 2015-07-11 19:08:00.000000000 Z
   data_status: 1
@@ -3908,11 +3909,11 @@ hardrock_2015_gus_walker_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 3340
   absolute_time: 2015-07-12 09:28:00.000000000 Z
   data_status: 2
@@ -3921,11 +3922,11 @@ hardrock_2015_gus_walker_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 3341
   absolute_time: 2015-07-12 09:30:00.000000000 Z
   data_status: 2
@@ -3934,11 +3935,11 @@ hardrock_2015_gus_walker_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_finish_1:
+  split: hardrock_ccw_finish
   id: 3342
   absolute_time: 2015-07-12 11:22:00.000000000 Z
   data_status: 2
@@ -3947,11 +3948,11 @@ hardrock_2015_gus_walker_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_start_1:
+  split: hardrock_ccw_start
   id: 3433
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -3960,11 +3961,11 @@ hardrock_2015_susanna_abshire_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 3434
   absolute_time: 2015-07-10 15:16:00.000000000 Z
   data_status: 2
@@ -3973,11 +3974,11 @@ hardrock_2015_susanna_abshire_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 3435
   absolute_time: 2015-07-10 15:16:00.000000000 Z
   data_status: 2
@@ -3986,11 +3987,11 @@ hardrock_2015_susanna_abshire_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_susanna_abshire_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 3440
   absolute_time: 2015-07-10 22:50:00.000000000 Z
   data_status: 2
@@ -3999,11 +4000,11 @@ hardrock_2015_susanna_abshire_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 3441
   absolute_time: 2015-07-10 23:02:00.000000000 Z
   data_status: 2
@@ -4012,11 +4013,11 @@ hardrock_2015_susanna_abshire_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_susanna_abshire_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 3444
   absolute_time: 2015-07-11 05:25:00.000000000 Z
   data_status: 2
@@ -4025,11 +4026,11 @@ hardrock_2015_susanna_abshire_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 3445
   absolute_time: 2015-07-11 05:38:00.000000000 Z
   data_status: 2
@@ -4038,11 +4039,11 @@ hardrock_2015_susanna_abshire_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_susanna_abshire_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 3454
   absolute_time: 2015-07-11 19:11:00.000000000 Z
   data_status: 2
@@ -4051,11 +4052,11 @@ hardrock_2015_susanna_abshire_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 3455
   absolute_time: 2015-07-11 19:21:00.000000000 Z
   data_status: 2
@@ -4064,11 +4065,11 @@ hardrock_2015_susanna_abshire_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_susanna_abshire_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 3460
   absolute_time: 2015-07-12 09:26:00.000000000 Z
   data_status: 2
@@ -4077,11 +4078,11 @@ hardrock_2015_susanna_abshire_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 3461
   absolute_time: 2015-07-12 09:26:00.000000000 Z
   data_status: 2
@@ -4090,11 +4091,11 @@ hardrock_2015_susanna_abshire_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_susanna_abshire_finish_1:
+  split: hardrock_ccw_finish
   id: 3462
   absolute_time: 2015-07-12 11:31:00.000000000 Z
   data_status: 2
@@ -4103,11 +4104,11 @@ hardrock_2015_susanna_abshire_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_start_1:
+  split: hardrock_ccw_start
   id: 3553
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -4116,11 +4117,11 @@ hardrock_2015_leandro_cole_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 3554
   absolute_time: 2015-07-10 15:14:00.000000000 Z
   data_status: 2
@@ -4129,11 +4130,11 @@ hardrock_2015_leandro_cole_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 3555
   absolute_time: 2015-07-10 15:14:00.000000000 Z
   data_status: 2
@@ -4142,11 +4143,11 @@ hardrock_2015_leandro_cole_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 3560
   absolute_time: 2015-07-10 22:15:00.000000000 Z
   data_status: 2
@@ -4155,11 +4156,11 @@ hardrock_2015_leandro_cole_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 3561
   absolute_time: 2015-07-10 22:35:00.000000000 Z
   data_status: 2
@@ -4168,11 +4169,11 @@ hardrock_2015_leandro_cole_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 3564
   absolute_time: 2015-07-11 04:18:00.000000000 Z
   data_status: 2
@@ -4181,11 +4182,11 @@ hardrock_2015_leandro_cole_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 3565
   absolute_time: 2015-07-11 04:53:00.000000000 Z
   data_status: 2
@@ -4194,11 +4195,11 @@ hardrock_2015_leandro_cole_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 3568
   absolute_time: 2015-07-11 07:39:00.000000000 Z
   data_status: 1
@@ -4207,11 +4208,11 @@ hardrock_2015_leandro_cole_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 3569
   absolute_time: 2015-07-11 07:47:00.000000000 Z
   data_status: 1
@@ -4220,11 +4221,11 @@ hardrock_2015_leandro_cole_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 3574
   absolute_time: 2015-07-11 18:49:00.000000000 Z
   data_status: 2
@@ -4233,11 +4234,11 @@ hardrock_2015_leandro_cole_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 3575
   absolute_time: 2015-07-11 19:14:00.000000000 Z
   data_status: 2
@@ -4246,11 +4247,11 @@ hardrock_2015_leandro_cole_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 3580
   absolute_time: 2015-07-12 09:30:00.000000000 Z
   data_status: 2
@@ -4259,11 +4260,11 @@ hardrock_2015_leandro_cole_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 3581
   absolute_time: 2015-07-12 09:32:00.000000000 Z
   data_status: 2
@@ -4272,11 +4273,11 @@ hardrock_2015_leandro_cole_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_finish_1:
+  split: hardrock_ccw_finish
   id: 3582
   absolute_time: 2015-07-12 11:37:00.000000000 Z
   data_status: 2
@@ -4285,11 +4286,11 @@ hardrock_2015_leandro_cole_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_start_1:
+  split: hardrock_ccw_start
   id: 3673
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -4298,11 +4299,11 @@ hardrock_2015_benedict_davis_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 3674
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
@@ -4311,11 +4312,11 @@ hardrock_2015_benedict_davis_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 3675
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
@@ -4324,11 +4325,11 @@ hardrock_2015_benedict_davis_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 3680
   absolute_time: 2015-07-10 22:29:00.000000000 Z
   data_status: 2
@@ -4337,11 +4338,11 @@ hardrock_2015_benedict_davis_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 3681
   absolute_time: 2015-07-10 22:58:00.000000000 Z
   data_status: 2
@@ -4350,11 +4351,11 @@ hardrock_2015_benedict_davis_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 3684
   absolute_time: 2015-07-11 04:59:00.000000000 Z
   data_status: 2
@@ -4363,11 +4364,11 @@ hardrock_2015_benedict_davis_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 3685
   absolute_time: 2015-07-11 05:36:00.000000000 Z
   data_status: 2
@@ -4376,11 +4377,11 @@ hardrock_2015_benedict_davis_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 3688
   absolute_time: 2015-07-11 08:24:00.000000000 Z
   data_status: 1
@@ -4389,11 +4390,11 @@ hardrock_2015_benedict_davis_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 3689
   absolute_time: 2015-07-11 08:30:00.000000000 Z
   data_status: 1
@@ -4402,11 +4403,11 @@ hardrock_2015_benedict_davis_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 3694
   absolute_time: 2015-07-11 17:55:00.000000000 Z
   data_status: 2
@@ -4415,11 +4416,11 @@ hardrock_2015_benedict_davis_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 3695
   absolute_time: 2015-07-11 18:27:00.000000000 Z
   data_status: 2
@@ -4428,11 +4429,11 @@ hardrock_2015_benedict_davis_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 3700
   absolute_time: 2015-07-12 09:58:00.000000000 Z
   data_status: 2
@@ -4441,11 +4442,11 @@ hardrock_2015_benedict_davis_putnam_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 3701
   absolute_time: 2015-07-12 10:00:00.000000000 Z
   data_status: 2
@@ -4454,11 +4455,11 @@ hardrock_2015_benedict_davis_putnam_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_finish_1:
+  split: hardrock_ccw_finish
   id: 3702
   absolute_time: 2015-07-12 11:59:00.000000000 Z
   data_status: 2
@@ -4467,11 +4468,11 @@ hardrock_2015_benedict_davis_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 34
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_start_1:
+  split: hardrock_ccw_start
   id: 3869
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -4480,11 +4481,11 @@ hardrock_2015_raphael_swift_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 3870
   absolute_time: 2015-07-10 15:24:00.000000000 Z
   data_status: 2
@@ -4493,11 +4494,11 @@ hardrock_2015_raphael_swift_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 3871
   absolute_time: 2015-07-10 15:24:00.000000000 Z
   data_status: 2
@@ -4506,11 +4507,11 @@ hardrock_2015_raphael_swift_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_raphael_swift_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 3876
   absolute_time: 2015-07-10 22:53:00.000000000 Z
   data_status: 2
@@ -4519,11 +4520,11 @@ hardrock_2015_raphael_swift_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 3877
   absolute_time: 2015-07-10 23:02:00.000000000 Z
   data_status: 2
@@ -4532,11 +4533,11 @@ hardrock_2015_raphael_swift_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_raphael_swift_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 3880
   absolute_time: 2015-07-11 05:04:00.000000000 Z
   data_status: 2
@@ -4545,11 +4546,11 @@ hardrock_2015_raphael_swift_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 3881
   absolute_time: 2015-07-11 05:13:00.000000000 Z
   data_status: 2
@@ -4558,11 +4559,11 @@ hardrock_2015_raphael_swift_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_raphael_swift_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 3884
   absolute_time: 2015-07-11 07:59:00.000000000 Z
   data_status: 1
@@ -4571,11 +4572,11 @@ hardrock_2015_raphael_swift_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 3885
   absolute_time: 2015-07-11 08:06:00.000000000 Z
   data_status: 1
@@ -4584,11 +4585,11 @@ hardrock_2015_raphael_swift_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_raphael_swift_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 3890
   absolute_time: 2015-07-11 18:22:00.000000000 Z
   data_status: 2
@@ -4597,11 +4598,11 @@ hardrock_2015_raphael_swift_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 3891
   absolute_time: 2015-07-11 18:44:00.000000000 Z
   data_status: 2
@@ -4610,11 +4611,11 @@ hardrock_2015_raphael_swift_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_start_1:
+  split: hardrock_ccw_start
   id: 3919
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -4623,11 +4624,11 @@ hardrock_2015_bad_status_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 3920
   absolute_time: 2015-07-10 15:13:00.000000000 Z
   data_status: 2
@@ -4636,11 +4637,11 @@ hardrock_2015_bad_status_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 3921
   absolute_time: 2015-07-10 15:13:00.000000000 Z
   data_status: 2
@@ -4649,11 +4650,11 @@ hardrock_2015_bad_status_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 3926
   absolute_time: 2015-07-10 23:11:00.000000000 Z
   data_status: 2
@@ -4662,11 +4663,11 @@ hardrock_2015_bad_status_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 3927
   absolute_time: 2015-07-10 23:22:00.000000000 Z
   data_status: 2
@@ -4675,11 +4676,11 @@ hardrock_2015_bad_status_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 3930
   absolute_time: 2015-07-11 06:37:00.000000000 Z
   data_status: 2
@@ -4688,11 +4689,11 @@ hardrock_2015_bad_status_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 3931
   absolute_time: 2015-07-11 06:51:00.000000000 Z
   data_status: 2
@@ -4701,11 +4702,11 @@ hardrock_2015_bad_status_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 3934
   absolute_time: 2015-07-11 13:19:00.000000000 Z
   data_status: 2
@@ -4714,11 +4715,11 @@ hardrock_2015_bad_status_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 3935
   absolute_time: 2015-07-11 14:09:00.000000000 Z
   data_status: 2
@@ -4727,11 +4728,11 @@ hardrock_2015_bad_status_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_irvin_harber_start_1:
+  split: hardrock_ccw_start
   id: 3980
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -4740,11 +4741,11 @@ hardrock_2015_irvin_harber_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 3981
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
@@ -4753,11 +4754,11 @@ hardrock_2015_irvin_harber_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 3982
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
@@ -4766,11 +4767,11 @@ hardrock_2015_irvin_harber_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_irvin_harber_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 3987
   absolute_time: 2015-07-10 19:39:00.000000000 Z
   data_status: 2
@@ -4779,11 +4780,11 @@ hardrock_2015_irvin_harber_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 3988
   absolute_time: 2015-07-10 19:45:00.000000000 Z
   data_status: 2
@@ -4792,11 +4793,11 @@ hardrock_2015_irvin_harber_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_irvin_harber_grouse_in_1:
+  split: hardrock_ccw_grouse
   id: 3991
   absolute_time: 2015-07-11 00:44:00.000000000 Z
   data_status: 2
@@ -4805,11 +4806,11 @@ hardrock_2015_irvin_harber_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_grouse_out_1:
+  split: hardrock_ccw_grouse
   id: 3992
   absolute_time: 2015-07-11 01:10:00.000000000 Z
   data_status: 2
@@ -4818,11 +4819,11 @@ hardrock_2015_irvin_harber_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 16
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_irvin_harber_ouray_in_1:
+  split: hardrock_ccw_ouray
   id: 3995
   absolute_time: 2015-07-11 05:46:00.000000000 Z
   data_status: 2
@@ -4831,11 +4832,11 @@ hardrock_2015_irvin_harber_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_ouray_out_1:
+  split: hardrock_ccw_ouray
   id: 3996
   absolute_time: 2015-07-11 05:46:00.000000000 Z
   data_status: 2
@@ -4844,11 +4845,11 @@ hardrock_2015_irvin_harber_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 20
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cassondra_nienow_start_1:
+  split: hardrock_ccw_start
   id: 4190
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -4857,11 +4858,11 @@ hardrock_2015_cassondra_nienow_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cassondra_nienow_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 4191
   absolute_time: 2015-07-10 15:31:00.000000000 Z
   data_status: 2
@@ -4870,11 +4871,11 @@ hardrock_2015_cassondra_nienow_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cassondra_nienow_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 4192
   absolute_time: 2015-07-10 15:31:00.000000000 Z
   data_status: 2
@@ -4883,11 +4884,11 @@ hardrock_2015_cassondra_nienow_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cassondra_nienow_sherman_in_1:
+  split: hardrock_ccw_sherman
   id: 4197
   absolute_time: 2015-07-11 00:03:00.000000000 Z
   data_status: 2
@@ -4896,11 +4897,11 @@ hardrock_2015_cassondra_nienow_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cassondra_nienow_sherman_out_1:
+  split: hardrock_ccw_sherman
   id: 4198
   absolute_time: 2015-07-11 00:03:00.000000000 Z
   data_status: 2
@@ -4909,11 +4910,11 @@ hardrock_2015_cassondra_nienow_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 12
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donn_mckenzie_start_1:
+  split: hardrock_ccw_start
   id: 4217
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -4922,11 +4923,11 @@ hardrock_2015_donn_mckenzie_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donn_mckenzie_cunningham_in_1:
+  split: hardrock_ccw_cunningham
   id: 4218
   absolute_time: 2015-07-10 14:30:00.000000000 Z
   data_status: 2
@@ -4935,11 +4936,11 @@ hardrock_2015_donn_mckenzie_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donn_mckenzie_cunningham_out_1:
+  split: hardrock_ccw_cunningham
   id: 4219
   absolute_time: 2015-07-10 14:30:00.000000000 Z
   data_status: 2
@@ -4948,11 +4949,11 @@ hardrock_2015_donn_mckenzie_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 6
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 ramble_finished_first_start_1:
+  split: ramble_even_course_start
   id: 15144
   absolute_time: 2006-09-16 14:00:00.000000000 Z
   data_status: 2
@@ -4961,11 +4962,11 @@ ramble_finished_first_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 46
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ramble_finished_first_finish_1:
+  split: ramble_even_course_finish
   id: 15145
   absolute_time: 2006-09-16 14:34:22.000000000 Z
   data_status: 2
@@ -4974,11 +4975,11 @@ ramble_finished_first_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 47
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 ramble_finished_second_start_1:
+  split: ramble_even_course_start
   id: 15160
   absolute_time: 2006-09-16 14:00:00.000000000 Z
   data_status: 2
@@ -4987,11 +4988,11 @@ ramble_finished_second_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 46
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ramble_finished_second_finish_1:
+  split: ramble_even_course_finish
   id: 15161
   absolute_time: 2006-09-16 14:37:31.000000000 Z
   data_status: 2
@@ -5000,11 +5001,11 @@ ramble_finished_second_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 47
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 ramble_start_only_start_1:
+  split: ramble_even_course_start
   id: 15166
   absolute_time: 2006-09-16 14:00:00.000000000 Z
   data_status: 2
@@ -5013,11 +5014,11 @@ ramble_start_only_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 46
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_start_1:
+  split: hardrock_cw_start
   id: 91259
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -5026,11 +5027,11 @@ hardrock_2014_finished_first_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 91264
   absolute_time: 2014-07-11 18:24:00.000000000 Z
   data_status:
@@ -5039,11 +5040,11 @@ hardrock_2014_finished_first_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 91265
   absolute_time: 2014-07-11 18:26:00.000000000 Z
   data_status:
@@ -5052,11 +5053,11 @@ hardrock_2014_finished_first_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_first_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 91270
   absolute_time: 2014-07-11 21:50:00.000000000 Z
   data_status:
@@ -5065,11 +5066,11 @@ hardrock_2014_finished_first_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 91271
   absolute_time: 2014-07-11 21:52:00.000000000 Z
   data_status:
@@ -5078,11 +5079,11 @@ hardrock_2014_finished_first_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_first_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 91274
   absolute_time: 2014-07-12 01:38:00.000000000 Z
   data_status:
@@ -5091,11 +5092,11 @@ hardrock_2014_finished_first_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 91275
   absolute_time: 2014-07-12 01:43:00.000000000 Z
   data_status:
@@ -5104,11 +5105,11 @@ hardrock_2014_finished_first_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_first_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 91278
   absolute_time: 2014-07-12 06:08:00.000000000 Z
   data_status:
@@ -5117,11 +5118,11 @@ hardrock_2014_finished_first_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 91279
   absolute_time: 2014-07-12 06:17:00.000000000 Z
   data_status:
@@ -5130,11 +5131,11 @@ hardrock_2014_finished_first_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_first_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 91284
   absolute_time: 2014-07-12 13:21:00.000000000 Z
   data_status:
@@ -5143,11 +5144,11 @@ hardrock_2014_finished_first_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 91285
   absolute_time: 2014-07-12 13:27:00.000000000 Z
   data_status:
@@ -5156,11 +5157,11 @@ hardrock_2014_finished_first_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_first_finish_1:
+  split: hardrock_cw_finish
   id: 91286
   absolute_time: 2014-07-12 16:07:38.000000000 Z
   data_status:
@@ -5169,11 +5170,11 @@ hardrock_2014_finished_first_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_start_1:
+  split: hardrock_cw_start
   id: 91287
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -5182,11 +5183,11 @@ hardrock_2014_finished_with_stop_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 91292
   absolute_time: 2014-07-11 18:59:00.000000000 Z
   data_status:
@@ -5195,11 +5196,11 @@ hardrock_2014_finished_with_stop_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 91293
   absolute_time: 2014-07-11 19:03:00.000000000 Z
   data_status:
@@ -5208,11 +5209,11 @@ hardrock_2014_finished_with_stop_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_with_stop_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 91298
   absolute_time: 2014-07-11 22:43:00.000000000 Z
   data_status:
@@ -5221,11 +5222,11 @@ hardrock_2014_finished_with_stop_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 91299
   absolute_time: 2014-07-11 22:46:00.000000000 Z
   data_status:
@@ -5234,11 +5235,11 @@ hardrock_2014_finished_with_stop_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_with_stop_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 91302
   absolute_time: 2014-07-12 02:56:00.000000000 Z
   data_status:
@@ -5247,11 +5248,11 @@ hardrock_2014_finished_with_stop_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 91303
   absolute_time: 2014-07-12 03:06:00.000000000 Z
   data_status:
@@ -5260,11 +5261,11 @@ hardrock_2014_finished_with_stop_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_with_stop_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 91306
   absolute_time: 2014-07-12 07:05:00.000000000 Z
   data_status:
@@ -5273,11 +5274,11 @@ hardrock_2014_finished_with_stop_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 91307
   absolute_time: 2014-07-12 07:15:00.000000000 Z
   data_status:
@@ -5286,11 +5287,11 @@ hardrock_2014_finished_with_stop_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_with_stop_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 91312
   absolute_time: 2014-07-12 13:43:00.000000000 Z
   data_status:
@@ -5299,11 +5300,11 @@ hardrock_2014_finished_with_stop_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 91313
   absolute_time: 2014-07-12 13:46:00.000000000 Z
   data_status:
@@ -5312,11 +5313,11 @@ hardrock_2014_finished_with_stop_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_with_stop_finish_1:
+  split: hardrock_cw_finish
   id: 91314
   absolute_time: 2014-07-12 16:23:42.000000000 Z
   data_status:
@@ -5325,11 +5326,11 @@ hardrock_2014_finished_with_stop_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_start_1:
+  split: hardrock_cw_start
   id: 91315
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -5338,11 +5339,11 @@ hardrock_2014_finished_without_stop_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 91320
   absolute_time: 2014-07-11 18:53:00.000000000 Z
   data_status:
@@ -5351,11 +5352,11 @@ hardrock_2014_finished_without_stop_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 91321
   absolute_time: 2014-07-11 18:56:00.000000000 Z
   data_status:
@@ -5364,11 +5365,11 @@ hardrock_2014_finished_without_stop_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_without_stop_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 91326
   absolute_time: 2014-07-11 22:43:00.000000000 Z
   data_status:
@@ -5377,11 +5378,11 @@ hardrock_2014_finished_without_stop_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 91327
   absolute_time: 2014-07-11 22:50:00.000000000 Z
   data_status:
@@ -5390,11 +5391,11 @@ hardrock_2014_finished_without_stop_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_without_stop_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 91330
   absolute_time: 2014-07-12 03:10:00.000000000 Z
   data_status:
@@ -5403,11 +5404,11 @@ hardrock_2014_finished_without_stop_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 91331
   absolute_time: 2014-07-12 03:15:00.000000000 Z
   data_status:
@@ -5416,11 +5417,11 @@ hardrock_2014_finished_without_stop_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_without_stop_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 91334
   absolute_time: 2014-07-12 07:15:00.000000000 Z
   data_status:
@@ -5429,11 +5430,11 @@ hardrock_2014_finished_without_stop_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 91335
   absolute_time: 2014-07-12 07:23:59.000000000 Z
   data_status:
@@ -5442,11 +5443,11 @@ hardrock_2014_finished_without_stop_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_without_stop_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 91340
   absolute_time: 2014-07-12 14:04:00.000000000 Z
   data_status:
@@ -5455,11 +5456,11 @@ hardrock_2014_finished_without_stop_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 91341
   absolute_time: 2014-07-12 14:04:00.000000000 Z
   data_status:
@@ -5468,11 +5469,11 @@ hardrock_2014_finished_without_stop_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_without_stop_finish_1:
+  split: hardrock_cw_finish
   id: 91342
   absolute_time: 2014-07-12 16:28:54.000000000 Z
   data_status:
@@ -5481,11 +5482,11 @@ hardrock_2014_finished_without_stop_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_start_1:
+  split: hardrock_cw_start
   id: 91819
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -5494,11 +5495,11 @@ hardrock_2014_claudio_wunsch_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 91824
   absolute_time: 2014-07-11 19:00:00.000000000 Z
   data_status:
@@ -5507,11 +5508,11 @@ hardrock_2014_claudio_wunsch_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 91825
   absolute_time: 2014-07-11 19:07:00.000000000 Z
   data_status:
@@ -5520,11 +5521,11 @@ hardrock_2014_claudio_wunsch_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_claudio_wunsch_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 91830
   absolute_time: 2014-07-11 23:04:00.000000000 Z
   data_status:
@@ -5533,11 +5534,11 @@ hardrock_2014_claudio_wunsch_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 91831
   absolute_time: 2014-07-11 23:24:00.000000000 Z
   data_status:
@@ -5546,11 +5547,11 @@ hardrock_2014_claudio_wunsch_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_claudio_wunsch_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 91834
   absolute_time: 2014-07-12 03:55:00.000000000 Z
   data_status:
@@ -5559,11 +5560,11 @@ hardrock_2014_claudio_wunsch_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 91835
   absolute_time: 2014-07-12 04:37:00.000000000 Z
   data_status:
@@ -5572,11 +5573,11 @@ hardrock_2014_claudio_wunsch_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_claudio_wunsch_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 91838
   absolute_time: 2014-07-12 10:17:00.000000000 Z
   data_status:
@@ -5585,11 +5586,11 @@ hardrock_2014_claudio_wunsch_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 91839
   absolute_time: 2014-07-12 10:33:00.000000000 Z
   data_status:
@@ -5598,11 +5599,11 @@ hardrock_2014_claudio_wunsch_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_claudio_wunsch_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 91844
   absolute_time: 2014-07-12 19:19:00.000000000 Z
   data_status:
@@ -5611,11 +5612,11 @@ hardrock_2014_claudio_wunsch_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 91845
   absolute_time: 2014-07-12 19:34:00.000000000 Z
   data_status:
@@ -5624,11 +5625,11 @@ hardrock_2014_claudio_wunsch_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_claudio_wunsch_finish_1:
+  split: hardrock_cw_finish
   id: 91846
   absolute_time: 2014-07-12 23:58:21.000000000 Z
   data_status:
@@ -5637,11 +5638,11 @@ hardrock_2014_claudio_wunsch_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_start_1:
+  split: hardrock_cw_start
   id: 92015
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -5650,11 +5651,11 @@ hardrock_2014_rachelle_eichmann_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 92020
   absolute_time: 2014-07-11 20:26:59.000000000 Z
   data_status:
@@ -5663,11 +5664,11 @@ hardrock_2014_rachelle_eichmann_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 92021
   absolute_time: 2014-07-11 20:39:00.000000000 Z
   data_status:
@@ -5676,11 +5677,11 @@ hardrock_2014_rachelle_eichmann_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_rachelle_eichmann_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 92026
   absolute_time: 2014-07-12 01:23:00.000000000 Z
   data_status:
@@ -5689,11 +5690,11 @@ hardrock_2014_rachelle_eichmann_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 92027
   absolute_time: 2014-07-12 01:33:00.000000000 Z
   data_status:
@@ -5702,11 +5703,11 @@ hardrock_2014_rachelle_eichmann_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_rachelle_eichmann_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 92030
   absolute_time: 2014-07-12 07:25:00.000000000 Z
   data_status:
@@ -5715,11 +5716,11 @@ hardrock_2014_rachelle_eichmann_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 92031
   absolute_time: 2014-07-12 07:49:00.000000000 Z
   data_status:
@@ -5728,11 +5729,11 @@ hardrock_2014_rachelle_eichmann_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_rachelle_eichmann_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 92034
   absolute_time: 2014-07-12 13:30:00.000000000 Z
   data_status:
@@ -5741,11 +5742,11 @@ hardrock_2014_rachelle_eichmann_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 92035
   absolute_time: 2014-07-12 13:49:00.000000000 Z
   data_status:
@@ -5754,11 +5755,11 @@ hardrock_2014_rachelle_eichmann_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_rachelle_eichmann_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 92040
   absolute_time: 2014-07-12 21:53:00.000000000 Z
   data_status:
@@ -5767,11 +5768,11 @@ hardrock_2014_rachelle_eichmann_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 92041
   absolute_time: 2014-07-12 21:58:00.000000000 Z
   data_status:
@@ -5780,11 +5781,11 @@ hardrock_2014_rachelle_eichmann_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_rachelle_eichmann_finish_1:
+  split: hardrock_cw_finish
   id: 92042
   absolute_time: 2014-07-13 01:39:17.000000000 Z
   data_status:
@@ -5793,11 +5794,11 @@ hardrock_2014_rachelle_eichmann_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_start_1:
+  split: hardrock_cw_start
   id: 92211
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -5806,11 +5807,11 @@ hardrock_2014_keith_metz_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 92216
   absolute_time: 2014-07-11 20:30:00.000000000 Z
   data_status:
@@ -5819,11 +5820,11 @@ hardrock_2014_keith_metz_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 92217
   absolute_time: 2014-07-11 20:42:00.000000000 Z
   data_status:
@@ -5832,11 +5833,11 @@ hardrock_2014_keith_metz_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_keith_metz_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 92222
   absolute_time: 2014-07-12 01:27:00.000000000 Z
   data_status:
@@ -5845,11 +5846,11 @@ hardrock_2014_keith_metz_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 92223
   absolute_time: 2014-07-12 01:43:00.000000000 Z
   data_status:
@@ -5858,11 +5859,11 @@ hardrock_2014_keith_metz_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_keith_metz_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 92226
   absolute_time: 2014-07-12 07:30:00.000000000 Z
   data_status:
@@ -5871,11 +5872,11 @@ hardrock_2014_keith_metz_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 92227
   absolute_time: 2014-07-12 07:56:00.000000000 Z
   data_status:
@@ -5884,11 +5885,11 @@ hardrock_2014_keith_metz_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_keith_metz_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 92230
   absolute_time: 2014-07-12 14:03:00.000000000 Z
   data_status:
@@ -5897,11 +5898,11 @@ hardrock_2014_keith_metz_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 92231
   absolute_time: 2014-07-12 14:22:00.000000000 Z
   data_status:
@@ -5910,11 +5911,11 @@ hardrock_2014_keith_metz_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_keith_metz_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 92236
   absolute_time: 2014-07-12 23:19:00.000000000 Z
   data_status:
@@ -5923,11 +5924,11 @@ hardrock_2014_keith_metz_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 92237
   absolute_time: 2014-07-12 23:30:00.000000000 Z
   data_status:
@@ -5936,11 +5937,11 @@ hardrock_2014_keith_metz_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_keith_metz_finish_1:
+  split: hardrock_cw_finish
   id: 92238
   absolute_time: 2014-07-13 02:59:02.000000000 Z
   data_status:
@@ -5949,11 +5950,11 @@ hardrock_2014_keith_metz_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_start_1:
+  split: hardrock_cw_start
   id: 92239
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -5962,11 +5963,11 @@ hardrock_2014_major_green_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 92244
   absolute_time: 2014-07-11 20:52:00.000000000 Z
   data_status:
@@ -5975,11 +5976,11 @@ hardrock_2014_major_green_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 92245
   absolute_time: 2014-07-11 20:58:00.000000000 Z
   data_status:
@@ -5988,11 +5989,11 @@ hardrock_2014_major_green_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_major_green_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 92250
   absolute_time: 2014-07-12 02:00:00.000000000 Z
   data_status:
@@ -6001,11 +6002,11 @@ hardrock_2014_major_green_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 92251
   absolute_time: 2014-07-12 02:12:00.000000000 Z
   data_status:
@@ -6014,11 +6015,11 @@ hardrock_2014_major_green_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_major_green_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 92254
   absolute_time: 2014-07-12 08:07:00.000000000 Z
   data_status:
@@ -6027,11 +6028,11 @@ hardrock_2014_major_green_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 92255
   absolute_time: 2014-07-12 08:18:00.000000000 Z
   data_status:
@@ -6040,11 +6041,11 @@ hardrock_2014_major_green_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_major_green_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 92258
   absolute_time: 2014-07-12 14:25:00.000000000 Z
   data_status:
@@ -6053,11 +6054,11 @@ hardrock_2014_major_green_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 92259
   absolute_time: 2014-07-12 14:40:00.000000000 Z
   data_status:
@@ -6066,11 +6067,11 @@ hardrock_2014_major_green_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_major_green_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 92264
   absolute_time: 2014-07-12 23:13:00.000000000 Z
   data_status:
@@ -6079,11 +6080,11 @@ hardrock_2014_major_green_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 92265
   absolute_time: 2014-07-12 23:23:00.000000000 Z
   data_status:
@@ -6092,11 +6093,11 @@ hardrock_2014_major_green_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_major_green_finish_1:
+  split: hardrock_cw_finish
   id: 92266
   absolute_time: 2014-07-13 03:03:41.000000000 Z
   data_status:
@@ -6105,11 +6106,11 @@ hardrock_2014_major_green_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_start_1:
+  split: hardrock_cw_start
   id: 92631
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -6118,11 +6119,11 @@ hardrock_2014_humberto_adams_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 92636
   absolute_time: 2014-07-11 20:54:59.000000000 Z
   data_status:
@@ -6131,11 +6132,11 @@ hardrock_2014_humberto_adams_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 92637
   absolute_time: 2014-07-11 21:58:00.000000000 Z
   data_status:
@@ -6144,11 +6145,11 @@ hardrock_2014_humberto_adams_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_humberto_adams_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 92642
   absolute_time: 2014-07-12 01:56:59.000000000 Z
   data_status:
@@ -6157,11 +6158,11 @@ hardrock_2014_humberto_adams_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 92643
   absolute_time: 2014-07-12 02:20:00.000000000 Z
   data_status:
@@ -6170,11 +6171,11 @@ hardrock_2014_humberto_adams_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_humberto_adams_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 92646
   absolute_time: 2014-07-12 09:36:00.000000000 Z
   data_status:
@@ -6183,11 +6184,11 @@ hardrock_2014_humberto_adams_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 92647
   absolute_time: 2014-07-12 10:22:00.000000000 Z
   data_status:
@@ -6196,11 +6197,11 @@ hardrock_2014_humberto_adams_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_humberto_adams_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 92650
   absolute_time: 2014-07-12 16:25:00.000000000 Z
   data_status:
@@ -6209,11 +6210,11 @@ hardrock_2014_humberto_adams_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 92651
   absolute_time: 2014-07-12 16:45:00.000000000 Z
   data_status:
@@ -6222,11 +6223,11 @@ hardrock_2014_humberto_adams_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_humberto_adams_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 92656
   absolute_time: 2014-07-13 01:18:00.000000000 Z
   data_status:
@@ -6235,11 +6236,11 @@ hardrock_2014_humberto_adams_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 92657
   absolute_time: 2014-07-13 01:30:00.000000000 Z
   data_status:
@@ -6248,11 +6249,11 @@ hardrock_2014_humberto_adams_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_humberto_adams_finish_1:
+  split: hardrock_cw_finish
   id: 92658
   absolute_time: 2014-07-13 05:40:21.000000000 Z
   data_status:
@@ -6261,11 +6262,11 @@ hardrock_2014_humberto_adams_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_start_1:
+  split: hardrock_cw_start
   id: 93331
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -6274,11 +6275,11 @@ hardrock_2014_omer_yundt_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 93336
   absolute_time: 2014-07-11 21:34:00.000000000 Z
   data_status:
@@ -6287,11 +6288,11 @@ hardrock_2014_omer_yundt_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 93337
   absolute_time: 2014-07-11 22:06:00.000000000 Z
   data_status:
@@ -6300,11 +6301,11 @@ hardrock_2014_omer_yundt_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_omer_yundt_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 93342
   absolute_time: 2014-07-12 03:38:00.000000000 Z
   data_status:
@@ -6313,11 +6314,11 @@ hardrock_2014_omer_yundt_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 93343
   absolute_time: 2014-07-12 04:26:00.000000000 Z
   data_status:
@@ -6326,11 +6327,11 @@ hardrock_2014_omer_yundt_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_omer_yundt_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 93346
   absolute_time: 2014-07-12 10:33:00.000000000 Z
   data_status:
@@ -6339,11 +6340,11 @@ hardrock_2014_omer_yundt_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 93347
   absolute_time: 2014-07-12 11:34:00.000000000 Z
   data_status:
@@ -6352,11 +6353,11 @@ hardrock_2014_omer_yundt_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_omer_yundt_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 93350
   absolute_time: 2014-07-12 17:22:00.000000000 Z
   data_status:
@@ -6365,11 +6366,11 @@ hardrock_2014_omer_yundt_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 93351
   absolute_time: 2014-07-12 18:00:00.000000000 Z
   data_status:
@@ -6378,11 +6379,11 @@ hardrock_2014_omer_yundt_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_omer_yundt_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 93356
   absolute_time: 2014-07-13 02:14:00.000000000 Z
   data_status:
@@ -6391,11 +6392,11 @@ hardrock_2014_omer_yundt_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 93357
   absolute_time: 2014-07-13 02:33:00.000000000 Z
   data_status:
@@ -6404,11 +6405,11 @@ hardrock_2014_omer_yundt_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_omer_yundt_finish_1:
+  split: hardrock_cw_finish
   id: 93358
   absolute_time: 2014-07-13 08:48:15.000000000 Z
   data_status:
@@ -6417,11 +6418,11 @@ hardrock_2014_omer_yundt_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_start_1:
+  split: hardrock_cw_start
   id: 93359
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status: 2
@@ -6430,11 +6431,11 @@ hardrock_2014_pat_schaden_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 93364
   absolute_time: 2014-07-11 22:35:00.000000000 Z
   data_status: 2
@@ -6443,11 +6444,11 @@ hardrock_2014_pat_schaden_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 93365
   absolute_time: 2014-07-11 22:47:00.000000000 Z
   data_status: 2
@@ -6456,11 +6457,11 @@ hardrock_2014_pat_schaden_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_pat_schaden_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 93370
   absolute_time: 2014-07-12 04:44:00.000000000 Z
   data_status: 2
@@ -6469,11 +6470,11 @@ hardrock_2014_pat_schaden_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 93371
   absolute_time: 2014-07-12 05:16:00.000000000 Z
   data_status: 2
@@ -6482,11 +6483,11 @@ hardrock_2014_pat_schaden_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_pat_schaden_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 93374
   absolute_time: 2014-07-12 12:27:00.000000000 Z
   data_status: 2
@@ -6495,11 +6496,11 @@ hardrock_2014_pat_schaden_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 93375
   absolute_time: 2014-07-12 12:48:00.000000000 Z
   data_status: 2
@@ -6508,11 +6509,11 @@ hardrock_2014_pat_schaden_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_pat_schaden_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 93378
   absolute_time: 2014-07-12 18:29:00.000000000 Z
   data_status: 2
@@ -6521,11 +6522,11 @@ hardrock_2014_pat_schaden_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 93379
   absolute_time: 2014-07-12 18:52:00.000000000 Z
   data_status: 2
@@ -6534,11 +6535,11 @@ hardrock_2014_pat_schaden_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_pat_schaden_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 93384
   absolute_time: 2014-07-13 04:14:00.000000000 Z
   data_status: 2
@@ -6547,11 +6548,11 @@ hardrock_2014_pat_schaden_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_start_1:
+  split: hardrock_cw_start
   id: 93415
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -6560,11 +6561,11 @@ hardrock_2014_clarence_goyette_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 93420
   absolute_time: 2014-07-11 22:05:00.000000000 Z
   data_status:
@@ -6573,11 +6574,11 @@ hardrock_2014_clarence_goyette_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 93421
   absolute_time: 2014-07-11 22:14:00.000000000 Z
   data_status:
@@ -6586,11 +6587,11 @@ hardrock_2014_clarence_goyette_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_clarence_goyette_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 93426
   absolute_time: 2014-07-12 04:32:00.000000000 Z
   data_status:
@@ -6599,11 +6600,11 @@ hardrock_2014_clarence_goyette_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 93427
   absolute_time: 2014-07-12 05:02:00.000000000 Z
   data_status:
@@ -6612,11 +6613,11 @@ hardrock_2014_clarence_goyette_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_clarence_goyette_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 93430
   absolute_time: 2014-07-12 11:19:00.000000000 Z
   data_status:
@@ -6625,11 +6626,11 @@ hardrock_2014_clarence_goyette_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 93431
   absolute_time: 2014-07-12 11:59:00.000000000 Z
   data_status:
@@ -6638,11 +6639,11 @@ hardrock_2014_clarence_goyette_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_clarence_goyette_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 93434
   absolute_time: 2014-07-12 18:06:00.000000000 Z
   data_status:
@@ -6651,11 +6652,11 @@ hardrock_2014_clarence_goyette_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 93435
   absolute_time: 2014-07-12 18:32:00.000000000 Z
   data_status:
@@ -6664,11 +6665,11 @@ hardrock_2014_clarence_goyette_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_clarence_goyette_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 93440
   absolute_time: 2014-07-13 04:02:00.000000000 Z
   data_status:
@@ -6677,11 +6678,11 @@ hardrock_2014_clarence_goyette_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 93441
   absolute_time: 2014-07-13 04:32:00.000000000 Z
   data_status:
@@ -6690,11 +6691,11 @@ hardrock_2014_clarence_goyette_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_clarence_goyette_finish_1:
+  split: hardrock_cw_finish
   id: 93442
   absolute_time: 2014-07-13 09:21:28.000000000 Z
   data_status:
@@ -6703,11 +6704,11 @@ hardrock_2014_clarence_goyette_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_start_1:
+  split: hardrock_cw_start
   id: 93471
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -6716,11 +6717,11 @@ hardrock_2014_irvin_corkery_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 93476
   absolute_time: 2014-07-11 20:21:00.000000000 Z
   data_status:
@@ -6729,11 +6730,11 @@ hardrock_2014_irvin_corkery_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 93477
   absolute_time: 2014-07-11 20:32:00.000000000 Z
   data_status:
@@ -6742,11 +6743,11 @@ hardrock_2014_irvin_corkery_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_irvin_corkery_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 93482
   absolute_time: 2014-07-12 01:25:00.000000000 Z
   data_status:
@@ -6755,11 +6756,11 @@ hardrock_2014_irvin_corkery_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 93483
   absolute_time: 2014-07-12 01:45:00.000000000 Z
   data_status:
@@ -6768,11 +6769,11 @@ hardrock_2014_irvin_corkery_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_irvin_corkery_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 93486
   absolute_time: 2014-07-12 07:39:00.000000000 Z
   data_status:
@@ -6781,11 +6782,11 @@ hardrock_2014_irvin_corkery_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 93487
   absolute_time: 2014-07-12 08:12:59.000000000 Z
   data_status:
@@ -6794,11 +6795,11 @@ hardrock_2014_irvin_corkery_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_irvin_corkery_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 93490
   absolute_time: 2014-07-12 15:59:00.000000000 Z
   data_status:
@@ -6807,11 +6808,11 @@ hardrock_2014_irvin_corkery_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 93491
   absolute_time: 2014-07-12 16:35:00.000000000 Z
   data_status:
@@ -6820,11 +6821,11 @@ hardrock_2014_irvin_corkery_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_irvin_corkery_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 93496
   absolute_time: 2014-07-13 03:38:00.000000000 Z
   data_status:
@@ -6833,11 +6834,11 @@ hardrock_2014_irvin_corkery_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 93497
   absolute_time: 2014-07-13 03:54:00.000000000 Z
   data_status:
@@ -6846,11 +6847,11 @@ hardrock_2014_irvin_corkery_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_irvin_corkery_finish_1:
+  split: hardrock_cw_finish
   id: 93498
   absolute_time: 2014-07-13 09:25:16.000000000 Z
   data_status:
@@ -6859,11 +6860,11 @@ hardrock_2014_irvin_corkery_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_start_1:
+  split: hardrock_cw_start
   id: 93527
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -6872,11 +6873,11 @@ hardrock_2014_willis_murray_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 93532
   absolute_time: 2014-07-11 22:05:00.000000000 Z
   data_status:
@@ -6885,11 +6886,11 @@ hardrock_2014_willis_murray_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 93533
   absolute_time: 2014-07-11 22:20:00.000000000 Z
   data_status:
@@ -6898,11 +6899,11 @@ hardrock_2014_willis_murray_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_willis_murray_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 93538
   absolute_time: 2014-07-12 03:53:00.000000000 Z
   data_status:
@@ -6911,11 +6912,11 @@ hardrock_2014_willis_murray_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 93539
   absolute_time: 2014-07-12 04:31:00.000000000 Z
   data_status:
@@ -6924,11 +6925,11 @@ hardrock_2014_willis_murray_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_willis_murray_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 93542
   absolute_time: 2014-07-12 11:49:00.000000000 Z
   data_status:
@@ -6937,11 +6938,11 @@ hardrock_2014_willis_murray_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 93543
   absolute_time: 2014-07-12 12:18:00.000000000 Z
   data_status:
@@ -6950,11 +6951,11 @@ hardrock_2014_willis_murray_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_willis_murray_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 93546
   absolute_time: 2014-07-12 18:11:00.000000000 Z
   data_status:
@@ -6963,11 +6964,11 @@ hardrock_2014_willis_murray_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 93547
   absolute_time: 2014-07-12 18:46:00.000000000 Z
   data_status:
@@ -6976,11 +6977,11 @@ hardrock_2014_willis_murray_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_willis_murray_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 93552
   absolute_time: 2014-07-13 04:11:00.000000000 Z
   data_status:
@@ -6989,11 +6990,11 @@ hardrock_2014_willis_murray_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 93553
   absolute_time: 2014-07-13 04:38:00.000000000 Z
   data_status:
@@ -7002,11 +7003,11 @@ hardrock_2014_willis_murray_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_willis_murray_finish_1:
+  split: hardrock_cw_finish
   id: 93554
   absolute_time: 2014-07-13 09:40:40.000000000 Z
   data_status:
@@ -7015,11 +7016,11 @@ hardrock_2014_willis_murray_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_start_1:
+  split: hardrock_cw_start
   id: 93611
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -7028,11 +7029,11 @@ hardrock_2014_ken_bradtke_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 93616
   absolute_time: 2014-07-11 21:58:00.000000000 Z
   data_status:
@@ -7041,11 +7042,11 @@ hardrock_2014_ken_bradtke_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 93617
   absolute_time: 2014-07-11 22:11:00.000000000 Z
   data_status:
@@ -7054,11 +7055,11 @@ hardrock_2014_ken_bradtke_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_ken_bradtke_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 93622
   absolute_time: 2014-07-12 04:48:00.000000000 Z
   data_status:
@@ -7067,11 +7068,11 @@ hardrock_2014_ken_bradtke_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 93623
   absolute_time: 2014-07-12 05:31:00.000000000 Z
   data_status:
@@ -7080,11 +7081,11 @@ hardrock_2014_ken_bradtke_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_ken_bradtke_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 93626
   absolute_time: 2014-07-12 12:07:00.000000000 Z
   data_status:
@@ -7093,11 +7094,11 @@ hardrock_2014_ken_bradtke_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 93627
   absolute_time: 2014-07-12 12:24:00.000000000 Z
   data_status:
@@ -7106,11 +7107,11 @@ hardrock_2014_ken_bradtke_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_ken_bradtke_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 93630
   absolute_time: 2014-07-12 18:02:00.000000000 Z
   data_status:
@@ -7119,11 +7120,11 @@ hardrock_2014_ken_bradtke_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 93631
   absolute_time: 2014-07-12 18:37:00.000000000 Z
   data_status:
@@ -7132,11 +7133,11 @@ hardrock_2014_ken_bradtke_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_ken_bradtke_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 93636
   absolute_time: 2014-07-13 04:54:00.000000000 Z
   data_status:
@@ -7145,11 +7146,11 @@ hardrock_2014_ken_bradtke_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 93637
   absolute_time: 2014-07-13 05:08:00.000000000 Z
   data_status:
@@ -7158,11 +7159,11 @@ hardrock_2014_ken_bradtke_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_ken_bradtke_finish_1:
+  split: hardrock_cw_finish
   id: 93638
   absolute_time: 2014-07-13 10:23:44.000000000 Z
   data_status:
@@ -7171,11 +7172,11 @@ hardrock_2014_ken_bradtke_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_start_1:
+  split: hardrock_cw_start
   id: 94155
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status: 2
@@ -7184,11 +7185,11 @@ hardrock_2014_progress_sherman_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 94160
   absolute_time: 2014-07-11 23:07:00.000000000 Z
   data_status: 2
@@ -7197,11 +7198,11 @@ hardrock_2014_progress_sherman_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 94161
   absolute_time: 2014-07-11 23:16:00.000000000 Z
   data_status: 2
@@ -7210,11 +7211,11 @@ hardrock_2014_progress_sherman_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_progress_sherman_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 94166
   absolute_time: 2014-07-12 05:57:59.000000000 Z
   data_status: 2
@@ -7223,11 +7224,11 @@ hardrock_2014_progress_sherman_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 94167
   absolute_time: 2014-07-12 06:16:00.000000000 Z
   data_status: 2
@@ -7236,11 +7237,11 @@ hardrock_2014_progress_sherman_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_progress_sherman_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 94170
   absolute_time: 2014-07-12 13:40:00.000000000 Z
   data_status: 2
@@ -7249,11 +7250,11 @@ hardrock_2014_progress_sherman_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 94171
   absolute_time: 2014-07-12 14:06:00.000000000 Z
   data_status: 2
@@ -7262,11 +7263,11 @@ hardrock_2014_progress_sherman_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_progress_sherman_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 94174
   absolute_time: 2014-07-12 21:13:00.000000000 Z
   data_status: 2
@@ -7275,11 +7276,11 @@ hardrock_2014_progress_sherman_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 94175
   absolute_time: 2014-07-12 21:28:00.000000000 Z
   data_status: 2
@@ -7288,11 +7289,11 @@ hardrock_2014_progress_sherman_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_multiple_stops_start_1:
+  split: hardrock_cw_start
   id: 94437
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
@@ -7301,11 +7302,11 @@ hardrock_2014_multiple_stops_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_multiple_stops_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 94442
   absolute_time: 2014-07-11 22:36:00.000000000 Z
   data_status:
@@ -7314,11 +7315,11 @@ hardrock_2014_multiple_stops_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_multiple_stops_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 94443
   absolute_time: 2014-07-11 22:52:00.000000000 Z
   data_status:
@@ -7327,11 +7328,11 @@ hardrock_2014_multiple_stops_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_multiple_stops_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 94448
   absolute_time: 2014-07-12 05:20:00.000000000 Z
   data_status:
@@ -7340,11 +7341,11 @@ hardrock_2014_multiple_stops_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_multiple_stops_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 94449
   absolute_time: 2014-07-12 05:48:00.000000000 Z
   data_status:
@@ -7353,11 +7354,11 @@ hardrock_2014_multiple_stops_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_multiple_stops_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 94452
   absolute_time: 2014-07-12 13:10:00.000000000 Z
   data_status:
@@ -7366,11 +7367,11 @@ hardrock_2014_multiple_stops_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_multiple_stops_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 94453
   absolute_time: 2014-07-12 13:10:00.000000000 Z
   data_status:
@@ -7379,11 +7380,11 @@ hardrock_2014_multiple_stops_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_without_start_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 94459
   absolute_time: 2014-07-11 23:17:00.000000000 Z
   data_status: 2
@@ -7392,11 +7393,11 @@ hardrock_2014_without_start_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_without_start_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 94460
   absolute_time: 2014-07-11 23:27:00.000000000 Z
   data_status: 2
@@ -7405,11 +7406,11 @@ hardrock_2014_without_start_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_without_start_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 94465
   absolute_time: 2014-07-12 06:06:00.000000000 Z
   data_status: 2
@@ -7418,11 +7419,11 @@ hardrock_2014_without_start_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_without_start_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 94466
   absolute_time: 2014-07-12 06:29:00.000000000 Z
   data_status: 2
@@ -7431,11 +7432,11 @@ hardrock_2014_without_start_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_without_start_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 94469
   absolute_time: 2014-07-12 13:56:00.000000000 Z
   data_status: 2
@@ -7444,11 +7445,11 @@ hardrock_2014_without_start_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_without_start_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 94470
   absolute_time: 2014-07-12 13:56:00.000000000 Z
   data_status: 2
@@ -7457,11 +7458,11 @@ hardrock_2014_without_start_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_drop_ouray_start_1:
+  split: hardrock_cw_start
   id: 94471
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status: 2
@@ -7470,11 +7471,11 @@ hardrock_2014_drop_ouray_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_drop_ouray_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 94476
   absolute_time: 2014-07-11 23:42:00.000000000 Z
   data_status: 2
@@ -7483,11 +7484,11 @@ hardrock_2014_drop_ouray_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_drop_ouray_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 94477
   absolute_time: 2014-07-11 23:54:00.000000000 Z
   data_status: 2
@@ -7496,11 +7497,11 @@ hardrock_2014_drop_ouray_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_drop_ouray_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 94482
   absolute_time: 2014-07-12 06:24:00.000000000 Z
   data_status: 2
@@ -7509,11 +7510,11 @@ hardrock_2014_drop_ouray_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_drop_ouray_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 94483
   absolute_time: 2014-07-12 06:28:00.000000000 Z
   data_status: 2
@@ -7522,11 +7523,11 @@ hardrock_2014_drop_ouray_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 101536
   absolute_time: 2015-07-11 21:05:00.000000000 Z
   data_status: 1
@@ -7535,11 +7536,11 @@ hardrock_2015_bad_status_telluride_in_1:
   lap: 1
   pacer: true
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 101537
   absolute_time: 2015-07-11 21:30:00.000000000 Z
   data_status: 1
@@ -7548,11 +7549,11 @@ hardrock_2015_bad_status_telluride_out_1:
   lap: 1
   pacer: true
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_irvin_harber_telluride_in_1:
+  split: hardrock_ccw_telluride
   id: 101540
   absolute_time: 2015-07-11 11:00:00.000000000 Z
   data_status: 2
@@ -7561,11 +7562,11 @@ hardrock_2015_irvin_harber_telluride_in_1:
   lap: 1
   pacer: true
   remarks:
-  split_id: 26
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_telluride_out_1:
+  split: hardrock_ccw_telluride
   id: 101541
   absolute_time: 2015-07-11 12:00:00.000000000 Z
   data_status: 2
@@ -7574,11 +7575,11 @@ hardrock_2015_irvin_harber_telluride_out_1:
   lap: 1
   pacer: true
   remarks:
-  split_id: 26
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_putnam_in_1:
+  split: hardrock_ccw_putnam
   id: 101555
   absolute_time: 2015-07-12 01:00:00.000000000 Z
   data_status: 0
@@ -7587,11 +7588,11 @@ hardrock_2015_bad_status_putnam_in_1:
   lap: 1
   pacer: true
   remarks:
-  split_id: 32
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_putnam_out_1:
+  split: hardrock_ccw_putnam
   id: 101556
   absolute_time: 2015-07-12 01:05:00.000000000 Z
   data_status: 0
@@ -7600,11 +7601,11 @@ hardrock_2015_bad_status_putnam_out_1:
   lap: 1
   pacer: true
   remarks:
-  split_id: 32
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 rufa_2016_finished_first_start_1:
+  split: rufa_course_start
   id: 132044
   absolute_time: 2016-02-13 13:00:00.000000000 Z
   data_status: 2
@@ -7613,11 +7614,11 @@ rufa_2016_finished_first_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_1:
+  split: rufa_course_grandeur_peak
   id: 132045
   absolute_time: 2016-02-13 13:59:00.000000000 Z
   data_status: 2
@@ -7626,11 +7627,11 @@ rufa_2016_finished_first_grandeur_peak_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_2:
+  split: rufa_course_grandeur_peak
   id: 132046
   absolute_time: 2016-02-13 15:39:00.000000000 Z
   data_status: 2
@@ -7639,11 +7640,11 @@ rufa_2016_finished_first_grandeur_peak_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_finish_2:
+  split: rufa_course_finish
   id: 132047
   absolute_time: 2016-02-13 16:12:00.000000000 Z
   data_status: 2
@@ -7652,11 +7653,11 @@ rufa_2016_finished_first_finish_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_3:
+  split: rufa_course_grandeur_peak
   id: 132048
   absolute_time: 2016-02-13 17:29:00.000000000 Z
   data_status: 2
@@ -7665,11 +7666,11 @@ rufa_2016_finished_first_grandeur_peak_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_4:
+  split: rufa_course_grandeur_peak
   id: 132049
   absolute_time: 2016-02-13 19:30:00.000000000 Z
   data_status: 2
@@ -7678,11 +7679,11 @@ rufa_2016_finished_first_grandeur_peak_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_finish_4:
+  split: rufa_course_finish
   id: 132050
   absolute_time: 2016-02-13 20:04:00.000000000 Z
   data_status: 2
@@ -7691,11 +7692,11 @@ rufa_2016_finished_first_finish_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_start_5:
+  split: rufa_course_start
   id: 132051
   absolute_time: 2016-02-13 20:09:00.000000000 Z
   data_status: 2
@@ -7704,11 +7705,11 @@ rufa_2016_finished_first_start_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_5:
+  split: rufa_course_grandeur_peak
   id: 132052
   absolute_time: 2016-02-13 21:22:00.000000000 Z
   data_status: 2
@@ -7717,11 +7718,11 @@ rufa_2016_finished_first_grandeur_peak_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_finish_5:
+  split: rufa_course_finish
   id: 132053
   absolute_time: 2016-02-13 21:59:00.000000000 Z
   data_status: 2
@@ -7730,11 +7731,11 @@ rufa_2016_finished_first_finish_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_start_6:
+  split: rufa_course_start
   id: 132054
   absolute_time: 2016-02-13 22:07:00.000000000 Z
   data_status: 2
@@ -7743,11 +7744,11 @@ rufa_2016_finished_first_start_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_6:
+  split: rufa_course_grandeur_peak
   id: 132055
   absolute_time: 2016-02-13 23:26:00.000000000 Z
   data_status: 2
@@ -7756,11 +7757,11 @@ rufa_2016_finished_first_grandeur_peak_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_finish_6:
+  split: rufa_course_finish
   id: 132056
   absolute_time: 2016-02-14 00:07:00.000000000 Z
   data_status: 2
@@ -7769,11 +7770,11 @@ rufa_2016_finished_first_finish_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_start_7:
+  split: rufa_course_start
   id: 132057
   absolute_time: 2016-02-14 00:55:00.000000000 Z
   data_status: 2
@@ -7782,11 +7783,11 @@ rufa_2016_finished_first_start_7:
   lap: 7
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_7:
+  split: rufa_course_grandeur_peak
   id: 132058
   absolute_time: 2016-02-14 02:17:00.000000000 Z
   data_status: 2
@@ -7795,11 +7796,11 @@ rufa_2016_finished_first_grandeur_peak_7:
   lap: 7
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_finish_7:
+  split: rufa_course_finish
   id: 132059
   absolute_time: 2016-02-14 03:01:00.000000000 Z
   data_status: 2
@@ -7808,11 +7809,11 @@ rufa_2016_finished_first_finish_7:
   lap: 7
   pacer:
   remarks:
-  split_id: 136
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_start_1:
+  split: rufa_course_start
   id: 132075
   absolute_time: 2016-02-13 13:00:00.000000000 Z
   data_status: 2
@@ -7821,11 +7822,11 @@ rufa_2016_finished_second_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_1:
+  split: rufa_course_grandeur_peak
   id: 132076
   absolute_time: 2016-02-13 13:47:00.000000000 Z
   data_status: 2
@@ -7834,11 +7835,11 @@ rufa_2016_finished_second_grandeur_peak_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_1:
+  split: rufa_course_finish
   id: 132077
   absolute_time: 2016-02-13 14:13:00.000000000 Z
   data_status: 2
@@ -7847,11 +7848,11 @@ rufa_2016_finished_second_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_start_2:
+  split: rufa_course_start
   id: 132078
   absolute_time: 2016-02-13 14:16:00.000000000 Z
   data_status: 2
@@ -7860,11 +7861,11 @@ rufa_2016_finished_second_start_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_2:
+  split: rufa_course_grandeur_peak
   id: 132079
   absolute_time: 2016-02-13 15:03:00.000000000 Z
   data_status: 2
@@ -7873,11 +7874,11 @@ rufa_2016_finished_second_grandeur_peak_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_2:
+  split: rufa_course_finish
   id: 132080
   absolute_time: 2016-02-13 15:29:00.000000000 Z
   data_status: 2
@@ -7886,11 +7887,11 @@ rufa_2016_finished_second_finish_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_3:
+  split: rufa_course_grandeur_peak
   id: 132081
   absolute_time: 2016-02-13 16:22:00.000000000 Z
   data_status: 2
@@ -7899,11 +7900,11 @@ rufa_2016_finished_second_grandeur_peak_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_3:
+  split: rufa_course_finish
   id: 132082
   absolute_time: 2016-02-13 16:47:00.000000000 Z
   data_status: 2
@@ -7912,11 +7913,11 @@ rufa_2016_finished_second_finish_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_start_4:
+  split: rufa_course_start
   id: 132083
   absolute_time: 2016-02-13 16:51:00.000000000 Z
   data_status: 2
@@ -7925,11 +7926,11 @@ rufa_2016_finished_second_start_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_4:
+  split: rufa_course_grandeur_peak
   id: 132084
   absolute_time: 2016-02-13 17:45:00.000000000 Z
   data_status: 2
@@ -7938,11 +7939,11 @@ rufa_2016_finished_second_grandeur_peak_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_4:
+  split: rufa_course_finish
   id: 132085
   absolute_time: 2016-02-13 18:12:00.000000000 Z
   data_status: 2
@@ -7951,11 +7952,11 @@ rufa_2016_finished_second_finish_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_5:
+  split: rufa_course_grandeur_peak
   id: 132086
   absolute_time: 2016-02-13 19:18:00.000000000 Z
   data_status: 2
@@ -7964,11 +7965,11 @@ rufa_2016_finished_second_grandeur_peak_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_5:
+  split: rufa_course_finish
   id: 132087
   absolute_time: 2016-02-13 19:49:00.000000000 Z
   data_status: 2
@@ -7977,11 +7978,11 @@ rufa_2016_finished_second_finish_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_start_6:
+  split: rufa_course_start
   id: 132088
   absolute_time: 2016-02-13 19:56:00.000000000 Z
   data_status: 2
@@ -7990,11 +7991,11 @@ rufa_2016_finished_second_start_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_6:
+  split: rufa_course_grandeur_peak
   id: 132089
   absolute_time: 2016-02-13 20:58:00.000000000 Z
   data_status: 2
@@ -8003,11 +8004,11 @@ rufa_2016_finished_second_grandeur_peak_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_6:
+  split: rufa_course_finish
   id: 132090
   absolute_time: 2016-02-13 21:28:00.000000000 Z
   data_status: 2
@@ -8016,11 +8017,11 @@ rufa_2016_finished_second_finish_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 136
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_progress_lap1_start_1:
+  split: rufa_course_start
   id: 132438
   absolute_time: 2016-02-13 13:00:00.000000000 Z
   data_status: 2
@@ -8029,11 +8030,11 @@ rufa_2016_progress_lap1_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_progress_lap1_grandeur_peak_1:
+  split: rufa_course_grandeur_peak
   id: 132439
   absolute_time: 2016-02-13 14:25:00.000000000 Z
   data_status: 2
@@ -8042,11 +8043,11 @@ rufa_2016_progress_lap1_grandeur_peak_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_1:
+  split: rufa_course_start
   id: 133963
   absolute_time: 2017-02-11 13:10:00.000000000 Z
   data_status: 2
@@ -8055,11 +8056,11 @@ rufa_2017_24h_finished_first_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_1:
+  split: rufa_course_grandeur_peak
   id: 133964
   absolute_time: 2017-02-11 14:23:00.000000000 Z
   data_status: 2
@@ -8068,11 +8069,11 @@ rufa_2017_24h_finished_first_grandeur_peak_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_1:
+  split: rufa_course_finish
   id: 133965
   absolute_time: 2017-02-11 15:05:00.000000000 Z
   data_status: 2
@@ -8081,11 +8082,11 @@ rufa_2017_24h_finished_first_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_2:
+  split: rufa_course_start
   id: 133966
   absolute_time: 2017-02-11 15:05:00.000000000 Z
   data_status: 2
@@ -8094,11 +8095,11 @@ rufa_2017_24h_finished_first_start_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_2:
+  split: rufa_course_grandeur_peak
   id: 133967
   absolute_time: 2017-02-11 16:36:00.000000000 Z
   data_status: 2
@@ -8107,11 +8108,11 @@ rufa_2017_24h_finished_first_grandeur_peak_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_2:
+  split: rufa_course_finish
   id: 133968
   absolute_time: 2017-02-11 17:12:00.000000000 Z
   data_status: 2
@@ -8120,11 +8121,11 @@ rufa_2017_24h_finished_first_finish_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_3:
+  split: rufa_course_start
   id: 133969
   absolute_time: 2017-02-11 17:19:00.000000000 Z
   data_status: 2
@@ -8133,11 +8134,11 @@ rufa_2017_24h_finished_first_start_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_3:
+  split: rufa_course_grandeur_peak
   id: 133970
   absolute_time: 2017-02-11 18:47:00.000000000 Z
   data_status: 2
@@ -8146,11 +8147,11 @@ rufa_2017_24h_finished_first_grandeur_peak_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_3:
+  split: rufa_course_finish
   id: 133971
   absolute_time: 2017-02-11 19:24:00.000000000 Z
   data_status: 2
@@ -8159,11 +8160,11 @@ rufa_2017_24h_finished_first_finish_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_4:
+  split: rufa_course_start
   id: 133972
   absolute_time: 2017-02-11 19:31:00.000000000 Z
   data_status: 2
@@ -8172,11 +8173,11 @@ rufa_2017_24h_finished_first_start_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_4:
+  split: rufa_course_grandeur_peak
   id: 133973
   absolute_time: 2017-02-11 21:05:00.000000000 Z
   data_status: 2
@@ -8185,11 +8186,11 @@ rufa_2017_24h_finished_first_grandeur_peak_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_4:
+  split: rufa_course_finish
   id: 133974
   absolute_time: 2017-02-11 21:46:00.000000000 Z
   data_status: 2
@@ -8198,11 +8199,11 @@ rufa_2017_24h_finished_first_finish_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_5:
+  split: rufa_course_start
   id: 133975
   absolute_time: 2017-02-11 22:06:00.000000000 Z
   data_status: 2
@@ -8211,11 +8212,11 @@ rufa_2017_24h_finished_first_start_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_5:
+  split: rufa_course_grandeur_peak
   id: 133976
   absolute_time: 2017-02-11 23:40:00.000000000 Z
   data_status: 2
@@ -8224,11 +8225,11 @@ rufa_2017_24h_finished_first_grandeur_peak_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_5:
+  split: rufa_course_finish
   id: 133977
   absolute_time: 2017-02-12 00:20:00.000000000 Z
   data_status: 2
@@ -8237,11 +8238,11 @@ rufa_2017_24h_finished_first_finish_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_6:
+  split: rufa_course_start
   id: 133978
   absolute_time: 2017-02-12 00:50:00.000000000 Z
   data_status: 2
@@ -8250,11 +8251,11 @@ rufa_2017_24h_finished_first_start_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_6:
+  split: rufa_course_grandeur_peak
   id: 133979
   absolute_time: 2017-02-12 02:25:00.000000000 Z
   data_status: 2
@@ -8263,11 +8264,11 @@ rufa_2017_24h_finished_first_grandeur_peak_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_6:
+  split: rufa_course_finish
   id: 133980
   absolute_time: 2017-02-12 03:15:00.000000000 Z
   data_status: 2
@@ -8276,11 +8277,11 @@ rufa_2017_24h_finished_first_finish_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_7:
+  split: rufa_course_start
   id: 133981
   absolute_time: 2017-02-12 03:38:00.000000000 Z
   data_status: 2
@@ -8289,11 +8290,11 @@ rufa_2017_24h_finished_first_start_7:
   lap: 7
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_7:
+  split: rufa_course_grandeur_peak
   id: 133982
   absolute_time: 2017-02-12 05:19:00.000000000 Z
   data_status: 2
@@ -8302,11 +8303,11 @@ rufa_2017_24h_finished_first_grandeur_peak_7:
   lap: 7
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_7:
+  split: rufa_course_finish
   id: 133983
   absolute_time: 2017-02-12 06:08:00.000000000 Z
   data_status: 2
@@ -8315,11 +8316,11 @@ rufa_2017_24h_finished_first_finish_7:
   lap: 7
   pacer:
   remarks:
-  split_id: 136
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_1:
+  split: rufa_course_start
   id: 134001
   absolute_time: 2017-02-11 15:00:00.000000000 Z
   data_status: 2
@@ -8328,11 +8329,11 @@ rufa_2017_24h_progress_lap6_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_1:
+  split: rufa_course_grandeur_peak
   id: 134002
   absolute_time: 2017-02-11 15:57:00.000000000 Z
   data_status: 2
@@ -8341,11 +8342,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_1:
+  split: rufa_course_finish
   id: 134003
   absolute_time: 2017-02-11 16:28:00.000000000 Z
   data_status: 2
@@ -8354,11 +8355,11 @@ rufa_2017_24h_progress_lap6_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_2:
+  split: rufa_course_start
   id: 134004
   absolute_time: 2017-02-11 16:28:00.000000000 Z
   data_status: 2
@@ -8367,11 +8368,11 @@ rufa_2017_24h_progress_lap6_start_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_2:
+  split: rufa_course_grandeur_peak
   id: 134005
   absolute_time: 2017-02-11 17:29:00.000000000 Z
   data_status: 2
@@ -8380,11 +8381,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_2:
+  split: rufa_course_finish
   id: 134006
   absolute_time: 2017-02-11 18:01:00.000000000 Z
   data_status: 2
@@ -8393,11 +8394,11 @@ rufa_2017_24h_progress_lap6_finish_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_3:
+  split: rufa_course_start
   id: 134007
   absolute_time: 2017-02-11 18:02:00.000000000 Z
   data_status: 2
@@ -8406,11 +8407,11 @@ rufa_2017_24h_progress_lap6_start_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_3:
+  split: rufa_course_grandeur_peak
   id: 134008
   absolute_time: 2017-02-11 19:13:00.000000000 Z
   data_status: 2
@@ -8419,11 +8420,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_3:
+  split: rufa_course_finish
   id: 134009
   absolute_time: 2017-02-11 19:46:00.000000000 Z
   data_status: 2
@@ -8432,11 +8433,11 @@ rufa_2017_24h_progress_lap6_finish_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_4:
+  split: rufa_course_start
   id: 134010
   absolute_time: 2017-02-11 19:48:00.000000000 Z
   data_status: 2
@@ -8445,11 +8446,11 @@ rufa_2017_24h_progress_lap6_start_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_4:
+  split: rufa_course_grandeur_peak
   id: 134011
   absolute_time: 2017-02-11 21:01:00.000000000 Z
   data_status: 2
@@ -8458,11 +8459,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_4:
+  split: rufa_course_finish
   id: 134012
   absolute_time: 2017-02-11 21:36:00.000000000 Z
   data_status: 2
@@ -8471,11 +8472,11 @@ rufa_2017_24h_progress_lap6_finish_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_5:
+  split: rufa_course_start
   id: 134013
   absolute_time: 2017-02-11 21:39:00.000000000 Z
   data_status: 2
@@ -8484,11 +8485,11 @@ rufa_2017_24h_progress_lap6_start_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_5:
+  split: rufa_course_grandeur_peak
   id: 134014
   absolute_time: 2017-02-11 22:53:00.000000000 Z
   data_status: 2
@@ -8497,11 +8498,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_5:
+  split: rufa_course_finish
   id: 134015
   absolute_time: 2017-02-11 23:27:00.000000000 Z
   data_status: 2
@@ -8510,11 +8511,11 @@ rufa_2017_24h_progress_lap6_finish_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_6:
+  split: rufa_course_start
   id: 134016
   absolute_time: 2017-02-11 23:30:00.000000000 Z
   data_status: 2
@@ -8523,11 +8524,11 @@ rufa_2017_24h_progress_lap6_start_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_6:
+  split: rufa_course_grandeur_peak
   id: 134017
   absolute_time: 2017-02-12 00:49:00.000000000 Z
   data_status: 2
@@ -8536,11 +8537,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_6:
+  split: rufa_course_finish
   id: 134018
   absolute_time: 2017-02-12 01:20:00.000000000 Z
   data_status: 2
@@ -8549,11 +8550,11 @@ rufa_2017_24h_progress_lap6_finish_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_start_1:
+  split: rufa_course_start
   id: 134805
   absolute_time: 2017-02-11 15:00:00.000000000 Z
   data_status: 2
@@ -8562,11 +8563,11 @@ rufa_2017_24h_multiple_stops_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_grandeur_peak_1:
+  split: rufa_course_grandeur_peak
   id: 134806
   absolute_time: 2017-02-11 16:05:00.000000000 Z
   data_status: 2
@@ -8575,11 +8576,11 @@ rufa_2017_24h_multiple_stops_grandeur_peak_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_finish_1:
+  split: rufa_course_finish
   id: 134807
   absolute_time: 2017-02-11 16:40:00.000000000 Z
   data_status: 2
@@ -8588,11 +8589,11 @@ rufa_2017_24h_multiple_stops_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_start_2:
+  split: rufa_course_start
   id: 134808
   absolute_time: 2017-02-11 16:40:00.000000000 Z
   data_status: 2
@@ -8601,11 +8602,11 @@ rufa_2017_24h_multiple_stops_start_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_grandeur_peak_2:
+  split: rufa_course_grandeur_peak
   id: 134809
   absolute_time: 2017-02-11 17:52:00.000000000 Z
   data_status: 2
@@ -8614,11 +8615,11 @@ rufa_2017_24h_multiple_stops_grandeur_peak_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_finish_2:
+  split: rufa_course_finish
   id: 134810
   absolute_time: 2017-02-11 18:24:00.000000000 Z
   data_status: 2
@@ -8627,11 +8628,11 @@ rufa_2017_24h_multiple_stops_finish_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 136
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_grandeur_peak_3:
+  split: rufa_course_grandeur_peak
   id: 134811
   absolute_time: 2017-02-11 19:55:00.000000000 Z
   data_status: 2
@@ -8640,11 +8641,11 @@ rufa_2017_24h_multiple_stops_grandeur_peak_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_finish_3:
+  split: rufa_course_finish
   id: 134812
   absolute_time: 2017-02-11 20:42:00.000000000 Z
   data_status: 2
@@ -8653,11 +8654,11 @@ rufa_2017_24h_multiple_stops_finish_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 136
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_start_1:
+  split: rufa_course_start
   id: 135007
   absolute_time: 2017-02-11 15:00:00.000000000 Z
   data_status: 2
@@ -8666,11 +8667,11 @@ rufa_2017_24h_finished_last_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_grandeur_peak_1:
+  split: rufa_course_grandeur_peak
   id: 135008
   absolute_time: 2017-02-11 16:17:00.000000000 Z
   data_status: 2
@@ -8679,11 +8680,11 @@ rufa_2017_24h_finished_last_grandeur_peak_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_finish_1:
+  split: rufa_course_finish
   id: 135009
   absolute_time: 2017-02-11 16:54:00.000000000 Z
   data_status: 2
@@ -8692,11 +8693,11 @@ rufa_2017_24h_finished_last_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_start_2:
+  split: rufa_course_start
   id: 135010
   absolute_time: 2017-02-11 16:58:00.000000000 Z
   data_status: 2
@@ -8705,11 +8706,11 @@ rufa_2017_24h_finished_last_start_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_grandeur_peak_2:
+  split: rufa_course_grandeur_peak
   id: 135011
   absolute_time: 2017-02-11 18:21:00.000000000 Z
   data_status: 2
@@ -8718,11 +8719,11 @@ rufa_2017_24h_finished_last_grandeur_peak_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_finish_2:
+  split: rufa_course_finish
   id: 135012
   absolute_time: 2017-02-11 18:57:00.000000000 Z
   data_status: 2
@@ -8731,11 +8732,11 @@ rufa_2017_24h_finished_last_finish_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 136
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap1_start_1:
+  split: rufa_course_start
   id: 135132
   absolute_time: 2017-02-11 16:00:00.000000000 Z
   data_status: 2
@@ -8744,11 +8745,11 @@ rufa_2017_24h_progress_lap1_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap1_grandeur_peak_1:
+  split: rufa_course_grandeur_peak
   id: 135133
   absolute_time: 2017-02-11 17:27:00.000000000 Z
   data_status: 2
@@ -8757,11 +8758,11 @@ rufa_2017_24h_progress_lap1_grandeur_peak_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap1_finish_1:
+  split: rufa_course_finish
   id: 135134
   absolute_time: 2017-02-11 18:53:00.000000000 Z
   data_status: 1
@@ -8770,11 +8771,11 @@ rufa_2017_24h_progress_lap1_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_start_1:
+  split: hardrock_cw_start
   id: 146923
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -8783,11 +8784,11 @@ hardrock_2016_lavon_paucek_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 146928
   absolute_time: 2016-07-15 18:36:00.000000000 Z
   data_status: 2
@@ -8796,11 +8797,11 @@ hardrock_2016_lavon_paucek_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 146929
   absolute_time: 2016-07-15 18:38:00.000000000 Z
   data_status: 2
@@ -8809,11 +8810,11 @@ hardrock_2016_lavon_paucek_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_lavon_paucek_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 146934
   absolute_time: 2016-07-15 22:11:00.000000000 Z
   data_status: 2
@@ -8822,11 +8823,11 @@ hardrock_2016_lavon_paucek_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 146935
   absolute_time: 2016-07-15 22:16:00.000000000 Z
   data_status: 2
@@ -8835,11 +8836,11 @@ hardrock_2016_lavon_paucek_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_lavon_paucek_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 146938
   absolute_time: 2016-07-16 02:36:00.000000000 Z
   data_status: 2
@@ -8848,11 +8849,11 @@ hardrock_2016_lavon_paucek_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 146939
   absolute_time: 2016-07-16 02:36:00.000000000 Z
   data_status: 2
@@ -8861,11 +8862,11 @@ hardrock_2016_lavon_paucek_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_lavon_paucek_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 146942
   absolute_time: 2016-07-16 07:02:00.000000000 Z
   data_status: 2
@@ -8874,11 +8875,11 @@ hardrock_2016_lavon_paucek_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 146943
   absolute_time: 2016-07-16 07:09:00.000000000 Z
   data_status: 2
@@ -8887,11 +8888,11 @@ hardrock_2016_lavon_paucek_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_lavon_paucek_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 146948
   absolute_time: 2016-07-16 14:11:00.000000000 Z
   data_status: 2
@@ -8900,11 +8901,11 @@ hardrock_2016_lavon_paucek_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 146949
   absolute_time: 2016-07-16 14:13:00.000000000 Z
   data_status: 2
@@ -8913,11 +8914,11 @@ hardrock_2016_lavon_paucek_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_lavon_paucek_finish_1:
+  split: hardrock_cw_finish
   id: 146950
   absolute_time: 2016-07-16 17:02:09.000000000 Z
   data_status: 2
@@ -8926,11 +8927,11 @@ hardrock_2016_lavon_paucek_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 82
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_start_1:
+  split: hardrock_cw_start
   id: 147315
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -8939,11 +8940,11 @@ hardrock_2016_vesta_borer_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 147320
   absolute_time: 2016-07-15 20:17:00.000000000 Z
   data_status: 2
@@ -8952,11 +8953,11 @@ hardrock_2016_vesta_borer_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 147321
   absolute_time: 2016-07-15 20:22:00.000000000 Z
   data_status: 2
@@ -8965,11 +8966,11 @@ hardrock_2016_vesta_borer_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_vesta_borer_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 147326
   absolute_time: 2016-07-16 00:49:00.000000000 Z
   data_status: 2
@@ -8978,11 +8979,11 @@ hardrock_2016_vesta_borer_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 147327
   absolute_time: 2016-07-16 00:58:00.000000000 Z
   data_status: 2
@@ -8991,11 +8992,11 @@ hardrock_2016_vesta_borer_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_vesta_borer_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 147330
   absolute_time: 2016-07-16 06:14:00.000000000 Z
   data_status: 2
@@ -9004,11 +9005,11 @@ hardrock_2016_vesta_borer_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 147331
   absolute_time: 2016-07-16 06:24:00.000000000 Z
   data_status: 2
@@ -9017,11 +9018,11 @@ hardrock_2016_vesta_borer_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_vesta_borer_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 147334
   absolute_time: 2016-07-16 11:23:00.000000000 Z
   data_status: 2
@@ -9030,11 +9031,11 @@ hardrock_2016_vesta_borer_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 147335
   absolute_time: 2016-07-16 11:41:00.000000000 Z
   data_status: 2
@@ -9043,11 +9044,11 @@ hardrock_2016_vesta_borer_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_vesta_borer_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 147340
   absolute_time: 2016-07-16 19:00:00.000000000 Z
   data_status: 2
@@ -9056,11 +9057,11 @@ hardrock_2016_vesta_borer_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 147341
   absolute_time: 2016-07-16 19:05:00.000000000 Z
   data_status: 2
@@ -9069,11 +9070,11 @@ hardrock_2016_vesta_borer_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kory_kulas_start_1:
+  split: hardrock_cw_start
   id: 147455
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -9082,11 +9083,11 @@ hardrock_2016_kory_kulas_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 147460
   absolute_time: 2016-07-15 20:16:00.000000000 Z
   data_status: 2
@@ -9095,11 +9096,11 @@ hardrock_2016_kory_kulas_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 147461
   absolute_time: 2016-07-15 20:25:00.000000000 Z
   data_status: 2
@@ -9108,11 +9109,11 @@ hardrock_2016_kory_kulas_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kory_kulas_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 147466
   absolute_time: 2016-07-16 01:05:00.000000000 Z
   data_status: 2
@@ -9121,11 +9122,11 @@ hardrock_2016_kory_kulas_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 147467
   absolute_time: 2016-07-16 01:16:00.000000000 Z
   data_status: 2
@@ -9134,11 +9135,11 @@ hardrock_2016_kory_kulas_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kory_kulas_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 147470
   absolute_time: 2016-07-16 07:30:00.000000000 Z
   data_status: 2
@@ -9147,11 +9148,11 @@ hardrock_2016_kory_kulas_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 147471
   absolute_time: 2016-07-16 07:55:00.000000000 Z
   data_status: 2
@@ -9160,11 +9161,11 @@ hardrock_2016_kory_kulas_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kory_kulas_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 147474
   absolute_time: 2016-07-16 13:00:00.000000000 Z
   data_status: 2
@@ -9173,11 +9174,11 @@ hardrock_2016_kory_kulas_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 147475
   absolute_time: 2016-07-16 13:08:00.000000000 Z
   data_status: 2
@@ -9186,11 +9187,11 @@ hardrock_2016_kory_kulas_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kory_kulas_cunningham_in_1:
+  split: hardrock_cw_cunningham
   id: 147480
   absolute_time: 2016-07-16 20:51:00.000000000 Z
   data_status: 2
@@ -9199,11 +9200,11 @@ hardrock_2016_kory_kulas_cunningham_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_cunningham_out_1:
+  split: hardrock_cw_cunningham
   id: 147481
   absolute_time: 2016-07-16 20:58:00.000000000 Z
   data_status: 2
@@ -9212,11 +9213,11 @@ hardrock_2016_kory_kulas_cunningham_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 107
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_shad_hirthe_start_1:
+  split: hardrock_cw_start
   id: 147679
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -9225,11 +9226,11 @@ hardrock_2016_shad_hirthe_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_shad_hirthe_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 147684
   absolute_time: 2016-07-15 19:59:00.000000000 Z
   data_status: 2
@@ -9238,11 +9239,11 @@ hardrock_2016_shad_hirthe_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_shad_hirthe_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 147685
   absolute_time: 2016-07-15 20:07:00.000000000 Z
   data_status: 2
@@ -9251,11 +9252,11 @@ hardrock_2016_shad_hirthe_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_shad_hirthe_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 147690
   absolute_time: 2016-07-16 00:35:00.000000000 Z
   data_status: 2
@@ -9264,11 +9265,11 @@ hardrock_2016_shad_hirthe_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_shad_hirthe_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 147691
   absolute_time: 2016-07-16 00:47:00.000000000 Z
   data_status: 2
@@ -9277,11 +9278,11 @@ hardrock_2016_shad_hirthe_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_shad_hirthe_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 147694
   absolute_time: 2016-07-16 06:28:00.000000000 Z
   data_status: 2
@@ -9290,11 +9291,11 @@ hardrock_2016_shad_hirthe_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_shad_hirthe_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 147695
   absolute_time: 2016-07-16 06:47:00.000000000 Z
   data_status: 2
@@ -9303,11 +9304,11 @@ hardrock_2016_shad_hirthe_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_shad_hirthe_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 147698
   absolute_time: 2016-07-16 12:35:00.000000000 Z
   data_status: 2
@@ -9316,11 +9317,11 @@ hardrock_2016_shad_hirthe_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_shad_hirthe_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 147699
   absolute_time: 2016-07-16 12:59:00.000000000 Z
   data_status: 2
@@ -9329,11 +9330,11 @@ hardrock_2016_shad_hirthe_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_douglas_vandervort_start_1:
+  split: hardrock_cw_start
   id: 147819
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -9342,11 +9343,11 @@ hardrock_2016_douglas_vandervort_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_douglas_vandervort_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 147824
   absolute_time: 2016-07-15 20:16:00.000000000 Z
   data_status: 2
@@ -9355,11 +9356,11 @@ hardrock_2016_douglas_vandervort_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_douglas_vandervort_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 147825
   absolute_time: 2016-07-15 20:27:00.000000000 Z
   data_status: 2
@@ -9368,11 +9369,11 @@ hardrock_2016_douglas_vandervort_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_douglas_vandervort_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 147830
   absolute_time: 2016-07-16 01:19:00.000000000 Z
   data_status: 2
@@ -9381,11 +9382,11 @@ hardrock_2016_douglas_vandervort_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_douglas_vandervort_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 147831
   absolute_time: 2016-07-16 01:46:00.000000000 Z
   data_status: 2
@@ -9394,11 +9395,11 @@ hardrock_2016_douglas_vandervort_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_douglas_vandervort_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 147834
   absolute_time: 2016-07-16 08:00:00.000000000 Z
   data_status: 2
@@ -9407,11 +9408,11 @@ hardrock_2016_douglas_vandervort_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_douglas_vandervort_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 147835
   absolute_time: 2016-07-16 08:27:00.000000000 Z
   data_status: 2
@@ -9420,11 +9421,11 @@ hardrock_2016_douglas_vandervort_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_douglas_vandervort_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 147838
   absolute_time: 2016-07-16 13:49:00.000000000 Z
   data_status: 2
@@ -9433,11 +9434,11 @@ hardrock_2016_douglas_vandervort_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_douglas_vandervort_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 147839
   absolute_time: 2016-07-16 14:19:00.000000000 Z
   data_status: 2
@@ -9446,11 +9447,11 @@ hardrock_2016_douglas_vandervort_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_missing_telluride_out_start_1:
+  split: hardrock_cw_start
   id: 147987
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -9459,11 +9460,11 @@ hardrock_2016_missing_telluride_out_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_missing_telluride_out_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 147992
   absolute_time: 2016-07-15 21:41:00.000000000 Z
   data_status: 2
@@ -9472,11 +9473,11 @@ hardrock_2016_missing_telluride_out_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_missing_telluride_out_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 147998
   absolute_time: 2016-07-16 02:54:00.000000000 Z
   data_status: 2
@@ -9485,11 +9486,11 @@ hardrock_2016_missing_telluride_out_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_missing_telluride_out_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 147999
   absolute_time: 2016-07-16 03:10:00.000000000 Z
   data_status: 2
@@ -9498,11 +9499,11 @@ hardrock_2016_missing_telluride_out_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_missing_telluride_out_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 148002
   absolute_time: 2016-07-16 09:04:00.000000000 Z
   data_status: 2
@@ -9511,11 +9512,11 @@ hardrock_2016_missing_telluride_out_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_missing_telluride_out_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 148003
   absolute_time: 2016-07-16 09:16:00.000000000 Z
   data_status: 2
@@ -9524,11 +9525,11 @@ hardrock_2016_missing_telluride_out_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_missing_telluride_out_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 148006
   absolute_time: 2016-07-16 14:51:00.000000000 Z
   data_status: 2
@@ -9537,11 +9538,11 @@ hardrock_2016_missing_telluride_out_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_missing_telluride_out_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 148007
   absolute_time: 2016-07-16 15:13:00.000000000 Z
   data_status: 2
@@ -9550,11 +9551,11 @@ hardrock_2016_missing_telluride_out_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_junior_lesch_start_1:
+  split: hardrock_cw_start
   id: 148071
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -9563,11 +9564,11 @@ hardrock_2016_junior_lesch_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_junior_lesch_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 148076
   absolute_time: 2016-07-15 20:10:00.000000000 Z
   data_status: 2
@@ -9576,11 +9577,11 @@ hardrock_2016_junior_lesch_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_junior_lesch_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 148077
   absolute_time: 2016-07-15 20:17:00.000000000 Z
   data_status: 2
@@ -9589,11 +9590,11 @@ hardrock_2016_junior_lesch_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_junior_lesch_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 148082
   absolute_time: 2016-07-16 00:57:00.000000000 Z
   data_status: 2
@@ -9602,11 +9603,11 @@ hardrock_2016_junior_lesch_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_junior_lesch_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 148083
   absolute_time: 2016-07-16 01:20:00.000000000 Z
   data_status: 2
@@ -9615,11 +9616,11 @@ hardrock_2016_junior_lesch_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_junior_lesch_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 148086
   absolute_time: 2016-07-16 07:31:00.000000000 Z
   data_status: 2
@@ -9628,11 +9629,11 @@ hardrock_2016_junior_lesch_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_junior_lesch_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 148087
   absolute_time: 2016-07-16 08:42:00.000000000 Z
   data_status: 2
@@ -9641,11 +9642,11 @@ hardrock_2016_junior_lesch_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_junior_lesch_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 148090
   absolute_time: 2016-07-16 15:10:00.000000000 Z
   data_status: 2
@@ -9654,11 +9655,11 @@ hardrock_2016_junior_lesch_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_junior_lesch_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 148091
   absolute_time: 2016-07-16 15:44:00.000000000 Z
   data_status: 2
@@ -9667,11 +9668,11 @@ hardrock_2016_junior_lesch_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_eddy_goldner_start_1:
+  split: hardrock_cw_start
   id: 148183
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -9680,11 +9681,11 @@ hardrock_2016_eddy_goldner_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_eddy_goldner_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 148188
   absolute_time: 2016-07-15 19:41:00.000000000 Z
   data_status: 2
@@ -9693,11 +9694,11 @@ hardrock_2016_eddy_goldner_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_eddy_goldner_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 148189
   absolute_time: 2016-07-15 19:54:00.000000000 Z
   data_status: 2
@@ -9706,11 +9707,11 @@ hardrock_2016_eddy_goldner_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_eddy_goldner_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 148194
   absolute_time: 2016-07-16 00:48:00.000000000 Z
   data_status: 2
@@ -9719,11 +9720,11 @@ hardrock_2016_eddy_goldner_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_eddy_goldner_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 148195
   absolute_time: 2016-07-16 01:05:00.000000000 Z
   data_status: 2
@@ -9732,11 +9733,11 @@ hardrock_2016_eddy_goldner_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_eddy_goldner_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 148198
   absolute_time: 2016-07-16 07:42:00.000000000 Z
   data_status: 2
@@ -9745,11 +9746,11 @@ hardrock_2016_eddy_goldner_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_eddy_goldner_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 148199
   absolute_time: 2016-07-16 08:25:00.000000000 Z
   data_status: 2
@@ -9758,11 +9759,11 @@ hardrock_2016_eddy_goldner_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_eddy_goldner_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 148202
   absolute_time: 2016-07-16 14:24:00.000000000 Z
   data_status: 2
@@ -9771,11 +9772,11 @@ hardrock_2016_eddy_goldner_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_eddy_goldner_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 148203
   absolute_time: 2016-07-16 15:00:00.000000000 Z
   data_status: 2
@@ -9784,11 +9785,11 @@ hardrock_2016_eddy_goldner_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_progress_sherman_start_1:
+  split: hardrock_cw_start
   id: 148547
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -9797,11 +9798,11 @@ hardrock_2016_progress_sherman_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_progress_sherman_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 148552
   absolute_time: 2016-07-15 19:44:00.000000000 Z
   data_status: 2
@@ -9810,11 +9811,11 @@ hardrock_2016_progress_sherman_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_progress_sherman_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 148553
   absolute_time: 2016-07-15 19:47:00.000000000 Z
   data_status: 2
@@ -9823,11 +9824,11 @@ hardrock_2016_progress_sherman_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_progress_sherman_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 148558
   absolute_time: 2016-07-16 00:03:00.000000000 Z
   data_status: 2
@@ -9836,11 +9837,11 @@ hardrock_2016_progress_sherman_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_progress_sherman_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 148559
   absolute_time: 2016-07-16 00:09:00.000000000 Z
   data_status: 2
@@ -9849,11 +9850,11 @@ hardrock_2016_progress_sherman_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_progress_sherman_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 148562
   absolute_time: 2016-07-16 05:08:00.000000000 Z
   data_status: 2
@@ -9862,11 +9863,11 @@ hardrock_2016_progress_sherman_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_progress_sherman_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 148563
   absolute_time: 2016-07-16 05:32:00.000000000 Z
   data_status: 2
@@ -9875,11 +9876,11 @@ hardrock_2016_progress_sherman_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_progress_sherman_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 148566
   absolute_time: 2016-07-16 11:27:00.000000000 Z
   data_status: 2
@@ -9888,11 +9889,11 @@ hardrock_2016_progress_sherman_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_progress_sherman_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 148567
   absolute_time: 2016-07-16 11:52:00.000000000 Z
   data_status: 2
@@ -9901,11 +9902,11 @@ hardrock_2016_progress_sherman_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_benito_moen_start_1:
+  split: hardrock_cw_start
   id: 148799
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -9914,11 +9915,11 @@ hardrock_2016_benito_moen_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_benito_moen_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 148804
   absolute_time: 2016-07-15 20:42:00.000000000 Z
   data_status: 2
@@ -9927,11 +9928,11 @@ hardrock_2016_benito_moen_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_benito_moen_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 148805
   absolute_time: 2016-07-15 20:54:00.000000000 Z
   data_status: 2
@@ -9940,11 +9941,11 @@ hardrock_2016_benito_moen_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_benito_moen_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 148810
   absolute_time: 2016-07-16 02:32:00.000000000 Z
   data_status: 2
@@ -9953,11 +9954,11 @@ hardrock_2016_benito_moen_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_benito_moen_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 148811
   absolute_time: 2016-07-16 03:32:00.000000000 Z
   data_status: 2
@@ -9966,11 +9967,11 @@ hardrock_2016_benito_moen_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_benito_moen_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 148814
   absolute_time: 2016-07-16 10:02:00.000000000 Z
   data_status: 2
@@ -9979,11 +9980,11 @@ hardrock_2016_benito_moen_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_benito_moen_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 148815
   absolute_time: 2016-07-16 11:05:00.000000000 Z
   data_status: 2
@@ -9992,11 +9993,11 @@ hardrock_2016_benito_moen_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_benito_moen_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 148818
   absolute_time: 2016-07-16 16:45:00.000000000 Z
   data_status: 2
@@ -10005,11 +10006,11 @@ hardrock_2016_benito_moen_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_benito_moen_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 148819
   absolute_time: 2016-07-16 17:27:00.000000000 Z
   data_status: 2
@@ -10018,11 +10019,11 @@ hardrock_2016_benito_moen_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kendall_koch_start_1:
+  split: hardrock_cw_start
   id: 148883
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -10031,11 +10032,11 @@ hardrock_2016_kendall_koch_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kendall_koch_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 148888
   absolute_time: 2016-07-15 21:44:00.000000000 Z
   data_status: 2
@@ -10044,11 +10045,11 @@ hardrock_2016_kendall_koch_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kendall_koch_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 148889
   absolute_time: 2016-07-15 21:54:00.000000000 Z
   data_status: 2
@@ -10057,11 +10058,11 @@ hardrock_2016_kendall_koch_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kendall_koch_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 148894
   absolute_time: 2016-07-16 03:43:00.000000000 Z
   data_status: 2
@@ -10070,11 +10071,11 @@ hardrock_2016_kendall_koch_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kendall_koch_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 148895
   absolute_time: 2016-07-16 03:46:00.000000000 Z
   data_status: 2
@@ -10083,11 +10084,11 @@ hardrock_2016_kendall_koch_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kendall_koch_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 148898
   absolute_time: 2016-07-16 10:18:00.000000000 Z
   data_status: 2
@@ -10096,11 +10097,11 @@ hardrock_2016_kendall_koch_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kendall_koch_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 148899
   absolute_time: 2016-07-16 10:22:00.000000000 Z
   data_status: 2
@@ -10109,11 +10110,11 @@ hardrock_2016_kendall_koch_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kendall_koch_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 148902
   absolute_time: 2016-07-16 17:08:00.000000000 Z
   data_status: 2
@@ -10122,11 +10123,11 @@ hardrock_2016_kendall_koch_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kendall_koch_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 148903
   absolute_time: 2016-07-16 17:32:00.000000000 Z
   data_status: 2
@@ -10135,11 +10136,11 @@ hardrock_2016_kendall_koch_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_charlie_mueller_start_1:
+  split: hardrock_cw_start
   id: 148967
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -10148,11 +10149,11 @@ hardrock_2016_charlie_mueller_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_charlie_mueller_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 148972
   absolute_time: 2016-07-15 21:45:00.000000000 Z
   data_status: 2
@@ -10161,11 +10162,11 @@ hardrock_2016_charlie_mueller_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_charlie_mueller_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 148973
   absolute_time: 2016-07-15 22:00:00.000000000 Z
   data_status: 2
@@ -10174,11 +10175,11 @@ hardrock_2016_charlie_mueller_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_charlie_mueller_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 148978
   absolute_time: 2016-07-16 03:38:00.000000000 Z
   data_status: 2
@@ -10187,11 +10188,11 @@ hardrock_2016_charlie_mueller_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_charlie_mueller_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 148979
   absolute_time: 2016-07-16 04:00:00.000000000 Z
   data_status: 2
@@ -10200,11 +10201,11 @@ hardrock_2016_charlie_mueller_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_charlie_mueller_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 148982
   absolute_time: 2016-07-16 10:15:00.000000000 Z
   data_status: 2
@@ -10213,11 +10214,11 @@ hardrock_2016_charlie_mueller_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_charlie_mueller_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 148983
   absolute_time: 2016-07-16 10:27:00.000000000 Z
   data_status: 2
@@ -10226,11 +10227,11 @@ hardrock_2016_charlie_mueller_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_charlie_mueller_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 148986
   absolute_time: 2016-07-16 16:45:00.000000000 Z
   data_status: 2
@@ -10239,11 +10240,11 @@ hardrock_2016_charlie_mueller_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_charlie_mueller_sherman_out_1:
+  split: hardrock_cw_sherman
   id: 148987
   absolute_time: 2016-07-16 17:05:00.000000000 Z
   data_status: 2
@@ -10252,11 +10253,11 @@ hardrock_2016_charlie_mueller_sherman_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_brinda_fisher_start_1:
+  split: hardrock_cw_start
   id: 149891
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -10265,11 +10266,11 @@ hardrock_2016_brinda_fisher_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_brinda_fisher_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 149896
   absolute_time: 2016-07-15 22:57:00.000000000 Z
   data_status: 2
@@ -10278,11 +10279,11 @@ hardrock_2016_brinda_fisher_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_brinda_fisher_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 149897
   absolute_time: 2016-07-15 23:00:00.000000000 Z
   data_status: 2
@@ -10291,11 +10292,11 @@ hardrock_2016_brinda_fisher_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_brinda_fisher_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 149902
   absolute_time: 2016-07-16 05:56:00.000000000 Z
   data_status: 2
@@ -10304,11 +10305,11 @@ hardrock_2016_brinda_fisher_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_brinda_fisher_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 149903
   absolute_time: 2016-07-16 06:25:00.000000000 Z
   data_status: 2
@@ -10317,11 +10318,11 @@ hardrock_2016_brinda_fisher_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_brinda_fisher_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 149906
   absolute_time: 2016-07-16 14:05:00.000000000 Z
   data_status: 2
@@ -10330,11 +10331,11 @@ hardrock_2016_brinda_fisher_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_brinda_fisher_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 149907
   absolute_time: 2016-07-16 14:19:00.000000000 Z
   data_status: 2
@@ -10343,11 +10344,11 @@ hardrock_2016_brinda_fisher_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rene_mclaughlin_start_1:
+  split: hardrock_cw_start
   id: 149997
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -10356,11 +10357,11 @@ hardrock_2016_rene_mclaughlin_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rene_mclaughlin_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 150002
   absolute_time: 2016-07-15 22:06:00.000000000 Z
   data_status: 2
@@ -10369,11 +10370,11 @@ hardrock_2016_rene_mclaughlin_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rene_mclaughlin_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 150003
   absolute_time: 2016-07-15 22:20:00.000000000 Z
   data_status: 2
@@ -10382,11 +10383,11 @@ hardrock_2016_rene_mclaughlin_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rene_mclaughlin_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 150008
   absolute_time: 2016-07-16 04:34:00.000000000 Z
   data_status: 2
@@ -10395,11 +10396,11 @@ hardrock_2016_rene_mclaughlin_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rene_mclaughlin_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 150009
   absolute_time: 2016-07-16 04:55:00.000000000 Z
   data_status: 2
@@ -10408,11 +10409,11 @@ hardrock_2016_rene_mclaughlin_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rene_mclaughlin_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 150012
   absolute_time: 2016-07-16 12:07:00.000000000 Z
   data_status: 2
@@ -10421,11 +10422,11 @@ hardrock_2016_rene_mclaughlin_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rene_mclaughlin_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 150013
   absolute_time: 2016-07-16 13:37:00.000000000 Z
   data_status: 2
@@ -10434,11 +10435,11 @@ hardrock_2016_rene_mclaughlin_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rene_mclaughlin_sherman_in_1:
+  split: hardrock_cw_sherman
   id: 150016
   absolute_time: 2016-07-16 20:41:00.000000000 Z
   data_status: 2
@@ -10447,11 +10448,11 @@ hardrock_2016_rene_mclaughlin_sherman_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 101
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_dropped_grouse_start_1:
+  split: hardrock_cw_start
   id: 150319
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -10460,11 +10461,11 @@ hardrock_2016_dropped_grouse_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_dropped_grouse_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 150324
   absolute_time: 2016-07-15 18:35:00.000000000 Z
   data_status: 2
@@ -10473,11 +10474,11 @@ hardrock_2016_dropped_grouse_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_dropped_grouse_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 150325
   absolute_time: 2016-07-15 18:39:00.000000000 Z
   data_status: 2
@@ -10486,11 +10487,11 @@ hardrock_2016_dropped_grouse_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_dropped_grouse_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 150330
   absolute_time: 2016-07-15 22:06:00.000000000 Z
   data_status: 2
@@ -10499,11 +10500,11 @@ hardrock_2016_dropped_grouse_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_dropped_grouse_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 150331
   absolute_time: 2016-07-15 22:12:00.000000000 Z
   data_status: 2
@@ -10512,11 +10513,11 @@ hardrock_2016_dropped_grouse_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_dropped_grouse_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 150334
   absolute_time: 2016-07-16 02:40:00.000000000 Z
   data_status: 2
@@ -10525,11 +10526,11 @@ hardrock_2016_dropped_grouse_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_dropped_grouse_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 150335
   absolute_time: 2016-07-16 02:40:00.000000000 Z
   data_status: 2
@@ -10538,11 +10539,11 @@ hardrock_2016_dropped_grouse_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_mervin_smitham_start_1:
+  split: hardrock_cw_start
   id: 150387
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -10551,11 +10552,11 @@ hardrock_2016_mervin_smitham_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_mervin_smitham_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 150392
   absolute_time: 2016-07-15 21:07:00.000000000 Z
   data_status: 2
@@ -10564,11 +10565,11 @@ hardrock_2016_mervin_smitham_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_mervin_smitham_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 150393
   absolute_time: 2016-07-15 21:25:00.000000000 Z
   data_status: 2
@@ -10577,11 +10578,11 @@ hardrock_2016_mervin_smitham_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_mervin_smitham_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 150398
   absolute_time: 2016-07-16 03:00:00.000000000 Z
   data_status: 2
@@ -10590,11 +10591,11 @@ hardrock_2016_mervin_smitham_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_mervin_smitham_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 150399
   absolute_time: 2016-07-16 03:59:00.000000000 Z
   data_status: 2
@@ -10603,11 +10604,11 @@ hardrock_2016_mervin_smitham_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_mervin_smitham_grouse_in_1:
+  split: hardrock_cw_grouse
   id: 150402
   absolute_time: 2016-07-16 11:53:00.000000000 Z
   data_status: 2
@@ -10616,11 +10617,11 @@ hardrock_2016_mervin_smitham_grouse_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_mervin_smitham_grouse_out_1:
+  split: hardrock_cw_grouse
   id: 150403
   absolute_time: 2016-07-16 11:53:00.000000000 Z
   data_status: 2
@@ -10629,11 +10630,11 @@ hardrock_2016_mervin_smitham_grouse_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 97
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rhett_auer_start_1:
+  split: hardrock_cw_start
   id: 150455
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -10642,11 +10643,11 @@ hardrock_2016_rhett_auer_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rhett_auer_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 150460
   absolute_time: 2016-07-15 18:04:00.000000000 Z
   data_status: 2
@@ -10655,11 +10656,11 @@ hardrock_2016_rhett_auer_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rhett_auer_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 150461
   absolute_time: 2016-07-15 18:06:00.000000000 Z
   data_status: 2
@@ -10668,11 +10669,11 @@ hardrock_2016_rhett_auer_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rhett_auer_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 150466
   absolute_time: 2016-07-15 21:40:00.000000000 Z
   data_status: 2
@@ -10681,11 +10682,11 @@ hardrock_2016_rhett_auer_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rhett_auer_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 150467
   absolute_time: 2016-07-15 21:53:00.000000000 Z
   data_status: 2
@@ -10694,11 +10695,11 @@ hardrock_2016_rhett_auer_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_hoyt_macejkovic_start_1:
+  split: hardrock_cw_start
   id: 150494
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
@@ -10707,11 +10708,11 @@ hardrock_2016_hoyt_macejkovic_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_hoyt_macejkovic_telluride_in_1:
+  split: hardrock_cw_telluride
   id: 150499
   absolute_time: 2016-07-15 21:56:00.000000000 Z
   data_status: 2
@@ -10720,11 +10721,11 @@ hardrock_2016_hoyt_macejkovic_telluride_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_hoyt_macejkovic_telluride_out_1:
+  split: hardrock_cw_telluride
   id: 150500
   absolute_time: 2016-07-15 22:11:00.000000000 Z
   data_status: 2
@@ -10733,11 +10734,11 @@ hardrock_2016_hoyt_macejkovic_telluride_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 87
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_hoyt_macejkovic_ouray_in_1:
+  split: hardrock_cw_ouray
   id: 150505
   absolute_time: 2016-07-16 04:44:00.000000000 Z
   data_status: 2
@@ -10746,11 +10747,11 @@ hardrock_2016_hoyt_macejkovic_ouray_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_hoyt_macejkovic_ouray_out_1:
+  split: hardrock_cw_ouray
   id: 150506
   absolute_time: 2016-07-16 05:46:00.000000000 Z
   data_status: 2
@@ -10759,11 +10760,11 @@ hardrock_2016_hoyt_macejkovic_ouray_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 93
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 ggd30_50k_finished_first_start_1:
+  split: d30_50k_course_start
   id: 184081
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status:
@@ -10772,11 +10773,11 @@ ggd30_50k_finished_first_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 164
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_aid_1_1:
+  split: d30_50k_course_aid_1
   id: 184082
   absolute_time: 2017-06-03 13:46:48.170000000 Z
   data_status:
@@ -10785,11 +10786,11 @@ ggd30_50k_finished_first_aid_1_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 167
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_aid_2_1:
+  split: d30_50k_course_aid_2
   id: 184083
   absolute_time: 2017-06-03 14:54:09.710000000 Z
   data_status:
@@ -10798,11 +10799,11 @@ ggd30_50k_finished_first_aid_2_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 171
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_aid_3_1:
+  split: d30_50k_course_aid_3
   id: 184084
   absolute_time: 2017-06-03 15:53:16.010000000 Z
   data_status:
@@ -10811,11 +10812,11 @@ ggd30_50k_finished_first_aid_3_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 170
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_start_1:
+  split: d30_50k_course_start
   id: 184337
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
@@ -10824,11 +10825,11 @@ ggd30_50k_bad_finish_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 164
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_aid_1_1:
+  split: d30_50k_course_aid_1
   id: 184338
   absolute_time: 2017-06-03 13:49:00.820000000 Z
   data_status: 2
@@ -10837,11 +10838,11 @@ ggd30_50k_bad_finish_aid_1_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 167
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_aid_2_1:
+  split: d30_50k_course_aid_2
   id: 184339
   absolute_time: 2017-06-03 15:05:22.760000000 Z
   data_status: 2
@@ -10850,11 +10851,11 @@ ggd30_50k_bad_finish_aid_2_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 171
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_aid_3_1:
+  split: d30_50k_course_aid_3
   id: 184340
   absolute_time: 2017-06-03 16:15:30.090000000 Z
   data_status: 2
@@ -10863,11 +10864,11 @@ ggd30_50k_bad_finish_aid_3_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 170
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid4_start_1:
+  split: d30_50k_course_start
   id: 185898
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status:
@@ -10876,11 +10877,11 @@ ggd30_50k_progress_aid4_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 164
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid4_aid_1_1:
+  split: d30_50k_course_aid_1
   id: 185899
   absolute_time: 2017-06-03 14:13:10.900000000 Z
   data_status:
@@ -10889,11 +10890,11 @@ ggd30_50k_progress_aid4_aid_1_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 167
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid4_aid_2_1:
+  split: d30_50k_course_aid_2
   id: 185900
   absolute_time: 2017-06-03 15:59:30.110000000 Z
   data_status:
@@ -10902,11 +10903,11 @@ ggd30_50k_progress_aid4_aid_2_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 171
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid3_start_1:
+  split: d30_50k_course_start
   id: 185965
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
@@ -10915,11 +10916,11 @@ ggd30_50k_progress_aid3_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 164
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid3_aid_1_1:
+  split: d30_50k_course_aid_1
   id: 185966
   absolute_time: 2017-06-03 14:11:47.000000000 Z
   data_status: 2
@@ -10928,11 +10929,11 @@ ggd30_50k_progress_aid3_aid_1_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 167
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid3_aid_2_1:
+  split: d30_50k_course_aid_2
   id: 185967
   absolute_time: 2017-06-03 15:56:58.000000000 Z
   data_status: 2
@@ -10941,11 +10942,11 @@ ggd30_50k_progress_aid3_aid_2_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 171
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_drop_aid4_start_1:
+  split: d30_50k_course_start
   id: 186151
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
@@ -10954,11 +10955,11 @@ ggd30_50k_drop_aid4_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 164
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_drop_aid4_aid_1_1:
+  split: d30_50k_course_aid_1
   id: 186152
   absolute_time: 2017-06-03 14:01:33.780000000 Z
   data_status: 2
@@ -10967,11 +10968,11 @@ ggd30_50k_drop_aid4_aid_1_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 167
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_drop_aid4_aid_2_1:
+  split: d30_50k_course_aid_2
   id: 186153
   absolute_time: 2017-06-03 15:35:56.730000000 Z
   data_status: 2
@@ -10980,11 +10981,11 @@ ggd30_50k_drop_aid4_aid_2_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 171
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_aid_4_1:
+  split: d30_50k_course_aid_4
   id: 188949
   absolute_time: 2017-06-03 17:11:12.540000000 Z
   data_status:
@@ -10993,11 +10994,11 @@ ggd30_50k_finished_first_aid_4_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 168
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_aid_5_1:
+  split: d30_50k_course_aid_5
   id: 188950
   absolute_time: 2017-06-03 18:09:59.140000000 Z
   data_status:
@@ -11006,11 +11007,11 @@ ggd30_50k_finished_first_aid_5_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 166
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_finish_1:
+  split: d30_50k_course_finish
   id: 188951
   absolute_time: 2017-06-03 18:29:47.410000000 Z
   data_status:
@@ -11019,11 +11020,11 @@ ggd30_50k_finished_first_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 165
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_aid_4_1:
+  split: d30_50k_course_aid_4
   id: 189053
   absolute_time: 2017-06-03 17:49:35.620000000 Z
   data_status: 2
@@ -11032,11 +11033,11 @@ ggd30_50k_bad_finish_aid_4_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 168
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_aid_5_1:
+  split: d30_50k_course_aid_5
   id: 189054
   absolute_time: 2017-06-03 19:40:01.980000000 Z
   data_status: 2
@@ -11045,11 +11046,11 @@ ggd30_50k_bad_finish_aid_5_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 166
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_finish_1:
+  split: d30_50k_course_finish
   id: 189055
   absolute_time: 2017-06-03 19:24:16.590000000 Z
   data_status: 0
@@ -11058,11 +11059,11 @@ ggd30_50k_bad_finish_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 165
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid4_aid_3_1:
+  split: d30_50k_course_aid_3
   id: 189813
   absolute_time: 2017-06-03 17:38:48.070000000 Z
   data_status:
@@ -11071,11 +11072,11 @@ ggd30_50k_progress_aid4_aid_3_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 170
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid4_aid_4_1:
+  split: d30_50k_course_aid_4
   id: 189814
   absolute_time: 2017-06-03 19:46:07.330000000 Z
   data_status:
@@ -11084,11 +11085,11 @@ ggd30_50k_progress_aid4_aid_4_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 168
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid3_aid_3_1:
+  split: d30_50k_course_aid_3
   id: 189850
   absolute_time: 2017-06-03 17:39:00.000000000 Z
   data_status: 2
@@ -11097,11 +11098,11 @@ ggd30_50k_progress_aid3_aid_3_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 170
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_drop_aid4_aid_3_1:
+  split: d30_50k_course_aid_3
   id: 189951
   absolute_time: 2017-06-03 17:11:07.470000000 Z
   data_status: 2
@@ -11110,11 +11111,11 @@ ggd30_50k_drop_aid4_aid_3_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 170
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_drop_aid4_aid_4_1:
+  split: d30_50k_course_aid_4
   id: 189952
   absolute_time: 2017-06-03 19:47:10.550000000 Z
   data_status: 2
@@ -11123,11 +11124,11 @@ ggd30_50k_drop_aid4_aid_4_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 168
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_finished_first_start_1:
+  split: d30_12m_course_start
   id: 190116
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status:
@@ -11136,11 +11137,11 @@ ggd30_12m_finished_first_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 172
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_finished_first_finish_1:
+  split: d30_12m_course_finish
   id: 190117
   absolute_time: 2017-06-03 17:48:09.280000000 Z
   data_status:
@@ -11149,11 +11150,11 @@ ggd30_12m_finished_first_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 173
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_finished_second_start_1:
+  split: d30_12m_course_start
   id: 190272
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status:
@@ -11162,11 +11163,11 @@ ggd30_12m_finished_second_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 172
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_finished_second_finish_1:
+  split: d30_12m_course_finish
   id: 190273
   absolute_time: 2017-06-03 18:54:56.690000000 Z
   data_status:
@@ -11175,11 +11176,11 @@ ggd30_12m_finished_second_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 173
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_start_1:
+  split: hardrock_ccw_start
   id: 190477
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -11188,11 +11189,11 @@ hardrock_2015_cedric_windler_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_start_1:
+  split: hardrock_ccw_start
   id: 190478
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
@@ -11201,11 +11202,11 @@ hardrock_2015_tuan_jacobs_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 5
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_start_1:
+  split: sum_55k_course_start
   id: 190499
   absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status: 2
@@ -11214,11 +11215,11 @@ sum_55k_finished_first_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 212
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_molas_pass_aid1_in_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 190500
   absolute_time: 2017-10-07 18:20:36.000000000 Z
   data_status: 2
@@ -11227,11 +11228,11 @@ sum_55k_finished_first_molas_pass_aid1_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_molas_pass_aid1_out_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 190501
   absolute_time: 2017-10-07 18:22:10.000000000 Z
   data_status: 2
@@ -11240,11 +11241,11 @@ sum_55k_finished_first_molas_pass_aid1_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_first_rolling_pass_aid2_in_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 190502
   absolute_time: 2017-10-07 20:48:20.000000000 Z
   data_status: 2
@@ -11253,11 +11254,11 @@ sum_55k_finished_first_rolling_pass_aid2_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_rolling_pass_aid2_out_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 190503
   absolute_time: 2017-10-07 20:50:20.000000000 Z
   data_status: 2
@@ -11266,11 +11267,11 @@ sum_55k_finished_first_rolling_pass_aid2_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_first_bandera_mine_aid5_in_1:
+  split: sum_55k_course_bandera_mine_aid5
   id: 190504
   absolute_time: 2017-10-07 21:28:20.000000000 Z
   data_status: 2
@@ -11279,11 +11280,11 @@ sum_55k_finished_first_bandera_mine_aid5_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 220
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_bandera_mine_aid5_out_1:
+  split: sum_55k_course_bandera_mine_aid5
   id: 190505
   absolute_time: 2017-10-07 21:28:20.000000000 Z
   data_status: 2
@@ -11292,11 +11293,11 @@ sum_55k_finished_first_bandera_mine_aid5_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 220
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_first_anvil_cg_aid6_in_1:
+  split: sum_55k_course_anvil_cg_aid6
   id: 190506
   absolute_time: 2017-10-07 22:43:35.000000000 Z
   data_status: 2
@@ -11305,11 +11306,11 @@ sum_55k_finished_first_anvil_cg_aid6_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 221
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_anvil_cg_aid6_out_1:
+  split: sum_55k_course_anvil_cg_aid6
   id: 190507
   absolute_time: 2017-10-07 22:51:27.000000000 Z
   data_status: 2
@@ -11318,11 +11319,11 @@ sum_55k_finished_first_anvil_cg_aid6_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 221
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_first_finish_1:
+  split: sum_55k_course_finish
   id: 190508
   absolute_time: 2017-10-07 23:58:06.000000000 Z
   data_status: 2
@@ -11331,11 +11332,11 @@ sum_55k_finished_first_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 213
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_start_1:
+  split: sum_55k_course_start
   id: 190519
   absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status: 2
@@ -11344,11 +11345,11 @@ sum_55k_finished_second_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 212
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_molas_pass_aid1_in_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 190520
   absolute_time: 2017-10-07 18:30:31.000000000 Z
   data_status: 2
@@ -11357,11 +11358,11 @@ sum_55k_finished_second_molas_pass_aid1_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_molas_pass_aid1_out_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 190521
   absolute_time: 2017-10-07 18:31:46.000000000 Z
   data_status: 2
@@ -11370,11 +11371,11 @@ sum_55k_finished_second_molas_pass_aid1_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_second_rolling_pass_aid2_in_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 190522
   absolute_time: 2017-10-07 21:13:00.000000000 Z
   data_status: 2
@@ -11383,11 +11384,11 @@ sum_55k_finished_second_rolling_pass_aid2_in_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_rolling_pass_aid2_out_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 190523
   absolute_time: 2017-10-07 21:18:00.000000000 Z
   data_status: 2
@@ -11396,11 +11397,11 @@ sum_55k_finished_second_rolling_pass_aid2_out_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_second_bandera_mine_aid5_in_1:
+  split: sum_55k_course_bandera_mine_aid5
   id: 190524
   absolute_time: 2017-10-07 22:04:20.000000000 Z
   data_status: 2
@@ -11409,11 +11410,11 @@ sum_55k_finished_second_bandera_mine_aid5_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 220
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_bandera_mine_aid5_out_1:
+  split: sum_55k_course_bandera_mine_aid5
   id: 190525
   absolute_time: 2017-10-07 22:05:20.000000000 Z
   data_status: 2
@@ -11422,11 +11423,11 @@ sum_55k_finished_second_bandera_mine_aid5_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 220
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_second_anvil_cg_aid6_in_1:
+  split: sum_55k_course_anvil_cg_aid6
   id: 190526
   absolute_time: 2017-10-07 23:13:46.000000000 Z
   data_status: 2
@@ -11435,11 +11436,11 @@ sum_55k_finished_second_anvil_cg_aid6_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 221
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_anvil_cg_aid6_out_1:
+  split: sum_55k_course_anvil_cg_aid6
   id: 190527
   absolute_time: 2017-10-07 23:13:50.000000000 Z
   data_status: 2
@@ -11448,11 +11449,11 @@ sum_55k_finished_second_anvil_cg_aid6_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 221
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_second_finish_1:
+  split: sum_55k_course_finish
   id: 190528
   absolute_time: 2017-10-08 00:07:38.000000000 Z
   data_status: 2
@@ -11461,11 +11462,11 @@ sum_55k_finished_second_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 213
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 sum_55k_progress_rolling_start_1:
+  split: sum_55k_course_start
   id: 190668
   absolute_time: 2017-10-07 13:00:00.000000000 Z
   data_status: 2
@@ -11474,11 +11475,11 @@ sum_55k_progress_rolling_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 212
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_progress_rolling_molas_pass_aid1_in_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 190669
   absolute_time: 2017-10-07 15:12:00.000000000 Z
   data_status: 2
@@ -11487,11 +11488,11 @@ sum_55k_progress_rolling_molas_pass_aid1_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_progress_rolling_molas_pass_aid1_out_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 190670
   absolute_time: 2017-10-07 15:19:00.000000000 Z
   data_status: 2
@@ -11500,11 +11501,11 @@ sum_55k_progress_rolling_molas_pass_aid1_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_progress_rolling_rolling_pass_aid2_in_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 190671
   absolute_time: 2017-10-07 17:05:00.000000000 Z
   data_status: 2
@@ -11513,11 +11514,11 @@ sum_55k_progress_rolling_rolling_pass_aid2_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_progress_rolling_rolling_pass_aid2_out_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 190672
   absolute_time: 2017-10-07 17:15:00.000000000 Z
   data_status: 2
@@ -11526,11 +11527,11 @@ sum_55k_progress_rolling_rolling_pass_aid2_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_drop_bandera_start_1:
+  split: sum_55k_course_start
   id: 190678
   absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status: 2
@@ -11539,11 +11540,11 @@ sum_55k_drop_bandera_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 212
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_drop_bandera_molas_pass_aid1_in_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 190679
   absolute_time: 2017-10-07 19:12:27.000000000 Z
   data_status: 2
@@ -11552,11 +11553,11 @@ sum_55k_drop_bandera_molas_pass_aid1_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_drop_bandera_molas_pass_aid1_out_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 190680
   absolute_time: 2017-10-07 19:19:02.000000000 Z
   data_status: 2
@@ -11565,11 +11566,11 @@ sum_55k_drop_bandera_molas_pass_aid1_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_drop_bandera_rolling_pass_aid2_in_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 190681
   absolute_time: 2017-10-07 22:27:20.000000000 Z
   data_status: 2
@@ -11578,11 +11579,11 @@ sum_55k_drop_bandera_rolling_pass_aid2_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_drop_bandera_rolling_pass_aid2_out_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 190682
   absolute_time: 2017-10-07 22:54:20.000000000 Z
   data_status:
@@ -11591,11 +11592,11 @@ sum_55k_drop_bandera_rolling_pass_aid2_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_drop_bandera_bandera_mine_aid5_in_1:
+  split: sum_55k_course_bandera_mine_aid5
   id: 190683
   absolute_time: 2017-10-08 00:21:20.000000000 Z
   data_status: 2
@@ -11604,11 +11605,11 @@ sum_55k_drop_bandera_bandera_mine_aid5_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 220
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_anvil_cg_aid6_in_1:
+  split: sum_100k_course_anvil_cg_aid6
   id: 190694
   absolute_time: 2017-09-24 03:11:00.000000000 Z
   data_status:
@@ -11617,11 +11618,11 @@ sum_100k_drop_anvil_anvil_cg_aid6_in_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 211
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_anvil_cg_aid6_out_1:
+  split: sum_100k_course_anvil_cg_aid6
   id: 190695
   absolute_time: 2017-09-24 03:21:00.000000000 Z
   data_status:
@@ -11630,11 +11631,11 @@ sum_100k_drop_anvil_anvil_cg_aid6_out_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 211
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
 sum_100k_drop_anvil_rolling_pass_aid2_in_1:
+  split: sum_100k_course_rolling_pass_aid2
   id: 190696
   absolute_time: 2017-09-23 15:09:00.000000000 Z
   data_status:
@@ -11643,11 +11644,11 @@ sum_100k_drop_anvil_rolling_pass_aid2_in_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 207
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_rolling_pass_aid2_out_1:
+  split: sum_100k_course_rolling_pass_aid2
   id: 190697
   absolute_time: 2017-09-24 07:03:05.000000000 Z
   data_status:
@@ -11656,11 +11657,11 @@ sum_100k_drop_anvil_rolling_pass_aid2_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 207
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_100k_drop_anvil_start_1:
+  split: sum_100k_course_start
   id: 190698
   absolute_time: 2017-09-23 13:00:00.000000000 Z
   data_status:
@@ -11669,11 +11670,11 @@ sum_100k_drop_anvil_start_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 204
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_molas_pass_aid1_in_1:
+  split: sum_100k_course_molas_pass_aid1
   id: 190699
   absolute_time: 2017-09-23 14:30:00.000000000 Z
   data_status:
@@ -11682,11 +11683,11 @@ sum_100k_drop_anvil_molas_pass_aid1_in_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 206
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_molas_pass_aid1_out_1:
+  split: sum_100k_course_molas_pass_aid1
   id: 190700
   absolute_time: 2017-09-23 14:32:00.000000000 Z
   data_status:
@@ -11695,11 +11696,11 @@ sum_100k_drop_anvil_molas_pass_aid1_out_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 206
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_100k_drop_anvil_cascade_creek_rd_aid3_in_1:
+  split: sum_100k_course_cascade_creek_rd_aid3
   id: 190701
   absolute_time: 2017-09-24 07:24:00.000000000 Z
   data_status:
@@ -11708,11 +11709,11 @@ sum_100k_drop_anvil_cascade_creek_rd_aid3_in_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 208
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_cascade_creek_rd_aid3_out_1:
+  split: sum_100k_course_cascade_creek_rd_aid3
   id: 190702
   absolute_time: 2017-09-24 07:28:00.000000000 Z
   data_status:
@@ -11721,11 +11722,11 @@ sum_100k_drop_anvil_cascade_creek_rd_aid3_out_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 208
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_100k_drop_anvil_engineer_mtn_th_aid4_in_1:
+  split: sum_100k_course_engineer_mtn_th_aid4
   id: 190703
   absolute_time: 2017-09-24 15:09:00.000000000 Z
   data_status:
@@ -11734,11 +11735,11 @@ sum_100k_drop_anvil_engineer_mtn_th_aid4_in_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 209
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_engineer_mtn_th_aid4_out_1:
+  split: sum_100k_course_engineer_mtn_th_aid4
   id: 190704
   absolute_time: 2017-09-24 15:09:09.000000000 Z
   data_status:
@@ -11747,11 +11748,11 @@ sum_100k_drop_anvil_engineer_mtn_th_aid4_out_1:
   lap: 1
   pacer: false
   remarks:
-  split_id: 209
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 ggd30_12m_start_only_start_1:
+  split: d30_12m_course_start
   id: 190731
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status:
@@ -11760,11 +11761,11 @@ ggd30_12m_start_only_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 172
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_start_only_start_1:
+  split: d30_50k_course_start
   id: 190761
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status:
@@ -11773,11 +11774,11 @@ ggd30_50k_start_only_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 164
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_start_only_start_1:
+  split: sum_55k_course_start
   id: 190816
   absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status:
@@ -11786,11 +11787,11 @@ sum_55k_start_only_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 212
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_1:
+  split: rufa_course_start
   id: 192182
   absolute_time: 2017-02-11 14:00:00.000000000 Z
   data_status:
@@ -11799,11 +11800,11 @@ rufa_2017_12h_finished_first_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_1:
+  split: rufa_course_finish
   id: 192183
   absolute_time: 2017-02-11 15:33:52.000000000 Z
   data_status:
@@ -11812,11 +11813,11 @@ rufa_2017_12h_finished_first_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_2:
+  split: rufa_course_start
   id: 192184
   absolute_time: 2017-02-11 15:40:32.000000000 Z
   data_status:
@@ -11825,11 +11826,11 @@ rufa_2017_12h_finished_first_start_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_2:
+  split: rufa_course_grandeur_peak
   id: 192185
   absolute_time: 2017-02-11 16:43:26.000000000 Z
   data_status:
@@ -11838,11 +11839,11 @@ rufa_2017_12h_finished_first_grandeur_peak_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_2:
+  split: rufa_course_finish
   id: 192186
   absolute_time: 2017-02-11 17:10:10.000000000 Z
   data_status:
@@ -11851,11 +11852,11 @@ rufa_2017_12h_finished_first_finish_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_3:
+  split: rufa_course_start
   id: 192187
   absolute_time: 2017-02-11 17:18:26.000000000 Z
   data_status:
@@ -11864,11 +11865,11 @@ rufa_2017_12h_finished_first_start_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_3:
+  split: rufa_course_grandeur_peak
   id: 192188
   absolute_time: 2017-02-11 18:15:00.000000000 Z
   data_status:
@@ -11877,11 +11878,11 @@ rufa_2017_12h_finished_first_grandeur_peak_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_3:
+  split: rufa_course_finish
   id: 192189
   absolute_time: 2017-02-11 18:41:05.000000000 Z
   data_status:
@@ -11890,11 +11891,11 @@ rufa_2017_12h_finished_first_finish_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_4:
+  split: rufa_course_start
   id: 192190
   absolute_time: 2017-02-11 18:44:57.000000000 Z
   data_status:
@@ -11903,11 +11904,11 @@ rufa_2017_12h_finished_first_start_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_4:
+  split: rufa_course_grandeur_peak
   id: 192191
   absolute_time: 2017-02-11 19:43:15.000000000 Z
   data_status:
@@ -11916,11 +11917,11 @@ rufa_2017_12h_finished_first_grandeur_peak_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_4:
+  split: rufa_course_finish
   id: 192192
   absolute_time: 2017-02-11 20:10:39.000000000 Z
   data_status:
@@ -11929,11 +11930,11 @@ rufa_2017_12h_finished_first_finish_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_5:
+  split: rufa_course_start
   id: 192193
   absolute_time: 2017-02-11 20:16:40.000000000 Z
   data_status:
@@ -11942,11 +11943,11 @@ rufa_2017_12h_finished_first_start_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_5:
+  split: rufa_course_grandeur_peak
   id: 192194
   absolute_time: 2017-02-11 21:19:28.000000000 Z
   data_status:
@@ -11955,11 +11956,11 @@ rufa_2017_12h_finished_first_grandeur_peak_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_5:
+  split: rufa_course_finish
   id: 192195
   absolute_time: 2017-02-11 21:50:23.000000000 Z
   data_status:
@@ -11968,11 +11969,11 @@ rufa_2017_12h_finished_first_finish_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_6:
+  split: rufa_course_start
   id: 192196
   absolute_time: 2017-02-11 21:59:13.000000000 Z
   data_status:
@@ -11981,11 +11982,11 @@ rufa_2017_12h_finished_first_start_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_6:
+  split: rufa_course_grandeur_peak
   id: 192197
   absolute_time: 2017-02-11 23:07:18.000000000 Z
   data_status:
@@ -11994,11 +11995,11 @@ rufa_2017_12h_finished_first_grandeur_peak_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_6:
+  split: rufa_course_finish
   id: 192198
   absolute_time: 2017-02-11 23:38:34.000000000 Z
   data_status:
@@ -12007,11 +12008,11 @@ rufa_2017_12h_finished_first_finish_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_7:
+  split: rufa_course_start
   id: 192199
   absolute_time: 2017-02-11 23:52:03.000000000 Z
   data_status:
@@ -12020,11 +12021,11 @@ rufa_2017_12h_finished_first_start_7:
   lap: 7
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_7:
+  split: rufa_course_grandeur_peak
   id: 192200
   absolute_time: 2017-02-12 01:01:00.000000000 Z
   data_status:
@@ -12033,11 +12034,11 @@ rufa_2017_12h_finished_first_grandeur_peak_7:
   lap: 7
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_7:
+  split: rufa_course_finish
   id: 192201
   absolute_time: 2017-02-12 01:35:12.000000000 Z
   data_status:
@@ -12046,11 +12047,11 @@ rufa_2017_12h_finished_first_finish_7:
   lap: 7
   pacer:
   remarks:
-  split_id: 136
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_1:
+  split: rufa_course_start
   id: 192278
   absolute_time: 2017-02-11 14:00:00.000000000 Z
   data_status:
@@ -12059,11 +12060,11 @@ rufa_2017_12h_finished_lap6_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_1:
+  split: rufa_course_grandeur_peak
   id: 192279
   absolute_time: 2017-02-11 14:58:53.000000000 Z
   data_status:
@@ -12072,11 +12073,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_1:
+  split: rufa_course_finish
   id: 192280
   absolute_time: 2017-02-11 15:30:50.000000000 Z
   data_status:
@@ -12085,11 +12086,11 @@ rufa_2017_12h_finished_lap6_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_2:
+  split: rufa_course_start
   id: 192281
   absolute_time: 2017-02-11 15:33:13.000000000 Z
   data_status:
@@ -12098,11 +12099,11 @@ rufa_2017_12h_finished_lap6_start_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_2:
+  split: rufa_course_grandeur_peak
   id: 192282
   absolute_time: 2017-02-11 16:38:35.000000000 Z
   data_status:
@@ -12111,11 +12112,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_2:
+  split: rufa_course_finish
   id: 192283
   absolute_time: 2017-02-11 17:10:32.000000000 Z
   data_status:
@@ -12124,11 +12125,11 @@ rufa_2017_12h_finished_lap6_finish_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_3:
+  split: rufa_course_start
   id: 192284
   absolute_time: 2017-02-11 17:21:18.000000000 Z
   data_status:
@@ -12137,11 +12138,11 @@ rufa_2017_12h_finished_lap6_start_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_3:
+  split: rufa_course_grandeur_peak
   id: 192285
   absolute_time: 2017-02-11 18:31:00.000000000 Z
   data_status:
@@ -12150,11 +12151,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_3:
+  split: rufa_course_finish
   id: 192286
   absolute_time: 2017-02-11 19:04:24.000000000 Z
   data_status:
@@ -12163,11 +12164,11 @@ rufa_2017_12h_finished_lap6_finish_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_4:
+  split: rufa_course_start
   id: 192287
   absolute_time: 2017-02-11 19:12:11.000000000 Z
   data_status:
@@ -12176,11 +12177,11 @@ rufa_2017_12h_finished_lap6_start_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_4:
+  split: rufa_course_grandeur_peak
   id: 192288
   absolute_time: 2017-02-11 20:23:51.000000000 Z
   data_status:
@@ -12189,11 +12190,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_4:
+  split: rufa_course_finish
   id: 192289
   absolute_time: 2017-02-11 21:02:55.000000000 Z
   data_status:
@@ -12202,11 +12203,11 @@ rufa_2017_12h_finished_lap6_finish_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_5:
+  split: rufa_course_start
   id: 192290
   absolute_time: 2017-02-11 21:25:05.000000000 Z
   data_status:
@@ -12215,11 +12216,11 @@ rufa_2017_12h_finished_lap6_start_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_5:
+  split: rufa_course_grandeur_peak
   id: 192291
   absolute_time: 2017-02-11 22:42:57.000000000 Z
   data_status:
@@ -12228,11 +12229,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_5:
+  split: rufa_course_finish
   id: 192292
   absolute_time: 2017-02-11 23:20:36.000000000 Z
   data_status:
@@ -12241,11 +12242,11 @@ rufa_2017_12h_finished_lap6_finish_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_6:
+  split: rufa_course_start
   id: 192293
   absolute_time: 2017-02-11 23:35:51.000000000 Z
   data_status:
@@ -12254,11 +12255,11 @@ rufa_2017_12h_finished_lap6_start_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_6:
+  split: rufa_course_grandeur_peak
   id: 192294
   absolute_time: 2017-02-12 00:51:18.000000000 Z
   data_status:
@@ -12267,11 +12268,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_6:
+  split: rufa_course_finish
   id: 192295
   absolute_time: 2017-02-12 01:27:38.000000000 Z
   data_status:
@@ -12280,11 +12281,11 @@ rufa_2017_12h_finished_lap6_finish_6:
   lap: 6
   pacer:
   remarks:
-  split_id: 136
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_start_1:
+  split: rufa_course_start
   id: 192420
   absolute_time: 2017-02-11 14:00:00.000000000 Z
   data_status: 2
@@ -12293,11 +12294,11 @@ rufa_2017_12h_progress_lap5_partial_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_1:
+  split: rufa_course_grandeur_peak
   id: 192421
   absolute_time: 2017-02-11 15:08:31.000000000 Z
   data_status: 2
@@ -12306,11 +12307,11 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_finish_1:
+  split: rufa_course_finish
   id: 192422
   absolute_time: 2017-02-11 15:44:16.000000000 Z
   data_status: 2
@@ -12319,11 +12320,11 @@ rufa_2017_12h_progress_lap5_partial_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_start_2:
+  split: rufa_course_start
   id: 192423
   absolute_time: 2017-02-11 15:47:17.000000000 Z
   data_status: 2
@@ -12332,11 +12333,11 @@ rufa_2017_12h_progress_lap5_partial_start_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_2:
+  split: rufa_course_grandeur_peak
   id: 192424
   absolute_time: 2017-02-11 17:07:41.000000000 Z
   data_status: 2
@@ -12345,11 +12346,11 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_finish_2:
+  split: rufa_course_finish
   id: 192425
   absolute_time: 2017-02-11 17:45:17.000000000 Z
   data_status: 2
@@ -12358,11 +12359,11 @@ rufa_2017_12h_progress_lap5_partial_finish_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_start_3:
+  split: rufa_course_start
   id: 192426
   absolute_time: 2017-02-11 17:51:49.000000000 Z
   data_status: 2
@@ -12371,11 +12372,11 @@ rufa_2017_12h_progress_lap5_partial_start_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_3:
+  split: rufa_course_grandeur_peak
   id: 192427
   absolute_time: 2017-02-11 19:16:00.000000000 Z
   data_status: 2
@@ -12384,11 +12385,11 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_finish_3:
+  split: rufa_course_finish
   id: 192428
   absolute_time: 2017-02-11 19:57:00.000000000 Z
   data_status: 2
@@ -12397,11 +12398,11 @@ rufa_2017_12h_progress_lap5_partial_finish_3:
   lap: 3
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_start_4:
+  split: rufa_course_start
   id: 192429
   absolute_time: 2017-02-11 20:06:16.000000000 Z
   data_status: 2
@@ -12410,11 +12411,11 @@ rufa_2017_12h_progress_lap5_partial_start_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_4:
+  split: rufa_course_grandeur_peak
   id: 192430
   absolute_time: 2017-02-11 21:36:13.000000000 Z
   data_status: 2
@@ -12423,11 +12424,11 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_finish_4:
+  split: rufa_course_finish
   id: 192431
   absolute_time: 2017-02-11 22:26:23.000000000 Z
   data_status: 2
@@ -12436,11 +12437,11 @@ rufa_2017_12h_progress_lap5_partial_finish_4:
   lap: 4
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_start_5:
+  split: rufa_course_start
   id: 192432
   absolute_time: 2017-02-11 22:47:18.000000000 Z
   data_status: 2
@@ -12449,11 +12450,11 @@ rufa_2017_12h_progress_lap5_partial_start_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_5:
+  split: rufa_course_grandeur_peak
   id: 192433
   absolute_time: 2017-02-12 00:29:17.000000000 Z
   data_status: 2
@@ -12462,11 +12463,11 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_5:
   lap: 5
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_start_1:
+  split: rufa_course_start
   id: 192497
   absolute_time: 2017-02-11 14:00:00.000000000 Z
   data_status: 2
@@ -12475,11 +12476,11 @@ rufa_2017_12h_progress_lap2_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_grandeur_peak_1:
+  split: rufa_course_grandeur_peak
   id: 192498
   absolute_time: 2017-02-11 15:13:16.000000000 Z
   data_status: 2
@@ -12488,11 +12489,11 @@ rufa_2017_12h_progress_lap2_grandeur_peak_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_finish_1:
+  split: rufa_course_finish
   id: 192499
   absolute_time: 2017-02-11 16:03:44.000000000 Z
   data_status: 2
@@ -12501,11 +12502,11 @@ rufa_2017_12h_progress_lap2_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_start_2:
+  split: rufa_course_start
   id: 192500
   absolute_time: 2017-02-11 16:05:43.000000000 Z
   data_status: 2
@@ -12514,11 +12515,11 @@ rufa_2017_12h_progress_lap2_start_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_grandeur_peak_2:
+  split: rufa_course_grandeur_peak
   id: 192501
   absolute_time: 2017-02-11 17:25:36.000000000 Z
   data_status: 2
@@ -12527,11 +12528,11 @@ rufa_2017_12h_progress_lap2_grandeur_peak_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 137
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_finish_2:
+  split: rufa_course_finish
   id: 192502
   absolute_time: 2017-02-11 18:13:54.000000000 Z
   data_status: 2
@@ -12540,11 +12541,11 @@ rufa_2017_12h_progress_lap2_finish_2:
   lap: 2
   pacer:
   remarks:
-  split_id: 136
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_start_only_start_1:
+  split: rufa_course_start
   id: 192542
   absolute_time: 2017-02-11 14:00:00.000000000 Z
   data_status: 2
@@ -12553,11 +12554,11 @@ rufa_2017_12h_start_only_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 135
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_progress_cascade_start_1:
+  split: sum_100k_course_start
   id: 192697
   absolute_time: 2017-09-23 13:00:00.000000000 Z
   data_status: 2
@@ -12566,11 +12567,11 @@ sum_100k_progress_cascade_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 204
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_progress_cascade_molas_pass_aid1_in_1:
+  split: sum_100k_course_molas_pass_aid1
   id: 192698
   absolute_time: 2017-09-23 15:20:00.000000000 Z
   data_status:
@@ -12579,11 +12580,11 @@ sum_100k_progress_cascade_molas_pass_aid1_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 206
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_progress_cascade_molas_pass_aid1_out_1:
+  split: sum_100k_course_molas_pass_aid1
   id: 192699
   absolute_time: 2017-09-23 15:25:00.000000000 Z
   data_status:
@@ -12592,11 +12593,11 @@ sum_100k_progress_cascade_molas_pass_aid1_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 206
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_100k_progress_cascade_rolling_pass_aid2_in_1:
+  split: sum_100k_course_rolling_pass_aid2
   id: 192700
   absolute_time: 2017-09-23 17:11:00.000000000 Z
   data_status:
@@ -12605,11 +12606,11 @@ sum_100k_progress_cascade_rolling_pass_aid2_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 207
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_progress_cascade_rolling_pass_aid2_out_1:
+  split: sum_100k_course_rolling_pass_aid2
   id: 192701
   absolute_time: 2017-09-23 17:22:00.000000000 Z
   data_status:
@@ -12618,11 +12619,11 @@ sum_100k_progress_cascade_rolling_pass_aid2_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 207
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_100k_progress_cascade_cascade_creek_rd_aid3_in_1:
+  split: sum_100k_course_cascade_creek_rd_aid3
   id: 192703
   absolute_time: 2017-09-23 19:50:00.000000000 Z
   data_status:
@@ -12631,11 +12632,11 @@ sum_100k_progress_cascade_cascade_creek_rd_aid3_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 208
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_progress_cascade_cascade_creek_rd_aid3_out_1:
+  split: sum_100k_course_cascade_creek_rd_aid3
   id: 192704
   absolute_time: 2017-09-23 20:14:00.000000000 Z
   data_status:
@@ -12644,11 +12645,11 @@ sum_100k_progress_cascade_cascade_creek_rd_aid3_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 208
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_start_only_start_1:
+  split: hardrock_cw_start
   id: 192705
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status:
@@ -12657,11 +12658,11 @@ hardrock_2016_start_only_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 81
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_on_dst_change_start_1:
+  split: sum_100k_course_start
   id: 192708
   absolute_time: 2017-11-05 14:00:00.000000000 Z
   data_status: 2
@@ -12670,11 +12671,11 @@ sum_100k_on_dst_change_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 204
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_across_dst_change_start_1:
+  split: sum_100k_course_start
   id: 192709
   absolute_time: 2017-11-05 06:30:00.000000000 Z
   data_status: 2
@@ -12683,11 +12684,11 @@ sum_100k_across_dst_change_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 204
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_across_dst_change_molas_pass_aid1_in_1:
+  split: sum_100k_course_molas_pass_aid1
   id: 192710
   absolute_time: 2017-11-05 09:30:00.000000000 Z
   data_status: 2
@@ -12696,11 +12697,11 @@ sum_100k_across_dst_change_molas_pass_aid1_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 206
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_100k_on_dst_change_molas_pass_aid1_in_1:
+  split: sum_100k_course_molas_pass_aid1
   id: 192715
   absolute_time: 2017-11-05 16:25:00.000000000 Z
   data_status: 2
@@ -12709,11 +12710,11 @@ sum_100k_on_dst_change_molas_pass_aid1_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 206
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_start_1:
+  split: d30_50k_course_start
   id: 192716
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
@@ -12722,11 +12723,11 @@ ggd30_50k_finished_second_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 164
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_aid_1_1:
+  split: d30_50k_course_aid_1
   id: 192717
   absolute_time: 2017-06-03 13:52:00.000000000 Z
   data_status: 2
@@ -12735,11 +12736,11 @@ ggd30_50k_finished_second_aid_1_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 167
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_aid_2_1:
+  split: d30_50k_course_aid_2
   id: 192718
   absolute_time: 2017-06-03 15:01:00.000000000 Z
   data_status: 2
@@ -12748,11 +12749,11 @@ ggd30_50k_finished_second_aid_2_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 171
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_aid_3_1:
+  split: d30_50k_course_aid_3
   id: 192719
   absolute_time: 2017-06-03 16:15:00.000000000 Z
   data_status: 2
@@ -12761,11 +12762,11 @@ ggd30_50k_finished_second_aid_3_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 170
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_aid_4_1:
+  split: d30_50k_course_aid_4
   id: 192720
   absolute_time: 2017-06-03 17:48:00.000000000 Z
   data_status: 2
@@ -12774,11 +12775,11 @@ ggd30_50k_finished_second_aid_4_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 168
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_aid_5_1:
+  split: d30_50k_course_aid_5
   id: 192721
   absolute_time: 2017-06-03 18:50:00.000000000 Z
   data_status:
@@ -12787,11 +12788,11 @@ ggd30_50k_finished_second_aid_5_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 166
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_finish_1:
+  split: d30_50k_course_finish
   id: 192722
   absolute_time: 2017-06-03 19:12:00.000000000 Z
   data_status:
@@ -12800,11 +12801,11 @@ ggd30_50k_finished_second_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 165
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_series_finisher_start_1:
+  split: d30_12m_course_start
   id: 192723
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status: 2
@@ -12813,11 +12814,11 @@ ggd30_12m_series_finisher_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 172
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_series_finisher_finish_1:
+  split: d30_12m_course_finish
   id: 192724
   absolute_time: 2017-06-03 18:55:00.000000000 Z
   data_status:
@@ -12826,11 +12827,11 @@ ggd30_12m_series_finisher_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 173
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_start_1:
+  split: sum_55k_course_start
   id: 192725
   absolute_time: 2017-09-23 15:00:00.000000000 Z
   data_status: 2
@@ -12839,11 +12840,11 @@ sum_55k_series_finisher_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 212
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_molas_pass_aid1_in_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 192726
   absolute_time: 2017-09-23 17:30:00.000000000 Z
   data_status: 2
@@ -12852,11 +12853,11 @@ sum_55k_series_finisher_molas_pass_aid1_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_molas_pass_aid1_out_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 192727
   absolute_time: 2017-09-23 17:35:00.000000000 Z
   data_status: 2
@@ -12865,11 +12866,11 @@ sum_55k_series_finisher_molas_pass_aid1_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_series_finisher_rolling_pass_aid2_in_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 192728
   absolute_time: 2017-09-23 20:20:00.000000000 Z
   data_status: 2
@@ -12878,11 +12879,11 @@ sum_55k_series_finisher_rolling_pass_aid2_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_rolling_pass_aid2_out_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 192729
   absolute_time: 2017-09-23 20:30:00.000000000 Z
   data_status: 2
@@ -12891,11 +12892,11 @@ sum_55k_series_finisher_rolling_pass_aid2_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_series_finisher_bandera_mine_aid5_in_1:
+  split: sum_55k_course_bandera_mine_aid5
   id: 192730
   absolute_time: 2017-09-23 22:30:00.000000000 Z
   data_status: 2
@@ -12904,11 +12905,11 @@ sum_55k_series_finisher_bandera_mine_aid5_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 220
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_bandera_mine_aid5_out_1:
+  split: sum_55k_course_bandera_mine_aid5
   id: 192731
   absolute_time: 2017-09-23 22:44:00.000000000 Z
   data_status:
@@ -12917,11 +12918,11 @@ sum_55k_series_finisher_bandera_mine_aid5_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 220
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_series_finisher_anvil_cg_aid6_in_1:
+  split: sum_55k_course_anvil_cg_aid6
   id: 192732
   absolute_time: 2017-09-24 00:15:00.000000000 Z
   data_status:
@@ -12930,11 +12931,11 @@ sum_55k_series_finisher_anvil_cg_aid6_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 221
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_anvil_cg_aid6_out_1:
+  split: sum_55k_course_anvil_cg_aid6
   id: 192733
   absolute_time: 2017-09-24 00:25:00.000000000 Z
   data_status:
@@ -12943,11 +12944,11 @@ sum_55k_series_finisher_anvil_cg_aid6_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 221
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_series_finisher_finish_1:
+  split: sum_55k_course_finish
   id: 192734
   absolute_time: 2017-09-24 01:20:00.000000000 Z
   data_status:
@@ -12956,11 +12957,11 @@ sum_55k_series_finisher_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 213
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_start_1:
+  split: sum_55k_course_start
   id: 192735
   absolute_time: 2017-09-23 15:00:00.000000000 Z
   data_status: 2
@@ -12969,11 +12970,11 @@ sum_55k_slow_finisher_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 212
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_molas_pass_aid1_in_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 192736
   absolute_time: 2017-09-23 18:10:00.000000000 Z
   data_status: 2
@@ -12982,11 +12983,11 @@ sum_55k_slow_finisher_molas_pass_aid1_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_molas_pass_aid1_out_1:
+  split: sum_55k_course_molas_pass_aid1
   id: 192737
   absolute_time: 2017-09-23 18:20:00.000000000 Z
   data_status: 2
@@ -12995,11 +12996,11 @@ sum_55k_slow_finisher_molas_pass_aid1_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 218
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_slow_finisher_rolling_pass_aid2_in_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 192738
   absolute_time: 2017-09-23 21:35:00.000000000 Z
   data_status: 2
@@ -13008,11 +13009,11 @@ sum_55k_slow_finisher_rolling_pass_aid2_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_rolling_pass_aid2_out_1:
+  split: sum_55k_course_rolling_pass_aid2
   id: 192739
   absolute_time: 2017-09-23 21:45:00.000000000 Z
   data_status: 2
@@ -13021,11 +13022,11 @@ sum_55k_slow_finisher_rolling_pass_aid2_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 219
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_slow_finisher_bandera_mine_aid5_in_1:
+  split: sum_55k_course_bandera_mine_aid5
   id: 192740
   absolute_time: 2017-09-23 23:20:00.000000000 Z
   data_status: 2
@@ -13034,11 +13035,11 @@ sum_55k_slow_finisher_bandera_mine_aid5_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 220
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_bandera_mine_aid5_out_1:
+  split: sum_55k_course_bandera_mine_aid5
   id: 192741
   absolute_time: 2017-09-23 23:40:00.000000000 Z
   data_status: 2
@@ -13047,11 +13048,11 @@ sum_55k_slow_finisher_bandera_mine_aid5_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 220
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_slow_finisher_anvil_cg_aid6_in_1:
+  split: sum_55k_course_anvil_cg_aid6
   id: 192742
   absolute_time: 2017-09-24 01:33:00.000000000 Z
   data_status: 2
@@ -13060,11 +13061,11 @@ sum_55k_slow_finisher_anvil_cg_aid6_in_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 221
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_anvil_cg_aid6_out_1:
+  split: sum_55k_course_anvil_cg_aid6
   id: 192743
   absolute_time: 2017-09-24 01:55:00.000000000 Z
   data_status: 2
@@ -13073,11 +13074,11 @@ sum_55k_slow_finisher_anvil_cg_aid6_out_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 221
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
 sum_55k_slow_finisher_finish_1:
+  split: sum_55k_course_finish
   id: 192744
   absolute_time: 2017-09-24 03:21:21.000000000 Z
   data_status: 2
@@ -13086,11 +13087,11 @@ sum_55k_slow_finisher_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 213
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_slow_finisher_start_1:
+  split: d30_12m_course_start
   id: 192745
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status: 2
@@ -13099,11 +13100,11 @@ ggd30_12m_slow_finisher_start_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 172
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_slow_finisher_finish_1:
+  split: d30_12m_course_finish
   id: 192746
   absolute_time: 2017-06-03 20:32:10.000000000 Z
   data_status:
@@ -13112,7 +13113,6 @@ ggd30_12m_slow_finisher_finish_1:
   lap: 1
   pacer:
   remarks:
-  split_id: 173
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:

--- a/spec/fixtures/splits.yml
+++ b/spec/fixtures/splits.yml
@@ -1,22 +1,132 @@
 ---
-hardrock_ccw_start:
-  course: hardrock_ccw
-  id: 5
+d30_12m_course_finish:
+  course: d30_12m_course
+  base_name: Finish
+  description:
+  distance_from_start: 19473
+  elevation: 2356.2763671875
+  kind: 1
+  latitude: !ruby/object:BigDecimal 18:0.3985021e2
+  longitude: !ruby/object:BigDecimal 18:-0.105359841e3
+  parameterized_base_name: finish
+  slug: d30-12m-course-finish
+  sub_split_bitmap: 1
+  vert_gain_from_start: 1066.7999658624
+  vert_loss_from_start: 1066.7999658624
+d30_12m_course_start:
+  course: d30_12m_course
   base_name: Start
-  description: Silverton High School
+  description:
   distance_from_start: 0
-  elevation: 2837.84594726562
+  elevation: 2356.51098632812
   kind: 0
-  latitude: !ruby/object:BigDecimal 18:0.37811954e2
-  longitude: !ruby/object:BigDecimal 18:-0.107664814e3
+  latitude: !ruby/object:BigDecimal 18:0.39850194e2
+  longitude: !ruby/object:BigDecimal 18:-0.105359809e3
   parameterized_base_name: start
-  slug: hardrock-ccw-start
+  slug: d30-12m-course-start
+  sub_split_bitmap: 1
+  vert_gain_from_start: 0.0
+  vert_loss_from_start: 0.0
+d30_50k_course_aid_1:
+  course: d30_50k_course
+  base_name: 'Aid #1'
+  description: In Forgotten Valley
+  distance_from_start: 8046
+  elevation: 2540.84106445312
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.39859303e2
+  longitude: !ruby/object:BigDecimal 18:-0.105385709e3
+  parameterized_base_name: aid-1
+  slug: d30-50k-course-aid-1
+  sub_split_bitmap: 1
+  vert_gain_from_start: 487.68
+  vert_loss_from_start: 243.84
+d30_50k_course_aid_2:
+  course: d30_50k_course
+  base_name: 'Aid #2'
+  description:
+  distance_from_start: 19473
+  elevation: 2637.22631835938
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.3985021e2
+  longitude: !ruby/object:BigDecimal 18:-0.105445211e3
+  parameterized_base_name: aid-2
+  slug: d30-50k-course-aid-2
+  sub_split_bitmap: 1
+  vert_gain_from_start: 1036.32
+  vert_loss_from_start: 701.04
+d30_50k_course_aid_3:
+  course: d30_50k_course
+  base_name: 'Aid #3'
+  description:
+  distance_from_start: 27680
+  elevation: 2488.14086914062
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.39835893e2
+  longitude: !ruby/object:BigDecimal 18:-0.105404978e3
+  parameterized_base_name: aid-3
+  slug: d30-50k-course-aid-3
+  sub_split_bitmap: 1
+  vert_gain_from_start: 1310.64
+  vert_loss_from_start: 1158.24
+d30_50k_course_aid_4:
+  course: d30_50k_course
+  base_name: 'Aid #4'
+  description:
+  distance_from_start: 39428
+  elevation: 2541.6455078125
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.39859352e2
+  longitude: !ruby/object:BigDecimal 18:-0.105385687e3
+  parameterized_base_name: aid-4
+  slug: d30-50k-course-aid-4
+  sub_split_bitmap: 1
+  vert_gain_from_start: 1798.32
+  vert_loss_from_start: 1615.44
+d30_50k_course_aid_5:
+  course: d30_50k_course
+  base_name: 'Aid #5'
+  description: On the Burro Trail on the slopes of Windy Peak
+  distance_from_start: 47475
+  elevation: 2434.32568359375
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.39855004e2
+  longitude: !ruby/object:BigDecimal 18:-0.105363479e3
+  parameterized_base_name: aid-5
+  slug: d30-50k-course-aid-5
+  sub_split_bitmap: 1
+  vert_gain_from_start: 2164.08
+  vert_loss_from_start: 2072.64
+d30_50k_course_finish:
+  course: d30_50k_course
+  base_name: Finish
+  description:
+  distance_from_start: 49889
+  elevation: 2356.2763671875
+  kind: 1
+  latitude: !ruby/object:BigDecimal 18:0.3985021e2
+  longitude: !ruby/object:BigDecimal 18:-0.105359841e3
+  parameterized_base_name: finish
+  slug: d30-50k-course-finish
+  sub_split_bitmap: 1
+  vert_gain_from_start: 2286.0
+  vert_loss_from_start: 2286.0
+d30_50k_course_start:
+  course: d30_50k_course
+  base_name: Start
+  description:
+  distance_from_start: 0
+  elevation: 2356.51098632812
+  kind: 0
+  latitude: !ruby/object:BigDecimal 18:0.39850194e2
+  longitude: !ruby/object:BigDecimal 18:-0.105359809e3
+  parameterized_base_name: start
+  slug: d30-50k-course-start
   sub_split_bitmap: 1
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
 hardrock_ccw_cunningham:
   course: hardrock_ccw
-  id: 6
   base_name: Cunningham
   description:
   distance_from_start: 14966
@@ -29,24 +139,22 @@ hardrock_ccw_cunningham:
   sub_split_bitmap: 65
   vert_gain_from_start: 1170.432
   vert_loss_from_start: 844.296
-hardrock_ccw_sherman:
+hardrock_ccw_finish:
   course: hardrock_ccw
-  id: 12
-  base_name: Sherman
+  base_name: Finish
   description:
-  distance_from_start: 46349
-  elevation: 2925.47534179688
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.3790117e2
-  longitude: !ruby/object:BigDecimal 18:-0.107430661e3
-  parameterized_base_name: sherman
-  slug: hardrock-ccw-sherman
-  sub_split_bitmap: 65
-  vert_gain_from_start: 3084.576
-  vert_loss_from_start: 2749.296
+  distance_from_start: 161739
+  elevation: 2837.96826171875
+  kind: 1
+  latitude: !ruby/object:BigDecimal 18:0.37811971e2
+  longitude: !ruby/object:BigDecimal 18:-0.107664771e3
+  parameterized_base_name: finish
+  slug: hardrock-ccw-finish
+  sub_split_bitmap: 1
+  vert_gain_from_start: 10073.64
+  vert_loss_from_start: 10073.64
 hardrock_ccw_grouse:
   course: hardrock_ccw
-  id: 16
   base_name: Grouse
   description:
   distance_from_start: 67914
@@ -61,7 +169,6 @@ hardrock_ccw_grouse:
   vert_loss_from_start: 4025.7984
 hardrock_ccw_ouray:
   course: hardrock_ccw
-  id: 20
   base_name: Ouray
   description:
   distance_from_start: 91088
@@ -74,24 +181,8 @@ hardrock_ccw_ouray:
   sub_split_bitmap: 65
   vert_gain_from_start: 5295.2904
   vert_loss_from_start: 5792.1144
-hardrock_ccw_telluride:
-  course: hardrock_ccw
-  id: 26
-  base_name: Telluride
-  description:
-  distance_from_start: 117160
-  elevation: 2690.43334960938
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.37938782e2
-  longitude: !ruby/object:BigDecimal 18:-0.107808838e3
-  parameterized_base_name: telluride
-  slug: hardrock-ccw-telluride
-  sub_split_bitmap: 65
-  vert_gain_from_start: 6961.9368
-  vert_loss_from_start: 7144.8168
 hardrock_ccw_putnam:
   course: hardrock_ccw
-  id: 32
   base_name: Putnam
   description:
   distance_from_start: 152404
@@ -104,144 +195,50 @@ hardrock_ccw_putnam:
   sub_split_bitmap: 65
   vert_gain_from_start: 9974.8848
   vert_loss_from_start: 9276.8928
-hardrock_ccw_finish:
+hardrock_ccw_sherman:
   course: hardrock_ccw
-  id: 34
-  base_name: Finish
-  description:
-  distance_from_start: 161739
-  elevation: 2837.96826171875
-  kind: 1
-  latitude: !ruby/object:BigDecimal 18:0.37811971e2
-  longitude: !ruby/object:BigDecimal 18:-0.107664771e3
-  parameterized_base_name: finish
-  slug: hardrock-ccw-finish
-  sub_split_bitmap: 1
-  vert_gain_from_start: 10073.64
-  vert_loss_from_start: 10073.64
-ramble_even_course_start:
-  course: ramble_even_course
-  id: 46
-  base_name: Start
-  description: Starting point for the Ramble Even-Year Course course.
-  distance_from_start: 0
-  elevation:
-  kind: 0
-  latitude:
-  longitude:
-  parameterized_base_name: start
-  slug: ramble-even-course-start
-  sub_split_bitmap: 1
-  vert_gain_from_start: 0.0
-  vert_loss_from_start: 0.0
-ramble_even_course_finish:
-  course: ramble_even_course
-  id: 47
-  base_name: Finish
-  description: Finish point for the Ramble Even-Year Course course.
-  distance_from_start: 6759
-  elevation:
-  kind: 1
-  latitude:
-  longitude:
-  parameterized_base_name: finish
-  slug: ramble-even-course-finish
-  sub_split_bitmap: 1
-  vert_gain_from_start: 249.935992002048
-  vert_loss_from_start: 249.935992002048
-hardrock_cw_start:
-  course: hardrock_cw
-  id: 81
-  base_name: Start
-  description: Starting point for the Hardrock CW course.
-  distance_from_start: 0
-  elevation: 2839.82150912571
-  kind: 0
-  latitude: !ruby/object:BigDecimal 18:0.37812496e2
-  longitude: !ruby/object:BigDecimal 18:-0.107665898e3
-  parameterized_base_name: start
-  slug: hardrock-cw-start
-  sub_split_bitmap: 1
-  vert_gain_from_start: 0.0
-  vert_loss_from_start: 0.0
-hardrock_cw_finish:
-  course: hardrock_cw
-  id: 82
-  base_name: Finish
-  description: Finish point for the Hardrock CW course.
-  distance_from_start: 161739
-  elevation: 2839.82150912571
-  kind: 1
-  latitude: !ruby/object:BigDecimal 18:0.37812496e2
-  longitude: !ruby/object:BigDecimal 18:-0.107665898e3
-  parameterized_base_name: finish
-  slug: hardrock-cw-finish
-  sub_split_bitmap: 1
-  vert_gain_from_start: 10073.64
-  vert_loss_from_start: 10073.64
-hardrock_cw_telluride:
-  course: hardrock_cw
-  id: 87
-  base_name: Telluride
-  description:
-  distance_from_start: 44578
-  elevation: 2678.88711427561
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.37935055e2
-  longitude: !ruby/object:BigDecimal 18:-0.107807532e3
-  parameterized_base_name: telluride
-  slug: hardrock-cw-telluride
-  sub_split_bitmap: 65
-  vert_gain_from_start: 2928.82310627766
-  vert_loss_from_start: 3099.51110081564
-hardrock_cw_ouray:
-  course: hardrock_cw
-  id: 93
-  base_name: Ouray
-  description:
-  distance_from_start: 70650
-  elevation: 7739.78615232684
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.38027895e2
-  longitude: !ruby/object:BigDecimal 18:-0.107672853e3
-  parameterized_base_name: ouray
-  slug: hardrock-cw-ouray
-  sub_split_bitmap: 65
-  vert_gain_from_start: 4281.52546299119
-  vert_loss_from_start: 4778.34944709282
-hardrock_cw_grouse:
-  course: hardrock_cw
-  id: 97
-  base_name: Grouse
-  description:
-  distance_from_start: 93824
-  elevation: 3291.83989466112
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.37917532e2
-  longitude: !ruby/object:BigDecimal 18:-0.107558352e3
-  parameterized_base_name: grouse
-  slug: hardrock-cw-grouse
-  sub_split_bitmap: 65
-  vert_gain_from_start: 6047.84140646908
-  vert_loss_from_start: 5621.12142012411
-hardrock_cw_sherman:
-  course: hardrock_cw
-  id: 101
   base_name: Sherman
   description:
-  distance_from_start: 115389
-  elevation: 2925.7751063752
+  distance_from_start: 46349
+  elevation: 2925.47534179688
   kind: 2
   latitude: !ruby/object:BigDecimal 18:0.3790117e2
   longitude: !ruby/object:BigDecimal 18:-0.107430661e3
   parameterized_base_name: sherman
-  slug: hardrock-cw-sherman
+  slug: hardrock-ccw-sherman
   sub_split_bitmap: 65
-  vert_gain_from_start: 7324.343765621
-  vert_loss_from_start: 7223.75976883969
+  vert_gain_from_start: 3084.576
+  vert_loss_from_start: 2749.296
+hardrock_ccw_start:
+  course: hardrock_ccw
+  base_name: Start
+  description: Silverton High School
+  distance_from_start: 0
+  elevation: 2837.84594726562
+  kind: 0
+  latitude: !ruby/object:BigDecimal 18:0.37811954e2
+  longitude: !ruby/object:BigDecimal 18:-0.107664814e3
+  parameterized_base_name: start
+  slug: hardrock-ccw-start
+  sub_split_bitmap: 1
+  vert_gain_from_start: 0.0
+  vert_loss_from_start: 0.0
+hardrock_ccw_telluride:
+  course: hardrock_ccw
+  base_name: Telluride
+  description:
+  distance_from_start: 117160
+  elevation: 2690.43334960938
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.37938782e2
+  longitude: !ruby/object:BigDecimal 18:-0.107808838e3
+  parameterized_base_name: telluride
+  slug: hardrock-ccw-telluride
+  sub_split_bitmap: 65
+  vert_gain_from_start: 6961.9368
+  vert_loss_from_start: 7144.8168
 hardrock_cw_cunningham:
   course: hardrock_cw
-  id: 107
   base_name: Cunningham
   description:
   distance_from_start: 146772
@@ -254,24 +251,120 @@ hardrock_cw_cunningham:
   sub_split_bitmap: 65
   vert_gain_from_start: 9229.343704661
   vert_loss_from_start: 8903.20771509735
-rufa_course_start:
-  course: rufa_course
-  id: 135
+hardrock_cw_finish:
+  course: hardrock_cw
+  base_name: Finish
+  description: Finish point for the Hardrock CW course.
+  distance_from_start: 161739
+  elevation: 2839.82150912571
+  kind: 1
+  latitude: !ruby/object:BigDecimal 18:0.37812496e2
+  longitude: !ruby/object:BigDecimal 18:-0.107665898e3
+  parameterized_base_name: finish
+  slug: hardrock-cw-finish
+  sub_split_bitmap: 1
+  vert_gain_from_start: 10073.64
+  vert_loss_from_start: 10073.64
+hardrock_cw_grouse:
+  course: hardrock_cw
+  base_name: Grouse
+  description:
+  distance_from_start: 93824
+  elevation: 3291.83989466112
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.37917532e2
+  longitude: !ruby/object:BigDecimal 18:-0.107558352e3
+  parameterized_base_name: grouse
+  slug: hardrock-cw-grouse
+  sub_split_bitmap: 65
+  vert_gain_from_start: 6047.84140646908
+  vert_loss_from_start: 5621.12142012411
+hardrock_cw_ouray:
+  course: hardrock_cw
+  base_name: Ouray
+  description:
+  distance_from_start: 70650
+  elevation: 7739.78615232684
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.38027895e2
+  longitude: !ruby/object:BigDecimal 18:-0.107672853e3
+  parameterized_base_name: ouray
+  slug: hardrock-cw-ouray
+  sub_split_bitmap: 65
+  vert_gain_from_start: 4281.52546299119
+  vert_loss_from_start: 4778.34944709282
+hardrock_cw_sherman:
+  course: hardrock_cw
+  base_name: Sherman
+  description:
+  distance_from_start: 115389
+  elevation: 2925.7751063752
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.3790117e2
+  longitude: !ruby/object:BigDecimal 18:-0.107430661e3
+  parameterized_base_name: sherman
+  slug: hardrock-cw-sherman
+  sub_split_bitmap: 65
+  vert_gain_from_start: 7324.343765621
+  vert_loss_from_start: 7223.75976883969
+hardrock_cw_start:
+  course: hardrock_cw
   base_name: Start
-  description: Starting point for the RUFA Course course.
+  description: Starting point for the Hardrock CW course.
   distance_from_start: 0
-  elevation: 1738.73815917969
+  elevation: 2839.82150912571
   kind: 0
-  latitude: !ruby/object:BigDecimal 18:0.40698096e2
-  longitude: !ruby/object:BigDecimal 18:-0.11174293e3
+  latitude: !ruby/object:BigDecimal 18:0.37812496e2
+  longitude: !ruby/object:BigDecimal 18:-0.107665898e3
   parameterized_base_name: start
-  slug: rufa-course-start
+  slug: hardrock-cw-start
+  sub_split_bitmap: 1
+  vert_gain_from_start: 0.0
+  vert_loss_from_start: 0.0
+hardrock_cw_telluride:
+  course: hardrock_cw
+  base_name: Telluride
+  description:
+  distance_from_start: 44578
+  elevation: 2678.88711427561
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.37935055e2
+  longitude: !ruby/object:BigDecimal 18:-0.107807532e3
+  parameterized_base_name: telluride
+  slug: hardrock-cw-telluride
+  sub_split_bitmap: 65
+  vert_gain_from_start: 2928.82310627766
+  vert_loss_from_start: 3099.51110081564
+ramble_even_course_finish:
+  course: ramble_even_course
+  base_name: Finish
+  description: Finish point for the Ramble Even-Year Course course.
+  distance_from_start: 6759
+  elevation:
+  kind: 1
+  latitude:
+  longitude:
+  parameterized_base_name: finish
+  slug: ramble-even-course-finish
+  sub_split_bitmap: 1
+  vert_gain_from_start: 249.935992002048
+  vert_loss_from_start: 249.935992002048
+ramble_even_course_start:
+  course: ramble_even_course
+  base_name: Start
+  description: Starting point for the Ramble Even-Year Course course.
+  distance_from_start: 0
+  elevation:
+  kind: 0
+  latitude:
+  longitude:
+  parameterized_base_name: start
+  slug: ramble-even-course-start
   sub_split_bitmap: 1
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
 rufa_course_finish:
   course: rufa_course
-  id: 136
   base_name: Finish
   description: Finish point for the RUFA Course course.
   distance_from_start: 8690
@@ -286,7 +379,6 @@ rufa_course_finish:
   vert_loss_from_start: 780.288
 rufa_course_grandeur_peak:
   course: rufa_course
-  id: 137
   base_name: Grandeur Peak
   description: Top of Grander Peak
   distance_from_start: 4345
@@ -299,204 +391,50 @@ rufa_course_grandeur_peak:
   sub_split_bitmap: 1
   vert_gain_from_start: 780.288
   vert_loss_from_start: 0.0
-d30_50k_course_start:
-  course: d30_50k_course
-  id: 164
+rufa_course_start:
+  course: rufa_course
   base_name: Start
-  description:
+  description: Starting point for the RUFA Course course.
   distance_from_start: 0
-  elevation: 2356.51098632812
+  elevation: 1738.73815917969
   kind: 0
-  latitude: !ruby/object:BigDecimal 18:0.39850194e2
-  longitude: !ruby/object:BigDecimal 18:-0.105359809e3
+  latitude: !ruby/object:BigDecimal 18:0.40698096e2
+  longitude: !ruby/object:BigDecimal 18:-0.11174293e3
   parameterized_base_name: start
-  slug: d30-50k-course-start
+  slug: rufa-course-start
   sub_split_bitmap: 1
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
-d30_50k_course_finish:
-  course: d30_50k_course
-  id: 165
-  base_name: Finish
-  description:
-  distance_from_start: 49889
-  elevation: 2356.2763671875
-  kind: 1
-  latitude: !ruby/object:BigDecimal 18:0.3985021e2
-  longitude: !ruby/object:BigDecimal 18:-0.105359841e3
-  parameterized_base_name: finish
-  slug: d30-50k-course-finish
-  sub_split_bitmap: 1
-  vert_gain_from_start: 2286.0
-  vert_loss_from_start: 2286.0
-d30_50k_course_aid_5:
-  course: d30_50k_course
-  id: 166
-  base_name: 'Aid #5'
-  description: On the Burro Trail on the slopes of Windy Peak
-  distance_from_start: 47475
-  elevation: 2434.32568359375
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.39855004e2
-  longitude: !ruby/object:BigDecimal 18:-0.105363479e3
-  parameterized_base_name: aid-5
-  slug: d30-50k-course-aid-5
-  sub_split_bitmap: 1
-  vert_gain_from_start: 2164.08
-  vert_loss_from_start: 2072.64
-d30_50k_course_aid_1:
-  course: d30_50k_course
-  id: 167
-  base_name: 'Aid #1'
-  description: In Forgotten Valley
-  distance_from_start: 8046
-  elevation: 2540.84106445312
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.39859303e2
-  longitude: !ruby/object:BigDecimal 18:-0.105385709e3
-  parameterized_base_name: aid-1
-  slug: d30-50k-course-aid-1
-  sub_split_bitmap: 1
-  vert_gain_from_start: 487.68
-  vert_loss_from_start: 243.84
-d30_50k_course_aid_4:
-  course: d30_50k_course
-  id: 168
-  base_name: 'Aid #4'
-  description:
-  distance_from_start: 39428
-  elevation: 2541.6455078125
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.39859352e2
-  longitude: !ruby/object:BigDecimal 18:-0.105385687e3
-  parameterized_base_name: aid-4
-  slug: d30-50k-course-aid-4
-  sub_split_bitmap: 1
-  vert_gain_from_start: 1798.32
-  vert_loss_from_start: 1615.44
-d30_50k_course_aid_3:
-  course: d30_50k_course
-  id: 170
-  base_name: 'Aid #3'
-  description:
-  distance_from_start: 27680
-  elevation: 2488.14086914062
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.39835893e2
-  longitude: !ruby/object:BigDecimal 18:-0.105404978e3
-  parameterized_base_name: aid-3
-  slug: d30-50k-course-aid-3
-  sub_split_bitmap: 1
-  vert_gain_from_start: 1310.64
-  vert_loss_from_start: 1158.24
-d30_50k_course_aid_2:
-  course: d30_50k_course
-  id: 171
-  base_name: 'Aid #2'
-  description:
-  distance_from_start: 19473
-  elevation: 2637.22631835938
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.3985021e2
-  longitude: !ruby/object:BigDecimal 18:-0.105445211e3
-  parameterized_base_name: aid-2
-  slug: d30-50k-course-aid-2
-  sub_split_bitmap: 1
-  vert_gain_from_start: 1036.32
-  vert_loss_from_start: 701.04
-d30_12m_course_start:
-  course: d30_12m_course
-  id: 172
-  base_name: Start
-  description:
-  distance_from_start: 0
-  elevation: 2356.51098632812
-  kind: 0
-  latitude: !ruby/object:BigDecimal 18:0.39850194e2
-  longitude: !ruby/object:BigDecimal 18:-0.105359809e3
-  parameterized_base_name: start
-  slug: d30-12m-course-start
-  sub_split_bitmap: 1
-  vert_gain_from_start: 0.0
-  vert_loss_from_start: 0.0
-d30_12m_course_finish:
-  course: d30_12m_course
-  id: 173
-  base_name: Finish
-  description:
-  distance_from_start: 19473
-  elevation: 2356.2763671875
-  kind: 1
-  latitude: !ruby/object:BigDecimal 18:0.3985021e2
-  longitude: !ruby/object:BigDecimal 18:-0.105359841e3
-  parameterized_base_name: finish
-  slug: d30-12m-course-finish
-  sub_split_bitmap: 1
-  vert_gain_from_start: 1066.7999658624
-  vert_loss_from_start: 1066.7999658624
-sum_100k_course_start:
+sum_100k_course_anvil_cg_aid6:
   course: sum_100k_course
-  id: 204
-  base_name: Start
+  base_name: Anvil CG (Aid6)
   description:
-  distance_from_start: 0
-  elevation: 2840.0
-  kind: 0
-  latitude: !ruby/object:BigDecimal 18:0.37812496e2
-  longitude: !ruby/object:BigDecimal 18:-0.107665898e3
-  parameterized_base_name: start
-  slug: sum-100k-course-start
-  sub_split_bitmap: 1
-  vert_gain_from_start: 0.0
-  vert_loss_from_start: 0.0
-sum_100k_course_finish:
-  course: sum_100k_course
-  id: 205
-  base_name: Finish
-  description:
-  distance_from_start: 99779
-  elevation: 2840.0
-  kind: 1
-  latitude: !ruby/object:BigDecimal 18:0.37812496e2
-  longitude: !ruby/object:BigDecimal 18:-0.107665898e3
-  parameterized_base_name: finish
-  slug: sum-100k-course-finish
-  sub_split_bitmap: 1
-  vert_gain_from_start: 2676.144
-  vert_loss_from_start: 2529.84
-sum_100k_course_molas_pass_aid1:
-  course: sum_100k_course
-  id: 206
-  base_name: Molas Pass (Aid1)
-  description:
-  distance_from_start: 18347
-  elevation: 3328.416
+  distance_from_start: 90268
+  elevation: 2886.456
   kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.37739536e2
-  longitude: !ruby/object:BigDecimal 18:-0.107698161e3
-  parameterized_base_name: molas-pass-aid1
-  slug: sum-100k-course-molas-pass-aid1
+  latitude: !ruby/object:BigDecimal 18:0.37820664e2
+  longitude: !ruby/object:BigDecimal 18:-0.1077192e3
+  parameterized_base_name: anvil-cg-aid6
+  slug: sum-100k-course-anvil-cg-aid6
   sub_split_bitmap: 65
-  vert_gain_from_start: 609.6
-  vert_loss_from_start: 60.96
-sum_100k_course_rolling_pass_aid2:
+  vert_gain_from_start: 2542.032
+  vert_loss_from_start: 2328.672
+sum_100k_course_bandera_mine_aid5:
   course: sum_100k_course
-  id: 207
-  base_name: Rolling Pass (Aid2)
+  base_name: Bandera Mine (Aid5)
   description:
-  distance_from_start: 35293
-  elevation: 3749.04
+  distance_from_start: 80741
+  elevation: 3243.9864
   kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.37747167e2
-  longitude: !ruby/object:BigDecimal 18:-0.107805658e3
-  parameterized_base_name: rolling-pass-aid2
-  slug: sum-100k-course-rolling-pass-aid2
+  latitude: !ruby/object:BigDecimal 18:0.37780772e2
+  longitude: !ruby/object:BigDecimal 18:-0.107803181e3
+  parameterized_base_name: bandera-mine-aid5
+  slug: sum-100k-course-bandera-mine-aid5
   sub_split_bitmap: 65
-  vert_gain_from_start: 1005.84
-  vert_loss_from_start: 152.4
+  vert_gain_from_start: 2496.312
+  vert_loss_from_start: 1938.528
 sum_100k_course_cascade_creek_rd_aid3:
   course: sum_100k_course
-  id: 208
   base_name: Cascade Creek Rd (Aid3)
   description:
   distance_from_start: 46317
@@ -511,7 +449,6 @@ sum_100k_course_cascade_creek_rd_aid3:
   vert_loss_from_start: 365.76
 sum_100k_course_engineer_mtn_th_aid4:
   course: sum_100k_course
-  id: 209
   base_name: Engineer Mtn TH (Aid4)
   description:
   distance_from_start: 59642
@@ -524,54 +461,92 @@ sum_100k_course_engineer_mtn_th_aid4:
   sub_split_bitmap: 65
   vert_gain_from_start: 1271.016
   vert_loss_from_start: 1203.96
-sum_100k_course_bandera_mine_aid5:
+sum_100k_course_finish:
   course: sum_100k_course
-  id: 210
-  base_name: Bandera Mine (Aid5)
+  base_name: Finish
   description:
-  distance_from_start: 80741
-  elevation: 3243.9864
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.37780772e2
-  longitude: !ruby/object:BigDecimal 18:-0.107803181e3
-  parameterized_base_name: bandera-mine-aid5
-  slug: sum-100k-course-bandera-mine-aid5
-  sub_split_bitmap: 65
-  vert_gain_from_start: 2496.312
-  vert_loss_from_start: 1938.528
-sum_100k_course_anvil_cg_aid6:
+  distance_from_start: 99779
+  elevation: 2840.0
+  kind: 1
+  latitude: !ruby/object:BigDecimal 18:0.37812496e2
+  longitude: !ruby/object:BigDecimal 18:-0.107665898e3
+  parameterized_base_name: finish
+  slug: sum-100k-course-finish
+  sub_split_bitmap: 1
+  vert_gain_from_start: 2676.144
+  vert_loss_from_start: 2529.84
+sum_100k_course_molas_pass_aid1:
   course: sum_100k_course
-  id: 211
-  base_name: Anvil CG (Aid6)
+  base_name: Molas Pass (Aid1)
   description:
-  distance_from_start: 90268
-  elevation: 2886.456
+  distance_from_start: 18347
+  elevation: 3328.416
   kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.37820664e2
-  longitude: !ruby/object:BigDecimal 18:-0.1077192e3
-  parameterized_base_name: anvil-cg-aid6
-  slug: sum-100k-course-anvil-cg-aid6
+  latitude: !ruby/object:BigDecimal 18:0.37739536e2
+  longitude: !ruby/object:BigDecimal 18:-0.107698161e3
+  parameterized_base_name: molas-pass-aid1
+  slug: sum-100k-course-molas-pass-aid1
   sub_split_bitmap: 65
-  vert_gain_from_start: 2542.032
-  vert_loss_from_start: 2328.672
-sum_55k_course_start:
-  course: sum_55k_course
-  id: 212
+  vert_gain_from_start: 609.6
+  vert_loss_from_start: 60.96
+sum_100k_course_rolling_pass_aid2:
+  course: sum_100k_course
+  base_name: Rolling Pass (Aid2)
+  description:
+  distance_from_start: 35293
+  elevation: 3749.04
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.37747167e2
+  longitude: !ruby/object:BigDecimal 18:-0.107805658e3
+  parameterized_base_name: rolling-pass-aid2
+  slug: sum-100k-course-rolling-pass-aid2
+  sub_split_bitmap: 65
+  vert_gain_from_start: 1005.84
+  vert_loss_from_start: 152.4
+sum_100k_course_start:
+  course: sum_100k_course
   base_name: Start
   description:
   distance_from_start: 0
-  elevation: 2838.857421875
+  elevation: 2840.0
   kind: 0
   latitude: !ruby/object:BigDecimal 18:0.37812496e2
   longitude: !ruby/object:BigDecimal 18:-0.107665898e3
   parameterized_base_name: start
-  slug: sum-55k-course-start
+  slug: sum-100k-course-start
   sub_split_bitmap: 1
   vert_gain_from_start: 0.0
   vert_loss_from_start: 0.0
+sum_55k_course_anvil_cg_aid6:
+  course: sum_55k_course
+  base_name: Anvil CG (Aid6)
+  description:
+  distance_from_start: 50292
+  elevation: 2904.18798828125
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.37820664e2
+  longitude: !ruby/object:BigDecimal 18:-0.1077192e3
+  parameterized_base_name: anvil-cg-aid6
+  slug: sum-55k-course-anvil-cg-aid6
+  sub_split_bitmap: 65
+  vert_gain_from_start: 1051.56
+  vert_loss_from_start: 1021.08
+sum_55k_course_bandera_mine_aid5:
+  course: sum_55k_course
+  base_name: Bandera Mine (Aid5)
+  description:
+  distance_from_start: 40765
+  elevation: 3252.72241210938
+  kind: 2
+  latitude: !ruby/object:BigDecimal 18:0.37780772e2
+  longitude: !ruby/object:BigDecimal 18:-0.107803181e3
+  parameterized_base_name: bandera-mine-aid5
+  slug: sum-55k-course-bandera-mine-aid5
+  sub_split_bitmap: 65
+  vert_gain_from_start: 1005.84
+  vert_loss_from_start: 670.56
 sum_55k_course_finish:
   course: sum_55k_course
-  id: 213
   base_name: Finish
   description:
   distance_from_start: 57277
@@ -586,7 +561,6 @@ sum_55k_course_finish:
   vert_loss_from_start: 1097.28
 sum_55k_course_molas_pass_aid1:
   course: sum_55k_course
-  id: 218
   base_name: Molas Pass (Aid1)
   description:
   distance_from_start: 18347
@@ -601,7 +575,6 @@ sum_55k_course_molas_pass_aid1:
   vert_loss_from_start: 60.96
 sum_55k_course_rolling_pass_aid2:
   course: sum_55k_course
-  id: 219
   base_name: Rolling Pass (Aid2)
   description:
   distance_from_start: 35293
@@ -614,33 +587,17 @@ sum_55k_course_rolling_pass_aid2:
   sub_split_bitmap: 65
   vert_gain_from_start: 1005.84
   vert_loss_from_start: 152.4
-sum_55k_course_bandera_mine_aid5:
+sum_55k_course_start:
   course: sum_55k_course
-  id: 220
-  base_name: Bandera Mine (Aid5)
+  base_name: Start
   description:
-  distance_from_start: 40765
-  elevation: 3252.72241210938
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.37780772e2
-  longitude: !ruby/object:BigDecimal 18:-0.107803181e3
-  parameterized_base_name: bandera-mine-aid5
-  slug: sum-55k-course-bandera-mine-aid5
-  sub_split_bitmap: 65
-  vert_gain_from_start: 1005.84
-  vert_loss_from_start: 670.56
-sum_55k_course_anvil_cg_aid6:
-  course: sum_55k_course
-  id: 221
-  base_name: Anvil CG (Aid6)
-  description:
-  distance_from_start: 50292
-  elevation: 2904.18798828125
-  kind: 2
-  latitude: !ruby/object:BigDecimal 18:0.37820664e2
-  longitude: !ruby/object:BigDecimal 18:-0.1077192e3
-  parameterized_base_name: anvil-cg-aid6
-  slug: sum-55k-course-anvil-cg-aid6
-  sub_split_bitmap: 65
-  vert_gain_from_start: 1051.56
-  vert_loss_from_start: 1021.08
+  distance_from_start: 0
+  elevation: 2838.857421875
+  kind: 0
+  latitude: !ruby/object:BigDecimal 18:0.37812496e2
+  longitude: !ruby/object:BigDecimal 18:-0.107665898e3
+  parameterized_base_name: start
+  slug: sum-55k-course-start
+  sub_split_bitmap: 1
+  vert_gain_from_start: 0.0
+  vert_loss_from_start: 0.0

--- a/spec/system/cutoff_analysis_flow_spec.rb
+++ b/spec/system/cutoff_analysis_flow_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe "Visit the cutoff analysis page", :js do
   let(:course) { courses(:hardrock_ccw) }
-  let(:first_split_name) { course.splits.intermediate.first.base_name }
+  # Matches CourseCutoffAnalysisPresenter#default_split, which picks
+  # `course.ordered_splits.second` (the first intermediate by distance from start).
+  let(:first_split_name) { course.ordered_splits.second.base_name }
 
   # rubocop:disable RSpec/BeforeAfterAll
   before(:all) do


### PR DESCRIPTION
## Summary

Continues the "Make X a portable fixture table" series. Splits now use Rails-assigned (label-hashed) ids; other fixtures reference them by label.

### Changes
- Add `:splits` to `PORTABLE_FIXTURE_TABLES`. splits is slugged, so no `ORDER_BY_MAP` entry is needed.
- `spec/fixtures/splits.yml`: drop the explicit `id:` from every entry; reorder by slug (matches the dump task's output).
- Replace `split_id: <int>` with `split: <label>` in three referencing fixtures:
  - `aid_stations.yml` (56 rows) — inserted after `event:` (AidStation declares `:event` before `:split`).
  - `split_times.yml` (1009 rows) — inserted at the top (`:split` is the only currently-portable belongs_to on SplitTime; effort is not yet portable, so `effort_id` stays as a literal int).
  - `projection_assessment_runs.yml`: `completed_split_id` / `projected_split_id` (backed by the belongs_to associations added in #2086) are written as `completed_split: <label>` / `projected_split: <label>` after `event:`, matching the declaration order on ProjectionAssessmentRun.

Specs that hardcode `split_id: 10` / `101` etc. are all in-memory constructions (`Split.new`, `described_class.new`, `build_stubbed`, ProtoRecord) — no DB writes — so they're unaffected.

## Testing

Ran a focused local selection (~680 examples covering Split, SplitTime, Event, EventGroup, Course, Effort, RawTime, AidStation, IntervalSplitTraffic, the API controllers, the SubmitRawTimeRows interactor, the projection runner, and the ETL loaders/importer) — all green, rubocop clean. Relying on CI for the full suite.

Part of #2065
