### PR TITLE
Make efforts a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -41,6 +41,7 @@ module FixtureHelper
     :course_groups,
     :courses,
     :credentials,
+    :efforts,
     :event_groups,
     :events,
     :historical_facts,

--- a/spec/fixtures/efforts.yml
+++ b/spec/fixtures/efforts.yml
@@ -1,1225 +1,167 @@
 ---
-hardrock_2015_tuan_jacobs:
-  event: hardrock_2015
-  person: tuan_jacobs
-  id: 7
-  age: 17
-  beacon_url:
-  beyond_start: true
-  bib_number: 1
-  bib_number_hardcoded:
-  birthdate: 1998-03-19
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: ES
-  country_name: Spain
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 42
-  finished: true
-  first_name: Tuan
-  gender: 0
-  last_name: Jacobs
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111011000001001010101110011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-tuan-jacobs
-  started: true
-  state_code: AN
-  state_name: Andalucía
-  stopped: true
-  stopped_split_time_id: 42
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_erich_larson:
-  event: hardrock_2015
-  person: erich_larson
-  id: 8
-  age: 36
-  beacon_url:
-  beyond_start: true
-  bib_number: 128
-  bib_number_hardcoded:
-  birthdate: 1979-07-10
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 72
-  finished: true
-  first_name: Erich
-  gender: 0
-  last_name: Larson
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111010011110011000101001101111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-erich-larson
-  started: true
-  state_code: MT
-  state_name: Montana
-  stopped: true
-  stopped_split_time_id: 72
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_leif_carter:
-  event: hardrock_2015
-  person: leif_carter
-  id: 15
-  age: 55
-  beacon_url:
-  beyond_start: true
-  bib_number: 146
-  bib_number_hardcoded:
-  birthdate: 1960-02-01
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: ES
-  country_name: Spain
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 282
-  finished: true
-  first_name: Leif
-  gender: 0
-  last_name: Carter
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111001110011000111100110111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-leif-carter
-  started: true
-  state_code:
-  state_name:
-  stopped: true
-  stopped_split_time_id: 282
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_carmine_adams:
-  event: hardrock_2015
-  person: carmine_adams
-  id: 20
-  age: 18
-  beacon_url:
-  beyond_start: true
-  bib_number: 140
-  bib_number_hardcoded:
-  birthdate: 1997-05-25
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 1
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 432
-  finished: true
-  first_name: Carmine
-  gender: 0
-  last_name: Adams
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111001010110111101110110011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-carmine-adams
-  started: true
-  state_code: WA
-  state_name: Washington
-  stopped: true
-  stopped_split_time_id: 432
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_garry_kuhlman:
-  event: hardrock_2015
-  person: garry_kuhlman
-  id: 24
-  age: 45
-  beacon_url:
-  beyond_start: true
-  bib_number: 11
-  bib_number_hardcoded:
-  birthdate: 1969-10-10
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 552
-  finished: true
-  first_name: Garry
-  gender: 0
-  last_name: Kuhlman
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111001001101010110100111011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-garry-kuhlman
-  started: true
-  state_code: MT
-  state_name: Montana
-  stopped: true
-  stopped_split_time_id: 552
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_darius_jacobson:
-  event: hardrock_2015
-  person: darius_jacobson
-  id: 25
-  age: 30
-  beacon_url:
-  beyond_start: true
-  bib_number: 8
-  bib_number_hardcoded:
-  birthdate: 1985-03-21
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 582
-  finished: true
-  first_name: Darius
-  gender: 0
-  last_name: Jacobson
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111001001100011100000001011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-darius-jacobson
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 582
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_santa_green:
-  event: hardrock_2015
-  person: santa_green
-  id: 29
-  age: 37
-  beacon_url:
-  beyond_start: true
-  bib_number: 133
-  bib_number_hardcoded:
-  birthdate: 1977-10-27
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 702
-  finished: true
-  first_name: Santa
-  gender: 1
-  last_name: Green
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111000110101110001110100111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-santa-green
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 702
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_gilberto_mckenzie:
-  event: hardrock_2015
-  person: gilberto_mckenzie
-  id: 31
-  age: 45
-  beacon_url:
-  beyond_start: true
-  bib_number: 121
-  bib_number_hardcoded:
-  birthdate: 1970-06-02
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 762
-  finished: true
-  first_name: Gilberto
-  gender: 0
-  last_name: McKenzie
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111000011011001110100110111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-gilberto-mckenzie
-  started: true
-  state_code: WA
-  state_name: Washington
-  stopped: true
-  stopped_split_time_id: 762
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_vince_willms:
-  event: hardrock_2015
-  person: vince_willms
-  id: 47
-  age: 50
-  beacon_url:
-  beyond_start: true
-  bib_number: 182
-  bib_number_hardcoded:
-  birthdate: 1964-10-22
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 1242
-  finished: true
-  first_name: Vince
-  gender: 0
-  last_name: Willms
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111000000100010101110000111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-vince-willms
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 1242
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_cedric_windler:
-  event: hardrock_2015
-  person: cedric_windler
-  id: 50
-  age: 36
-  beacon_url:
-  beyond_start: true
-  bib_number: 9
-  bib_number_hardcoded:
-  birthdate: 1979-07-10
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 1332
-  finished: true
-  first_name: Cedric
-  gender: 0
-  last_name: Windler
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111111111100010001001011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-cedric-windler
-  started: true
-  state_code: TN
-  state_name: Tennessee
-  stopped: true
-  stopped_split_time_id: 1332
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_chris_rempel:
-  event: hardrock_2015
-  person: chris_rempel
-  id: 56
-  age: 26
-  beacon_url:
-  beyond_start: true
-  bib_number: 26
-  bib_number_hardcoded:
-  birthdate: 1988-12-28
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 1512
-  finished: true
-  first_name: Chris
-  gender: 0
-  last_name: Rempel
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111110111100001011100111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-chris-rempel
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 1512
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_robby_gerlach:
-  event: hardrock_2015
-  person: robby_gerlach
-  id: 57
-  age: 45
-  beacon_url:
-  beyond_start: true
-  bib_number: 105
-  bib_number_hardcoded:
-  birthdate: 1970-05-18
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 1542
-  finished: true
-  first_name: Robby
-  gender: 0
-  last_name: Gerlach
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111110111000100001001111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-robby-gerlach
-  started: true
-  state_code: VA
-  state_name: Virginia
-  stopped: true
-  stopped_split_time_id: 1542
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_rachelle_eichmann:
-  event: hardrock_2015
-  person: rachelle_eichmann
-  id: 59
+ggd30_12m_finished_first:
+  event: ggd30_12m
+  person: finished_first_france
   age: 23
   beacon_url:
   beyond_start: true
-  bib_number: 22
+  bib_number: 1586
   bib_number_hardcoded:
-  birthdate: 1992-01-11
-  checked_in: false
-  city:
+  birthdate: 1993-06-05
+  checked_in: true
+  city: LE VIBAL
   comments:
   completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
+  country_code: FR
+  country_name: France
+  data_status:
   dropped: false
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 1602
-  finished: true
-  first_name: Rachelle
-  gender: 1
-  last_name: Eichmann
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111101101111010001101111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-rachelle-eichmann
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 1602
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_elden_morissette:
-  event: hardrock_2015
-  person: elden_morissette
-  id: 61
-  age: 42
-  beacon_url:
-  beyond_start: true
-  bib_number: 170
-  bib_number_hardcoded:
-  birthdate: 1972-11-21
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 1662
-  finished: true
-  first_name: Elden
-  gender: 0
-  last_name: Morissette
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111101100110000111110011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-elden-morissette
-  started: true
-  state_code: WI
-  state_name: Wisconsin
-  stopped: true
-  stopped_split_time_id: 1662
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_leroy_leffler:
-  event: hardrock_2015
-  person: leroy_leffler
-  id: 63
-  age: 48
-  beacon_url:
-  beyond_start: true
-  bib_number: 34
-  bib_number_hardcoded:
-  birthdate: 1967-06-18
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 1722
-  finished: true
-  first_name: Leroy
-  gender: 0
-  last_name: Leffler
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111100101111001100001011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-leroy-leffler
-  started: true
-  state_code: NM
-  state_name: New Mexico
-  stopped: true
-  stopped_split_time_id: 1722
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_samara_vandervort:
-  event: hardrock_2015
-  person: samara_vandervort
-  id: 73
-  age: 22
-  beacon_url:
-  beyond_start: true
-  bib_number: 35
-  bib_number_hardcoded:
-  birthdate: 1992-12-15
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 0
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 2022
-  finished: true
-  first_name: Samara
-  gender: 1
-  last_name: Vandervort
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111010111000001010111111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-samara-vandervort
-  started: true
-  state_code: CA
-  state_name: California
-  stopped: true
-  stopped_split_time_id: 2022
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_robt_wintheiser:
-  event: hardrock_2015
-  person: robt_wintheiser
-  id: 94
-  age: 57
-  beacon_url:
-  beyond_start: true
-  bib_number: 30
-  bib_number_hardcoded:
-  birthdate: 1957-09-14
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 2652
-  finished: true
-  first_name: Robt
-  gender: 0
-  last_name: Wintheiser
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110100100101010101101111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-robt-wintheiser
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 2652
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_demetrius_moen:
-  event: hardrock_2015
-  person: demetrius_moen
-  id: 96
-  age: 40
-  beacon_url:
-  beyond_start: true
-  bib_number: 39
-  bib_number_hardcoded:
-  birthdate: 1975-06-06
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 2712
-  finished: true
-  first_name: Demetrius
-  gender: 0
-  last_name: Moen
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110100011100001011110011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-demetrius-moen
-  started: true
-  state_code: OR
-  state_name: Oregon
-  stopped: true
-  stopped_split_time_id: 2712
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_vern_buckridge:
-  event: hardrock_2015
-  person: vern_buckridge
-  id: 105
-  age: 33
-  beacon_url:
-  beyond_start: true
-  bib_number: 176
-  bib_number_hardcoded:
-  birthdate: 1981-10-15
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 2982
-  finished: true
-  first_name: Vern
-  gender: 0
-  last_name: Buckridge
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110010001011100001111111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-vern-buckridge
-  started: true
-  state_code: TX
-  state_name: Texas
-  stopped: true
-  stopped_split_time_id: 2982
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_donte_spencer:
-  event: hardrock_2015
-  person: donte_spencer
-  id: 112
-  age: 30
-  beacon_url:
-  beyond_start: true
-  bib_number: 157
-  bib_number_hardcoded:
-  birthdate: 1984-07-14
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 3192
-  finished: true
-  first_name: Donte
-  gender: 0
-  last_name: Spencer
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101111101010011001011111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-donte-spencer
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: true
-  stopped_split_time_id: 3192
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_bruno_fadel:
-  event: hardrock_2015
-  person: bruno_fadel
-  id: 116
-  age: 27
-  beacon_url:
-  beyond_start: true
-  bib_number: 103
-  bib_number_hardcoded:
-  birthdate: 1988-05-11
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 3312
-  finished: true
-  first_name: Bruno
-  gender: 0
-  last_name: Fadel
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101110110101010011000011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-bruno-fadel
-  started: true
-  state_code: CA
-  state_name: California
-  stopped: true
-  stopped_split_time_id: 3312
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_gus_walker:
-  event: hardrock_2015
-  person: gus_walker
-  id: 117
-  age: 54
-  beacon_url:
-  beyond_start: true
-  bib_number: 156
-  bib_number_hardcoded:
-  birthdate: 1960-11-23
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 0
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 3342
-  finished: true
-  first_name: Gus
-  gender: 0
-  last_name: Walker
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101110101100001001000111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-gus-walker
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 3342
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_susanna_abshire:
-  event: hardrock_2015
-  person: susanna_abshire
-  id: 121
-  age: 34
-  beacon_url:
-  beyond_start: true
-  bib_number: 144
-  bib_number_hardcoded:
-  birthdate: 1980-08-17
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 0
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 3462
-  finished: true
-  first_name: Susanna
-  gender: 1
-  last_name: Abshire
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101110011011101010011011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-susanna-abshire
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 3462
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_leandro_cole:
-  event: hardrock_2015
-  person: leandro_cole
-  id: 125
-  age: 45
-  beacon_url:
-  beyond_start: true
-  bib_number: 168
-  bib_number_hardcoded:
-  birthdate: 1970-06-26
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 0
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 3582
-  finished: true
-  first_name: Leandro
-  gender: 0
-  last_name: Cole
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101110010000101011010011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-leandro-cole
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: true
-  stopped_split_time_id: 3582
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_benedict_davis:
-  event: hardrock_2015
-  person: benedict_davis
-  id: 129
-  age: 32
-  beacon_url:
-  beyond_start: true
-  bib_number: 122
-  bib_number_hardcoded:
-  birthdate:
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 0
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 3702
-  finished: true
-  first_name: Benedict
-  gender: 0
-  last_name: Davis
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101101101000011001001011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-benedict-davis
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 3702
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_raphael_swift:
-  event: hardrock_2015
-  person: raphael_swift
-  id: 136
-  age: 40
-  beacon_url:
-  beyond_start: true
-  bib_number: 171
-  bib_number_hardcoded:
-  birthdate: 1974-07-14
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 0
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 3891
-  finished: false
-  first_name: Raphael
-  gender: 0
-  last_name: Swift
-  overall_performance: '100000000000001000000000000011100100110101000100000011111111111111111001011001111100010001111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-raphael-swift
-  started: true
-  state_code: AR
-  state_name: Arkansas
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_bad_status:
-  event: hardrock_2015
-  person: bad_status
-  id: 138
-  age: 21
-  beacon_url:
-  beyond_start: true
-  bib_number: 108
-  bib_number_hardcoded:
-  birthdate: 1994-04-18
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 0
-  dropped: true
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 101556
-  finished: false
-  first_name: Bad
-  gender: 0
-  last_name: Status
-  overall_performance: '000000000000001000000000000100101001101010100100000011111111111111111000000010101111001110011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-bad-status
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 101556
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_irvin_harber:
-  event: hardrock_2015
-  person: irvin_harber
-  id: 141
-  age: 19
-  beacon_url:
-  beyond_start: true
-  bib_number: 134
-  bib_number_hardcoded:
-  birthdate: 1996-07-05
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: true
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 101541
-  finished: false
-  first_name: Irvin
-  gender: 0
-  last_name: Harber
-  overall_performance: '000000000000001000000000000011100100110101000100000011111111111111111010110110011010001111111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-irvin-harber
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 101541
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_cassondra_nienow:
-  event: hardrock_2015
-  person: cassondra_nienow
-  id: 155
-  age: 56
-  beacon_url:
-  beyond_start: true
-  bib_number: 155
-  bib_number_hardcoded:
-  birthdate: 1958-09-07
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: true
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 4198
-  finished: false
-  first_name: Cassondra
-  gender: 1
-  last_name: Nienow
-  overall_performance: '000000000000001000000000000001011010100001101100000011111111111111111101011010100001001011011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-cassondra-nienow
-  started: true
-  state_code: OH
-  state_name: Ohio
-  stopped: true
-  stopped_split_time_id: 4198
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2015_donn_mckenzie:
-  event: hardrock_2015
-  person: donn_mckenzie
-  id: 158
-  age: 16
-  beacon_url:
-  beyond_start: true
-  bib_number: 119
-  bib_number_hardcoded:
-  birthdate: 1998-12-29
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 4219
-  finished: false
-  first_name: Donn
-  gender: 0
-  last_name: McKenzie
-  overall_performance: '100000000000001000000000000000011101001110110100000011111111111111111111011101101010101110111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
-  slug: hardrock-2015-donn-mckenzie
-  started: true
-  state_code: WY
-  state_name: Wyoming
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-ramble_finished_first:
-  event: ramble
-  person: finished_first_2019_02_01
-  id: 1040
-  age: 49
-  beacon_url:
-  beyond_start: true
-  bib_number:
-  bib_number_hardcoded:
-  birthdate: 1957-02-04
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code:
-  country_name:
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 15145
+  final_split_time_id: 190117
   finished: true
   first_name: Finished
   gender: 0
   last_name: First
-  overall_performance: '100000000000001000000000000000001101001100111000000111111111111111111111111000001000100101001111'
+  overall_performance: '100000000000001000000000000000100110000010001000000111111111111111111111100111001111101100111111'
   phone:
   report_url:
-  scheduled_start_time: 2006-09-16 14:00:00.000000000 Z
-  slug: ramble-finished-first
+  scheduled_start_time: 2017-06-03 16:00:00.000000000 Z
+  slug: ggd30-12m-finished-first
   started: true
-  state_code:
-  state_name:
+  state_code: ARA
+  state_name: Auvergne-Rhône-Alpes
   stopped: true
-  stopped_split_time_id: 15145
+  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
-ramble_finished_second:
-  event: ramble
-  person: finished_second_montana_us
-  id: 1048
-  age: 12
+ggd30_12m_finished_second:
+  event: ggd30_12m
+  person: finished_second_colorado_us
+  age: 43
   beacon_url:
   beyond_start: true
-  bib_number:
+  bib_number: 1519
   bib_number_hardcoded:
-  birthdate: 1994-08-16
+  birthdate: 1973-07-23
+  checked_in: true
+  city: Boulder
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 190273
+  finished: true
+  first_name: Finished
+  gender: 1
+  last_name: Second
+  overall_performance: '100000000000001000000000000000100110000010001000000111111111111111111111010111111101010101001101'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-06-03 16:00:00.000000000 Z
+  slug: ggd30-12m-finished-second
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+ggd30_12m_not_started:
+  event: ggd30_12m
+  person: not_started_colorado_us
+  age: 22
+  beacon_url:
+  beyond_start: false
+  bib_number: 1622
+  bib_number_hardcoded:
+  birthdate: 1995-03-06
+  checked_in: true
+  city: Greeley
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id:
+  finished: false
+  first_name: Not
+  gender: 1
+  last_name: Started
+  overall_performance: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-06-03 16:00:00.000000000 Z
+  slug: ggd30-12m-not-started
+  started: false
+  state_code: CO
+  state_name: Colorado
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+ggd30_12m_series_finisher:
+  event: ggd30_12m
+  person: series_finisher
+  age: 34
+  beacon_url:
+  beyond_start: true
+  bib_number: 1515
+  bib_number_hardcoded:
+  birthdate: 1983-03-03
   checked_in: false
-  city:
+  city: Superior
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 192724
+  finished: true
+  first_name: Series
+  gender: 0
+  last_name: Finisher
+  overall_performance: '100000000000001000000000000000100110000010001000000111111111111111111111010111111100100001011111'
+  phone:
+  report_url:
+  scheduled_start_time:
+  slug: ggd30-12m-series-finisher
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+ggd30_12m_slow_finisher:
+  event: ggd30_12m
+  person: slow_finisher
+  age: 64
+  beacon_url:
+  beyond_start: true
+  bib_number: 1616
+  bib_number_hardcoded:
+  birthdate: 1953-03-03
+  checked_in: false
+  city: Orem
   comments:
   completed_laps: 1
   country_code:
@@ -1229,46 +171,45 @@ ramble_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 15161
+  final_split_time_id: 192746
   finished: true
-  first_name: Finished
-  gender: 1
-  last_name: Second
-  overall_performance: '100000000000001000000000000000001101001100111000000111111111111111111111110111011010011100000111'
+  first_name: Slow
+  gender: 0
+  last_name: Finisher
+  overall_performance: '100000000000001000000000000000100110000010001000000111111111111111111111000001101101001011101111'
   phone:
   report_url:
-  scheduled_start_time: 2006-09-16 14:00:00.000000000 Z
-  slug: ramble-finished-second
+  scheduled_start_time:
+  slug: ggd30-12m-slow-finisher
   started: true
-  state_code:
+  state_code: UT
   state_name:
   stopped: true
-  stopped_split_time_id: 15161
+  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
-ramble_start_only:
-  event: ramble
-  person: start_only_2019_02_01
-  id: 1051
-  age: 38
+ggd30_12m_start_only:
+  event: ggd30_12m
+  person: start_only_colorado_us
+  age: 27
   beacon_url:
   beyond_start: false
-  bib_number:
+  bib_number: 1506
   bib_number_hardcoded:
-  birthdate: 1968-07-11
-  checked_in: false
-  city:
+  birthdate: 1989-09-09
+  checked_in: true
+  city: Aurora
   comments:
   completed_laps: 0
-  country_code:
-  country_name:
-  data_status: 2
+  country_code: US
+  country_name: United States
+  data_status:
   dropped: false
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 15166
+  final_split_time_id: 190731
   finished: false
   first_name: Start
   gender: 1
@@ -1276,33 +217,184 @@ ramble_start_only:
   overall_performance: '100000000000001000000000000000000000000000000000000111111111111111111111111111111111111111111111'
   phone:
   report_url:
-  scheduled_start_time: 2006-09-16 14:00:00.000000000 Z
-  slug: ramble-start-only
+  scheduled_start_time: 2017-06-03 16:00:00.000000000 Z
+  slug: ggd30-12m-start-only
   started: true
-  state_code:
-  state_name:
+  state_code: CO
+  state_name: Colorado
   stopped: false
   stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
-ramble_not_started:
-  event: ramble
-  person: not_started_2019_02_01
-  id: 1061
-  age: 17
+ggd30_50k_bad_finish:
+  event: ggd30_50k
+  person: bad_finish
+  age: 21
   beacon_url:
-  beyond_start: false
-  bib_number:
+  beyond_start: true
+  bib_number: 1079
   bib_number_hardcoded:
-  birthdate: 1989-03-22
-  checked_in: false
+  birthdate: 1995-07-25
+  checked_in: true
+  city:
+  comments:
+  completed_laps: 1
+  country_code:
+  country_name:
+  data_status: 0
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 189055
+  finished: true
+  first_name: Bad
+  gender: 0
+  last_name: Finish
+  overall_performance: '100000000000001000000000000001100001011100001000000111111111111111111110101000000010111100110001'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
+  slug: ggd30-50k-bad-finish
+  started: true
+  state_code:
+  state_name:
+  stopped: true
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+ggd30_50k_drop_aid4:
+  event: ggd30_50k
+  person: drop_aid4
+  age: 18
+  beacon_url:
+  beyond_start: true
+  bib_number: 1029
+  bib_number_hardcoded:
+  birthdate:
+  checked_in: true
   city:
   comments:
   completed_laps: 0
   country_code:
   country_name:
   data_status: 2
+  dropped: true
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 189952
+  finished: false
+  first_name: Drop
+  gender: 0
+  last_name: Aid4
+  overall_performance: '000000000000001000000000000001001101000000100000000111111111111111111110100010110011100000101001'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
+  slug: ggd30-50k-drop-aid4
+  started: true
+  state_code:
+  state_name:
+  stopped: true
+  stopped_split_time_id: 189952
+  synced_at:
+  topic_resource_key:
+  wave:
+ggd30_50k_finished_first:
+  event: ggd30_50k
+  person: finished_first_colorado_us
+  age: 44
+  beacon_url:
+  beyond_start: true
+  bib_number: 1116
+  bib_number_hardcoded:
+  birthdate: 1973-05-25
+  checked_in: true
+  city:
+  comments:
+  completed_laps: 1
+  country_code:
+  country_name:
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 188951
+  finished: true
+  first_name: Finished
+  gender: 0
+  last_name: First
+  overall_performance: '100000000000001000000000000001100001011100001000000111111111111111111110110100100001000101101101'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
+  slug: ggd30-50k-finished-first
+  started: true
+  state_code:
+  state_name:
+  stopped: true
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+ggd30_50k_finished_second:
+  event: ggd30_50k
+  person:
+  age: 43
+  beacon_url:
+  beyond_start: true
+  bib_number: 1117
+  bib_number_hardcoded:
+  birthdate: 1975-07-25
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code:
+  country_name:
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 192722
+  finished: true
+  first_name: Finished
+  gender: 1
+  last_name: Second
+  overall_performance: '100000000000001000000000000001100001011100001000000111111111111111111110101010110110110001111111'
+  phone:
+  report_url:
+  scheduled_start_time:
+  slug: ggd30-50k-finished-second
+  started: true
+  state_code:
+  state_name:
+  stopped: true
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+ggd30_50k_not_started:
+  event: ggd30_50k
+  person: not_started
+  age: 31
+  beacon_url:
+  beyond_start: false
+  bib_number: 49
+  bib_number_hardcoded:
+  birthdate: 1986-03-23
+  checked_in: true
+  city:
+  comments:
+  completed_laps: 0
+  country_code:
+  country_name:
+  data_status:
   dropped: false
   email:
   emergency_contact:
@@ -1315,8 +407,8 @@ ramble_not_started:
   overall_performance: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
   phone:
   report_url:
-  scheduled_start_time: 2006-09-16 14:00:00.000000000 Z
-  slug: ramble-not-started
+  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
+  slug: ggd30-50k-not-started
   started: false
   state_code:
   state_name:
@@ -1325,10 +417,237 @@ ramble_not_started:
   synced_at:
   topic_resource_key:
   wave:
+ggd30_50k_progress_aid3:
+  event: ggd30_50k
+  person: progress_aid3
+  age: 31
+  beacon_url:
+  beyond_start: true
+  bib_number: 219
+  bib_number_hardcoded:
+  birthdate: 1986-03-04
+  checked_in: true
+  city:
+  comments:
+  completed_laps: 0
+  country_code:
+  country_name:
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 189850
+  finished: false
+  first_name: Progress
+  gender: 0
+  last_name: Aid3
+  overall_performance: '100000000000001000000000000000110110000100000000000111111111111111111111000000001001000101011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
+  slug: ggd30-50k-progress-aid3
+  started: true
+  state_code:
+  state_name:
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+ggd30_50k_progress_aid4:
+  event: ggd30_50k
+  person: progress_aid4
+  age: 35
+  beacon_url:
+  beyond_start: true
+  bib_number: 1118
+  bib_number_hardcoded:
+  birthdate: 1982-03-29
+  checked_in: true
+  city:
+  comments:
+  completed_laps: 0
+  country_code:
+  country_name:
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 189814
+  finished: false
+  first_name: Progress
+  gender: 1
+  last_name: Aid4
+  overall_performance: '100000000000001000000000000001001101000000100000000111111111111111111110100011000010111100011101'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
+  slug: ggd30-50k-progress-aid4
+  started: true
+  state_code:
+  state_name:
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+ggd30_50k_start_only:
+  event: ggd30_50k
+  person: start_only_2019_02_01_07_19_53
+  age: 31
+  beacon_url:
+  beyond_start: false
+  bib_number: 433
+  bib_number_hardcoded:
+  birthdate: 1985-11-14
+  checked_in: true
+  city:
+  comments:
+  completed_laps: 0
+  country_code:
+  country_name:
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 190761
+  finished: false
+  first_name: Start
+  gender: 1
+  last_name: Only
+  overall_performance: '100000000000001000000000000000000000000000000000000111111111111111111111111111111111111111111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
+  slug: ggd30-50k-start-only
+  started: true
+  state_code:
+  state_name:
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2014_clarence_goyette:
+  event: hardrock_2014
+  person: clarence_goyette
+  age: 52
+  beacon_url:
+  beyond_start: true
+  bib_number: 36
+  bib_number_hardcoded:
+  birthdate: 1961-09-18
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 93442
+  finished: true
+  first_name: Clarence
+  gender: 0
+  last_name: Goyette
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110010001000110110000111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
+  slug: hardrock-2014-clarence-goyette
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 93442
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2014_claudio_wunsch:
+  event: hardrock_2014
+  person: claudio_wunsch
+  age: 33
+  beacon_url:
+  beyond_start: true
+  bib_number: 104
+  bib_number_hardcoded:
+  birthdate: 1981-04-17
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 91846
+  finished: true
+  first_name: Claudio
+  gender: 0
+  last_name: Wunsch
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111000010001111111100010110111'
+  phone:
+  report_url:
+  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
+  slug: hardrock-2014-claudio-wunsch
+  started: true
+  state_code:
+  state_name:
+  stopped: true
+  stopped_split_time_id: 91846
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2014_drop_ouray:
+  event: hardrock_2014
+  person: drop_ouray
+  age: 40
+  beacon_url:
+  beyond_start: true
+  bib_number: 142
+  bib_number_hardcoded:
+  birthdate: 1974-01-05
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: true
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 94483
+  finished: false
+  first_name: Drop
+  gender: 1
+  last_name: Ouray
+  overall_performance: '000000000000001000000000000010001001111111010100000011111111111111111100000010011001100001111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
+  slug: hardrock-2014-drop-ouray
+  started: true
+  state_code: CA
+  state_name: California
+  stopped: true
+  stopped_split_time_id: 94483
+  synced_at:
+  topic_resource_key:
+  wave:
 hardrock_2014_finished_first:
   event: hardrock_2014
   person: finished_first_japan
-  id: 4172
   age: 19
   beacon_url:
   beyond_start: true
@@ -1367,7 +686,6 @@ hardrock_2014_finished_first:
 hardrock_2014_finished_with_stop:
   event: hardrock_2014
   person: finished_with_stop
-  id: 4173
   age: 40
   beacon_url:
   beyond_start: true
@@ -1406,7 +724,6 @@ hardrock_2014_finished_with_stop:
 hardrock_2014_finished_without_stop:
   event: hardrock_2014
   person: finished_without_stop
-  id: 4174
   age: 25
   beacon_url:
   beyond_start: true
@@ -1442,166 +759,9 @@ hardrock_2014_finished_without_stop:
   synced_at:
   topic_resource_key:
   wave:
-hardrock_2014_claudio_wunsch:
-  event: hardrock_2014
-  person: claudio_wunsch
-  id: 4192
-  age: 33
-  beacon_url:
-  beyond_start: true
-  bib_number: 104
-  bib_number_hardcoded:
-  birthdate: 1981-04-17
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 91846
-  finished: true
-  first_name: Claudio
-  gender: 0
-  last_name: Wunsch
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111000010001111111100010110111'
-  phone:
-  report_url:
-  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  slug: hardrock-2014-claudio-wunsch
-  started: true
-  state_code:
-  state_name:
-  stopped: true
-  stopped_split_time_id: 91846
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2014_rachelle_eichmann:
-  event: hardrock_2014
-  person: rachelle_eichmann
-  id: 4199
-  age: 22
-  beacon_url:
-  beyond_start: true
-  bib_number: 123
-  bib_number_hardcoded:
-  birthdate: 1992-01-11
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 92042
-  finished: true
-  first_name: Rachelle
-  gender: 1
-  last_name: Eichmann
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111111010111001000001110111'
-  phone:
-  report_url:
-  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  slug: hardrock-2014-rachelle-eichmann
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 92042
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2014_keith_metz:
-  event: hardrock_2014
-  person: keith_metz
-  id: 4206
-  age: 42
-  beacon_url:
-  beyond_start: true
-  bib_number: 159
-  bib_number_hardcoded:
-  birthdate: 1971-11-06
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 92238
-  finished: true
-  first_name: Keith
-  gender: 0
-  last_name: Metz
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111101000101000110100001111'
-  phone:
-  report_url:
-  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  slug: hardrock-2014-keith-metz
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: true
-  stopped_split_time_id: 92238
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2014_major_green:
-  event: hardrock_2014
-  person: major_green
-  id: 4207
-  age: 58
-  beacon_url:
-  beyond_start: true
-  bib_number: 121
-  bib_number_hardcoded:
-  birthdate: 1955-09-29
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 92266
-  finished: true
-  first_name: Major
-  gender: 0
-  last_name: Green
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111100111100100101100110111'
-  phone:
-  report_url:
-  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  slug: hardrock-2014-major-green
-  started: true
-  state_code: NC
-  state_name: North Carolina
-  stopped: true
-  stopped_split_time_id: 92266
-  synced_at:
-  topic_resource_key:
-  wave:
 hardrock_2014_humberto_adams:
   event: hardrock_2014
   person: humberto_adams
-  id: 4221
   age: 24
   beacon_url:
   beyond_start: true
@@ -1637,10 +797,237 @@ hardrock_2014_humberto_adams:
   synced_at:
   topic_resource_key:
   wave:
+hardrock_2014_irvin_corkery:
+  event: hardrock_2014
+  person: irvin_corkery
+  age: 22
+  beacon_url:
+  beyond_start: true
+  bib_number: 120
+  bib_number_hardcoded:
+  birthdate: 1991-11-01
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 93498
+  finished: true
+  first_name: Irvin
+  gender: 0
+  last_name: Corkery
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110010000001111000110011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
+  slug: hardrock-2014-irvin-corkery
+  started: true
+  state_code: DC
+  state_name: District of Columbia
+  stopped: true
+  stopped_split_time_id: 93498
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2014_keith_metz:
+  event: hardrock_2014
+  person: keith_metz
+  age: 42
+  beacon_url:
+  beyond_start: true
+  bib_number: 159
+  bib_number_hardcoded:
+  birthdate: 1971-11-06
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 92238
+  finished: true
+  first_name: Keith
+  gender: 0
+  last_name: Metz
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111101000101000110100001111'
+  phone:
+  report_url:
+  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
+  slug: hardrock-2014-keith-metz
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: true
+  stopped_split_time_id: 92238
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2014_ken_bradtke:
+  event: hardrock_2014
+  person: ken_bradtke
+  age: 47
+  beacon_url:
+  beyond_start: true
+  bib_number: 158
+  bib_number_hardcoded:
+  birthdate: 1966-07-21
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 93638
+  finished: true
+  first_name: Ken
+  gender: 0
+  last_name: Bradtke
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110000010110110101001111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
+  slug: hardrock-2014-ken-bradtke
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 93638
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2014_major_green:
+  event: hardrock_2014
+  person: major_green
+  age: 58
+  beacon_url:
+  beyond_start: true
+  bib_number: 121
+  bib_number_hardcoded:
+  birthdate: 1955-09-29
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 92266
+  finished: true
+  first_name: Major
+  gender: 0
+  last_name: Green
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111100111100100101100110111'
+  phone:
+  report_url:
+  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
+  slug: hardrock-2014-major-green
+  started: true
+  state_code: NC
+  state_name: North Carolina
+  stopped: true
+  stopped_split_time_id: 92266
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2014_multiple_stops:
+  event: hardrock_2014
+  person: multiple_stops
+  age: 60
+  beacon_url:
+  beyond_start: true
+  bib_number: 187
+  bib_number_hardcoded:
+  birthdate: 1954-03-21
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status:
+  dropped: true
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 94453
+  finished: false
+  first_name: Multiple
+  gender: 1
+  last_name: Stops
+  overall_performance: '000000000000001000000000000010110111010000000100000011111111111111111010100110011000110110111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
+  slug: hardrock-2014-multiple-stops
+  started: true
+  state_code: HI
+  state_name: Hawaii
+  stopped: true
+  stopped_split_time_id: 94453
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2014_not_started:
+  event: hardrock_2014
+  person: not_started
+  age: 28
+  beacon_url:
+  beyond_start: false
+  bib_number: 115
+  bib_number_hardcoded:
+  birthdate: 1986-03-23
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id:
+  finished: false
+  first_name: Not
+  gender: 0
+  last_name: Started
+  overall_performance: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+  phone:
+  report_url:
+  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
+  slug: hardrock-2014-not-started
+  started: false
+  state_code: CO
+  state_name: Colorado
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
 hardrock_2014_omer_yundt:
   event: hardrock_2014
   person: omer_yundt
-  id: 4246
   age: 40
   beacon_url:
   beyond_start: true
@@ -1679,7 +1066,6 @@ hardrock_2014_omer_yundt:
 hardrock_2014_pat_schaden:
   event: hardrock_2014
   person: pat_schaden
-  id: 4247
   age: 53
   beacon_url:
   beyond_start: true
@@ -1715,166 +1101,9 @@ hardrock_2014_pat_schaden:
   synced_at:
   topic_resource_key:
   wave:
-hardrock_2014_clarence_goyette:
-  event: hardrock_2014
-  person: clarence_goyette
-  id: 4249
-  age: 52
-  beacon_url:
-  beyond_start: true
-  bib_number: 36
-  bib_number_hardcoded:
-  birthdate: 1961-09-18
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 93442
-  finished: true
-  first_name: Clarence
-  gender: 0
-  last_name: Goyette
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110010001000110110000111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  slug: hardrock-2014-clarence-goyette
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 93442
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2014_irvin_corkery:
-  event: hardrock_2014
-  person: irvin_corkery
-  id: 4251
-  age: 22
-  beacon_url:
-  beyond_start: true
-  bib_number: 120
-  bib_number_hardcoded:
-  birthdate: 1991-11-01
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 93498
-  finished: true
-  first_name: Irvin
-  gender: 0
-  last_name: Corkery
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110010000001111000110011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  slug: hardrock-2014-irvin-corkery
-  started: true
-  state_code: DC
-  state_name: District of Columbia
-  stopped: true
-  stopped_split_time_id: 93498
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2014_willis_murray:
-  event: hardrock_2014
-  person: willis_murray
-  id: 4253
-  age: 16
-  beacon_url:
-  beyond_start: true
-  bib_number: 32
-  bib_number_hardcoded:
-  birthdate: 1998-02-04
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 93554
-  finished: true
-  first_name: Willis
-  gender: 0
-  last_name: Murray
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110001100101101100000111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  slug: hardrock-2014-willis-murray
-  started: true
-  state_code: GA
-  state_name: Georgia
-  stopped: true
-  stopped_split_time_id: 93554
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2014_ken_bradtke:
-  event: hardrock_2014
-  person: ken_bradtke
-  id: 4256
-  age: 47
-  beacon_url:
-  beyond_start: true
-  bib_number: 158
-  bib_number_hardcoded:
-  birthdate: 1966-07-21
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 93638
-  finished: true
-  first_name: Ken
-  gender: 0
-  last_name: Bradtke
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110000010110110101001111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  slug: hardrock-2014-ken-bradtke
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 93638
-  synced_at:
-  topic_resource_key:
-  wave:
 hardrock_2014_progress_sherman:
   event: hardrock_2014
   person: progress_sherman_colorado_us
-  id: 4277
   age: 36
   beacon_url:
   beyond_start: true
@@ -1910,49 +1139,85 @@ hardrock_2014_progress_sherman:
   synced_at:
   topic_resource_key:
   wave:
-hardrock_2014_multiple_stops:
+hardrock_2014_rachelle_eichmann:
   event: hardrock_2014
-  person: multiple_stops
-  id: 4293
-  age: 60
+  person: rachelle_eichmann
+  age: 22
   beacon_url:
   beyond_start: true
-  bib_number: 187
+  bib_number: 123
   bib_number_hardcoded:
-  birthdate: 1954-03-21
+  birthdate: 1992-01-11
   checked_in: false
   city:
   comments:
-  completed_laps: 0
+  completed_laps: 1
   country_code: US
   country_name: United States
   data_status:
-  dropped: true
+  dropped: false
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 94453
-  finished: false
-  first_name: Multiple
+  final_split_time_id: 92042
+  finished: true
+  first_name: Rachelle
   gender: 1
-  last_name: Stops
-  overall_performance: '000000000000001000000000000010110111010000000100000011111111111111111010100110011000110110111111'
+  last_name: Eichmann
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111111010111001000001110111'
   phone:
   report_url:
   scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  slug: hardrock-2014-multiple-stops
+  slug: hardrock-2014-rachelle-eichmann
   started: true
-  state_code: HI
-  state_name: Hawaii
+  state_code: CO
+  state_name: Colorado
   stopped: true
-  stopped_split_time_id: 94453
+  stopped_split_time_id: 92042
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2014_willis_murray:
+  event: hardrock_2014
+  person: willis_murray
+  age: 16
+  beacon_url:
+  beyond_start: true
+  bib_number: 32
+  bib_number_hardcoded:
+  birthdate: 1998-02-04
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 93554
+  finished: true
+  first_name: Willis
+  gender: 0
+  last_name: Murray
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110001100101101100000111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
+  slug: hardrock-2014-willis-murray
+  started: true
+  state_code: GA
+  state_name: Georgia
+  stopped: true
+  stopped_split_time_id: 93554
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_without_start:
   event: hardrock_2014
   person: without_start
-  id: 4294
   age: 49
   beacon_url:
   beyond_start: true
@@ -1988,16 +1253,167 @@ hardrock_2014_without_start:
   synced_at:
   topic_resource_key:
   wave:
-hardrock_2014_drop_ouray:
-  event: hardrock_2014
-  person: drop_ouray
-  id: 4295
-  age: 40
+hardrock_2015_bad_status:
+  event: hardrock_2015
+  person: bad_status
+  age: 21
   beacon_url:
   beyond_start: true
-  bib_number: 142
+  bib_number: 108
   bib_number_hardcoded:
-  birthdate: 1974-01-05
+  birthdate: 1994-04-18
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 0
+  dropped: true
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 101556
+  finished: false
+  first_name: Bad
+  gender: 0
+  last_name: Status
+  overall_performance: '000000000000001000000000000100101001101010100100000011111111111111111000000010101111001110011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-bad-status
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 101556
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_benedict_davis:
+  event: hardrock_2015
+  person: benedict_davis
+  age: 32
+  beacon_url:
+  beyond_start: true
+  bib_number: 122
+  bib_number_hardcoded:
+  birthdate:
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 0
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 3702
+  finished: true
+  first_name: Benedict
+  gender: 0
+  last_name: Davis
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101101101000011001001011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-benedict-davis
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 3702
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_bruno_fadel:
+  event: hardrock_2015
+  person: bruno_fadel
+  age: 27
+  beacon_url:
+  beyond_start: true
+  bib_number: 103
+  bib_number_hardcoded:
+  birthdate: 1988-05-11
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 3312
+  finished: true
+  first_name: Bruno
+  gender: 0
+  last_name: Fadel
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101110110101010011000011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-bruno-fadel
+  started: true
+  state_code: CA
+  state_name: California
+  stopped: true
+  stopped_split_time_id: 3312
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_carmine_adams:
+  event: hardrock_2015
+  person: carmine_adams
+  age: 18
+  beacon_url:
+  beyond_start: true
+  bib_number: 140
+  bib_number_hardcoded:
+  birthdate: 1997-05-25
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 1
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 432
+  finished: true
+  first_name: Carmine
+  gender: 0
+  last_name: Adams
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111001010110111101110110011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-carmine-adams
+  started: true
+  state_code: WA
+  state_name: Washington
+  stopped: true
+  stopped_split_time_id: 432
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_cassondra_nienow:
+  event: hardrock_2015
+  person: cassondra_nienow
+  age: 56
+  beacon_url:
+  beyond_start: true
+  bib_number: 155
+  bib_number_hardcoded:
+  birthdate: 1958-09-07
   checked_in: false
   city:
   comments:
@@ -2009,40 +1425,1787 @@ hardrock_2014_drop_ouray:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 94483
+  final_split_time_id: 4198
   finished: false
-  first_name: Drop
+  first_name: Cassondra
   gender: 1
-  last_name: Ouray
-  overall_performance: '000000000000001000000000000010001001111111010100000011111111111111111100000010011001100001111111'
+  last_name: Nienow
+  overall_performance: '000000000000001000000000000001011010100001101100000011111111111111111101011010100001001011011111'
   phone:
   report_url:
-  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  slug: hardrock-2014-drop-ouray
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-cassondra-nienow
   started: true
-  state_code: CA
-  state_name: California
+  state_code: OH
+  state_name: Ohio
   stopped: true
-  stopped_split_time_id: 94483
+  stopped_split_time_id: 4198
   synced_at:
   topic_resource_key:
   wave:
-hardrock_2014_not_started:
-  event: hardrock_2014
-  person: not_started
-  id: 4302
-  age: 28
+hardrock_2015_cedric_windler:
+  event: hardrock_2015
+  person: cedric_windler
+  age: 36
   beacon_url:
-  beyond_start: false
-  bib_number: 115
+  beyond_start: true
+  bib_number: 9
   bib_number_hardcoded:
-  birthdate: 1986-03-23
+  birthdate: 1979-07-10
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 1332
+  finished: true
+  first_name: Cedric
+  gender: 0
+  last_name: Windler
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111111111100010001001011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-cedric-windler
+  started: true
+  state_code: TN
+  state_name: Tennessee
+  stopped: true
+  stopped_split_time_id: 1332
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_chris_rempel:
+  event: hardrock_2015
+  person: chris_rempel
+  age: 26
+  beacon_url:
+  beyond_start: true
+  bib_number: 26
+  bib_number_hardcoded:
+  birthdate: 1988-12-28
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 1512
+  finished: true
+  first_name: Chris
+  gender: 0
+  last_name: Rempel
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111110111100001011100111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-chris-rempel
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 1512
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_darius_jacobson:
+  event: hardrock_2015
+  person: darius_jacobson
+  age: 30
+  beacon_url:
+  beyond_start: true
+  bib_number: 8
+  bib_number_hardcoded:
+  birthdate: 1985-03-21
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 582
+  finished: true
+  first_name: Darius
+  gender: 0
+  last_name: Jacobson
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111001001100011100000001011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-darius-jacobson
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 582
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_demetrius_moen:
+  event: hardrock_2015
+  person: demetrius_moen
+  age: 40
+  beacon_url:
+  beyond_start: true
+  bib_number: 39
+  bib_number_hardcoded:
+  birthdate: 1975-06-06
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 2712
+  finished: true
+  first_name: Demetrius
+  gender: 0
+  last_name: Moen
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110100011100001011110011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-demetrius-moen
+  started: true
+  state_code: OR
+  state_name: Oregon
+  stopped: true
+  stopped_split_time_id: 2712
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_donn_mckenzie:
+  event: hardrock_2015
+  person: donn_mckenzie
+  age: 16
+  beacon_url:
+  beyond_start: true
+  bib_number: 119
+  bib_number_hardcoded:
+  birthdate: 1998-12-29
   checked_in: false
   city:
   comments:
   completed_laps: 0
   country_code: US
   country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 4219
+  finished: false
+  first_name: Donn
+  gender: 0
+  last_name: McKenzie
+  overall_performance: '100000000000001000000000000000011101001110110100000011111111111111111111011101101010101110111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-donn-mckenzie
+  started: true
+  state_code: WY
+  state_name: Wyoming
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_donte_spencer:
+  event: hardrock_2015
+  person: donte_spencer
+  age: 30
+  beacon_url:
+  beyond_start: true
+  bib_number: 157
+  bib_number_hardcoded:
+  birthdate: 1984-07-14
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 3192
+  finished: true
+  first_name: Donte
+  gender: 0
+  last_name: Spencer
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101111101010011001011111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-donte-spencer
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: true
+  stopped_split_time_id: 3192
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_elden_morissette:
+  event: hardrock_2015
+  person: elden_morissette
+  age: 42
+  beacon_url:
+  beyond_start: true
+  bib_number: 170
+  bib_number_hardcoded:
+  birthdate: 1972-11-21
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 1662
+  finished: true
+  first_name: Elden
+  gender: 0
+  last_name: Morissette
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111101100110000111110011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-elden-morissette
+  started: true
+  state_code: WI
+  state_name: Wisconsin
+  stopped: true
+  stopped_split_time_id: 1662
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_erich_larson:
+  event: hardrock_2015
+  person: erich_larson
+  age: 36
+  beacon_url:
+  beyond_start: true
+  bib_number: 128
+  bib_number_hardcoded:
+  birthdate: 1979-07-10
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 72
+  finished: true
+  first_name: Erich
+  gender: 0
+  last_name: Larson
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111010011110011000101001101111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-erich-larson
+  started: true
+  state_code: MT
+  state_name: Montana
+  stopped: true
+  stopped_split_time_id: 72
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_garry_kuhlman:
+  event: hardrock_2015
+  person: garry_kuhlman
+  age: 45
+  beacon_url:
+  beyond_start: true
+  bib_number: 11
+  bib_number_hardcoded:
+  birthdate: 1969-10-10
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 552
+  finished: true
+  first_name: Garry
+  gender: 0
+  last_name: Kuhlman
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111001001101010110100111011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-garry-kuhlman
+  started: true
+  state_code: MT
+  state_name: Montana
+  stopped: true
+  stopped_split_time_id: 552
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_gilberto_mckenzie:
+  event: hardrock_2015
+  person: gilberto_mckenzie
+  age: 45
+  beacon_url:
+  beyond_start: true
+  bib_number: 121
+  bib_number_hardcoded:
+  birthdate: 1970-06-02
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 762
+  finished: true
+  first_name: Gilberto
+  gender: 0
+  last_name: McKenzie
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111000011011001110100110111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-gilberto-mckenzie
+  started: true
+  state_code: WA
+  state_name: Washington
+  stopped: true
+  stopped_split_time_id: 762
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_gus_walker:
+  event: hardrock_2015
+  person: gus_walker
+  age: 54
+  beacon_url:
+  beyond_start: true
+  bib_number: 156
+  bib_number_hardcoded:
+  birthdate: 1960-11-23
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 0
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 3342
+  finished: true
+  first_name: Gus
+  gender: 0
+  last_name: Walker
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101110101100001001000111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-gus-walker
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 3342
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_irvin_harber:
+  event: hardrock_2015
+  person: irvin_harber
+  age: 19
+  beacon_url:
+  beyond_start: true
+  bib_number: 134
+  bib_number_hardcoded:
+  birthdate: 1996-07-05
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: true
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 101541
+  finished: false
+  first_name: Irvin
+  gender: 0
+  last_name: Harber
+  overall_performance: '000000000000001000000000000011100100110101000100000011111111111111111010110110011010001111111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-irvin-harber
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 101541
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_leandro_cole:
+  event: hardrock_2015
+  person: leandro_cole
+  age: 45
+  beacon_url:
+  beyond_start: true
+  bib_number: 168
+  bib_number_hardcoded:
+  birthdate: 1970-06-26
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 0
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 3582
+  finished: true
+  first_name: Leandro
+  gender: 0
+  last_name: Cole
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101110010000101011010011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-leandro-cole
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: true
+  stopped_split_time_id: 3582
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_leif_carter:
+  event: hardrock_2015
+  person: leif_carter
+  age: 55
+  beacon_url:
+  beyond_start: true
+  bib_number: 146
+  bib_number_hardcoded:
+  birthdate: 1960-02-01
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: ES
+  country_name: Spain
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 282
+  finished: true
+  first_name: Leif
+  gender: 0
+  last_name: Carter
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111001110011000111100110111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-leif-carter
+  started: true
+  state_code:
+  state_name:
+  stopped: true
+  stopped_split_time_id: 282
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_leroy_leffler:
+  event: hardrock_2015
+  person: leroy_leffler
+  age: 48
+  beacon_url:
+  beyond_start: true
+  bib_number: 34
+  bib_number_hardcoded:
+  birthdate: 1967-06-18
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 1722
+  finished: true
+  first_name: Leroy
+  gender: 0
+  last_name: Leffler
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111100101111001100001011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-leroy-leffler
+  started: true
+  state_code: NM
+  state_name: New Mexico
+  stopped: true
+  stopped_split_time_id: 1722
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_rachelle_eichmann:
+  event: hardrock_2015
+  person: rachelle_eichmann
+  age: 23
+  beacon_url:
+  beyond_start: true
+  bib_number: 22
+  bib_number_hardcoded:
+  birthdate: 1992-01-11
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 1602
+  finished: true
+  first_name: Rachelle
+  gender: 1
+  last_name: Eichmann
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111101101111010001101111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-rachelle-eichmann
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 1602
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_raphael_swift:
+  event: hardrock_2015
+  person: raphael_swift
+  age: 40
+  beacon_url:
+  beyond_start: true
+  bib_number: 171
+  bib_number_hardcoded:
+  birthdate: 1974-07-14
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 0
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 3891
+  finished: false
+  first_name: Raphael
+  gender: 0
+  last_name: Swift
+  overall_performance: '100000000000001000000000000011100100110101000100000011111111111111111001011001111100010001111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-raphael-swift
+  started: true
+  state_code: AR
+  state_name: Arkansas
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_robby_gerlach:
+  event: hardrock_2015
+  person: robby_gerlach
+  age: 45
+  beacon_url:
+  beyond_start: true
+  bib_number: 105
+  bib_number_hardcoded:
+  birthdate: 1970-05-18
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 1542
+  finished: true
+  first_name: Robby
+  gender: 0
+  last_name: Gerlach
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111110111000100001001111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-robby-gerlach
+  started: true
+  state_code: VA
+  state_name: Virginia
+  stopped: true
+  stopped_split_time_id: 1542
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_robt_wintheiser:
+  event: hardrock_2015
+  person: robt_wintheiser
+  age: 57
+  beacon_url:
+  beyond_start: true
+  bib_number: 30
+  bib_number_hardcoded:
+  birthdate: 1957-09-14
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 2652
+  finished: true
+  first_name: Robt
+  gender: 0
+  last_name: Wintheiser
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110100100101010101101111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-robt-wintheiser
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 2652
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_samara_vandervort:
+  event: hardrock_2015
+  person: samara_vandervort
+  age: 22
+  beacon_url:
+  beyond_start: true
+  bib_number: 35
+  bib_number_hardcoded:
+  birthdate: 1992-12-15
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 0
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 2022
+  finished: true
+  first_name: Samara
+  gender: 1
+  last_name: Vandervort
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110111010111000001010111111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-samara-vandervort
+  started: true
+  state_code: CA
+  state_name: California
+  stopped: true
+  stopped_split_time_id: 2022
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_santa_green:
+  event: hardrock_2015
+  person: santa_green
+  age: 37
+  beacon_url:
+  beyond_start: true
+  bib_number: 133
+  bib_number_hardcoded:
+  birthdate: 1977-10-27
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 702
+  finished: true
+  first_name: Santa
+  gender: 1
+  last_name: Green
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111000110101110001110100111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-santa-green
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 702
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_susanna_abshire:
+  event: hardrock_2015
+  person: susanna_abshire
+  age: 34
+  beacon_url:
+  beyond_start: true
+  bib_number: 144
+  bib_number_hardcoded:
+  birthdate: 1980-08-17
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 0
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 3462
+  finished: true
+  first_name: Susanna
+  gender: 1
+  last_name: Abshire
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110101110011011101010011011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-susanna-abshire
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 3462
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_tuan_jacobs:
+  event: hardrock_2015
+  person: tuan_jacobs
+  age: 17
+  beacon_url:
+  beyond_start: true
+  bib_number: 1
+  bib_number_hardcoded:
+  birthdate: 1998-03-19
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: ES
+  country_name: Spain
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 42
+  finished: true
+  first_name: Tuan
+  gender: 0
+  last_name: Jacobs
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111011000001001010101110011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-tuan-jacobs
+  started: true
+  state_code: AN
+  state_name: Andalucía
+  stopped: true
+  stopped_split_time_id: 42
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_vern_buckridge:
+  event: hardrock_2015
+  person: vern_buckridge
+  age: 33
+  beacon_url:
+  beyond_start: true
+  bib_number: 176
+  bib_number_hardcoded:
+  birthdate: 1981-10-15
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 2982
+  finished: true
+  first_name: Vern
+  gender: 0
+  last_name: Buckridge
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111110110010001011100001111111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-vern-buckridge
+  started: true
+  state_code: TX
+  state_name: Texas
+  stopped: true
+  stopped_split_time_id: 2982
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2015_vince_willms:
+  event: hardrock_2015
+  person: vince_willms
+  age: 50
+  beacon_url:
+  beyond_start: true
+  bib_number: 182
+  bib_number_hardcoded:
+  birthdate: 1964-10-22
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 1242
+  finished: true
+  first_name: Vince
+  gender: 0
+  last_name: Willms
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111000000100010101110000111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2015-07-10 12:00:00.000000000 Z
+  slug: hardrock-2015-vince-willms
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 1242
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_benito_moen:
+  event: hardrock_2016
+  person: benito_moen
+  age: 52
+  beacon_url:
+  beyond_start: true
+  bib_number: 177
+  bib_number_hardcoded:
+  birthdate: 1964-01-16
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 148819
+  finished: false
+  first_name: Benito
+  gender: 0
+  last_name: Moen
+  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111001101011100100001101011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-benito-moen
+  started: true
+  state_code: OH
+  state_name: Ohio
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_brinda_fisher:
+  event: hardrock_2016
+  person: brinda_fisher
+  age: 22
+  beacon_url:
+  beyond_start: true
+  bib_number: 37
+  bib_number_hardcoded:
+  birthdate:
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 149907
+  finished: false
+  first_name: Brinda
+  gender: 1
+  last_name: Fisher
+  overall_performance: '100000000000001000000000000010110111010000000100000011111111111111111010010110100110000111011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-brinda-fisher
+  started: true
+  state_code: SC
+  state_name: South Carolina
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_charlie_mueller:
+  event: hardrock_2016
+  person: charlie_mueller
+  age: 27
+  beacon_url:
+  beyond_start: true
+  bib_number: 159
+  bib_number_hardcoded:
+  birthdate: 1989-06-10
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 148987
+  finished: false
+  first_name: Charlie
+  gender: 0
+  last_name: Mueller
+  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111001110000100110011110011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-charlie-mueller
+  started: true
+  state_code: OR
+  state_name: Oregon
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_douglas_vandervort:
+  event: hardrock_2016
+  person: douglas_vandervort
+  age: 52
+  beacon_url:
+  beyond_start: true
+  bib_number: 26
+  bib_number_hardcoded:
+  birthdate: 1964-02-16
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 147839
+  finished: false
+  first_name: Douglas
+  gender: 0
+  last_name: Vandervort
+  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010010110100110000111011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-douglas-vandervort
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_dropped_grouse:
+  event: hardrock_2016
+  person: dropped_grouse
+  age: 47
+  beacon_url:
+  beyond_start: true
+  bib_number: 117
+  bib_number_hardcoded:
+  birthdate: 1969-05-13
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: true
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 150335
+  finished: false
+  first_name: Dropped
+  gender: 0
+  last_name: Grouse
+  overall_performance: '000000000000001000000000000010110111010000000100000011111111111111111100110110100101010111111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-dropped-grouse
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 150335
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_eddy_goldner:
+  event: hardrock_2016
+  person: eddy_goldner
+  age: 18
+  beacon_url:
+  beyond_start: true
+  bib_number: 9
+  bib_number_hardcoded:
+  birthdate: 1997-07-26
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 148203
+  finished: false
+  first_name: Eddy
+  gender: 0
+  last_name: Goldner
+  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010001101001101100001111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-eddy-goldner
+  started: true
+  state_code: WA
+  state_name: Washington
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_hoyt_macejkovic:
+  event: hardrock_2016
+  person: hoyt_macejkovic
+  age: 55
+  beacon_url:
+  beyond_start: true
+  bib_number: 125
+  bib_number_hardcoded:
+  birthdate: 1960-07-23
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: true
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 150506
+  finished: false
+  first_name: Hoyt
+  gender: 0
+  last_name: Macejkovic
+  overall_performance: '000000000000001000000000000010001001111111010100000011111111111111111100001100000000110000111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-hoyt-macejkovic
+  started: true
+  state_code: MD
+  state_name: Maryland
+  stopped: true
+  stopped_split_time_id: 150506
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_junior_lesch:
+  event: hardrock_2016
+  person: junior_lesch
+  age: 49
+  beacon_url:
+  beyond_start: true
+  bib_number: 135
+  bib_number_hardcoded:
+  birthdate: 1967-02-21
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 148091
+  finished: false
+  first_name: Junior
+  gender: 0
+  last_name: Lesch
+  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010000011001000111111111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-junior-lesch
+  started: true
+  state_code: NM
+  state_name: New Mexico
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_kendall_koch:
+  event: hardrock_2016
+  person: kendall_koch
+  age: 40
+  beacon_url:
+  beyond_start: true
+  bib_number: 188
+  bib_number_hardcoded:
+  birthdate: 1976-02-05
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 148903
+  finished: false
+  first_name: Kendall
+  gender: 0
+  last_name: Koch
+  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111001101010011010111101111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-kendall-koch
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_kory_kulas:
+  event: hardrock_2016
+  person: kory_kulas
+  age: 42
+  beacon_url:
+  beyond_start: true
+  bib_number: 118
+  bib_number_hardcoded:
+  birthdate: 1974-01-25
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 147481
+  finished: false
+  first_name: Kory
+  gender: 0
+  last_name: Kulas
+  overall_performance: '100000000000001000000000000100011110101010100100000011111111111111111000111011010001011000111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-kory-kulas
+  started: true
+  state_code: CA
+  state_name: California
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_lavon_paucek:
+  event: hardrock_2016
+  person: lavon_paucek
+  age: 41
+  beacon_url:
+  beyond_start: true
+  bib_number: 4
+  bib_number_hardcoded:
+  birthdate: 1974-07-29
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: NZ
+  country_name: New Zealand
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 146950
+  finished: true
+  first_name: Lavon
+  gender: 1
+  last_name: Paucek
+  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111001110001010000001110010111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-lavon-paucek
+  started: true
+  state_code:
+  state_name:
+  stopped: true
+  stopped_split_time_id: 146950
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_mervin_smitham:
+  event: hardrock_2016
+  person: mervin_smitham
+  age: 24
+  beacon_url:
+  beyond_start: true
+  bib_number: 109
+  bib_number_hardcoded:
+  birthdate: 1991-10-08
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: true
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 150403
+  finished: false
+  first_name: Mervin
+  gender: 0
+  last_name: Smitham
+  overall_performance: '000000000000001000000000000010110111010000000100000011111111111111111010111000000000110010011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-mervin-smitham
+  started: true
+  state_code: NM
+  state_name: New Mexico
+  stopped: true
+  stopped_split_time_id: 150403
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_missing_telluride_out:
+  event: hardrock_2016
+  person:
+  age: 20
+  beacon_url:
+  beyond_start: true
+  bib_number: 121
+  bib_number_hardcoded:
+  birthdate: 1996-02-11
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 148007
+  finished: false
+  first_name: Missing
+  gender: 0
+  last_name: Telluride Out
+  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010001010001111000110011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-missing-telluride-out
+  started: true
+  state_code: AK
+  state_name: Alaska
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_progress_sherman:
+  event: hardrock_2016
+  person: progress_sherman
+  age: 33
+  beacon_url:
+  beyond_start: true
+  bib_number: 150
+  bib_number_hardcoded:
+  birthdate: 1982-07-28
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 0
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 148567
+  finished: false
+  first_name: Progress
+  gender: 0
+  last_name: Sherman
+  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010111000001111011011111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-progress-sherman
+  started: true
+  state_code: VA
+  state_name: Virginia
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_rene_mclaughlin:
+  event: hardrock_2016
+  person: rene_mclaughlin
+  age: 32
+  beacon_url:
+  beyond_start: true
+  bib_number: 113
+  bib_number_hardcoded:
+  birthdate: 1984-04-30
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 150016
+  finished: false
+  first_name: Rene
+  gender: 0
+  last_name: McLaughlin
+  overall_performance: '100000000000001000000000000011100001010111101000000111111111111111111000111111001010011010011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-rene-mclaughlin
+  started: true
+  state_code: TX
+  state_name: Texas
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_rhett_auer:
+  event: hardrock_2016
+  person:
+  age: 41
+  beacon_url:
+  beyond_start: true
+  bib_number: 131
+  bib_number_hardcoded:
+  birthdate: 1974-11-07
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: true
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 150467
+  finished: false
+  first_name: Rhett
+  gender: 0
+  last_name: Auer
+  overall_performance: '000000000000001000000000000010001001111111010100000011111111111111111101111000010001011110011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-rhett-auer
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 150467
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_shad_hirthe:
+  event: hardrock_2016
+  person: shad_hirthe
+  age: 40
+  beacon_url:
+  beyond_start: true
+  bib_number: 133
+  bib_number_hardcoded:
+  birthdate: 1975-09-05
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 147699
+  finished: false
+  first_name: Shad
+  gender: 0
+  last_name: Hirthe
+  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010101000111001111111011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-shad-hirthe
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_start_only:
+  event: hardrock_2016
+  person: start_only_maine_us
+  age: 26
+  beacon_url:
+  beyond_start: false
+  bib_number: 199
+  bib_number_hardcoded:
+  birthdate: 1990-04-23
+  checked_in: true
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 192705
+  finished: false
+  first_name: Start
+  gender: 0
+  last_name: Only
+  overall_performance: '100000000000001000000000000000000000000000000000000111111111111111111111111111111111111111111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-start-only
+  started: true
+  state_code: ME
+  state_name: Maine
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+hardrock_2016_vesta_borer:
+  event: hardrock_2016
+  person: vesta_borer
+  age: 21
+  beacon_url:
+  beyond_start: true
+  bib_number: 24
+  bib_number_hardcoded:
+  birthdate: 1995-04-24
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 147341
+  finished: false
+  first_name: Vesta
+  gender: 1
+  last_name: Borer
+  overall_performance: '100000000000001000000000000100011110101010100100000011111111111111111001010101001000101010011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
+  slug: hardrock-2016-vesta-borer
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+ramble_finished_first:
+  event: ramble
+  person: finished_first_2019_02_01
+  age: 49
+  beacon_url:
+  beyond_start: true
+  bib_number:
+  bib_number_hardcoded:
+  birthdate: 1957-02-04
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code:
+  country_name:
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 15145
+  finished: true
+  first_name: Finished
+  gender: 0
+  last_name: First
+  overall_performance: '100000000000001000000000000000001101001100111000000111111111111111111111111000001000100101001111'
+  phone:
+  report_url:
+  scheduled_start_time: 2006-09-16 14:00:00.000000000 Z
+  slug: ramble-finished-first
+  started: true
+  state_code:
+  state_name:
+  stopped: true
+  stopped_split_time_id: 15145
+  synced_at:
+  topic_resource_key:
+  wave:
+ramble_finished_second:
+  event: ramble
+  person: finished_second_montana_us
+  age: 12
+  beacon_url:
+  beyond_start: true
+  bib_number:
+  bib_number_hardcoded:
+  birthdate: 1994-08-16
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code:
+  country_name:
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 15161
+  finished: true
+  first_name: Finished
+  gender: 1
+  last_name: Second
+  overall_performance: '100000000000001000000000000000001101001100111000000111111111111111111111110111011010011100000111'
+  phone:
+  report_url:
+  scheduled_start_time: 2006-09-16 14:00:00.000000000 Z
+  slug: ramble-finished-second
+  started: true
+  state_code:
+  state_name:
+  stopped: true
+  stopped_split_time_id: 15161
+  synced_at:
+  topic_resource_key:
+  wave:
+ramble_not_started:
+  event: ramble
+  person: not_started_2019_02_01
+  age: 17
+  beacon_url:
+  beyond_start: false
+  bib_number:
+  bib_number_hardcoded:
+  birthdate: 1989-03-22
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code:
+  country_name:
   data_status: 2
   dropped: false
   email:
@@ -2056,11 +3219,49 @@ hardrock_2014_not_started:
   overall_performance: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
   phone:
   report_url:
-  scheduled_start_time: 2014-07-11 12:00:00.000000000 Z
-  slug: hardrock-2014-not-started
+  scheduled_start_time: 2006-09-16 14:00:00.000000000 Z
+  slug: ramble-not-started
   started: false
-  state_code: CO
-  state_name: Colorado
+  state_code:
+  state_name:
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+ramble_start_only:
+  event: ramble
+  person: start_only_2019_02_01
+  age: 38
+  beacon_url:
+  beyond_start: false
+  bib_number:
+  bib_number_hardcoded:
+  birthdate: 1968-07-11
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code:
+  country_name:
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 15166
+  finished: false
+  first_name: Start
+  gender: 1
+  last_name: Only
+  overall_performance: '100000000000001000000000000000000000000000000000000111111111111111111111111111111111111111111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2006-09-16 14:00:00.000000000 Z
+  slug: ramble-start-only
+  started: true
+  state_code:
+  state_name:
   stopped: false
   stopped_split_time_id:
   synced_at:
@@ -2069,7 +3270,6 @@ hardrock_2014_not_started:
 rufa_2016_finished_first:
   event: rufa_2016
   person:
-  id: 6518
   age: 35
   beacon_url:
   beyond_start: true
@@ -2108,7 +3308,6 @@ rufa_2016_finished_first:
 rufa_2016_finished_second:
   event: rufa_2016
   person:
-  id: 6520
   age: 32
   beacon_url:
   beyond_start: true
@@ -2144,49 +3343,9 @@ rufa_2016_finished_second:
   synced_at:
   topic_resource_key:
   wave:
-rufa_2016_progress_lap1:
-  event: rufa_2016
-  person:
-  id: 6560
-  age: 25
-  beacon_url:
-  beyond_start: true
-  bib_number: 48
-  bib_number_hardcoded:
-  birthdate: 1991-01-16
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code:
-  country_name:
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 132439
-  finished: false
-  first_name: Progress
-  gender: 0
-  last_name: Lap1
-  overall_performance: '100000000000001000000000000000001000011111001000000111111111111111111111101100100010111000011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-02-13 13:00:00.000000000 Z
-  slug: rufa-2016-progress-lap1
-  started: true
-  state_code:
-  state_name:
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
 rufa_2016_not_started:
   event: rufa_2016
   person:
-  id: 6561
   age: 57
   beacon_url:
   beyond_start: false
@@ -2222,1717 +3381,39 @@ rufa_2016_not_started:
   synced_at:
   topic_resource_key:
   wave:
-rufa_2017_24h_finished_first:
-  event: rufa_2017_24h
-  person: finished_first_utah_us
-  id: 6693
-  age: 47
+rufa_2016_progress_lap1:
+  event: rufa_2016
+  person:
+  age: 25
   beacon_url:
   beyond_start: true
-  bib_number: 16
+  bib_number: 48
   bib_number_hardcoded:
-  birthdate: 1969-04-04
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 7
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 133983
-  finished: true
-  first_name: Finished
-  gender: 1
-  last_name: First
-  overall_performance: '100000000000111000000000000000010000111110010000000111111111111111111100010110111111111000111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-02-11 13:10:00.000000000 Z
-  slug: rufa-2017-24h-finished-first
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: true
-  stopped_split_time_id: 133983
-  synced_at:
-  topic_resource_key:
-  wave:
-rufa_2017_24h_progress_lap6:
-  event: rufa_2017_24h
-  person: progress_lap6
-  id: 6695
-  age: 33
-  beacon_url:
-  beyond_start: true
-  bib_number: 60
-  bib_number_hardcoded:
-  birthdate: 1983-03-13
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 6
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 134018
-  finished: false
-  first_name: Progress
-  gender: 0
-  last_name: Lap6
-  overall_performance: '100000000000110000000000000000010000111110010000000111111111111111111101110010000101111101111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-02-11 15:00:00.000000000 Z
-  slug: rufa-2017-24h-progress-lap6
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-rufa_2017_24h_multiple_stops:
-  event: rufa_2017_24h
-  person: multiple_stops_utah_us
-  id: 6756
-  age: 43
-  beacon_url:
-  beyond_start: true
-  bib_number: 142
-  bib_number_hardcoded:
-  birthdate: 1973-11-14
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 3
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 134812
-  finished: true
-  first_name: Multiple
-  gender: 1
-  last_name: Stops
-  overall_performance: '100000000000011000000000000000010000111110010000000111111111111111111110110001101110001110111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-02-11 15:00:00.000000000 Z
-  slug: rufa-2017-24h-multiple-stops
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: true
-  stopped_split_time_id: 134812
-  synced_at:
-  topic_resource_key:
-  wave:
-rufa_2017_24h_finished_last:
-  event: rufa_2017_24h
-  person: finished_last
-  id: 6780
-  age: 40
-  beacon_url:
-  beyond_start: true
-  bib_number: 112
-  bib_number_hardcoded:
-  birthdate: 1976-05-03
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 2
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 135012
-  finished: true
-  first_name: Finished
-  gender: 0
-  last_name: Last
-  overall_performance: '100000000000010000000000000000010000111110010000000111111111111111111111001001110000010100011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-02-11 15:00:00.000000000 Z
-  slug: rufa-2017-24h-finished-last
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: true
-  stopped_split_time_id: 135012
-  synced_at:
-  topic_resource_key:
-  wave:
-rufa_2017_24h_not_started:
-  event: rufa_2017_24h
-  person: not_started
-  id: 6782
-  age: 30
-  beacon_url:
-  beyond_start: false
-  bib_number: 149
-  bib_number_hardcoded:
-  birthdate: 1986-03-23
+  birthdate: 1991-01-16
   checked_in: false
   city:
   comments:
   completed_laps: 0
-  country_code: US
-  country_name: United States
+  country_code:
+  country_name:
   data_status: 2
   dropped: false
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id:
-  finished: false
-  first_name: Not
-  gender: 0
-  last_name: Started
-  overall_performance: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-02-12 01:00:00.000000000 Z
-  slug: rufa-2017-24h-not-started
-  started: false
-  state_code: UT
-  state_name: Utah
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-rufa_2017_24h_progress_lap1:
-  event: rufa_2017_24h
-  person: progress_lap1
-  id: 6805
-  age: 49
-  beacon_url:
-  beyond_start: true
-  bib_number: 134
-  bib_number_hardcoded:
-  birthdate: 1967-03-21
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 1
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 135134
+  final_split_time_id: 132439
   finished: false
   first_name: Progress
   gender: 0
   last_name: Lap1
-  overall_performance: '100000000000001000000000000000010000111110010000000111111111111111111111011000011001110100011111'
+  overall_performance: '100000000000001000000000000000001000011111001000000111111111111111111111101100100010111000011111'
   phone:
   report_url:
-  scheduled_start_time: 2017-02-11 16:00:00.000000000 Z
-  slug: rufa-2017-24h-progress-lap1
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_lavon_paucek:
-  event: hardrock_2016
-  person: lavon_paucek
-  id: 7270
-  age: 41
-  beacon_url:
-  beyond_start: true
-  bib_number: 4
-  bib_number_hardcoded:
-  birthdate: 1974-07-29
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: NZ
-  country_name: New Zealand
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 146950
-  finished: true
-  first_name: Lavon
-  gender: 1
-  last_name: Paucek
-  overall_performance: '100000000000001000000000000100111011111001011000000111111111111111111001110001010000001110010111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-lavon-paucek
+  scheduled_start_time: 2016-02-13 13:00:00.000000000 Z
+  slug: rufa-2016-progress-lap1
   started: true
   state_code:
   state_name:
-  stopped: true
-  stopped_split_time_id: 146950
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_vesta_borer:
-  event: hardrock_2016
-  person: vesta_borer
-  id: 7284
-  age: 21
-  beacon_url:
-  beyond_start: true
-  bib_number: 24
-  bib_number_hardcoded:
-  birthdate: 1995-04-24
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 147341
-  finished: false
-  first_name: Vesta
-  gender: 1
-  last_name: Borer
-  overall_performance: '100000000000001000000000000100011110101010100100000011111111111111111001010101001000101010011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-vesta-borer
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_kory_kulas:
-  event: hardrock_2016
-  person: kory_kulas
-  id: 7289
-  age: 42
-  beacon_url:
-  beyond_start: true
-  bib_number: 118
-  bib_number_hardcoded:
-  birthdate: 1974-01-25
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 147481
-  finished: false
-  first_name: Kory
-  gender: 0
-  last_name: Kulas
-  overall_performance: '100000000000001000000000000100011110101010100100000011111111111111111000111011010001011000111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-kory-kulas
-  started: true
-  state_code: CA
-  state_name: California
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_shad_hirthe:
-  event: hardrock_2016
-  person: shad_hirthe
-  id: 7297
-  age: 40
-  beacon_url:
-  beyond_start: true
-  bib_number: 133
-  bib_number_hardcoded:
-  birthdate: 1975-09-05
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 147699
-  finished: false
-  first_name: Shad
-  gender: 0
-  last_name: Hirthe
-  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010101000111001111111011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-shad-hirthe
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_douglas_vandervort:
-  event: hardrock_2016
-  person: douglas_vandervort
-  id: 7302
-  age: 52
-  beacon_url:
-  beyond_start: true
-  bib_number: 26
-  bib_number_hardcoded:
-  birthdate: 1964-02-16
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 147839
-  finished: false
-  first_name: Douglas
-  gender: 0
-  last_name: Vandervort
-  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010010110100110000111011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-douglas-vandervort
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_missing_telluride_out:
-  event: hardrock_2016
-  person:
-  id: 7308
-  age: 20
-  beacon_url:
-  beyond_start: true
-  bib_number: 121
-  bib_number_hardcoded:
-  birthdate: 1996-02-11
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 148007
-  finished: false
-  first_name: Missing
-  gender: 0
-  last_name: Telluride Out
-  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010001010001111000110011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-missing-telluride-out
-  started: true
-  state_code: AK
-  state_name: Alaska
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_junior_lesch:
-  event: hardrock_2016
-  person: junior_lesch
-  id: 7311
-  age: 49
-  beacon_url:
-  beyond_start: true
-  bib_number: 135
-  bib_number_hardcoded:
-  birthdate: 1967-02-21
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 148091
-  finished: false
-  first_name: Junior
-  gender: 0
-  last_name: Lesch
-  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010000011001000111111111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-junior-lesch
-  started: true
-  state_code: NM
-  state_name: New Mexico
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_eddy_goldner:
-  event: hardrock_2016
-  person: eddy_goldner
-  id: 7315
-  age: 18
-  beacon_url:
-  beyond_start: true
-  bib_number: 9
-  bib_number_hardcoded:
-  birthdate: 1997-07-26
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 148203
-  finished: false
-  first_name: Eddy
-  gender: 0
-  last_name: Goldner
-  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010001101001101100001111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-eddy-goldner
-  started: true
-  state_code: WA
-  state_name: Washington
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_progress_sherman:
-  event: hardrock_2016
-  person: progress_sherman
-  id: 7328
-  age: 33
-  beacon_url:
-  beyond_start: true
-  bib_number: 150
-  bib_number_hardcoded:
-  birthdate: 1982-07-28
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 0
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 148567
-  finished: false
-  first_name: Progress
-  gender: 0
-  last_name: Sherman
-  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111010111000001111011011111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-progress-sherman
-  started: true
-  state_code: VA
-  state_name: Virginia
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_benito_moen:
-  event: hardrock_2016
-  person: benito_moen
-  id: 7337
-  age: 52
-  beacon_url:
-  beyond_start: true
-  bib_number: 177
-  bib_number_hardcoded:
-  birthdate: 1964-01-16
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 148819
-  finished: false
-  first_name: Benito
-  gender: 0
-  last_name: Moen
-  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111001101011100100001101011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-benito-moen
-  started: true
-  state_code: OH
-  state_name: Ohio
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_kendall_koch:
-  event: hardrock_2016
-  person: kendall_koch
-  id: 7340
-  age: 40
-  beacon_url:
-  beyond_start: true
-  bib_number: 188
-  bib_number_hardcoded:
-  birthdate: 1976-02-05
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 148903
-  finished: false
-  first_name: Kendall
-  gender: 0
-  last_name: Koch
-  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111001101010011010111101111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-kendall-koch
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_charlie_mueller:
-  event: hardrock_2016
-  person: charlie_mueller
-  id: 7343
-  age: 27
-  beacon_url:
-  beyond_start: true
-  bib_number: 159
-  bib_number_hardcoded:
-  birthdate: 1989-06-10
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 148987
-  finished: false
-  first_name: Charlie
-  gender: 0
-  last_name: Mueller
-  overall_performance: '100000000000001000000000000011100001010111101100000011111111111111111001110000100110011110011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-charlie-mueller
-  started: true
-  state_code: OR
-  state_name: Oregon
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_brinda_fisher:
-  event: hardrock_2016
-  person: brinda_fisher
-  id: 7376
-  age: 22
-  beacon_url:
-  beyond_start: true
-  bib_number: 37
-  bib_number_hardcoded:
-  birthdate:
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 149907
-  finished: false
-  first_name: Brinda
-  gender: 1
-  last_name: Fisher
-  overall_performance: '100000000000001000000000000010110111010000000100000011111111111111111010010110100110000111011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-brinda-fisher
-  started: true
-  state_code: SC
-  state_name: South Carolina
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_rene_mclaughlin:
-  event: hardrock_2016
-  person: rene_mclaughlin
-  id: 7380
-  age: 32
-  beacon_url:
-  beyond_start: true
-  bib_number: 113
-  bib_number_hardcoded:
-  birthdate: 1984-04-30
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 150016
-  finished: false
-  first_name: Rene
-  gender: 0
-  last_name: McLaughlin
-  overall_performance: '100000000000001000000000000011100001010111101000000111111111111111111000111111001010011010011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-rene-mclaughlin
-  started: true
-  state_code: TX
-  state_name: Texas
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_dropped_grouse:
-  event: hardrock_2016
-  person: dropped_grouse
-  id: 7396
-  age: 47
-  beacon_url:
-  beyond_start: true
-  bib_number: 117
-  bib_number_hardcoded:
-  birthdate: 1969-05-13
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: true
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 150335
-  finished: false
-  first_name: Dropped
-  gender: 0
-  last_name: Grouse
-  overall_performance: '000000000000001000000000000010110111010000000100000011111111111111111100110110100101010111111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-dropped-grouse
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 150335
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_mervin_smitham:
-  event: hardrock_2016
-  person: mervin_smitham
-  id: 7400
-  age: 24
-  beacon_url:
-  beyond_start: true
-  bib_number: 109
-  bib_number_hardcoded:
-  birthdate: 1991-10-08
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: true
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 150403
-  finished: false
-  first_name: Mervin
-  gender: 0
-  last_name: Smitham
-  overall_performance: '000000000000001000000000000010110111010000000100000011111111111111111010111000000000110010011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-mervin-smitham
-  started: true
-  state_code: NM
-  state_name: New Mexico
-  stopped: true
-  stopped_split_time_id: 150403
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_rhett_auer:
-  event: hardrock_2016
-  person:
-  id: 7404
-  age: 41
-  beacon_url:
-  beyond_start: true
-  bib_number: 131
-  bib_number_hardcoded:
-  birthdate: 1974-11-07
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: true
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 150467
-  finished: false
-  first_name: Rhett
-  gender: 0
-  last_name: Auer
-  overall_performance: '000000000000001000000000000010001001111111010100000011111111111111111101111000010001011110011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-rhett-auer
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 150467
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_hoyt_macejkovic:
-  event: hardrock_2016
-  person: hoyt_macejkovic
-  id: 7407
-  age: 55
-  beacon_url:
-  beyond_start: true
-  bib_number: 125
-  bib_number_hardcoded:
-  birthdate: 1960-07-23
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: true
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 150506
-  finished: false
-  first_name: Hoyt
-  gender: 0
-  last_name: Macejkovic
-  overall_performance: '000000000000001000000000000010001001111111010100000011111111111111111100001100000000110000111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-hoyt-macejkovic
-  started: true
-  state_code: MD
-  state_name: Maryland
-  stopped: true
-  stopped_split_time_id: 150506
-  synced_at:
-  topic_resource_key:
-  wave:
-hardrock_2016_start_only:
-  event: hardrock_2016
-  person: start_only_maine_us
-  id: 7411
-  age: 26
-  beacon_url:
-  beyond_start: false
-  bib_number: 199
-  bib_number_hardcoded:
-  birthdate: 1990-04-23
-  checked_in: true
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 192705
-  finished: false
-  first_name: Start
-  gender: 0
-  last_name: Only
-  overall_performance: '100000000000001000000000000000000000000000000000000111111111111111111111111111111111111111111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2016-07-15 12:00:00.000000000 Z
-  slug: hardrock-2016-start-only
-  started: true
-  state_code: ME
-  state_name: Maine
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-ggd30_50k_finished_first:
-  event: ggd30_50k
-  person: finished_first_colorado_us
-  id: 15626
-  age: 44
-  beacon_url:
-  beyond_start: true
-  bib_number: 1116
-  bib_number_hardcoded:
-  birthdate: 1973-05-25
-  checked_in: true
-  city:
-  comments:
-  completed_laps: 1
-  country_code:
-  country_name:
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 188951
-  finished: true
-  first_name: Finished
-  gender: 0
-  last_name: First
-  overall_performance: '100000000000001000000000000001100001011100001000000111111111111111111110110100100001000101101101'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
-  slug: ggd30-50k-finished-first
-  started: true
-  state_code:
-  state_name:
-  stopped: true
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-ggd30_50k_bad_finish:
-  event: ggd30_50k
-  person: bad_finish
-  id: 15664
-  age: 21
-  beacon_url:
-  beyond_start: true
-  bib_number: 1079
-  bib_number_hardcoded:
-  birthdate: 1995-07-25
-  checked_in: true
-  city:
-  comments:
-  completed_laps: 1
-  country_code:
-  country_name:
-  data_status: 0
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 189055
-  finished: true
-  first_name: Bad
-  gender: 0
-  last_name: Finish
-  overall_performance: '100000000000001000000000000001100001011100001000000111111111111111111110101000000010111100110001'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
-  slug: ggd30-50k-bad-finish
-  started: true
-  state_code:
-  state_name:
-  stopped: true
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-ggd30_50k_progress_aid4:
-  event: ggd30_50k
-  person: progress_aid4
-  id: 15891
-  age: 35
-  beacon_url:
-  beyond_start: true
-  bib_number: 1118
-  bib_number_hardcoded:
-  birthdate: 1982-03-29
-  checked_in: true
-  city:
-  comments:
-  completed_laps: 0
-  country_code:
-  country_name:
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 189814
-  finished: false
-  first_name: Progress
-  gender: 1
-  last_name: Aid4
-  overall_performance: '100000000000001000000000000001001101000000100000000111111111111111111110100011000010111100011101'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
-  slug: ggd30-50k-progress-aid4
-  started: true
-  state_code:
-  state_name:
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-ggd30_50k_progress_aid3:
-  event: ggd30_50k
-  person: progress_aid3
-  id: 15901
-  age: 31
-  beacon_url:
-  beyond_start: true
-  bib_number: 219
-  bib_number_hardcoded:
-  birthdate: 1986-03-04
-  checked_in: true
-  city:
-  comments:
-  completed_laps: 0
-  country_code:
-  country_name:
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 189850
-  finished: false
-  first_name: Progress
-  gender: 0
-  last_name: Aid3
-  overall_performance: '100000000000001000000000000000110110000100000000000111111111111111111111000000001001000101011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
-  slug: ggd30-50k-progress-aid3
-  started: true
-  state_code:
-  state_name:
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-ggd30_50k_drop_aid4:
-  event: ggd30_50k
-  person: drop_aid4
-  id: 15931
-  age: 18
-  beacon_url:
-  beyond_start: true
-  bib_number: 1029
-  bib_number_hardcoded:
-  birthdate:
-  checked_in: true
-  city:
-  comments:
-  completed_laps: 0
-  country_code:
-  country_name:
-  data_status: 2
-  dropped: true
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 189952
-  finished: false
-  first_name: Drop
-  gender: 0
-  last_name: Aid4
-  overall_performance: '000000000000001000000000000001001101000000100000000111111111111111111110100010110011100000101001'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
-  slug: ggd30-50k-drop-aid4
-  started: true
-  state_code:
-  state_name:
-  stopped: true
-  stopped_split_time_id: 189952
-  synced_at:
-  topic_resource_key:
-  wave:
-ggd30_50k_start_only:
-  event: ggd30_50k
-  person: start_only_2019_02_01_07_19_53
-  id: 16023
-  age: 31
-  beacon_url:
-  beyond_start: false
-  bib_number: 433
-  bib_number_hardcoded:
-  birthdate: 1985-11-14
-  checked_in: true
-  city:
-  comments:
-  completed_laps: 0
-  country_code:
-  country_name:
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 190761
-  finished: false
-  first_name: Start
-  gender: 1
-  last_name: Only
-  overall_performance: '100000000000001000000000000000000000000000000000000111111111111111111111111111111111111111111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
-  slug: ggd30-50k-start-only
-  started: true
-  state_code:
-  state_name:
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-ggd30_50k_not_started:
-  event: ggd30_50k
-  person: not_started
-  id: 16032
-  age: 31
-  beacon_url:
-  beyond_start: false
-  bib_number: 49
-  bib_number_hardcoded:
-  birthdate: 1986-03-23
-  checked_in: true
-  city:
-  comments:
-  completed_laps: 0
-  country_code:
-  country_name:
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id:
-  finished: false
-  first_name: Not
-  gender: 0
-  last_name: Started
-  overall_performance: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-06-03 13:00:00.000000000 Z
-  slug: ggd30-50k-not-started
-  started: false
-  state_code:
-  state_name:
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-ggd30_12m_start_only:
-  event: ggd30_12m
-  person: start_only_colorado_us
-  id: 16094
-  age: 27
-  beacon_url:
-  beyond_start: false
-  bib_number: 1506
-  bib_number_hardcoded:
-  birthdate: 1989-09-09
-  checked_in: true
-  city: Aurora
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 190731
-  finished: false
-  first_name: Start
-  gender: 1
-  last_name: Only
-  overall_performance: '100000000000001000000000000000000000000000000000000111111111111111111111111111111111111111111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-06-03 16:00:00.000000000 Z
-  slug: ggd30-12m-start-only
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-ggd30_12m_finished_second:
-  event: ggd30_12m
-  person: finished_second_colorado_us
-  id: 16107
-  age: 43
-  beacon_url:
-  beyond_start: true
-  bib_number: 1519
-  bib_number_hardcoded:
-  birthdate: 1973-07-23
-  checked_in: true
-  city: Boulder
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 190273
-  finished: true
-  first_name: Finished
-  gender: 1
-  last_name: Second
-  overall_performance: '100000000000001000000000000000100110000010001000000111111111111111111111010111111101010101001101'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-06-03 16:00:00.000000000 Z
-  slug: ggd30-12m-finished-second
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-ggd30_12m_finished_first:
-  event: ggd30_12m
-  person: finished_first_france
-  id: 16173
-  age: 23
-  beacon_url:
-  beyond_start: true
-  bib_number: 1586
-  bib_number_hardcoded:
-  birthdate: 1993-06-05
-  checked_in: true
-  city: LE VIBAL
-  comments:
-  completed_laps: 1
-  country_code: FR
-  country_name: France
-  data_status:
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 190117
-  finished: true
-  first_name: Finished
-  gender: 0
-  last_name: First
-  overall_performance: '100000000000001000000000000000100110000010001000000111111111111111111111100111001111101100111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-06-03 16:00:00.000000000 Z
-  slug: ggd30-12m-finished-first
-  started: true
-  state_code: ARA
-  state_name: Auvergne-Rhône-Alpes
-  stopped: true
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-ggd30_12m_not_started:
-  event: ggd30_12m
-  person: not_started_colorado_us
-  id: 16209
-  age: 22
-  beacon_url:
-  beyond_start: false
-  bib_number: 1622
-  bib_number_hardcoded:
-  birthdate: 1995-03-06
-  checked_in: true
-  city: Greeley
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id:
-  finished: false
-  first_name: Not
-  gender: 1
-  last_name: Started
-  overall_performance: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-06-03 16:00:00.000000000 Z
-  slug: ggd30-12m-not-started
-  started: false
-  state_code: CO
-  state_name: Colorado
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-sum_55k_finished_first:
-  event: sum_55k
-  person: finished_first_colorado_us
-  id: 16227
-  age: 44
-  beacon_url:
-  beyond_start: true
-  bib_number: 134
-  bib_number_hardcoded:
-  birthdate: 1973-08-18
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 190508
-  finished: true
-  first_name: Finished
-  gender: 0
-  last_name: First
-  overall_performance: '100000000000001000000000000001101111110111101000000111111111111111111110000100110101101011001111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
-  slug: sum-55k-finished-first
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 190508
-  synced_at:
-  topic_resource_key:
-  wave:
-sum_55k_finished_second:
-  event: sum_55k
-  person: finished_second_colorado_us
-  id: 16229
-  age: 44
-  beacon_url:
-  beyond_start: true
-  bib_number: 101
-  bib_number_hardcoded:
-  birthdate: 1973-07-23
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 1
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 190528
-  finished: true
-  first_name: Finished
-  gender: 1
-  last_name: Second
-  overall_performance: '100000000000001000000000000001101111110111101000000111111111111111111110000010101010000001101111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
-  slug: sum-55k-finished-second
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 190528
-  synced_at:
-  topic_resource_key:
-  wave:
-sum_55k_not_started:
-  event: sum_55k
-  person: not_started_colorado_us_2019_02_01
-  id: 16242
-  age: 36
-  beacon_url:
-  beyond_start: false
-  bib_number: 114
-  bib_number_hardcoded:
-  birthdate: 1981-03-31
-  checked_in: true
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id:
-  finished: false
-  first_name: Not
-  gender: 2
-  last_name: Started
-  overall_performance: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
-  slug: sum-55k-not-started
-  started: false
-  state_code: CO
-  state_name: Colorado
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-sum_55k_progress_rolling:
-  event: sum_55k
-  person: progress_rolling
-  id: 16244
-  age: 55
-  beacon_url:
-  beyond_start: true
-  bib_number: 111
-  bib_number_hardcoded:
-  birthdate: 1962-04-23
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 190672
-  finished: false
-  first_name: Progress
-  gender: 1
-  last_name: Rolling
-  overall_performance: '100000000000001000000000000001000100111011101100000011111111111111111111000101101000101001011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
-  slug: sum-55k-progress-rolling
-  started: true
-  state_code: CA
-  state_name: California
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-sum_55k_drop_bandera:
-  event: sum_55k
-  person: drop_bandera
-  id: 16245
-  age: 19
-  beacon_url:
-  beyond_start: true
-  bib_number: 109
-  bib_number_hardcoded:
-  birthdate: 1998-08-31
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: true
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 190683
-  finished: false
-  first_name: Drop
-  gender: 1
-  last_name: Bandera
-  overall_performance: '000000000000001000000000000001001111100111101000000111111111111111111101111111100001010101111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
-  slug: sum-55k-drop-bandera
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: true
-  stopped_split_time_id: 190683
-  synced_at:
-  topic_resource_key:
-  wave:
-sum_55k_start_only:
-  event: sum_55k
-  person: start_only_colorado_us_2019_02_01
-  id: 16246
-  age: 49
-  beacon_url:
-  beyond_start: false
-  bib_number: 132
-  bib_number_hardcoded:
-  birthdate: 1967-10-27
-  checked_in: true
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 190816
-  finished: false
-  first_name: Start
-  gender: 0
-  last_name: Only
-  overall_performance: '100000000000001000000000000000000000000000000000000111111111111111111111111111111111111111111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
-  slug: sum-55k-start-only
-  started: true
-  state_code: CO
-  state_name: Colorado
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-sum_100k_drop_anvil:
-  event: sum_100k
-  person: drop_anvil
-  id: 16247
-  age: 28
-  beacon_url:
-  beyond_start: true
-  bib_number: 999
-  bib_number_hardcoded:
-  birthdate: 1988-09-29
-  checked_in: false
-  city: Akron
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: true
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 190695
-  finished: false
-  first_name: Drop
-  gender: 0
-  last_name: Anvil
-  overall_performance: '000000000000001000000000000010110000010011100100000011111111111111111100111010111011101100011111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-09-23 13:00:00.000000000 Z
-  slug: sum-100k-drop-anvil
-  started: true
-  state_code: OH
-  state_name: Ohio
-  stopped: true
-  stopped_split_time_id: 190695
-  synced_at:
-  topic_resource_key:
-  wave:
-sum_100k_progress_cascade:
-  event: sum_100k
-  person: progress_cascade
-  id: 16248
-  age: 20
-  beacon_url:
-  beyond_start: true
-  bib_number: 777
-  bib_number_hardcoded:
-  birthdate: 1997-05-20
-  checked_in: true
-  city: Provo
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 192704
-  finished: false
-  first_name: Progress
-  gender: 0
-  last_name: Cascade
-  overall_performance: '100000000000001000000000000001011010011101101100000011111111111111111110011100101010100100111111'
-  phone:
-  report_url:
-  scheduled_start_time:
-  slug: sum-100k-progress-cascade
-  started: true
-  state_code: UT
-  state_name: Utah
   stopped: false
   stopped_split_time_id:
   synced_at:
@@ -3941,7 +3422,6 @@ sum_100k_progress_cascade:
 rufa_2017_12h_finished_first:
   event: rufa_2017_12h
   person: finished_first
-  id: 16643
   age: 20
   beacon_url:
   beyond_start: true
@@ -3980,7 +3460,6 @@ rufa_2017_12h_finished_first:
 rufa_2017_12h_finished_lap6:
   event: rufa_2017_12h
   person: finished_lap6
-  id: 16648
   age: 53
   beacon_url:
   beyond_start: true
@@ -4016,127 +3495,9 @@ rufa_2017_12h_finished_lap6:
   synced_at:
   topic_resource_key:
   wave:
-rufa_2017_12h_progress_lap5_partial:
-  event: rufa_2017_12h
-  person: progress_lap5_partial
-  id: 16657
-  age: 28
-  beacon_url:
-  beyond_start: true
-  bib_number: 53
-  bib_number_hardcoded:
-  birthdate: 1988-09-15
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 4
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 192433
-  finished: false
-  first_name: Progress
-  gender: 0
-  last_name: Lap5 Partial
-  overall_performance: '100000000000101000000000000000001000011111001000000111111111111111111101101111111101111110110111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-02-11 14:00:00.000000000 Z
-  slug: rufa-2017-12h-progress-lap5-partial
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-rufa_2017_12h_progress_lap2:
-  event: rufa_2017_12h
-  person: progress_lap2
-  id: 16663
-  age: 24
-  beacon_url:
-  beyond_start: true
-  bib_number: 68
-  bib_number_hardcoded:
-  birthdate:
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 2
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 192502
-  finished: false
-  first_name: Progress
-  gender: 1
-  last_name: Lap2
-  overall_performance: '100000000000010000000000000000010000111110010000000111111111111111111111000101111000110000101111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-02-11 14:00:00.000000000 Z
-  slug: rufa-2017-12h-progress-lap2
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
-rufa_2017_12h_start_only:
-  event: rufa_2017_12h
-  person: start_only
-  id: 16667
-  age: 44
-  beacon_url:
-  beyond_start: false
-  bib_number: 73
-  bib_number_hardcoded:
-  birthdate: 1972-12-19
-  checked_in: false
-  city:
-  comments:
-  completed_laps: 0
-  country_code: US
-  country_name: United States
-  data_status: 2
-  dropped: false
-  email:
-  emergency_contact:
-  emergency_phone:
-  final_split_time_id: 192542
-  finished: false
-  first_name: Start
-  gender: 0
-  last_name: Only
-  overall_performance: '100000000000001000000000000000000000000000000000000111111111111111111111111111111111111111111111'
-  phone:
-  report_url:
-  scheduled_start_time: 2017-02-11 14:00:00.000000000 Z
-  slug: rufa-2017-12h-start-only
-  started: true
-  state_code: UT
-  state_name: Utah
-  stopped: false
-  stopped_split_time_id:
-  synced_at:
-  topic_resource_key:
-  wave:
 rufa_2017_12h_not_started:
   event: rufa_2017_12h
   person: not_started_utah_us
-  id: 16673
   age: 49
   beacon_url:
   beyond_start: false
@@ -4172,79 +3533,343 @@ rufa_2017_12h_not_started:
   synced_at:
   topic_resource_key:
   wave:
-sum_100k_un_started:
-  event: sum_100k
-  person: un_started
-  id: 16683
-  age: 29
+rufa_2017_12h_progress_lap2:
+  event: rufa_2017_12h
+  person: progress_lap2
+  age: 24
+  beacon_url:
+  beyond_start: true
+  bib_number: 68
+  bib_number_hardcoded:
+  birthdate:
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 2
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 192502
+  finished: false
+  first_name: Progress
+  gender: 1
+  last_name: Lap2
+  overall_performance: '100000000000010000000000000000010000111110010000000111111111111111111111000101111000110000101111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-02-11 14:00:00.000000000 Z
+  slug: rufa-2017-12h-progress-lap2
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+rufa_2017_12h_progress_lap5_partial:
+  event: rufa_2017_12h
+  person: progress_lap5_partial
+  age: 28
+  beacon_url:
+  beyond_start: true
+  bib_number: 53
+  bib_number_hardcoded:
+  birthdate: 1988-09-15
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 4
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 192433
+  finished: false
+  first_name: Progress
+  gender: 0
+  last_name: Lap5 Partial
+  overall_performance: '100000000000101000000000000000001000011111001000000111111111111111111101101111111101111110110111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-02-11 14:00:00.000000000 Z
+  slug: rufa-2017-12h-progress-lap5-partial
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+rufa_2017_12h_start_only:
+  event: rufa_2017_12h
+  person: start_only
+  age: 44
   beacon_url:
   beyond_start: false
-  bib_number: 444
+  bib_number: 73
   bib_number_hardcoded:
-  birthdate: 1988-09-01
+  birthdate: 1972-12-19
   checked_in: false
-  city: Fort Collins
+  city:
   comments:
   completed_laps: 0
   country_code: US
   country_name: United States
-  data_status:
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 192542
+  finished: false
+  first_name: Start
+  gender: 0
+  last_name: Only
+  overall_performance: '100000000000001000000000000000000000000000000000000111111111111111111111111111111111111111111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-02-11 14:00:00.000000000 Z
+  slug: rufa-2017-12h-start-only
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+rufa_2017_24h_finished_first:
+  event: rufa_2017_24h
+  person: finished_first_utah_us
+  age: 47
+  beacon_url:
+  beyond_start: true
+  bib_number: 16
+  bib_number_hardcoded:
+  birthdate: 1969-04-04
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 7
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 133983
+  finished: true
+  first_name: Finished
+  gender: 1
+  last_name: First
+  overall_performance: '100000000000111000000000000000010000111110010000000111111111111111111100010110111111111000111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-02-11 13:10:00.000000000 Z
+  slug: rufa-2017-24h-finished-first
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: true
+  stopped_split_time_id: 133983
+  synced_at:
+  topic_resource_key:
+  wave:
+rufa_2017_24h_finished_last:
+  event: rufa_2017_24h
+  person: finished_last
+  age: 40
+  beacon_url:
+  beyond_start: true
+  bib_number: 112
+  bib_number_hardcoded:
+  birthdate: 1976-05-03
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 2
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 135012
+  finished: true
+  first_name: Finished
+  gender: 0
+  last_name: Last
+  overall_performance: '100000000000010000000000000000010000111110010000000111111111111111111111001001110000010100011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-02-11 15:00:00.000000000 Z
+  slug: rufa-2017-24h-finished-last
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: true
+  stopped_split_time_id: 135012
+  synced_at:
+  topic_resource_key:
+  wave:
+rufa_2017_24h_multiple_stops:
+  event: rufa_2017_24h
+  person: multiple_stops_utah_us
+  age: 43
+  beacon_url:
+  beyond_start: true
+  bib_number: 142
+  bib_number_hardcoded:
+  birthdate: 1973-11-14
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 3
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 134812
+  finished: true
+  first_name: Multiple
+  gender: 1
+  last_name: Stops
+  overall_performance: '100000000000011000000000000000010000111110010000000111111111111111111110110001101110001110111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-02-11 15:00:00.000000000 Z
+  slug: rufa-2017-24h-multiple-stops
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: true
+  stopped_split_time_id: 134812
+  synced_at:
+  topic_resource_key:
+  wave:
+rufa_2017_24h_not_started:
+  event: rufa_2017_24h
+  person: not_started
+  age: 30
+  beacon_url:
+  beyond_start: false
+  bib_number: 149
+  bib_number_hardcoded:
+  birthdate: 1986-03-23
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
   dropped: false
   email:
   emergency_contact:
   emergency_phone:
   final_split_time_id:
   finished: false
-  first_name: Un
-  gender: 1
+  first_name: Not
+  gender: 0
   last_name: Started
   overall_performance: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
   phone:
   report_url:
-  scheduled_start_time: 2017-09-23 13:00:00.000000000 Z
-  slug: sum-100k-un-started
+  scheduled_start_time: 2017-02-12 01:00:00.000000000 Z
+  slug: rufa-2017-24h-not-started
   started: false
-  state_code: CO
-  state_name: Colorado
+  state_code: UT
+  state_name: Utah
   stopped: false
   stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
-sum_100k_on_dst_change:
-  event: sum_100k
-  person: on_dst_change
-  id: 16684
-  age:
+rufa_2017_24h_progress_lap1:
+  event: rufa_2017_24h
+  person: progress_lap1
+  age: 49
   beacon_url:
   beyond_start: true
-  bib_number: 333
+  bib_number: 134
   bib_number_hardcoded:
-  birthdate:
+  birthdate: 1967-03-21
   checked_in: false
   city:
   comments:
-  completed_laps: 0
-  country_code:
-  country_name:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 1
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 135134
+  finished: false
+  first_name: Progress
+  gender: 0
+  last_name: Lap1
+  overall_performance: '100000000000001000000000000000010000111110010000000111111111111111111111011000011001110100011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-02-11 16:00:00.000000000 Z
+  slug: rufa-2017-24h-progress-lap1
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+rufa_2017_24h_progress_lap6:
+  event: rufa_2017_24h
+  person: progress_lap6
+  age: 33
+  beacon_url:
+  beyond_start: true
+  bib_number: 60
+  bib_number_hardcoded:
+  birthdate: 1983-03-13
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 6
+  country_code: US
+  country_name: United States
   data_status: 2
   dropped: false
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192715
+  final_split_time_id: 134018
   finished: false
-  first_name: 'On'
-  gender: 1
-  last_name: DST Change
-  overall_performance: '100000000000001000000000000000100011110101011000000111111111111111111111011110110011111110011111'
+  first_name: Progress
+  gender: 0
+  last_name: Lap6
+  overall_performance: '100000000000110000000000000000010000111110010000000111111111111111111101110010000101111101111111'
   phone:
   report_url:
-  scheduled_start_time:
-  slug: sum-100k-on-dst-change
+  scheduled_start_time: 2017-02-11 15:00:00.000000000 Z
+  slug: rufa-2017-24h-progress-lap6
   started: true
-  state_code:
-  state_name:
+  state_code: UT
+  state_name: Utah
   stopped: false
   stopped_split_time_id:
   synced_at:
@@ -4253,7 +3878,6 @@ sum_100k_on_dst_change:
 sum_100k_across_dst_change:
   event: sum_100k
   person: across_dst_change
-  id: 16685
   age:
   beacon_url:
   beyond_start: true
@@ -4289,20 +3913,57 @@ sum_100k_across_dst_change:
   synced_at:
   topic_resource_key:
   wave:
-ggd30_50k_finished_second:
-  event: ggd30_50k
-  person:
-  id: 16686
-  age: 43
+sum_100k_drop_anvil:
+  event: sum_100k
+  person: drop_anvil
+  age: 28
   beacon_url:
   beyond_start: true
-  bib_number: 1117
+  bib_number: 999
   bib_number_hardcoded:
-  birthdate: 1975-07-25
+  birthdate: 1988-09-29
+  checked_in: false
+  city: Akron
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: true
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 190695
+  finished: false
+  first_name: Drop
+  gender: 0
+  last_name: Anvil
+  overall_performance: '000000000000001000000000000010110000010011100100000011111111111111111100111010111011101100011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-09-23 13:00:00.000000000 Z
+  slug: sum-100k-drop-anvil
+  started: true
+  state_code: OH
+  state_name: Ohio
+  stopped: true
+  stopped_split_time_id: 190695
+  synced_at:
+  topic_resource_key:
+  wave:
+sum_100k_on_dst_change:
+  event: sum_100k
+  person: on_dst_change
+  age:
+  beacon_url:
+  beyond_start: true
+  bib_number: 333
+  bib_number_hardcoded:
+  birthdate:
   checked_in: false
   city:
   comments:
-  completed_laps: 1
+  completed_laps: 0
   country_code:
   country_name:
   data_status: 2
@@ -4310,36 +3971,149 @@ ggd30_50k_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192722
-  finished: true
-  first_name: Finished
+  final_split_time_id: 192715
+  finished: false
+  first_name: 'On'
   gender: 1
-  last_name: Second
-  overall_performance: '100000000000001000000000000001100001011100001000000111111111111111111110101010110110110001111111'
+  last_name: DST Change
+  overall_performance: '100000000000001000000000000000100011110101011000000111111111111111111111011110110011111110011111'
   phone:
   report_url:
   scheduled_start_time:
-  slug: ggd30-50k-finished-second
+  slug: sum-100k-on-dst-change
   started: true
   state_code:
   state_name:
-  stopped: true
+  stopped: false
   stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
-ggd30_12m_series_finisher:
-  event: ggd30_12m
-  person: series_finisher
-  id: 16687
-  age: 34
+sum_100k_progress_cascade:
+  event: sum_100k
+  person: progress_cascade
+  age: 20
   beacon_url:
   beyond_start: true
-  bib_number: 1515
+  bib_number: 777
   bib_number_hardcoded:
-  birthdate: 1983-03-03
+  birthdate: 1997-05-20
+  checked_in: true
+  city: Provo
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 192704
+  finished: false
+  first_name: Progress
+  gender: 0
+  last_name: Cascade
+  overall_performance: '100000000000001000000000000001011010011101101100000011111111111111111110011100101010100100111111'
+  phone:
+  report_url:
+  scheduled_start_time:
+  slug: sum-100k-progress-cascade
+  started: true
+  state_code: UT
+  state_name: Utah
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+sum_100k_un_started:
+  event: sum_100k
+  person: un_started
+  age: 29
+  beacon_url:
+  beyond_start: false
+  bib_number: 444
+  bib_number_hardcoded:
+  birthdate: 1988-09-01
   checked_in: false
-  city: Superior
+  city: Fort Collins
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status:
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id:
+  finished: false
+  first_name: Un
+  gender: 1
+  last_name: Started
+  overall_performance: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-09-23 13:00:00.000000000 Z
+  slug: sum-100k-un-started
+  started: false
+  state_code: CO
+  state_name: Colorado
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+sum_55k_drop_bandera:
+  event: sum_55k
+  person: drop_bandera
+  age: 19
+  beacon_url:
+  beyond_start: true
+  bib_number: 109
+  bib_number_hardcoded:
+  birthdate: 1998-08-31
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: true
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 190683
+  finished: false
+  first_name: Drop
+  gender: 1
+  last_name: Bandera
+  overall_performance: '000000000000001000000000000001001111100111101000000111111111111111111101111111100001010101111111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
+  slug: sum-55k-drop-bandera
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 190683
+  synced_at:
+  topic_resource_key:
+  wave:
+sum_55k_finished_first:
+  event: sum_55k
+  person: finished_first_colorado_us
+  age: 44
+  beacon_url:
+  beyond_start: true
+  bib_number: 134
+  bib_number_hardcoded:
+  birthdate: 1973-08-18
+  checked_in: false
+  city:
   comments:
   completed_laps: 1
   country_code: US
@@ -4349,20 +4123,134 @@ ggd30_12m_series_finisher:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192724
+  final_split_time_id: 190508
   finished: true
-  first_name: Series
+  first_name: Finished
   gender: 0
-  last_name: Finisher
-  overall_performance: '100000000000001000000000000000100110000010001000000111111111111111111111010111111100100001011111'
+  last_name: First
+  overall_performance: '100000000000001000000000000001101111110111101000000111111111111111111110000100110101101011001111'
   phone:
   report_url:
-  scheduled_start_time:
-  slug: ggd30-12m-series-finisher
+  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
+  slug: sum-55k-finished-first
   started: true
   state_code: CO
   state_name: Colorado
   stopped: true
+  stopped_split_time_id: 190508
+  synced_at:
+  topic_resource_key:
+  wave:
+sum_55k_finished_second:
+  event: sum_55k
+  person: finished_second_colorado_us
+  age: 44
+  beacon_url:
+  beyond_start: true
+  bib_number: 101
+  bib_number_hardcoded:
+  birthdate: 1973-07-23
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 1
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 190528
+  finished: true
+  first_name: Finished
+  gender: 1
+  last_name: Second
+  overall_performance: '100000000000001000000000000001101111110111101000000111111111111111111110000010101010000001101111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
+  slug: sum-55k-finished-second
+  started: true
+  state_code: CO
+  state_name: Colorado
+  stopped: true
+  stopped_split_time_id: 190528
+  synced_at:
+  topic_resource_key:
+  wave:
+sum_55k_not_started:
+  event: sum_55k
+  person: not_started_colorado_us_2019_02_01
+  age: 36
+  beacon_url:
+  beyond_start: false
+  bib_number: 114
+  bib_number_hardcoded:
+  birthdate: 1981-03-31
+  checked_in: true
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id:
+  finished: false
+  first_name: Not
+  gender: 2
+  last_name: Started
+  overall_performance: '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
+  slug: sum-55k-not-started
+  started: false
+  state_code: CO
+  state_name: Colorado
+  stopped: false
+  stopped_split_time_id:
+  synced_at:
+  topic_resource_key:
+  wave:
+sum_55k_progress_rolling:
+  event: sum_55k
+  person: progress_rolling
+  age: 55
+  beacon_url:
+  beyond_start: true
+  bib_number: 111
+  bib_number_hardcoded:
+  birthdate: 1962-04-23
+  checked_in: false
+  city:
+  comments:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
+  data_status: 2
+  dropped: false
+  email:
+  emergency_contact:
+  emergency_phone:
+  final_split_time_id: 190672
+  finished: false
+  first_name: Progress
+  gender: 1
+  last_name: Rolling
+  overall_performance: '100000000000001000000000000001000100111011101100000011111111111111111111000101101000101001011111'
+  phone:
+  report_url:
+  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
+  slug: sum-55k-progress-rolling
+  started: true
+  state_code: CA
+  state_name: California
+  stopped: false
   stopped_split_time_id:
   synced_at:
   topic_resource_key:
@@ -4370,7 +4258,6 @@ ggd30_12m_series_finisher:
 sum_55k_series_finisher:
   event: sum_55k
   person: series_finisher
-  id: 16688
   age: 34
   beacon_url:
   beyond_start: true
@@ -4409,7 +4296,6 @@ sum_55k_series_finisher:
 sum_55k_slow_finisher:
   event: sum_55k
   person: slow_finisher
-  id: 16689
   age: 64
   beacon_url:
   beyond_start: true
@@ -4445,41 +4331,40 @@ sum_55k_slow_finisher:
   synced_at:
   topic_resource_key:
   wave:
-ggd30_12m_slow_finisher:
-  event: ggd30_12m
-  person: slow_finisher
-  id: 16690
-  age: 64
+sum_55k_start_only:
+  event: sum_55k
+  person: start_only_colorado_us_2019_02_01
+  age: 49
   beacon_url:
-  beyond_start: true
-  bib_number: 1616
+  beyond_start: false
+  bib_number: 132
   bib_number_hardcoded:
-  birthdate: 1953-03-03
-  checked_in: false
-  city: Orem
+  birthdate: 1967-10-27
+  checked_in: true
+  city:
   comments:
-  completed_laps: 1
-  country_code:
-  country_name:
+  completed_laps: 0
+  country_code: US
+  country_name: United States
   data_status: 2
   dropped: false
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192746
-  finished: true
-  first_name: Slow
+  final_split_time_id: 190816
+  finished: false
+  first_name: Start
   gender: 0
-  last_name: Finisher
-  overall_performance: '100000000000001000000000000000100110000010001000000111111111111111111111000001101101001011101111'
+  last_name: Only
+  overall_performance: '100000000000001000000000000000000000000000000000000111111111111111111111111111111111111111111111'
   phone:
   report_url:
-  scheduled_start_time:
-  slug: ggd30-12m-slow-finisher
+  scheduled_start_time: 2017-10-07 15:00:00.000000000 Z
+  slug: sum-55k-start-only
   started: true
-  state_code: UT
-  state_name:
-  stopped: true
+  state_code: CO
+  state_name: Colorado
+  stopped: false
   stopped_split_time_id:
   synced_at:
   topic_resource_key:

--- a/spec/fixtures/notifications.yml
+++ b/spec/fixtures/notifications.yml
@@ -1,809 +1,809 @@
 ---
 notification_0001:
+  effort: rufa_2017_12h_progress_lap2
   id: 1
   bitkey: 1
   distance: 8690
-  effort_id: 16663
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0002:
+  effort: rufa_2017_12h_start_only
   id: 2
   bitkey: 1
   distance: 0
-  effort_id: 16667
   follower_ids: "{4,3}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0003:
+  effort: rufa_2017_12h_start_only
   id: 3
   bitkey: 1
   distance: 8690
-  effort_id: 16667
   follower_ids: "{3}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0004:
+  effort: rufa_2017_12h_start_only
   id: 4
   bitkey: 1
   distance: 4345
-  effort_id: 16667
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0005:
+  effort: rufa_2017_24h_progress_lap1
   id: 5
   bitkey: 1
   distance: 4345
-  effort_id: 6805
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0006:
+  effort: rufa_2017_12h_progress_lap2
   id: 6
   bitkey: 1
   distance: 8690
-  effort_id: 16663
   follower_ids: "{11,4}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0007:
+  effort: rufa_2017_12h_finished_lap6
   id: 7
   bitkey: 1
   distance: 8690
-  effort_id: 16648
   follower_ids: "{11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0008:
+  effort: rufa_2017_24h_progress_lap1
   id: 8
   bitkey: 1
   distance: 4345
-  effort_id: 6805
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0009:
+  effort: rufa_2017_12h_finished_first
   id: 9
   bitkey: 1
   distance: 4345
-  effort_id: 16643
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0010:
+  effort: rufa_2017_24h_finished_first
   id: 10
   bitkey: 1
   distance: 4345
-  effort_id: 6693
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0011:
+  effort: rufa_2017_24h_multiple_stops
   id: 11
   bitkey: 1
   distance: 0
-  effort_id: 6756
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0012:
+  effort: rufa_2017_24h_progress_lap6
   id: 12
   bitkey: 1
   distance: 0
-  effort_id: 6695
   follower_ids: "{1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0013:
+  effort: rufa_2017_12h_start_only
   id: 13
   bitkey: 1
   distance: 4345
-  effort_id: 16667
   follower_ids: "{11,1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0014:
+  effort: rufa_2017_24h_not_started
   id: 14
   bitkey: 1
   distance: 8690
-  effort_id: 6782
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0015:
+  effort: rufa_2017_12h_not_started
   id: 15
   bitkey: 1
   distance: 0
-  effort_id: 16673
   follower_ids: "{1,11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0016:
+  effort: rufa_2017_12h_not_started
   id: 16
   bitkey: 1
   distance: 4345
-  effort_id: 16673
   follower_ids: "{1,11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0017:
+  effort: rufa_2017_12h_progress_lap2
   id: 17
   bitkey: 1
   distance: 4345
-  effort_id: 16663
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0018:
+  effort: rufa_2017_12h_finished_first
   id: 18
   bitkey: 1
   distance: 4345
-  effort_id: 16643
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0019:
+  effort: rufa_2017_24h_progress_lap1
   id: 19
   bitkey: 1
   distance: 8690
-  effort_id: 6805
   follower_ids: "{1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0020:
+  effort: rufa_2017_12h_finished_lap6
   id: 20
   bitkey: 1
   distance: 4345
-  effort_id: 16648
   follower_ids: "{3,1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0021:
+  effort: rufa_2017_12h_progress_lap2
   id: 21
   bitkey: 1
   distance: 8690
-  effort_id: 16663
   follower_ids: "{4}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0022:
+  effort: rufa_2017_12h_finished_first
   id: 22
   bitkey: 1
   distance: 4345
-  effort_id: 16643
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0023:
+  effort: rufa_2017_12h_start_only
   id: 23
   bitkey: 1
   distance: 0
-  effort_id: 16667
   follower_ids: "{3,1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0024:
+  effort: rufa_2017_24h_progress_lap6
   id: 24
   bitkey: 1
   distance: 8690
-  effort_id: 6695
   follower_ids: "{4,1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0025:
+  effort: rufa_2017_24h_progress_lap1
   id: 25
   bitkey: 1
   distance: 8690
-  effort_id: 6805
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0026:
+  effort: rufa_2017_12h_finished_first
   id: 26
   bitkey: 1
   distance: 0
-  effort_id: 16643
   follower_ids: "{3,1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0027:
+  effort: rufa_2017_24h_progress_lap1
   id: 27
   bitkey: 1
   distance: 4345
-  effort_id: 6805
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0028:
+  effort: rufa_2017_12h_not_started
   id: 28
   bitkey: 1
   distance: 8690
-  effort_id: 16673
   follower_ids: "{1,11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0029:
+  effort: rufa_2017_12h_progress_lap2
   id: 29
   bitkey: 1
   distance: 4345
-  effort_id: 16663
   follower_ids: "{1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0030:
+  effort: rufa_2017_24h_finished_last
   id: 30
   bitkey: 1
   distance: 4345
-  effort_id: 6780
   follower_ids: "{3,11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0031:
+  effort: rufa_2017_24h_not_started
   id: 31
   bitkey: 1
   distance: 0
-  effort_id: 6782
   follower_ids: "{11,4}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0032:
+  effort: rufa_2017_12h_start_only
   id: 32
   bitkey: 1
   distance: 4345
-  effort_id: 16667
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0033:
+  effort: rufa_2017_24h_finished_first
   id: 33
   bitkey: 1
   distance: 0
-  effort_id: 6693
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0034:
+  effort: rufa_2017_12h_not_started
   id: 34
   bitkey: 1
   distance: 0
-  effort_id: 16673
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0035:
+  effort: rufa_2017_24h_finished_last
   id: 35
   bitkey: 1
   distance: 8690
-  effort_id: 6780
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0036:
+  effort: rufa_2017_12h_finished_lap6
   id: 36
   bitkey: 1
   distance: 8690
-  effort_id: 16648
   follower_ids: "{3,4}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0037:
+  effort: rufa_2017_24h_multiple_stops
   id: 37
   bitkey: 1
   distance: 4345
-  effort_id: 6756
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0038:
+  effort: rufa_2017_12h_finished_lap6
   id: 38
   bitkey: 1
   distance: 8690
-  effort_id: 16648
   follower_ids: "{3,11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0039:
+  effort: rufa_2017_12h_not_started
   id: 39
   bitkey: 1
   distance: 8690
-  effort_id: 16673
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0040:
+  effort: rufa_2017_12h_finished_lap6
   id: 40
   bitkey: 1
   distance: 4345
-  effort_id: 16648
   follower_ids: "{4}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0041:
+  effort: rufa_2017_24h_progress_lap6
   id: 41
   bitkey: 1
   distance: 4345
-  effort_id: 6695
   follower_ids: "{4,11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0042:
+  effort: rufa_2017_12h_not_started
   id: 42
   bitkey: 1
   distance: 8690
-  effort_id: 16673
   follower_ids: "{11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0043:
+  effort: rufa_2017_24h_progress_lap1
   id: 43
   bitkey: 1
   distance: 0
-  effort_id: 6805
   follower_ids: "{3,4}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0044:
+  effort: rufa_2017_24h_finished_first
   id: 44
   bitkey: 1
   distance: 0
-  effort_id: 6693
   follower_ids: "{4,1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0045:
+  effort: rufa_2017_24h_progress_lap1
   id: 45
   bitkey: 1
   distance: 0
-  effort_id: 6805
   follower_ids: "{11,1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0046:
+  effort: rufa_2017_24h_multiple_stops
   id: 46
   bitkey: 1
   distance: 4345
-  effort_id: 6756
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0047:
+  effort: rufa_2017_12h_not_started
   id: 47
   bitkey: 1
   distance: 0
-  effort_id: 16673
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0048:
+  effort: rufa_2017_12h_progress_lap5_partial
   id: 48
   bitkey: 1
   distance: 8690
-  effort_id: 16657
   follower_ids: "{11,1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0049:
+  effort: rufa_2017_12h_not_started
   id: 49
   bitkey: 1
   distance: 4345
-  effort_id: 16673
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0050:
+  effort: rufa_2017_12h_finished_first
   id: 50
   bitkey: 1
   distance: 8690
-  effort_id: 16643
   follower_ids: "{11,1}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0051:
+  effort: rufa_2017_12h_finished_lap6
   id: 51
   bitkey: 1
   distance: 8690
-  effort_id: 16648
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0052:
+  effort: rufa_2017_24h_progress_lap1
   id: 52
   bitkey: 1
   distance: 8690
-  effort_id: 6805
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0053:
+  effort: rufa_2017_12h_finished_lap6
   id: 53
   bitkey: 1
   distance: 4345
-  effort_id: 16648
   follower_ids: "{3}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0054:
+  effort: rufa_2017_12h_finished_lap6
   id: 54
   bitkey: 1
   distance: 8690
-  effort_id: 16648
   follower_ids: "{3}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0055:
+  effort: rufa_2017_24h_progress_lap6
   id: 55
   bitkey: 1
   distance: 0
-  effort_id: 6695
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0056:
+  effort: rufa_2017_12h_finished_first
   id: 56
   bitkey: 1
   distance: 4345
-  effort_id: 16643
   follower_ids: "{11,3}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0057:
+  effort: rufa_2017_24h_finished_last
   id: 57
   bitkey: 1
   distance: 8690
-  effort_id: 6780
   follower_ids: "{3,11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0058:
+  effort: rufa_2017_12h_start_only
   id: 58
   bitkey: 1
   distance: 8690
-  effort_id: 16667
   follower_ids: "{3,11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0059:
+  effort: rufa_2017_12h_not_started
   id: 59
   bitkey: 1
   distance: 8690
-  effort_id: 16673
   follower_ids: "{3}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0060:
+  effort: rufa_2017_12h_start_only
   id: 60
   bitkey: 1
   distance: 0
-  effort_id: 16667
   follower_ids: "{11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0061:
+  effort: rufa_2017_12h_progress_lap5_partial
   id: 61
   bitkey: 1
   distance: 4345
-  effort_id: 16657
   follower_ids: "{3,11}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0062:
+  effort: rufa_2017_24h_finished_first
   id: 62
   bitkey: 1
   distance: 0
-  effort_id: 6693
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0063:
+  effort: rufa_2017_24h_finished_first
   id: 63
   bitkey: 1
   distance: 0
-  effort_id: 6693
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0064:
+  effort: rufa_2017_24h_progress_lap6
   id: 64
   bitkey: 1
   distance: 4345
-  effort_id: 6695
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0065:
+  effort: rufa_2017_24h_progress_lap6
   id: 65
   bitkey: 1
   distance: 0
-  effort_id: 6695
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0066:
+  effort: rufa_2017_12h_progress_lap5_partial
   id: 66
   bitkey: 1
   distance: 0
-  effort_id: 16657
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0067:
+  effort: rufa_2017_12h_finished_lap6
   id: 67
   bitkey: 1
   distance: 8690
-  effort_id: 16648
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0068:
+  effort: rufa_2017_24h_not_started
   id: 68
   bitkey: 1
   distance: 4345
-  effort_id: 6782
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0069:
+  effort: rufa_2017_12h_finished_lap6
   id: 69
   bitkey: 1
   distance: 0
-  effort_id: 16648
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0070:
+  effort: rufa_2017_12h_finished_lap6
   id: 70
   bitkey: 1
   distance: 8690
-  effort_id: 16648
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0071:
+  effort: rufa_2017_24h_multiple_stops
   id: 71
   bitkey: 1
   distance: 4345
-  effort_id: 6756
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0072:
+  effort: rufa_2017_24h_progress_lap6
   id: 72
   bitkey: 1
   distance: 4345
-  effort_id: 6695
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0073:
+  effort: rufa_2017_12h_progress_lap5_partial
   id: 73
   bitkey: 1
   distance: 8690
-  effort_id: 16657
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0074:
+  effort: rufa_2017_24h_finished_last
   id: 74
   bitkey: 1
   distance: 0
-  effort_id: 6780
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0075:
+  effort: rufa_2017_24h_finished_last
   id: 75
   bitkey: 1
   distance: 8690
-  effort_id: 6780
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0076:
+  effort: rufa_2017_24h_finished_last
   id: 76
   bitkey: 1
   distance: 4345
-  effort_id: 6780
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0077:
+  effort: rufa_2017_24h_not_started
   id: 77
   bitkey: 1
   distance: 8690
-  effort_id: 6782
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0078:
+  effort: rufa_2017_24h_finished_last
   id: 78
   bitkey: 1
   distance: 0
-  effort_id: 6780
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0079:
+  effort: rufa_2017_12h_finished_lap6
   id: 79
   bitkey: 1
   distance: 0
-  effort_id: 16648
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0080:
+  effort: rufa_2017_12h_progress_lap2
   id: 80
   bitkey: 1
   distance: 0
-  effort_id: 16663
   follower_ids: "{}"
   kind:
   notice_text:
   subject:
   topic_resource_key:
 notification_0081:
+  effort: rufa_2017_24h_multiple_stops
   id: 81
   bitkey: 1
   distance: 8690
-  effort_id: 6756
   follower_ids: "{}"
   kind:
   notice_text:

--- a/spec/fixtures/split_times.yml
+++ b/spec/fixtures/split_times.yml
@@ -1,10 +1,10 @@
 ---
 hardrock_2015_tuan_jacobs_cunningham_in_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_cunningham
   id: 14
   absolute_time: 2015-07-10 13:38:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 5880.0
   lap: 1
   pacer: false
@@ -13,11 +13,11 @@ hardrock_2015_tuan_jacobs_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_cunningham_out_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_cunningham
   id: 15
   absolute_time: 2015-07-10 13:38:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 5880.0
   lap: 1
   pacer: false
@@ -26,11 +26,11 @@ hardrock_2015_tuan_jacobs_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_sherman_in_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_sherman
   id: 20
   absolute_time: 2015-07-10 17:38:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 20280.0
   lap: 1
   pacer:
@@ -39,11 +39,11 @@ hardrock_2015_tuan_jacobs_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_sherman_out_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_sherman
   id: 21
   absolute_time: 2015-07-10 17:39:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 20340.0
   lap: 1
   pacer:
@@ -52,11 +52,11 @@ hardrock_2015_tuan_jacobs_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_grouse_in_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_grouse
   id: 24
   absolute_time: 2015-07-10 20:52:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 31920.0
   lap: 1
   pacer: false
@@ -65,11 +65,11 @@ hardrock_2015_tuan_jacobs_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_grouse_out_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_grouse
   id: 25
   absolute_time: 2015-07-10 20:57:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 32220.0
   lap: 1
   pacer: false
@@ -78,11 +78,11 @@ hardrock_2015_tuan_jacobs_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_ouray_in_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_ouray
   id: 28
   absolute_time: 2015-07-10 23:39:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 41940.0
   lap: 1
   pacer:
@@ -91,11 +91,11 @@ hardrock_2015_tuan_jacobs_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_ouray_out_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_ouray
   id: 29
   absolute_time: 2015-07-10 23:45:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 42300.0
   lap: 1
   pacer:
@@ -104,11 +104,11 @@ hardrock_2015_tuan_jacobs_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_telluride_in_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_telluride
   id: 34
   absolute_time: 2015-07-11 03:12:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 54720.0
   lap: 1
   pacer:
@@ -117,11 +117,11 @@ hardrock_2015_tuan_jacobs_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_telluride_out_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_telluride
   id: 35
   absolute_time: 2015-07-11 03:22:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 55320.0
   lap: 1
   pacer:
@@ -130,11 +130,11 @@ hardrock_2015_tuan_jacobs_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_putnam_in_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_putnam
   id: 40
   absolute_time: 2015-07-11 10:06:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 79560.0
   lap: 1
   pacer: false
@@ -143,11 +143,11 @@ hardrock_2015_tuan_jacobs_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_putnam_out_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_putnam
   id: 41
   absolute_time: 2015-07-11 10:06:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 79560.0
   lap: 1
   pacer: false
@@ -156,11 +156,11 @@ hardrock_2015_tuan_jacobs_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_tuan_jacobs_finish_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_finish
   id: 42
   absolute_time: 2015-07-11 11:13:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 83580.0
   lap: 1
   pacer:
@@ -169,11 +169,11 @@ hardrock_2015_tuan_jacobs_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_start_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_start
   id: 43
   absolute_time: 2015-07-10 12:00:11.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -182,11 +182,11 @@ hardrock_2015_erich_larson_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_cunningham_in_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_cunningham
   id: 44
   absolute_time: 2015-07-10 14:00:22.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 7211.0
   lap: 1
   pacer:
@@ -195,11 +195,11 @@ hardrock_2015_erich_larson_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_cunningham_out_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_cunningham
   id: 45
   absolute_time: 2015-07-10 14:01:33.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 7282.0
   lap: 1
   pacer:
@@ -208,11 +208,11 @@ hardrock_2015_erich_larson_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_sherman_in_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_sherman
   id: 50
   absolute_time: 2015-07-10 18:06:50.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 21999.0
   lap: 1
   pacer:
@@ -221,11 +221,11 @@ hardrock_2015_erich_larson_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_sherman_out_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_sherman
   id: 51
   absolute_time: 2015-07-10 18:07:00.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 22009.0
   lap: 1
   pacer:
@@ -234,11 +234,11 @@ hardrock_2015_erich_larson_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_grouse_in_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_grouse
   id: 54
   absolute_time: 2015-07-10 21:21:00.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 33649.0
   lap: 1
   pacer:
@@ -247,11 +247,11 @@ hardrock_2015_erich_larson_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_grouse_out_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_grouse
   id: 55
   absolute_time: 2015-07-10 21:24:59.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 33888.0
   lap: 1
   pacer:
@@ -260,11 +260,11 @@ hardrock_2015_erich_larson_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_ouray_in_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_ouray
   id: 58
   absolute_time: 2015-07-11 00:20:00.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 44389.0
   lap: 1
   pacer:
@@ -273,11 +273,11 @@ hardrock_2015_erich_larson_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_ouray_out_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_ouray
   id: 59
   absolute_time: 2015-07-11 00:24:00.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 44629.0
   lap: 1
   pacer:
@@ -286,11 +286,11 @@ hardrock_2015_erich_larson_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_telluride_in_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_telluride
   id: 64
   absolute_time: 2015-07-11 04:29:00.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 59329.0
   lap: 1
   pacer:
@@ -299,11 +299,11 @@ hardrock_2015_erich_larson_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_telluride_out_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_telluride
   id: 65
   absolute_time: 2015-07-11 04:33:03.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 59572.0
   lap: 1
   pacer:
@@ -312,11 +312,11 @@ hardrock_2015_erich_larson_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_putnam_in_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_putnam
   id: 70
   absolute_time: 2015-07-11 12:39:05.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 88734.0
   lap: 1
   pacer:
@@ -325,11 +325,11 @@ hardrock_2015_erich_larson_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_erich_larson_putnam_out_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_putnam
   id: 71
   absolute_time: 2015-07-11 12:39:07.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 88736.0
   lap: 1
   pacer:
@@ -338,11 +338,11 @@ hardrock_2015_erich_larson_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_erich_larson_finish_1:
+  effort: hardrock_2015_erich_larson
   split: hardrock_ccw_finish
   id: 72
   absolute_time: 2015-07-11 13:45:09.000000000 Z
   data_status: 2
-  effort_id: 8
   elapsed_seconds: 92698.0
   lap: 1
   pacer:
@@ -351,11 +351,11 @@ hardrock_2015_erich_larson_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_start_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_start
   id: 253
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -364,11 +364,11 @@ hardrock_2015_leif_carter_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_cunningham_in_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_cunningham
   id: 254
   absolute_time: 2015-07-10 13:53:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 6780.0
   lap: 1
   pacer:
@@ -377,11 +377,11 @@ hardrock_2015_leif_carter_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_cunningham_out_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_cunningham
   id: 255
   absolute_time: 2015-07-10 13:53:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 6780.0
   lap: 1
   pacer:
@@ -390,11 +390,11 @@ hardrock_2015_leif_carter_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_sherman_in_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_sherman
   id: 260
   absolute_time: 2015-07-10 18:06:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 21960.0
   lap: 1
   pacer:
@@ -403,11 +403,11 @@ hardrock_2015_leif_carter_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_sherman_out_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_sherman
   id: 261
   absolute_time: 2015-07-10 18:08:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 22080.0
   lap: 1
   pacer:
@@ -416,11 +416,11 @@ hardrock_2015_leif_carter_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_grouse_in_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_grouse
   id: 264
   absolute_time: 2015-07-10 21:30:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 34200.0
   lap: 1
   pacer:
@@ -429,11 +429,11 @@ hardrock_2015_leif_carter_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_grouse_out_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_grouse
   id: 265
   absolute_time: 2015-07-10 21:36:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 34560.0
   lap: 1
   pacer:
@@ -442,11 +442,11 @@ hardrock_2015_leif_carter_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_ouray_in_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_ouray
   id: 268
   absolute_time: 2015-07-11 00:46:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 45960.0
   lap: 1
   pacer:
@@ -455,11 +455,11 @@ hardrock_2015_leif_carter_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_ouray_out_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_ouray
   id: 269
   absolute_time: 2015-07-11 00:46:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 45960.0
   lap: 1
   pacer:
@@ -468,11 +468,11 @@ hardrock_2015_leif_carter_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_telluride_in_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_telluride
   id: 274
   absolute_time: 2015-07-11 05:18:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 62280.0
   lap: 1
   pacer:
@@ -481,11 +481,11 @@ hardrock_2015_leif_carter_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_telluride_out_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_telluride
   id: 275
   absolute_time: 2015-07-11 05:24:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 62640.0
   lap: 1
   pacer:
@@ -494,11 +494,11 @@ hardrock_2015_leif_carter_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_putnam_in_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_putnam
   id: 280
   absolute_time: 2015-07-11 15:02:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 97320.0
   lap: 1
   pacer:
@@ -507,11 +507,11 @@ hardrock_2015_leif_carter_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leif_carter_putnam_out_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_putnam
   id: 281
   absolute_time: 2015-07-11 15:06:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 97560.0
   lap: 1
   pacer:
@@ -520,11 +520,11 @@ hardrock_2015_leif_carter_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leif_carter_finish_1:
+  effort: hardrock_2015_leif_carter
   split: hardrock_ccw_finish
   id: 282
   absolute_time: 2015-07-11 16:54:00.000000000 Z
   data_status: 2
-  effort_id: 15
   elapsed_seconds: 104040.0
   lap: 1
   pacer:
@@ -533,11 +533,11 @@ hardrock_2015_leif_carter_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_start_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_start
   id: 403
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -546,11 +546,11 @@ hardrock_2015_carmine_adams_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_cunningham_in_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_cunningham
   id: 404
   absolute_time: 2015-07-10 14:22:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 8520.0
   lap: 1
   pacer:
@@ -559,11 +559,11 @@ hardrock_2015_carmine_adams_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_cunningham_out_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_cunningham
   id: 405
   absolute_time: 2015-07-10 14:22:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 8520.0
   lap: 1
   pacer:
@@ -572,11 +572,11 @@ hardrock_2015_carmine_adams_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_sherman_in_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_sherman
   id: 410
   absolute_time: 2015-07-10 19:34:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 27240.0
   lap: 1
   pacer:
@@ -585,11 +585,11 @@ hardrock_2015_carmine_adams_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_sherman_out_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_sherman
   id: 411
   absolute_time: 2015-07-10 19:40:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 27600.0
   lap: 1
   pacer:
@@ -598,11 +598,11 @@ hardrock_2015_carmine_adams_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_grouse_in_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_grouse
   id: 414
   absolute_time: 2015-07-10 23:55:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 42900.0
   lap: 1
   pacer:
@@ -611,11 +611,11 @@ hardrock_2015_carmine_adams_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_grouse_out_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_grouse
   id: 415
   absolute_time: 2015-07-11 00:00:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 43200.0
   lap: 1
   pacer:
@@ -624,11 +624,11 @@ hardrock_2015_carmine_adams_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_ouray_in_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_ouray
   id: 418
   absolute_time: 2015-07-11 03:51:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 57060.0
   lap: 1
   pacer:
@@ -637,11 +637,11 @@ hardrock_2015_carmine_adams_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_ouray_out_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_ouray
   id: 419
   absolute_time: 2015-07-11 04:00:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 57600.0
   lap: 1
   pacer:
@@ -650,11 +650,11 @@ hardrock_2015_carmine_adams_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_telluride_in_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_telluride
   id: 424
   absolute_time: 2015-07-11 08:59:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 75540.0
   lap: 1
   pacer:
@@ -663,11 +663,11 @@ hardrock_2015_carmine_adams_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_telluride_out_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_telluride
   id: 425
   absolute_time: 2015-07-11 09:09:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 76140.0
   lap: 1
   pacer:
@@ -676,11 +676,11 @@ hardrock_2015_carmine_adams_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_putnam_in_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_putnam
   id: 430
   absolute_time: 2015-07-11 17:40:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 106800.0
   lap: 1
   pacer:
@@ -689,11 +689,11 @@ hardrock_2015_carmine_adams_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_carmine_adams_putnam_out_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_putnam
   id: 431
   absolute_time: 2015-07-11 17:40:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 106800.0
   lap: 1
   pacer:
@@ -702,11 +702,11 @@ hardrock_2015_carmine_adams_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_carmine_adams_finish_1:
+  effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_finish
   id: 432
   absolute_time: 2015-07-11 18:57:00.000000000 Z
   data_status: 2
-  effort_id: 20
   elapsed_seconds: 111420.0
   lap: 1
   pacer:
@@ -715,11 +715,11 @@ hardrock_2015_carmine_adams_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_start_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_start
   id: 523
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -728,11 +728,11 @@ hardrock_2015_garry_kuhlman_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_cunningham_in_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_cunningham
   id: 524
   absolute_time: 2015-07-10 14:30:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 9000.0
   lap: 1
   pacer:
@@ -741,11 +741,11 @@ hardrock_2015_garry_kuhlman_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_cunningham_out_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_cunningham
   id: 525
   absolute_time: 2015-07-10 14:30:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 9000.0
   lap: 1
   pacer:
@@ -754,11 +754,11 @@ hardrock_2015_garry_kuhlman_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_sherman_in_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_sherman
   id: 530
   absolute_time: 2015-07-10 19:52:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 28320.0
   lap: 1
   pacer:
@@ -767,11 +767,11 @@ hardrock_2015_garry_kuhlman_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_sherman_out_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_sherman
   id: 531
   absolute_time: 2015-07-10 19:58:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 28680.0
   lap: 1
   pacer:
@@ -780,11 +780,11 @@ hardrock_2015_garry_kuhlman_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_grouse_in_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_grouse
   id: 534
   absolute_time: 2015-07-10 23:53:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 42780.0
   lap: 1
   pacer:
@@ -793,11 +793,11 @@ hardrock_2015_garry_kuhlman_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_grouse_out_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_grouse
   id: 535
   absolute_time: 2015-07-10 23:56:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 42960.0
   lap: 1
   pacer:
@@ -806,11 +806,11 @@ hardrock_2015_garry_kuhlman_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_ouray_in_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_ouray
   id: 538
   absolute_time: 2015-07-11 03:42:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 56520.0
   lap: 1
   pacer:
@@ -819,11 +819,11 @@ hardrock_2015_garry_kuhlman_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_ouray_out_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_ouray
   id: 539
   absolute_time: 2015-07-11 03:51:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 57060.0
   lap: 1
   pacer:
@@ -832,11 +832,11 @@ hardrock_2015_garry_kuhlman_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_telluride_in_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_telluride
   id: 544
   absolute_time: 2015-07-11 08:59:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 75540.0
   lap: 1
   pacer:
@@ -845,11 +845,11 @@ hardrock_2015_garry_kuhlman_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_telluride_out_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_telluride
   id: 545
   absolute_time: 2015-07-11 09:04:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 75840.0
   lap: 1
   pacer:
@@ -858,11 +858,11 @@ hardrock_2015_garry_kuhlman_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_putnam_in_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_putnam
   id: 550
   absolute_time: 2015-07-11 18:11:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 108660.0
   lap: 1
   pacer:
@@ -871,11 +871,11 @@ hardrock_2015_garry_kuhlman_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_garry_kuhlman_putnam_out_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_putnam
   id: 551
   absolute_time: 2015-07-11 18:11:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 108660.0
   lap: 1
   pacer:
@@ -884,11 +884,11 @@ hardrock_2015_garry_kuhlman_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_garry_kuhlman_finish_1:
+  effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_finish
   id: 552
   absolute_time: 2015-07-11 19:39:00.000000000 Z
   data_status: 2
-  effort_id: 24
   elapsed_seconds: 113940.0
   lap: 1
   pacer:
@@ -897,11 +897,11 @@ hardrock_2015_garry_kuhlman_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_start_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_start
   id: 553
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -910,11 +910,11 @@ hardrock_2015_darius_jacobson_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_cunningham_in_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_cunningham
   id: 554
   absolute_time: 2015-07-10 14:18:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 8280.0
   lap: 1
   pacer:
@@ -923,11 +923,11 @@ hardrock_2015_darius_jacobson_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_cunningham_out_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_cunningham
   id: 555
   absolute_time: 2015-07-10 14:18:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 8280.0
   lap: 1
   pacer:
@@ -936,11 +936,11 @@ hardrock_2015_darius_jacobson_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_darius_jacobson_sherman_in_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_sherman
   id: 560
   absolute_time: 2015-07-10 19:09:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 25740.0
   lap: 1
   pacer:
@@ -949,11 +949,11 @@ hardrock_2015_darius_jacobson_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_sherman_out_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_sherman
   id: 561
   absolute_time: 2015-07-10 19:18:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 26280.0
   lap: 1
   pacer:
@@ -962,11 +962,11 @@ hardrock_2015_darius_jacobson_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_darius_jacobson_grouse_in_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_grouse
   id: 564
   absolute_time: 2015-07-10 23:17:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 40620.0
   lap: 1
   pacer:
@@ -975,11 +975,11 @@ hardrock_2015_darius_jacobson_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_grouse_out_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_grouse
   id: 565
   absolute_time: 2015-07-10 23:34:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 41640.0
   lap: 1
   pacer:
@@ -988,11 +988,11 @@ hardrock_2015_darius_jacobson_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_darius_jacobson_telluride_in_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_telluride
   id: 574
   absolute_time: 2015-07-11 08:40:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 74400.0
   lap: 1
   pacer:
@@ -1001,11 +1001,11 @@ hardrock_2015_darius_jacobson_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_telluride_out_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_telluride
   id: 575
   absolute_time: 2015-07-11 08:54:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 75240.0
   lap: 1
   pacer:
@@ -1014,11 +1014,11 @@ hardrock_2015_darius_jacobson_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_darius_jacobson_putnam_in_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_putnam
   id: 580
   absolute_time: 2015-07-11 18:26:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 109560.0
   lap: 1
   pacer:
@@ -1027,11 +1027,11 @@ hardrock_2015_darius_jacobson_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_darius_jacobson_putnam_out_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_putnam
   id: 581
   absolute_time: 2015-07-11 18:27:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 109620.0
   lap: 1
   pacer:
@@ -1040,11 +1040,11 @@ hardrock_2015_darius_jacobson_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_darius_jacobson_finish_1:
+  effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_finish
   id: 582
   absolute_time: 2015-07-11 19:43:00.000000000 Z
   data_status: 2
-  effort_id: 25
   elapsed_seconds: 114180.0
   lap: 1
   pacer:
@@ -1053,11 +1053,11 @@ hardrock_2015_darius_jacobson_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_start_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_start
   id: 673
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -1066,11 +1066,11 @@ hardrock_2015_santa_green_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_cunningham_in_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_cunningham
   id: 674
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 8640.0
   lap: 1
   pacer:
@@ -1079,11 +1079,11 @@ hardrock_2015_santa_green_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_cunningham_out_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_cunningham
   id: 675
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 8640.0
   lap: 1
   pacer:
@@ -1092,11 +1092,11 @@ hardrock_2015_santa_green_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_sherman_in_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_sherman
   id: 680
   absolute_time: 2015-07-10 19:36:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 27360.0
   lap: 1
   pacer:
@@ -1105,11 +1105,11 @@ hardrock_2015_santa_green_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_sherman_out_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_sherman
   id: 681
   absolute_time: 2015-07-10 19:42:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 27720.0
   lap: 1
   pacer:
@@ -1118,11 +1118,11 @@ hardrock_2015_santa_green_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_grouse_in_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_grouse
   id: 684
   absolute_time: 2015-07-10 23:52:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 42720.0
   lap: 1
   pacer:
@@ -1131,11 +1131,11 @@ hardrock_2015_santa_green_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_grouse_out_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_grouse
   id: 685
   absolute_time: 2015-07-10 23:52:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 42720.0
   lap: 1
   pacer:
@@ -1144,11 +1144,11 @@ hardrock_2015_santa_green_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_ouray_in_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_ouray
   id: 688
   absolute_time: 2015-07-11 04:14:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 58440.0
   lap: 1
   pacer:
@@ -1157,11 +1157,11 @@ hardrock_2015_santa_green_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_ouray_out_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_ouray
   id: 689
   absolute_time: 2015-07-11 04:27:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 59220.0
   lap: 1
   pacer:
@@ -1170,11 +1170,11 @@ hardrock_2015_santa_green_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_telluride_in_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_telluride
   id: 694
   absolute_time: 2015-07-11 10:05:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 79500.0
   lap: 1
   pacer:
@@ -1183,11 +1183,11 @@ hardrock_2015_santa_green_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_telluride_out_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_telluride
   id: 695
   absolute_time: 2015-07-11 10:14:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 80040.0
   lap: 1
   pacer:
@@ -1196,11 +1196,11 @@ hardrock_2015_santa_green_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_putnam_in_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_putnam
   id: 700
   absolute_time: 2015-07-11 19:38:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 113880.0
   lap: 1
   pacer:
@@ -1209,11 +1209,11 @@ hardrock_2015_santa_green_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_santa_green_putnam_out_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_putnam
   id: 701
   absolute_time: 2015-07-11 19:43:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 114180.0
   lap: 1
   pacer:
@@ -1222,11 +1222,11 @@ hardrock_2015_santa_green_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_santa_green_finish_1:
+  effort: hardrock_2015_santa_green
   split: hardrock_ccw_finish
   id: 702
   absolute_time: 2015-07-11 21:22:00.000000000 Z
   data_status: 2
-  effort_id: 29
   elapsed_seconds: 120120.0
   lap: 1
   pacer:
@@ -1235,11 +1235,11 @@ hardrock_2015_santa_green_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_start_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_start
   id: 733
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -1248,11 +1248,11 @@ hardrock_2015_gilberto_mckenzie_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_cunningham_in_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_cunningham
   id: 734
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 8640.0
   lap: 1
   pacer:
@@ -1261,11 +1261,11 @@ hardrock_2015_gilberto_mckenzie_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_cunningham_out_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_cunningham
   id: 735
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 8640.0
   lap: 1
   pacer:
@@ -1274,11 +1274,11 @@ hardrock_2015_gilberto_mckenzie_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_sherman_in_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_sherman
   id: 740
   absolute_time: 2015-07-10 19:56:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 28560.0
   lap: 1
   pacer:
@@ -1287,11 +1287,11 @@ hardrock_2015_gilberto_mckenzie_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_sherman_out_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_sherman
   id: 741
   absolute_time: 2015-07-10 20:02:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 28920.0
   lap: 1
   pacer:
@@ -1300,11 +1300,11 @@ hardrock_2015_gilberto_mckenzie_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_grouse_in_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_grouse
   id: 744
   absolute_time: 2015-07-11 00:58:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 46680.0
   lap: 1
   pacer:
@@ -1313,11 +1313,11 @@ hardrock_2015_gilberto_mckenzie_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_grouse_out_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_grouse
   id: 745
   absolute_time: 2015-07-11 01:12:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 47520.0
   lap: 1
   pacer:
@@ -1326,11 +1326,11 @@ hardrock_2015_gilberto_mckenzie_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_ouray_in_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_ouray
   id: 748
   absolute_time: 2015-07-11 05:59:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 64740.0
   lap: 1
   pacer:
@@ -1339,11 +1339,11 @@ hardrock_2015_gilberto_mckenzie_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_ouray_out_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_ouray
   id: 749
   absolute_time: 2015-07-11 06:09:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 65340.0
   lap: 1
   pacer:
@@ -1352,11 +1352,11 @@ hardrock_2015_gilberto_mckenzie_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_telluride_in_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_telluride
   id: 754
   absolute_time: 2015-07-11 11:33:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 84780.0
   lap: 1
   pacer:
@@ -1365,11 +1365,11 @@ hardrock_2015_gilberto_mckenzie_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_telluride_out_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_telluride
   id: 755
   absolute_time: 2015-07-11 11:45:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 85500.0
   lap: 1
   pacer:
@@ -1378,11 +1378,11 @@ hardrock_2015_gilberto_mckenzie_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_putnam_in_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_putnam
   id: 760
   absolute_time: 2015-07-11 21:46:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 121560.0
   lap: 1
   pacer:
@@ -1391,11 +1391,11 @@ hardrock_2015_gilberto_mckenzie_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gilberto_mckenzie_putnam_out_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_putnam
   id: 761
   absolute_time: 2015-07-11 21:46:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 121560.0
   lap: 1
   pacer:
@@ -1404,11 +1404,11 @@ hardrock_2015_gilberto_mckenzie_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gilberto_mckenzie_finish_1:
+  effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_finish
   id: 762
   absolute_time: 2015-07-11 23:18:00.000000000 Z
   data_status: 2
-  effort_id: 31
   elapsed_seconds: 127080.0
   lap: 1
   pacer:
@@ -1417,11 +1417,11 @@ hardrock_2015_gilberto_mckenzie_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_start_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_start
   id: 1213
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -1430,11 +1430,11 @@ hardrock_2015_vince_willms_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_cunningham_in_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_cunningham
   id: 1214
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 8640.0
   lap: 1
   pacer:
@@ -1443,11 +1443,11 @@ hardrock_2015_vince_willms_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_cunningham_out_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_cunningham
   id: 1215
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 8640.0
   lap: 1
   pacer:
@@ -1456,11 +1456,11 @@ hardrock_2015_vince_willms_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_sherman_in_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_sherman
   id: 1220
   absolute_time: 2015-07-10 19:47:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 28020.0
   lap: 1
   pacer:
@@ -1469,11 +1469,11 @@ hardrock_2015_vince_willms_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_sherman_out_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_sherman
   id: 1221
   absolute_time: 2015-07-10 19:59:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 28740.0
   lap: 1
   pacer:
@@ -1482,11 +1482,11 @@ hardrock_2015_vince_willms_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_grouse_in_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_grouse
   id: 1224
   absolute_time: 2015-07-10 23:58:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 43080.0
   lap: 1
   pacer:
@@ -1495,11 +1495,11 @@ hardrock_2015_vince_willms_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_grouse_out_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_grouse
   id: 1225
   absolute_time: 2015-07-11 00:06:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 43560.0
   lap: 1
   pacer:
@@ -1508,11 +1508,11 @@ hardrock_2015_vince_willms_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_ouray_in_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_ouray
   id: 1228
   absolute_time: 2015-07-11 04:34:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 59640.0
   lap: 1
   pacer:
@@ -1521,11 +1521,11 @@ hardrock_2015_vince_willms_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_ouray_out_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_ouray
   id: 1229
   absolute_time: 2015-07-11 04:58:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 61080.0
   lap: 1
   pacer:
@@ -1534,11 +1534,11 @@ hardrock_2015_vince_willms_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_telluride_in_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_telluride
   id: 1234
   absolute_time: 2015-07-11 11:40:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 85200.0
   lap: 1
   pacer:
@@ -1547,11 +1547,11 @@ hardrock_2015_vince_willms_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_telluride_out_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_telluride
   id: 1235
   absolute_time: 2015-07-11 12:53:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 89580.0
   lap: 1
   pacer:
@@ -1560,11 +1560,11 @@ hardrock_2015_vince_willms_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_putnam_in_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_putnam
   id: 1240
   absolute_time: 2015-07-11 23:23:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 127380.0
   lap: 1
   pacer:
@@ -1573,11 +1573,11 @@ hardrock_2015_vince_willms_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vince_willms_putnam_out_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_putnam
   id: 1241
   absolute_time: 2015-07-11 23:25:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 127500.0
   lap: 1
   pacer:
@@ -1586,11 +1586,11 @@ hardrock_2015_vince_willms_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vince_willms_finish_1:
+  effort: hardrock_2015_vince_willms
   split: hardrock_ccw_finish
   id: 1242
   absolute_time: 2015-07-12 00:58:00.000000000 Z
   data_status: 2
-  effort_id: 47
   elapsed_seconds: 133080.0
   lap: 1
   pacer:
@@ -1599,11 +1599,11 @@ hardrock_2015_vince_willms_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_cunningham_in_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_cunningham
   id: 1304
   absolute_time: 2015-07-10 14:32:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 9120.0
   lap: 1
   pacer:
@@ -1612,11 +1612,11 @@ hardrock_2015_cedric_windler_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_cunningham_out_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_cunningham
   id: 1305
   absolute_time: 2015-07-10 14:32:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 9120.0
   lap: 1
   pacer:
@@ -1625,11 +1625,11 @@ hardrock_2015_cedric_windler_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_sherman_in_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_sherman
   id: 1310
   absolute_time: 2015-07-10 19:52:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 28320.0
   lap: 1
   pacer:
@@ -1638,11 +1638,11 @@ hardrock_2015_cedric_windler_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_sherman_out_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_sherman
   id: 1311
   absolute_time: 2015-07-10 19:59:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 28740.0
   lap: 1
   pacer:
@@ -1651,11 +1651,11 @@ hardrock_2015_cedric_windler_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_grouse_in_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_grouse
   id: 1314
   absolute_time: 2015-07-11 00:51:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 46260.0
   lap: 1
   pacer:
@@ -1664,11 +1664,11 @@ hardrock_2015_cedric_windler_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_grouse_out_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_grouse
   id: 1315
   absolute_time: 2015-07-11 01:02:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 46920.0
   lap: 1
   pacer:
@@ -1677,11 +1677,11 @@ hardrock_2015_cedric_windler_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_ouray_in_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_ouray
   id: 1318
   absolute_time: 2015-07-11 06:06:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 65160.0
   lap: 1
   pacer:
@@ -1690,11 +1690,11 @@ hardrock_2015_cedric_windler_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_ouray_out_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_ouray
   id: 1319
   absolute_time: 2015-07-11 06:53:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 67980.0
   lap: 1
   pacer:
@@ -1703,11 +1703,11 @@ hardrock_2015_cedric_windler_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_telluride_in_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_telluride
   id: 1324
   absolute_time: 2015-07-11 13:10:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 90600.0
   lap: 1
   pacer:
@@ -1716,11 +1716,11 @@ hardrock_2015_cedric_windler_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_telluride_out_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_telluride
   id: 1325
   absolute_time: 2015-07-11 13:20:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 91200.0
   lap: 1
   pacer:
@@ -1729,11 +1729,11 @@ hardrock_2015_cedric_windler_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_putnam_in_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_putnam
   id: 1330
   absolute_time: 2015-07-11 23:39:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 128340.0
   lap: 1
   pacer:
@@ -1742,11 +1742,11 @@ hardrock_2015_cedric_windler_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_putnam_out_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_putnam
   id: 1331
   absolute_time: 2015-07-11 23:39:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 128340.0
   lap: 1
   pacer:
@@ -1755,11 +1755,11 @@ hardrock_2015_cedric_windler_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cedric_windler_finish_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_finish
   id: 1332
   absolute_time: 2015-07-12 01:19:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 134340.0
   lap: 1
   pacer:
@@ -1768,11 +1768,11 @@ hardrock_2015_cedric_windler_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_start_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_start
   id: 1483
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -1781,11 +1781,11 @@ hardrock_2015_chris_rempel_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_cunningham_in_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_cunningham
   id: 1484
   absolute_time: 2015-07-10 14:36:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 9360.0
   lap: 1
   pacer:
@@ -1794,11 +1794,11 @@ hardrock_2015_chris_rempel_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_cunningham_out_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_cunningham
   id: 1485
   absolute_time: 2015-07-10 14:36:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 9360.0
   lap: 1
   pacer:
@@ -1807,11 +1807,11 @@ hardrock_2015_chris_rempel_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_sherman_in_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_sherman
   id: 1490
   absolute_time: 2015-07-10 20:12:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 29520.0
   lap: 1
   pacer:
@@ -1820,11 +1820,11 @@ hardrock_2015_chris_rempel_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_sherman_out_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_sherman
   id: 1491
   absolute_time: 2015-07-10 20:23:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 30180.0
   lap: 1
   pacer:
@@ -1833,11 +1833,11 @@ hardrock_2015_chris_rempel_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_grouse_in_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_grouse
   id: 1494
   absolute_time: 2015-07-11 00:57:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 46620.0
   lap: 1
   pacer:
@@ -1846,11 +1846,11 @@ hardrock_2015_chris_rempel_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_grouse_out_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_grouse
   id: 1495
   absolute_time: 2015-07-11 01:09:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 47340.0
   lap: 1
   pacer:
@@ -1859,11 +1859,11 @@ hardrock_2015_chris_rempel_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_ouray_in_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_ouray
   id: 1498
   absolute_time: 2015-07-11 06:05:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 65100.0
   lap: 1
   pacer:
@@ -1872,11 +1872,11 @@ hardrock_2015_chris_rempel_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_ouray_out_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_ouray
   id: 1499
   absolute_time: 2015-07-11 06:23:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 66180.0
   lap: 1
   pacer:
@@ -1885,11 +1885,11 @@ hardrock_2015_chris_rempel_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_telluride_in_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_telluride
   id: 1504
   absolute_time: 2015-07-11 12:40:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 88800.0
   lap: 1
   pacer:
@@ -1898,11 +1898,11 @@ hardrock_2015_chris_rempel_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_telluride_out_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_telluride
   id: 1505
   absolute_time: 2015-07-11 13:00:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 90000.0
   lap: 1
   pacer:
@@ -1911,11 +1911,11 @@ hardrock_2015_chris_rempel_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_putnam_in_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_putnam
   id: 1510
   absolute_time: 2015-07-12 00:03:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 129780.0
   lap: 1
   pacer:
@@ -1924,11 +1924,11 @@ hardrock_2015_chris_rempel_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_chris_rempel_putnam_out_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_putnam
   id: 1511
   absolute_time: 2015-07-12 00:04:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 129840.0
   lap: 1
   pacer:
@@ -1937,11 +1937,11 @@ hardrock_2015_chris_rempel_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_chris_rempel_finish_1:
+  effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_finish
   id: 1512
   absolute_time: 2015-07-12 01:54:00.000000000 Z
   data_status: 2
-  effort_id: 56
   elapsed_seconds: 136440.0
   lap: 1
   pacer:
@@ -1950,11 +1950,11 @@ hardrock_2015_chris_rempel_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_start_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_start
   id: 1513
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -1963,11 +1963,11 @@ hardrock_2015_robby_gerlach_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_cunningham_in_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_cunningham
   id: 1514
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 9600.0
   lap: 1
   pacer:
@@ -1976,11 +1976,11 @@ hardrock_2015_robby_gerlach_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_cunningham_out_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_cunningham
   id: 1515
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 9600.0
   lap: 1
   pacer:
@@ -1989,11 +1989,11 @@ hardrock_2015_robby_gerlach_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_sherman_in_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_sherman
   id: 1520
   absolute_time: 2015-07-10 20:51:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 31860.0
   lap: 1
   pacer:
@@ -2002,11 +2002,11 @@ hardrock_2015_robby_gerlach_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_sherman_out_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_sherman
   id: 1521
   absolute_time: 2015-07-10 21:03:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 32580.0
   lap: 1
   pacer:
@@ -2015,11 +2015,11 @@ hardrock_2015_robby_gerlach_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_grouse_in_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_grouse
   id: 1524
   absolute_time: 2015-07-11 01:51:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 49860.0
   lap: 1
   pacer:
@@ -2028,11 +2028,11 @@ hardrock_2015_robby_gerlach_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_grouse_out_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_grouse
   id: 1525
   absolute_time: 2015-07-11 02:08:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 50880.0
   lap: 1
   pacer:
@@ -2041,11 +2041,11 @@ hardrock_2015_robby_gerlach_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_ouray_in_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_ouray
   id: 1528
   absolute_time: 2015-07-11 07:15:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 69300.0
   lap: 1
   pacer:
@@ -2054,11 +2054,11 @@ hardrock_2015_robby_gerlach_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_ouray_out_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_ouray
   id: 1529
   absolute_time: 2015-07-11 07:32:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 70320.0
   lap: 1
   pacer:
@@ -2067,11 +2067,11 @@ hardrock_2015_robby_gerlach_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_telluride_in_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_telluride
   id: 1534
   absolute_time: 2015-07-11 13:29:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 91740.0
   lap: 1
   pacer:
@@ -2080,11 +2080,11 @@ hardrock_2015_robby_gerlach_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_telluride_out_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_telluride
   id: 1535
   absolute_time: 2015-07-11 14:44:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 96240.0
   lap: 1
   pacer:
@@ -2093,11 +2093,11 @@ hardrock_2015_robby_gerlach_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_putnam_in_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_putnam
   id: 1540
   absolute_time: 2015-07-12 00:14:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 130440.0
   lap: 1
   pacer:
@@ -2106,11 +2106,11 @@ hardrock_2015_robby_gerlach_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robby_gerlach_putnam_out_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_putnam
   id: 1541
   absolute_time: 2015-07-12 00:14:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 130440.0
   lap: 1
   pacer:
@@ -2119,11 +2119,11 @@ hardrock_2015_robby_gerlach_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robby_gerlach_finish_1:
+  effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_finish
   id: 1542
   absolute_time: 2015-07-12 01:56:00.000000000 Z
   data_status: 2
-  effort_id: 57
   elapsed_seconds: 136560.0
   lap: 1
   pacer:
@@ -2132,11 +2132,11 @@ hardrock_2015_robby_gerlach_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_start_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_start
   id: 1573
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -2145,11 +2145,11 @@ hardrock_2015_rachelle_eichmann_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_cunningham_in_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_cunningham
   id: 1574
   absolute_time: 2015-07-10 14:28:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 8880.0
   lap: 1
   pacer:
@@ -2158,11 +2158,11 @@ hardrock_2015_rachelle_eichmann_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_cunningham_out_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_cunningham
   id: 1575
   absolute_time: 2015-07-10 14:28:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 8880.0
   lap: 1
   pacer:
@@ -2171,11 +2171,11 @@ hardrock_2015_rachelle_eichmann_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_sherman_in_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_sherman
   id: 1580
   absolute_time: 2015-07-10 20:11:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 29460.0
   lap: 1
   pacer:
@@ -2184,11 +2184,11 @@ hardrock_2015_rachelle_eichmann_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_sherman_out_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_sherman
   id: 1581
   absolute_time: 2015-07-10 20:24:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 30240.0
   lap: 1
   pacer:
@@ -2197,11 +2197,11 @@ hardrock_2015_rachelle_eichmann_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_grouse_in_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_grouse
   id: 1584
   absolute_time: 2015-07-11 00:53:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 46380.0
   lap: 1
   pacer:
@@ -2210,11 +2210,11 @@ hardrock_2015_rachelle_eichmann_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_grouse_out_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_grouse
   id: 1585
   absolute_time: 2015-07-11 01:10:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 47400.0
   lap: 1
   pacer:
@@ -2223,11 +2223,11 @@ hardrock_2015_rachelle_eichmann_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_ouray_in_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_ouray
   id: 1588
   absolute_time: 2015-07-11 06:30:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 66600.0
   lap: 1
   pacer:
@@ -2236,11 +2236,11 @@ hardrock_2015_rachelle_eichmann_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_ouray_out_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_ouray
   id: 1589
   absolute_time: 2015-07-11 06:40:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 67200.0
   lap: 1
   pacer:
@@ -2249,11 +2249,11 @@ hardrock_2015_rachelle_eichmann_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_telluride_in_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_telluride
   id: 1594
   absolute_time: 2015-07-11 13:45:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 92700.0
   lap: 1
   pacer:
@@ -2262,11 +2262,11 @@ hardrock_2015_rachelle_eichmann_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_telluride_out_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_telluride
   id: 1595
   absolute_time: 2015-07-11 14:05:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 93900.0
   lap: 1
   pacer:
@@ -2275,11 +2275,11 @@ hardrock_2015_rachelle_eichmann_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_putnam_in_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_putnam
   id: 1600
   absolute_time: 2015-07-12 01:05:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 133500.0
   lap: 1
   pacer:
@@ -2288,11 +2288,11 @@ hardrock_2015_rachelle_eichmann_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_rachelle_eichmann_putnam_out_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_putnam
   id: 1601
   absolute_time: 2015-07-12 01:05:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 133500.0
   lap: 1
   pacer:
@@ -2301,11 +2301,11 @@ hardrock_2015_rachelle_eichmann_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_rachelle_eichmann_finish_1:
+  effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_finish
   id: 1602
   absolute_time: 2015-07-12 02:36:00.000000000 Z
   data_status: 2
-  effort_id: 59
   elapsed_seconds: 138960.0
   lap: 1
   pacer:
@@ -2314,11 +2314,11 @@ hardrock_2015_rachelle_eichmann_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_start_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_start
   id: 1633
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -2327,11 +2327,11 @@ hardrock_2015_elden_morissette_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_cunningham_in_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_cunningham
   id: 1634
   absolute_time: 2015-07-10 14:33:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 9180.0
   lap: 1
   pacer:
@@ -2340,11 +2340,11 @@ hardrock_2015_elden_morissette_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_cunningham_out_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_cunningham
   id: 1635
   absolute_time: 2015-07-10 14:33:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 9180.0
   lap: 1
   pacer:
@@ -2353,11 +2353,11 @@ hardrock_2015_elden_morissette_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_sherman_in_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_sherman
   id: 1640
   absolute_time: 2015-07-10 20:20:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 30000.0
   lap: 1
   pacer:
@@ -2366,11 +2366,11 @@ hardrock_2015_elden_morissette_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_sherman_out_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_sherman
   id: 1641
   absolute_time: 2015-07-10 20:38:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 31080.0
   lap: 1
   pacer:
@@ -2379,11 +2379,11 @@ hardrock_2015_elden_morissette_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_grouse_in_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_grouse
   id: 1644
   absolute_time: 2015-07-11 01:24:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 48240.0
   lap: 1
   pacer:
@@ -2392,11 +2392,11 @@ hardrock_2015_elden_morissette_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_grouse_out_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_grouse
   id: 1645
   absolute_time: 2015-07-11 01:50:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 49800.0
   lap: 1
   pacer:
@@ -2405,11 +2405,11 @@ hardrock_2015_elden_morissette_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_ouray_in_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_ouray
   id: 1648
   absolute_time: 2015-07-11 06:15:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 65700.0
   lap: 1
   pacer:
@@ -2418,11 +2418,11 @@ hardrock_2015_elden_morissette_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_ouray_out_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_ouray
   id: 1649
   absolute_time: 2015-07-11 06:59:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 68340.0
   lap: 1
   pacer:
@@ -2431,11 +2431,11 @@ hardrock_2015_elden_morissette_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_telluride_in_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_telluride
   id: 1654
   absolute_time: 2015-07-11 13:08:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 90480.0
   lap: 1
   pacer:
@@ -2444,11 +2444,11 @@ hardrock_2015_elden_morissette_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_telluride_out_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_telluride
   id: 1655
   absolute_time: 2015-07-11 13:33:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 91980.0
   lap: 1
   pacer:
@@ -2457,11 +2457,11 @@ hardrock_2015_elden_morissette_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_putnam_in_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_putnam
   id: 1660
   absolute_time: 2015-07-12 00:48:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 132480.0
   lap: 1
   pacer:
@@ -2470,11 +2470,11 @@ hardrock_2015_elden_morissette_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_elden_morissette_putnam_out_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_putnam
   id: 1661
   absolute_time: 2015-07-12 00:53:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 132780.0
   lap: 1
   pacer:
@@ -2483,11 +2483,11 @@ hardrock_2015_elden_morissette_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_elden_morissette_finish_1:
+  effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_finish
   id: 1662
   absolute_time: 2015-07-12 02:41:00.000000000 Z
   data_status: 2
-  effort_id: 61
   elapsed_seconds: 139260.0
   lap: 1
   pacer:
@@ -2496,11 +2496,11 @@ hardrock_2015_elden_morissette_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_start_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_start
   id: 1693
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -2509,11 +2509,11 @@ hardrock_2015_leroy_leffler_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_cunningham_in_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_cunningham
   id: 1694
   absolute_time: 2015-07-10 14:38:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 9480.0
   lap: 1
   pacer:
@@ -2522,11 +2522,11 @@ hardrock_2015_leroy_leffler_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_cunningham_out_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_cunningham
   id: 1695
   absolute_time: 2015-07-10 14:38:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 9480.0
   lap: 1
   pacer:
@@ -2535,11 +2535,11 @@ hardrock_2015_leroy_leffler_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_sherman_in_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_sherman
   id: 1700
   absolute_time: 2015-07-10 20:22:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 30120.0
   lap: 1
   pacer:
@@ -2548,11 +2548,11 @@ hardrock_2015_leroy_leffler_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_sherman_out_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_sherman
   id: 1701
   absolute_time: 2015-07-10 20:38:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 31080.0
   lap: 1
   pacer:
@@ -2561,11 +2561,11 @@ hardrock_2015_leroy_leffler_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_grouse_in_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_grouse
   id: 1704
   absolute_time: 2015-07-11 01:21:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 48060.0
   lap: 1
   pacer:
@@ -2574,11 +2574,11 @@ hardrock_2015_leroy_leffler_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_grouse_out_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_grouse
   id: 1705
   absolute_time: 2015-07-11 01:38:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 49080.0
   lap: 1
   pacer:
@@ -2587,11 +2587,11 @@ hardrock_2015_leroy_leffler_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_ouray_in_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_ouray
   id: 1708
   absolute_time: 2015-07-11 06:32:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 66720.0
   lap: 1
   pacer:
@@ -2600,11 +2600,11 @@ hardrock_2015_leroy_leffler_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_ouray_out_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_ouray
   id: 1709
   absolute_time: 2015-07-11 07:21:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 69660.0
   lap: 1
   pacer:
@@ -2613,11 +2613,11 @@ hardrock_2015_leroy_leffler_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_telluride_in_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_telluride
   id: 1714
   absolute_time: 2015-07-11 13:07:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 90420.0
   lap: 1
   pacer:
@@ -2626,11 +2626,11 @@ hardrock_2015_leroy_leffler_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_telluride_out_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_telluride
   id: 1715
   absolute_time: 2015-07-11 13:43:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 92580.0
   lap: 1
   pacer:
@@ -2639,11 +2639,11 @@ hardrock_2015_leroy_leffler_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_putnam_in_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_putnam
   id: 1720
   absolute_time: 2015-07-12 01:15:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 134100.0
   lap: 1
   pacer:
@@ -2652,11 +2652,11 @@ hardrock_2015_leroy_leffler_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leroy_leffler_putnam_out_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_putnam
   id: 1721
   absolute_time: 2015-07-12 01:15:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 134100.0
   lap: 1
   pacer:
@@ -2665,11 +2665,11 @@ hardrock_2015_leroy_leffler_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leroy_leffler_finish_1:
+  effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_finish
   id: 1722
   absolute_time: 2015-07-12 03:11:00.000000000 Z
   data_status: 2
-  effort_id: 63
   elapsed_seconds: 141060.0
   lap: 1
   pacer:
@@ -2678,11 +2678,11 @@ hardrock_2015_leroy_leffler_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_start_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_start
   id: 1993
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -2691,11 +2691,11 @@ hardrock_2015_samara_vandervort_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_cunningham_in_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_cunningham
   id: 1994
   absolute_time: 2015-07-10 14:35:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 9300.0
   lap: 1
   pacer:
@@ -2704,11 +2704,11 @@ hardrock_2015_samara_vandervort_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_cunningham_out_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_cunningham
   id: 1995
   absolute_time: 2015-07-10 14:35:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 9300.0
   lap: 1
   pacer:
@@ -2717,11 +2717,11 @@ hardrock_2015_samara_vandervort_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_sherman_in_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_sherman
   id: 2000
   absolute_time: 2015-07-10 20:28:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 30480.0
   lap: 1
   pacer:
@@ -2730,11 +2730,11 @@ hardrock_2015_samara_vandervort_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_sherman_out_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_sherman
   id: 2001
   absolute_time: 2015-07-10 20:42:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 31320.0
   lap: 1
   pacer:
@@ -2743,11 +2743,11 @@ hardrock_2015_samara_vandervort_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_grouse_in_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_grouse
   id: 2004
   absolute_time: 2015-07-11 01:50:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 49800.0
   lap: 1
   pacer:
@@ -2756,11 +2756,11 @@ hardrock_2015_samara_vandervort_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_grouse_out_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_grouse
   id: 2005
   absolute_time: 2015-07-11 02:03:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 50580.0
   lap: 1
   pacer:
@@ -2769,11 +2769,11 @@ hardrock_2015_samara_vandervort_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_ouray_in_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_ouray
   id: 2008
   absolute_time: 2015-07-11 07:06:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 68760.0
   lap: 1
   pacer:
@@ -2782,11 +2782,11 @@ hardrock_2015_samara_vandervort_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_ouray_out_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_ouray
   id: 2009
   absolute_time: 2015-07-11 07:20:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 69600.0
   lap: 1
   pacer:
@@ -2795,11 +2795,11 @@ hardrock_2015_samara_vandervort_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_telluride_in_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_telluride
   id: 2014
   absolute_time: 2015-07-11 14:11:00.000000000 Z
   data_status: 0
-  effort_id: 73
   elapsed_seconds: 94260.0
   lap: 1
   pacer:
@@ -2808,11 +2808,11 @@ hardrock_2015_samara_vandervort_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_telluride_out_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_telluride
   id: 2015
   absolute_time: 2015-07-11 14:29:00.000000000 Z
   data_status: 0
-  effort_id: 73
   elapsed_seconds: 95340.0
   lap: 1
   pacer:
@@ -2821,11 +2821,11 @@ hardrock_2015_samara_vandervort_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_putnam_in_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_putnam
   id: 2020
   absolute_time: 2015-07-12 01:58:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 136680.0
   lap: 1
   pacer:
@@ -2834,11 +2834,11 @@ hardrock_2015_samara_vandervort_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_samara_vandervort_putnam_out_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_putnam
   id: 2021
   absolute_time: 2015-07-12 02:04:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 137040.0
   lap: 1
   pacer:
@@ -2847,11 +2847,11 @@ hardrock_2015_samara_vandervort_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_samara_vandervort_finish_1:
+  effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_finish
   id: 2022
   absolute_time: 2015-07-12 04:16:00.000000000 Z
   data_status: 2
-  effort_id: 73
   elapsed_seconds: 144960.0
   lap: 1
   pacer:
@@ -2860,11 +2860,11 @@ hardrock_2015_samara_vandervort_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_start_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_start
   id: 2623
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -2873,11 +2873,11 @@ hardrock_2015_robt_wintheiser_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_cunningham_in_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_cunningham
   id: 2624
   absolute_time: 2015-07-10 14:52:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 10320.0
   lap: 1
   pacer:
@@ -2886,11 +2886,11 @@ hardrock_2015_robt_wintheiser_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_cunningham_out_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_cunningham
   id: 2625
   absolute_time: 2015-07-10 14:52:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 10320.0
   lap: 1
   pacer:
@@ -2899,11 +2899,11 @@ hardrock_2015_robt_wintheiser_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_sherman_in_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_sherman
   id: 2630
   absolute_time: 2015-07-10 21:10:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 33000.0
   lap: 1
   pacer:
@@ -2912,11 +2912,11 @@ hardrock_2015_robt_wintheiser_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_sherman_out_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_sherman
   id: 2631
   absolute_time: 2015-07-10 21:27:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 34020.0
   lap: 1
   pacer:
@@ -2925,11 +2925,11 @@ hardrock_2015_robt_wintheiser_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_grouse_in_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_grouse
   id: 2634
   absolute_time: 2015-07-11 02:37:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 52620.0
   lap: 1
   pacer:
@@ -2938,11 +2938,11 @@ hardrock_2015_robt_wintheiser_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_grouse_out_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_grouse
   id: 2635
   absolute_time: 2015-07-11 03:00:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 54000.0
   lap: 1
   pacer:
@@ -2951,11 +2951,11 @@ hardrock_2015_robt_wintheiser_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_ouray_in_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_ouray
   id: 2638
   absolute_time: 2015-07-11 08:24:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 73440.0
   lap: 1
   pacer:
@@ -2964,11 +2964,11 @@ hardrock_2015_robt_wintheiser_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_ouray_out_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_ouray
   id: 2639
   absolute_time: 2015-07-11 08:27:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 73620.0
   lap: 1
   pacer:
@@ -2977,11 +2977,11 @@ hardrock_2015_robt_wintheiser_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_telluride_in_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_telluride
   id: 2644
   absolute_time: 2015-07-11 15:34:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 99240.0
   lap: 1
   pacer:
@@ -2990,11 +2990,11 @@ hardrock_2015_robt_wintheiser_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_telluride_out_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_telluride
   id: 2645
   absolute_time: 2015-07-11 16:34:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 102840.0
   lap: 1
   pacer:
@@ -3003,11 +3003,11 @@ hardrock_2015_robt_wintheiser_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_putnam_in_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_putnam
   id: 2650
   absolute_time: 2015-07-12 05:22:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 148920.0
   lap: 1
   pacer:
@@ -3016,11 +3016,11 @@ hardrock_2015_robt_wintheiser_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_robt_wintheiser_putnam_out_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_putnam
   id: 2651
   absolute_time: 2015-07-12 05:33:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 149580.0
   lap: 1
   pacer:
@@ -3029,11 +3029,11 @@ hardrock_2015_robt_wintheiser_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_robt_wintheiser_finish_1:
+  effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_finish
   id: 2652
   absolute_time: 2015-07-12 07:56:00.000000000 Z
   data_status: 2
-  effort_id: 94
   elapsed_seconds: 158160.0
   lap: 1
   pacer:
@@ -3042,11 +3042,11 @@ hardrock_2015_robt_wintheiser_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_start_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_start
   id: 2683
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -3055,11 +3055,11 @@ hardrock_2015_demetrius_moen_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_cunningham_in_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_cunningham
   id: 2684
   absolute_time: 2015-07-10 14:45:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 9900.0
   lap: 1
   pacer:
@@ -3068,11 +3068,11 @@ hardrock_2015_demetrius_moen_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_cunningham_out_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_cunningham
   id: 2685
   absolute_time: 2015-07-10 14:45:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 9900.0
   lap: 1
   pacer:
@@ -3081,11 +3081,11 @@ hardrock_2015_demetrius_moen_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_sherman_in_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_sherman
   id: 2690
   absolute_time: 2015-07-10 21:21:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 33660.0
   lap: 1
   pacer:
@@ -3094,11 +3094,11 @@ hardrock_2015_demetrius_moen_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_sherman_out_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_sherman
   id: 2691
   absolute_time: 2015-07-10 21:36:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 34560.0
   lap: 1
   pacer:
@@ -3107,11 +3107,11 @@ hardrock_2015_demetrius_moen_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_grouse_in_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_grouse
   id: 2694
   absolute_time: 2015-07-11 03:07:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 54420.0
   lap: 1
   pacer:
@@ -3120,11 +3120,11 @@ hardrock_2015_demetrius_moen_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_grouse_out_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_grouse
   id: 2695
   absolute_time: 2015-07-11 03:27:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 55620.0
   lap: 1
   pacer:
@@ -3133,11 +3133,11 @@ hardrock_2015_demetrius_moen_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_ouray_in_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_ouray
   id: 2698
   absolute_time: 2015-07-11 08:53:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 75180.0
   lap: 1
   pacer:
@@ -3146,11 +3146,11 @@ hardrock_2015_demetrius_moen_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_ouray_out_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_ouray
   id: 2699
   absolute_time: 2015-07-11 09:15:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 76500.0
   lap: 1
   pacer:
@@ -3159,11 +3159,11 @@ hardrock_2015_demetrius_moen_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_telluride_in_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_telluride
   id: 2704
   absolute_time: 2015-07-11 15:43:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 99780.0
   lap: 1
   pacer:
@@ -3172,11 +3172,11 @@ hardrock_2015_demetrius_moen_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_telluride_out_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_telluride
   id: 2705
   absolute_time: 2015-07-11 16:02:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 100920.0
   lap: 1
   pacer:
@@ -3185,11 +3185,11 @@ hardrock_2015_demetrius_moen_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_putnam_in_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_putnam
   id: 2710
   absolute_time: 2015-07-12 05:27:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 149220.0
   lap: 1
   pacer:
@@ -3198,11 +3198,11 @@ hardrock_2015_demetrius_moen_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_demetrius_moen_putnam_out_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_putnam
   id: 2711
   absolute_time: 2015-07-12 05:36:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 149760.0
   lap: 1
   pacer:
@@ -3211,11 +3211,11 @@ hardrock_2015_demetrius_moen_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_demetrius_moen_finish_1:
+  effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_finish
   id: 2712
   absolute_time: 2015-07-12 08:01:00.000000000 Z
   data_status: 2
-  effort_id: 96
   elapsed_seconds: 158460.0
   lap: 1
   pacer:
@@ -3224,11 +3224,11 @@ hardrock_2015_demetrius_moen_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_start_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_start
   id: 2953
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -3237,11 +3237,11 @@ hardrock_2015_vern_buckridge_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_cunningham_in_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_cunningham
   id: 2954
   absolute_time: 2015-07-10 14:46:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 9960.0
   lap: 1
   pacer:
@@ -3250,11 +3250,11 @@ hardrock_2015_vern_buckridge_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_cunningham_out_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_cunningham
   id: 2955
   absolute_time: 2015-07-10 14:46:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 9960.0
   lap: 1
   pacer:
@@ -3263,11 +3263,11 @@ hardrock_2015_vern_buckridge_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_sherman_in_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_sherman
   id: 2960
   absolute_time: 2015-07-10 21:45:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 35100.0
   lap: 1
   pacer:
@@ -3276,11 +3276,11 @@ hardrock_2015_vern_buckridge_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_sherman_out_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_sherman
   id: 2961
   absolute_time: 2015-07-10 22:09:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 36540.0
   lap: 1
   pacer:
@@ -3289,11 +3289,11 @@ hardrock_2015_vern_buckridge_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_grouse_in_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_grouse
   id: 2964
   absolute_time: 2015-07-11 04:04:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 57840.0
   lap: 1
   pacer:
@@ -3302,11 +3302,11 @@ hardrock_2015_vern_buckridge_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_grouse_out_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_grouse
   id: 2965
   absolute_time: 2015-07-11 04:21:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 58860.0
   lap: 1
   pacer:
@@ -3315,11 +3315,11 @@ hardrock_2015_vern_buckridge_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_ouray_in_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_ouray
   id: 2968
   absolute_time: 2015-07-11 09:48:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 78480.0
   lap: 1
   pacer:
@@ -3328,11 +3328,11 @@ hardrock_2015_vern_buckridge_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_ouray_out_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_ouray
   id: 2969
   absolute_time: 2015-07-11 10:15:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 80100.0
   lap: 1
   pacer:
@@ -3341,11 +3341,11 @@ hardrock_2015_vern_buckridge_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_telluride_in_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_telluride
   id: 2974
   absolute_time: 2015-07-11 17:08:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 104880.0
   lap: 1
   pacer:
@@ -3354,11 +3354,11 @@ hardrock_2015_vern_buckridge_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_telluride_out_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_telluride
   id: 2975
   absolute_time: 2015-07-11 17:29:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 106140.0
   lap: 1
   pacer:
@@ -3367,11 +3367,11 @@ hardrock_2015_vern_buckridge_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_putnam_in_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_putnam
   id: 2980
   absolute_time: 2015-07-12 06:54:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 154440.0
   lap: 1
   pacer:
@@ -3380,11 +3380,11 @@ hardrock_2015_vern_buckridge_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_vern_buckridge_putnam_out_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_putnam
   id: 2981
   absolute_time: 2015-07-12 07:00:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 154800.0
   lap: 1
   pacer:
@@ -3393,11 +3393,11 @@ hardrock_2015_vern_buckridge_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_vern_buckridge_finish_1:
+  effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_finish
   id: 2982
   absolute_time: 2015-07-12 09:20:00.000000000 Z
   data_status: 2
-  effort_id: 105
   elapsed_seconds: 163200.0
   lap: 1
   pacer:
@@ -3406,11 +3406,11 @@ hardrock_2015_vern_buckridge_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_start_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_start
   id: 3163
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -3419,11 +3419,11 @@ hardrock_2015_donte_spencer_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_cunningham_in_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_cunningham
   id: 3164
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 9600.0
   lap: 1
   pacer:
@@ -3432,11 +3432,11 @@ hardrock_2015_donte_spencer_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_cunningham_out_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_cunningham
   id: 3165
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 9600.0
   lap: 1
   pacer:
@@ -3445,11 +3445,11 @@ hardrock_2015_donte_spencer_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_sherman_in_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_sherman
   id: 3170
   absolute_time: 2015-07-10 20:54:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 32040.0
   lap: 1
   pacer:
@@ -3458,11 +3458,11 @@ hardrock_2015_donte_spencer_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_sherman_out_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_sherman
   id: 3171
   absolute_time: 2015-07-10 21:17:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 33420.0
   lap: 1
   pacer:
@@ -3471,11 +3471,11 @@ hardrock_2015_donte_spencer_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_grouse_in_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_grouse
   id: 3174
   absolute_time: 2015-07-11 02:11:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 51060.0
   lap: 1
   pacer:
@@ -3484,11 +3484,11 @@ hardrock_2015_donte_spencer_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_grouse_out_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_grouse
   id: 3175
   absolute_time: 2015-07-11 02:43:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 52980.0
   lap: 1
   pacer:
@@ -3497,11 +3497,11 @@ hardrock_2015_donte_spencer_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_ouray_in_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_ouray
   id: 3178
   absolute_time: 2015-07-11 09:34:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 77640.0
   lap: 1
   pacer:
@@ -3510,11 +3510,11 @@ hardrock_2015_donte_spencer_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_ouray_out_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_ouray
   id: 3179
   absolute_time: 2015-07-11 11:19:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 83940.0
   lap: 1
   pacer:
@@ -3523,11 +3523,11 @@ hardrock_2015_donte_spencer_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_telluride_in_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_telluride
   id: 3184
   absolute_time: 2015-07-11 17:44:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 107040.0
   lap: 1
   pacer:
@@ -3536,11 +3536,11 @@ hardrock_2015_donte_spencer_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_telluride_out_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_telluride
   id: 3185
   absolute_time: 2015-07-11 17:56:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 107760.0
   lap: 1
   pacer:
@@ -3549,11 +3549,11 @@ hardrock_2015_donte_spencer_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_putnam_in_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_putnam
   id: 3190
   absolute_time: 2015-07-12 07:24:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 156240.0
   lap: 1
   pacer:
@@ -3562,11 +3562,11 @@ hardrock_2015_donte_spencer_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donte_spencer_putnam_out_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_putnam
   id: 3191
   absolute_time: 2015-07-12 08:48:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 161280.0
   lap: 1
   pacer:
@@ -3575,11 +3575,11 @@ hardrock_2015_donte_spencer_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donte_spencer_finish_1:
+  effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_finish
   id: 3192
   absolute_time: 2015-07-12 10:48:00.000000000 Z
   data_status: 2
-  effort_id: 112
   elapsed_seconds: 168480.0
   lap: 1
   pacer:
@@ -3588,11 +3588,11 @@ hardrock_2015_donte_spencer_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_start_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_start
   id: 3283
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -3601,11 +3601,11 @@ hardrock_2015_bruno_fadel_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_cunningham_in_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_cunningham
   id: 3284
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 11100.0
   lap: 1
   pacer:
@@ -3614,11 +3614,11 @@ hardrock_2015_bruno_fadel_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_cunningham_out_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_cunningham
   id: 3285
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 11100.0
   lap: 1
   pacer:
@@ -3627,11 +3627,11 @@ hardrock_2015_bruno_fadel_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_sherman_in_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_sherman
   id: 3290
   absolute_time: 2015-07-10 22:10:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 36600.0
   lap: 1
   pacer:
@@ -3640,11 +3640,11 @@ hardrock_2015_bruno_fadel_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_sherman_out_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_sherman
   id: 3291
   absolute_time: 2015-07-10 22:20:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 37200.0
   lap: 1
   pacer:
@@ -3653,11 +3653,11 @@ hardrock_2015_bruno_fadel_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_grouse_in_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_grouse
   id: 3294
   absolute_time: 2015-07-11 04:15:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 58500.0
   lap: 1
   pacer:
@@ -3666,11 +3666,11 @@ hardrock_2015_bruno_fadel_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_grouse_out_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_grouse
   id: 3295
   absolute_time: 2015-07-11 04:32:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 59520.0
   lap: 1
   pacer:
@@ -3679,11 +3679,11 @@ hardrock_2015_bruno_fadel_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_ouray_in_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_ouray
   id: 3298
   absolute_time: 2015-07-11 10:13:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 79980.0
   lap: 1
   pacer:
@@ -3692,11 +3692,11 @@ hardrock_2015_bruno_fadel_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_ouray_out_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_ouray
   id: 3299
   absolute_time: 2015-07-11 10:35:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 81300.0
   lap: 1
   pacer:
@@ -3705,11 +3705,11 @@ hardrock_2015_bruno_fadel_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_telluride_in_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_telluride
   id: 3304
   absolute_time: 2015-07-11 17:18:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 105480.0
   lap: 1
   pacer:
@@ -3718,11 +3718,11 @@ hardrock_2015_bruno_fadel_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_telluride_out_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_telluride
   id: 3305
   absolute_time: 2015-07-11 17:37:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 106620.0
   lap: 1
   pacer:
@@ -3731,11 +3731,11 @@ hardrock_2015_bruno_fadel_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_putnam_in_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_putnam
   id: 3310
   absolute_time: 2015-07-12 08:22:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 159720.0
   lap: 1
   pacer:
@@ -3744,11 +3744,11 @@ hardrock_2015_bruno_fadel_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bruno_fadel_putnam_out_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_putnam
   id: 3311
   absolute_time: 2015-07-12 08:28:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 160080.0
   lap: 1
   pacer:
@@ -3757,11 +3757,11 @@ hardrock_2015_bruno_fadel_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bruno_fadel_finish_1:
+  effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_finish
   id: 3312
   absolute_time: 2015-07-12 11:17:00.000000000 Z
   data_status: 2
-  effort_id: 116
   elapsed_seconds: 170220.0
   lap: 1
   pacer:
@@ -3770,11 +3770,11 @@ hardrock_2015_bruno_fadel_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_start_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_start
   id: 3313
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -3783,11 +3783,11 @@ hardrock_2015_gus_walker_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_cunningham_in_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_cunningham
   id: 3314
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 11100.0
   lap: 1
   pacer:
@@ -3796,11 +3796,11 @@ hardrock_2015_gus_walker_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_cunningham_out_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_cunningham
   id: 3315
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 11100.0
   lap: 1
   pacer:
@@ -3809,11 +3809,11 @@ hardrock_2015_gus_walker_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_sherman_in_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_sherman
   id: 3320
   absolute_time: 2015-07-10 22:26:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 37560.0
   lap: 1
   pacer:
@@ -3822,11 +3822,11 @@ hardrock_2015_gus_walker_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_sherman_out_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_sherman
   id: 3321
   absolute_time: 2015-07-10 22:46:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 38760.0
   lap: 1
   pacer:
@@ -3835,11 +3835,11 @@ hardrock_2015_gus_walker_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_grouse_in_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_grouse
   id: 3324
   absolute_time: 2015-07-11 05:05:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 61500.0
   lap: 1
   pacer:
@@ -3848,11 +3848,11 @@ hardrock_2015_gus_walker_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_grouse_out_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_grouse
   id: 3325
   absolute_time: 2015-07-11 05:09:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 61740.0
   lap: 1
   pacer:
@@ -3861,11 +3861,11 @@ hardrock_2015_gus_walker_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_ouray_in_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_ouray
   id: 3328
   absolute_time: 2015-07-11 09:04:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 75840.0
   lap: 1
   pacer:
@@ -3874,11 +3874,11 @@ hardrock_2015_gus_walker_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_ouray_out_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_ouray
   id: 3329
   absolute_time: 2015-07-11 09:16:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 76560.0
   lap: 1
   pacer:
@@ -3887,11 +3887,11 @@ hardrock_2015_gus_walker_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_telluride_in_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_telluride
   id: 3334
   absolute_time: 2015-07-11 18:49:00.000000000 Z
   data_status: 1
-  effort_id: 117
   elapsed_seconds: 110940.0
   lap: 1
   pacer:
@@ -3900,11 +3900,11 @@ hardrock_2015_gus_walker_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_telluride_out_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_telluride
   id: 3335
   absolute_time: 2015-07-11 19:08:00.000000000 Z
   data_status: 1
-  effort_id: 117
   elapsed_seconds: 112080.0
   lap: 1
   pacer:
@@ -3913,11 +3913,11 @@ hardrock_2015_gus_walker_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_putnam_in_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_putnam
   id: 3340
   absolute_time: 2015-07-12 09:28:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 163680.0
   lap: 1
   pacer:
@@ -3926,11 +3926,11 @@ hardrock_2015_gus_walker_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_gus_walker_putnam_out_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_putnam
   id: 3341
   absolute_time: 2015-07-12 09:30:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 163800.0
   lap: 1
   pacer:
@@ -3939,11 +3939,11 @@ hardrock_2015_gus_walker_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_gus_walker_finish_1:
+  effort: hardrock_2015_gus_walker
   split: hardrock_ccw_finish
   id: 3342
   absolute_time: 2015-07-12 11:22:00.000000000 Z
   data_status: 2
-  effort_id: 117
   elapsed_seconds: 170520.0
   lap: 1
   pacer:
@@ -3952,11 +3952,11 @@ hardrock_2015_gus_walker_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_start_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_start
   id: 3433
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -3965,11 +3965,11 @@ hardrock_2015_susanna_abshire_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_cunningham_in_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_cunningham
   id: 3434
   absolute_time: 2015-07-10 15:16:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 11760.0
   lap: 1
   pacer:
@@ -3978,11 +3978,11 @@ hardrock_2015_susanna_abshire_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_cunningham_out_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_cunningham
   id: 3435
   absolute_time: 2015-07-10 15:16:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 11760.0
   lap: 1
   pacer:
@@ -3991,11 +3991,11 @@ hardrock_2015_susanna_abshire_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_susanna_abshire_sherman_in_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_sherman
   id: 3440
   absolute_time: 2015-07-10 22:50:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 39000.0
   lap: 1
   pacer:
@@ -4004,11 +4004,11 @@ hardrock_2015_susanna_abshire_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_sherman_out_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_sherman
   id: 3441
   absolute_time: 2015-07-10 23:02:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 39720.0
   lap: 1
   pacer:
@@ -4017,11 +4017,11 @@ hardrock_2015_susanna_abshire_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_susanna_abshire_grouse_in_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_grouse
   id: 3444
   absolute_time: 2015-07-11 05:25:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 62700.0
   lap: 1
   pacer:
@@ -4030,11 +4030,11 @@ hardrock_2015_susanna_abshire_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_grouse_out_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_grouse
   id: 3445
   absolute_time: 2015-07-11 05:38:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 63480.0
   lap: 1
   pacer:
@@ -4043,11 +4043,11 @@ hardrock_2015_susanna_abshire_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_susanna_abshire_telluride_in_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_telluride
   id: 3454
   absolute_time: 2015-07-11 19:11:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 112260.0
   lap: 1
   pacer:
@@ -4056,11 +4056,11 @@ hardrock_2015_susanna_abshire_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_telluride_out_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_telluride
   id: 3455
   absolute_time: 2015-07-11 19:21:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 112860.0
   lap: 1
   pacer:
@@ -4069,11 +4069,11 @@ hardrock_2015_susanna_abshire_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_susanna_abshire_putnam_in_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_putnam
   id: 3460
   absolute_time: 2015-07-12 09:26:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 163560.0
   lap: 1
   pacer:
@@ -4082,11 +4082,11 @@ hardrock_2015_susanna_abshire_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_susanna_abshire_putnam_out_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_putnam
   id: 3461
   absolute_time: 2015-07-12 09:26:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 163560.0
   lap: 1
   pacer:
@@ -4095,11 +4095,11 @@ hardrock_2015_susanna_abshire_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_susanna_abshire_finish_1:
+  effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_finish
   id: 3462
   absolute_time: 2015-07-12 11:31:00.000000000 Z
   data_status: 2
-  effort_id: 121
   elapsed_seconds: 171060.0
   lap: 1
   pacer:
@@ -4108,11 +4108,11 @@ hardrock_2015_susanna_abshire_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_start_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_start
   id: 3553
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -4121,11 +4121,11 @@ hardrock_2015_leandro_cole_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_cunningham_in_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_cunningham
   id: 3554
   absolute_time: 2015-07-10 15:14:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 11640.0
   lap: 1
   pacer:
@@ -4134,11 +4134,11 @@ hardrock_2015_leandro_cole_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_cunningham_out_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_cunningham
   id: 3555
   absolute_time: 2015-07-10 15:14:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 11640.0
   lap: 1
   pacer:
@@ -4147,11 +4147,11 @@ hardrock_2015_leandro_cole_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_sherman_in_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_sherman
   id: 3560
   absolute_time: 2015-07-10 22:15:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 36900.0
   lap: 1
   pacer:
@@ -4160,11 +4160,11 @@ hardrock_2015_leandro_cole_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_sherman_out_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_sherman
   id: 3561
   absolute_time: 2015-07-10 22:35:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 38100.0
   lap: 1
   pacer:
@@ -4173,11 +4173,11 @@ hardrock_2015_leandro_cole_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_grouse_in_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_grouse
   id: 3564
   absolute_time: 2015-07-11 04:18:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 58680.0
   lap: 1
   pacer:
@@ -4186,11 +4186,11 @@ hardrock_2015_leandro_cole_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_grouse_out_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_grouse
   id: 3565
   absolute_time: 2015-07-11 04:53:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 60780.0
   lap: 1
   pacer:
@@ -4199,11 +4199,11 @@ hardrock_2015_leandro_cole_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_ouray_in_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_ouray
   id: 3568
   absolute_time: 2015-07-11 07:39:00.000000000 Z
   data_status: 1
-  effort_id: 125
   elapsed_seconds: 70740.0
   lap: 1
   pacer:
@@ -4212,11 +4212,11 @@ hardrock_2015_leandro_cole_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_ouray_out_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_ouray
   id: 3569
   absolute_time: 2015-07-11 07:47:00.000000000 Z
   data_status: 1
-  effort_id: 125
   elapsed_seconds: 71220.0
   lap: 1
   pacer:
@@ -4225,11 +4225,11 @@ hardrock_2015_leandro_cole_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_telluride_in_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_telluride
   id: 3574
   absolute_time: 2015-07-11 18:49:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 110940.0
   lap: 1
   pacer:
@@ -4238,11 +4238,11 @@ hardrock_2015_leandro_cole_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_telluride_out_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_telluride
   id: 3575
   absolute_time: 2015-07-11 19:14:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 112440.0
   lap: 1
   pacer:
@@ -4251,11 +4251,11 @@ hardrock_2015_leandro_cole_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_putnam_in_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_putnam
   id: 3580
   absolute_time: 2015-07-12 09:30:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 163800.0
   lap: 1
   pacer:
@@ -4264,11 +4264,11 @@ hardrock_2015_leandro_cole_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_leandro_cole_putnam_out_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_putnam
   id: 3581
   absolute_time: 2015-07-12 09:32:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 163920.0
   lap: 1
   pacer:
@@ -4277,11 +4277,11 @@ hardrock_2015_leandro_cole_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_leandro_cole_finish_1:
+  effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_finish
   id: 3582
   absolute_time: 2015-07-12 11:37:00.000000000 Z
   data_status: 2
-  effort_id: 125
   elapsed_seconds: 171420.0
   lap: 1
   pacer:
@@ -4290,11 +4290,11 @@ hardrock_2015_leandro_cole_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_start_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_start
   id: 3673
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -4303,11 +4303,11 @@ hardrock_2015_benedict_davis_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_cunningham_in_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_cunningham
   id: 3674
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 11100.0
   lap: 1
   pacer:
@@ -4316,11 +4316,11 @@ hardrock_2015_benedict_davis_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_cunningham_out_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_cunningham
   id: 3675
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 11100.0
   lap: 1
   pacer:
@@ -4329,11 +4329,11 @@ hardrock_2015_benedict_davis_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_sherman_in_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_sherman
   id: 3680
   absolute_time: 2015-07-10 22:29:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 37740.0
   lap: 1
   pacer:
@@ -4342,11 +4342,11 @@ hardrock_2015_benedict_davis_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_sherman_out_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_sherman
   id: 3681
   absolute_time: 2015-07-10 22:58:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 39480.0
   lap: 1
   pacer:
@@ -4355,11 +4355,11 @@ hardrock_2015_benedict_davis_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_grouse_in_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_grouse
   id: 3684
   absolute_time: 2015-07-11 04:59:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 61140.0
   lap: 1
   pacer:
@@ -4368,11 +4368,11 @@ hardrock_2015_benedict_davis_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_grouse_out_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_grouse
   id: 3685
   absolute_time: 2015-07-11 05:36:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 63360.0
   lap: 1
   pacer:
@@ -4381,11 +4381,11 @@ hardrock_2015_benedict_davis_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_ouray_in_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_ouray
   id: 3688
   absolute_time: 2015-07-11 08:24:00.000000000 Z
   data_status: 1
-  effort_id: 129
   elapsed_seconds: 73440.0
   lap: 1
   pacer:
@@ -4394,11 +4394,11 @@ hardrock_2015_benedict_davis_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_ouray_out_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_ouray
   id: 3689
   absolute_time: 2015-07-11 08:30:00.000000000 Z
   data_status: 1
-  effort_id: 129
   elapsed_seconds: 73800.0
   lap: 1
   pacer:
@@ -4407,11 +4407,11 @@ hardrock_2015_benedict_davis_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_telluride_in_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_telluride
   id: 3694
   absolute_time: 2015-07-11 17:55:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 107700.0
   lap: 1
   pacer:
@@ -4420,11 +4420,11 @@ hardrock_2015_benedict_davis_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_telluride_out_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_telluride
   id: 3695
   absolute_time: 2015-07-11 18:27:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 109620.0
   lap: 1
   pacer:
@@ -4433,11 +4433,11 @@ hardrock_2015_benedict_davis_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_putnam_in_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_putnam
   id: 3700
   absolute_time: 2015-07-12 09:58:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 165480.0
   lap: 1
   pacer:
@@ -4446,11 +4446,11 @@ hardrock_2015_benedict_davis_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_benedict_davis_putnam_out_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_putnam
   id: 3701
   absolute_time: 2015-07-12 10:00:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 165600.0
   lap: 1
   pacer:
@@ -4459,11 +4459,11 @@ hardrock_2015_benedict_davis_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_benedict_davis_finish_1:
+  effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_finish
   id: 3702
   absolute_time: 2015-07-12 11:59:00.000000000 Z
   data_status: 2
-  effort_id: 129
   elapsed_seconds: 172740.0
   lap: 1
   pacer:
@@ -4472,11 +4472,11 @@ hardrock_2015_benedict_davis_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_start_1:
+  effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_start
   id: 3869
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 136
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -4485,11 +4485,11 @@ hardrock_2015_raphael_swift_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_cunningham_in_1:
+  effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_cunningham
   id: 3870
   absolute_time: 2015-07-10 15:24:00.000000000 Z
   data_status: 2
-  effort_id: 136
   elapsed_seconds: 12240.0
   lap: 1
   pacer:
@@ -4498,11 +4498,11 @@ hardrock_2015_raphael_swift_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_cunningham_out_1:
+  effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_cunningham
   id: 3871
   absolute_time: 2015-07-10 15:24:00.000000000 Z
   data_status: 2
-  effort_id: 136
   elapsed_seconds: 12240.0
   lap: 1
   pacer:
@@ -4511,11 +4511,11 @@ hardrock_2015_raphael_swift_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_raphael_swift_sherman_in_1:
+  effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_sherman
   id: 3876
   absolute_time: 2015-07-10 22:53:00.000000000 Z
   data_status: 2
-  effort_id: 136
   elapsed_seconds: 39180.0
   lap: 1
   pacer:
@@ -4524,11 +4524,11 @@ hardrock_2015_raphael_swift_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_sherman_out_1:
+  effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_sherman
   id: 3877
   absolute_time: 2015-07-10 23:02:00.000000000 Z
   data_status: 2
-  effort_id: 136
   elapsed_seconds: 39720.0
   lap: 1
   pacer:
@@ -4537,11 +4537,11 @@ hardrock_2015_raphael_swift_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_raphael_swift_grouse_in_1:
+  effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_grouse
   id: 3880
   absolute_time: 2015-07-11 05:04:00.000000000 Z
   data_status: 2
-  effort_id: 136
   elapsed_seconds: 61440.0
   lap: 1
   pacer:
@@ -4550,11 +4550,11 @@ hardrock_2015_raphael_swift_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_grouse_out_1:
+  effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_grouse
   id: 3881
   absolute_time: 2015-07-11 05:13:00.000000000 Z
   data_status: 2
-  effort_id: 136
   elapsed_seconds: 61980.0
   lap: 1
   pacer:
@@ -4563,11 +4563,11 @@ hardrock_2015_raphael_swift_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_raphael_swift_ouray_in_1:
+  effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_ouray
   id: 3884
   absolute_time: 2015-07-11 07:59:00.000000000 Z
   data_status: 1
-  effort_id: 136
   elapsed_seconds: 71940.0
   lap: 1
   pacer:
@@ -4576,11 +4576,11 @@ hardrock_2015_raphael_swift_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_ouray_out_1:
+  effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_ouray
   id: 3885
   absolute_time: 2015-07-11 08:06:00.000000000 Z
   data_status: 1
-  effort_id: 136
   elapsed_seconds: 72360.0
   lap: 1
   pacer:
@@ -4589,11 +4589,11 @@ hardrock_2015_raphael_swift_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_raphael_swift_telluride_in_1:
+  effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_telluride
   id: 3890
   absolute_time: 2015-07-11 18:22:00.000000000 Z
   data_status: 2
-  effort_id: 136
   elapsed_seconds: 109320.0
   lap: 1
   pacer:
@@ -4602,11 +4602,11 @@ hardrock_2015_raphael_swift_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_raphael_swift_telluride_out_1:
+  effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_telluride
   id: 3891
   absolute_time: 2015-07-11 18:44:00.000000000 Z
   data_status: 2
-  effort_id: 136
   elapsed_seconds: 110640.0
   lap: 1
   pacer:
@@ -4615,11 +4615,11 @@ hardrock_2015_raphael_swift_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_start_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_start
   id: 3919
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 138
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -4628,11 +4628,11 @@ hardrock_2015_bad_status_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_cunningham_in_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_cunningham
   id: 3920
   absolute_time: 2015-07-10 15:13:00.000000000 Z
   data_status: 2
-  effort_id: 138
   elapsed_seconds: 11580.0
   lap: 1
   pacer:
@@ -4641,11 +4641,11 @@ hardrock_2015_bad_status_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_cunningham_out_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_cunningham
   id: 3921
   absolute_time: 2015-07-10 15:13:00.000000000 Z
   data_status: 2
-  effort_id: 138
   elapsed_seconds: 11580.0
   lap: 1
   pacer:
@@ -4654,11 +4654,11 @@ hardrock_2015_bad_status_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_sherman_in_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_sherman
   id: 3926
   absolute_time: 2015-07-10 23:11:00.000000000 Z
   data_status: 2
-  effort_id: 138
   elapsed_seconds: 40260.0
   lap: 1
   pacer:
@@ -4667,11 +4667,11 @@ hardrock_2015_bad_status_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_sherman_out_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_sherman
   id: 3927
   absolute_time: 2015-07-10 23:22:00.000000000 Z
   data_status: 2
-  effort_id: 138
   elapsed_seconds: 40920.0
   lap: 1
   pacer:
@@ -4680,11 +4680,11 @@ hardrock_2015_bad_status_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_grouse_in_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_grouse
   id: 3930
   absolute_time: 2015-07-11 06:37:00.000000000 Z
   data_status: 2
-  effort_id: 138
   elapsed_seconds: 67020.0
   lap: 1
   pacer:
@@ -4693,11 +4693,11 @@ hardrock_2015_bad_status_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_grouse_out_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_grouse
   id: 3931
   absolute_time: 2015-07-11 06:51:00.000000000 Z
   data_status: 2
-  effort_id: 138
   elapsed_seconds: 67860.0
   lap: 1
   pacer:
@@ -4706,11 +4706,11 @@ hardrock_2015_bad_status_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_ouray_in_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_ouray
   id: 3934
   absolute_time: 2015-07-11 13:19:00.000000000 Z
   data_status: 2
-  effort_id: 138
   elapsed_seconds: 91140.0
   lap: 1
   pacer:
@@ -4719,11 +4719,11 @@ hardrock_2015_bad_status_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_ouray_out_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_ouray
   id: 3935
   absolute_time: 2015-07-11 14:09:00.000000000 Z
   data_status: 2
-  effort_id: 138
   elapsed_seconds: 94140.0
   lap: 1
   pacer:
@@ -4732,11 +4732,11 @@ hardrock_2015_bad_status_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_irvin_harber_start_1:
+  effort: hardrock_2015_irvin_harber
   split: hardrock_ccw_start
   id: 3980
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 141
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -4745,11 +4745,11 @@ hardrock_2015_irvin_harber_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_cunningham_in_1:
+  effort: hardrock_2015_irvin_harber
   split: hardrock_ccw_cunningham
   id: 3981
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
-  effort_id: 141
   elapsed_seconds: 8640.0
   lap: 1
   pacer:
@@ -4758,11 +4758,11 @@ hardrock_2015_irvin_harber_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_cunningham_out_1:
+  effort: hardrock_2015_irvin_harber
   split: hardrock_ccw_cunningham
   id: 3982
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
-  effort_id: 141
   elapsed_seconds: 8640.0
   lap: 1
   pacer:
@@ -4771,11 +4771,11 @@ hardrock_2015_irvin_harber_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_irvin_harber_sherman_in_1:
+  effort: hardrock_2015_irvin_harber
   split: hardrock_ccw_sherman
   id: 3987
   absolute_time: 2015-07-10 19:39:00.000000000 Z
   data_status: 2
-  effort_id: 141
   elapsed_seconds: 27540.0
   lap: 1
   pacer:
@@ -4784,11 +4784,11 @@ hardrock_2015_irvin_harber_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_sherman_out_1:
+  effort: hardrock_2015_irvin_harber
   split: hardrock_ccw_sherman
   id: 3988
   absolute_time: 2015-07-10 19:45:00.000000000 Z
   data_status: 2
-  effort_id: 141
   elapsed_seconds: 27900.0
   lap: 1
   pacer:
@@ -4797,11 +4797,11 @@ hardrock_2015_irvin_harber_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_irvin_harber_grouse_in_1:
+  effort: hardrock_2015_irvin_harber
   split: hardrock_ccw_grouse
   id: 3991
   absolute_time: 2015-07-11 00:44:00.000000000 Z
   data_status: 2
-  effort_id: 141
   elapsed_seconds: 45840.0
   lap: 1
   pacer:
@@ -4810,11 +4810,11 @@ hardrock_2015_irvin_harber_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_grouse_out_1:
+  effort: hardrock_2015_irvin_harber
   split: hardrock_ccw_grouse
   id: 3992
   absolute_time: 2015-07-11 01:10:00.000000000 Z
   data_status: 2
-  effort_id: 141
   elapsed_seconds: 47400.0
   lap: 1
   pacer:
@@ -4823,11 +4823,11 @@ hardrock_2015_irvin_harber_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_irvin_harber_ouray_in_1:
+  effort: hardrock_2015_irvin_harber
   split: hardrock_ccw_ouray
   id: 3995
   absolute_time: 2015-07-11 05:46:00.000000000 Z
   data_status: 2
-  effort_id: 141
   elapsed_seconds: 63960.0
   lap: 1
   pacer:
@@ -4836,11 +4836,11 @@ hardrock_2015_irvin_harber_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_ouray_out_1:
+  effort: hardrock_2015_irvin_harber
   split: hardrock_ccw_ouray
   id: 3996
   absolute_time: 2015-07-11 05:46:00.000000000 Z
   data_status: 2
-  effort_id: 141
   elapsed_seconds: 63960.0
   lap: 1
   pacer:
@@ -4849,11 +4849,11 @@ hardrock_2015_irvin_harber_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cassondra_nienow_start_1:
+  effort: hardrock_2015_cassondra_nienow
   split: hardrock_ccw_start
   id: 4190
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 155
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -4862,11 +4862,11 @@ hardrock_2015_cassondra_nienow_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cassondra_nienow_cunningham_in_1:
+  effort: hardrock_2015_cassondra_nienow
   split: hardrock_ccw_cunningham
   id: 4191
   absolute_time: 2015-07-10 15:31:00.000000000 Z
   data_status: 2
-  effort_id: 155
   elapsed_seconds: 12660.0
   lap: 1
   pacer:
@@ -4875,11 +4875,11 @@ hardrock_2015_cassondra_nienow_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cassondra_nienow_cunningham_out_1:
+  effort: hardrock_2015_cassondra_nienow
   split: hardrock_ccw_cunningham
   id: 4192
   absolute_time: 2015-07-10 15:31:00.000000000 Z
   data_status: 2
-  effort_id: 155
   elapsed_seconds: 12660.0
   lap: 1
   pacer:
@@ -4888,11 +4888,11 @@ hardrock_2015_cassondra_nienow_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_cassondra_nienow_sherman_in_1:
+  effort: hardrock_2015_cassondra_nienow
   split: hardrock_ccw_sherman
   id: 4197
   absolute_time: 2015-07-11 00:03:00.000000000 Z
   data_status: 2
-  effort_id: 155
   elapsed_seconds: 43380.0
   lap: 1
   pacer:
@@ -4901,11 +4901,11 @@ hardrock_2015_cassondra_nienow_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cassondra_nienow_sherman_out_1:
+  effort: hardrock_2015_cassondra_nienow
   split: hardrock_ccw_sherman
   id: 4198
   absolute_time: 2015-07-11 00:03:00.000000000 Z
   data_status: 2
-  effort_id: 155
   elapsed_seconds: 43380.0
   lap: 1
   pacer:
@@ -4914,11 +4914,11 @@ hardrock_2015_cassondra_nienow_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_donn_mckenzie_start_1:
+  effort: hardrock_2015_donn_mckenzie
   split: hardrock_ccw_start
   id: 4217
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 158
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -4927,11 +4927,11 @@ hardrock_2015_donn_mckenzie_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donn_mckenzie_cunningham_in_1:
+  effort: hardrock_2015_donn_mckenzie
   split: hardrock_ccw_cunningham
   id: 4218
   absolute_time: 2015-07-10 14:30:00.000000000 Z
   data_status: 2
-  effort_id: 158
   elapsed_seconds: 9000.0
   lap: 1
   pacer:
@@ -4940,11 +4940,11 @@ hardrock_2015_donn_mckenzie_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_donn_mckenzie_cunningham_out_1:
+  effort: hardrock_2015_donn_mckenzie
   split: hardrock_ccw_cunningham
   id: 4219
   absolute_time: 2015-07-10 14:30:00.000000000 Z
   data_status: 2
-  effort_id: 158
   elapsed_seconds: 9000.0
   lap: 1
   pacer:
@@ -4953,11 +4953,11 @@ hardrock_2015_donn_mckenzie_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 ramble_finished_first_start_1:
+  effort: ramble_finished_first
   split: ramble_even_course_start
   id: 15144
   absolute_time: 2006-09-16 14:00:00.000000000 Z
   data_status: 2
-  effort_id: 1040
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -4966,11 +4966,11 @@ ramble_finished_first_start_1:
   sub_split_bitkey: 1
   status_reason:
 ramble_finished_first_finish_1:
+  effort: ramble_finished_first
   split: ramble_even_course_finish
   id: 15145
   absolute_time: 2006-09-16 14:34:22.000000000 Z
   data_status: 2
-  effort_id: 1040
   elapsed_seconds: 2062.0
   lap: 1
   pacer:
@@ -4979,11 +4979,11 @@ ramble_finished_first_finish_1:
   sub_split_bitkey: 1
   status_reason:
 ramble_finished_second_start_1:
+  effort: ramble_finished_second
   split: ramble_even_course_start
   id: 15160
   absolute_time: 2006-09-16 14:00:00.000000000 Z
   data_status: 2
-  effort_id: 1048
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -4992,11 +4992,11 @@ ramble_finished_second_start_1:
   sub_split_bitkey: 1
   status_reason:
 ramble_finished_second_finish_1:
+  effort: ramble_finished_second
   split: ramble_even_course_finish
   id: 15161
   absolute_time: 2006-09-16 14:37:31.000000000 Z
   data_status: 2
-  effort_id: 1048
   elapsed_seconds: 2251.0
   lap: 1
   pacer:
@@ -5005,11 +5005,11 @@ ramble_finished_second_finish_1:
   sub_split_bitkey: 1
   status_reason:
 ramble_start_only_start_1:
+  effort: ramble_start_only
   split: ramble_even_course_start
   id: 15166
   absolute_time: 2006-09-16 14:00:00.000000000 Z
   data_status: 2
-  effort_id: 1051
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -5018,11 +5018,11 @@ ramble_start_only_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_start_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_start
   id: 91259
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -5031,11 +5031,11 @@ hardrock_2014_finished_first_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_telluride_in_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_telluride
   id: 91264
   absolute_time: 2014-07-11 18:24:00.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 23040.0
   lap: 1
   pacer:
@@ -5044,11 +5044,11 @@ hardrock_2014_finished_first_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_telluride_out_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_telluride
   id: 91265
   absolute_time: 2014-07-11 18:26:00.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 23160.0
   lap: 1
   pacer:
@@ -5057,11 +5057,11 @@ hardrock_2014_finished_first_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_first_ouray_in_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_ouray
   id: 91270
   absolute_time: 2014-07-11 21:50:00.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 35400.0
   lap: 1
   pacer:
@@ -5070,11 +5070,11 @@ hardrock_2014_finished_first_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_ouray_out_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_ouray
   id: 91271
   absolute_time: 2014-07-11 21:52:00.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 35520.0
   lap: 1
   pacer:
@@ -5083,11 +5083,11 @@ hardrock_2014_finished_first_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_first_grouse_in_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_grouse
   id: 91274
   absolute_time: 2014-07-12 01:38:00.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 49080.0
   lap: 1
   pacer:
@@ -5096,11 +5096,11 @@ hardrock_2014_finished_first_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_grouse_out_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_grouse
   id: 91275
   absolute_time: 2014-07-12 01:43:00.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 49380.0
   lap: 1
   pacer:
@@ -5109,11 +5109,11 @@ hardrock_2014_finished_first_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_first_sherman_in_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_sherman
   id: 91278
   absolute_time: 2014-07-12 06:08:00.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 65280.0
   lap: 1
   pacer:
@@ -5122,11 +5122,11 @@ hardrock_2014_finished_first_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_sherman_out_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_sherman
   id: 91279
   absolute_time: 2014-07-12 06:17:00.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 65820.0
   lap: 1
   pacer:
@@ -5135,11 +5135,11 @@ hardrock_2014_finished_first_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_first_cunningham_in_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_cunningham
   id: 91284
   absolute_time: 2014-07-12 13:21:00.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 91260.0
   lap: 1
   pacer:
@@ -5148,11 +5148,11 @@ hardrock_2014_finished_first_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_first_cunningham_out_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_cunningham
   id: 91285
   absolute_time: 2014-07-12 13:27:00.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 91620.0
   lap: 1
   pacer:
@@ -5161,11 +5161,11 @@ hardrock_2014_finished_first_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_first_finish_1:
+  effort: hardrock_2014_finished_first
   split: hardrock_cw_finish
   id: 91286
   absolute_time: 2014-07-12 16:07:38.000000000 Z
   data_status:
-  effort_id: 4172
   elapsed_seconds: 101258.0
   lap: 1
   pacer:
@@ -5174,11 +5174,11 @@ hardrock_2014_finished_first_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_start_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_start
   id: 91287
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -5187,11 +5187,11 @@ hardrock_2014_finished_with_stop_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_telluride_in_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_telluride
   id: 91292
   absolute_time: 2014-07-11 18:59:00.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 25140.0
   lap: 1
   pacer:
@@ -5200,11 +5200,11 @@ hardrock_2014_finished_with_stop_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_telluride_out_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_telluride
   id: 91293
   absolute_time: 2014-07-11 19:03:00.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 25380.0
   lap: 1
   pacer:
@@ -5213,11 +5213,11 @@ hardrock_2014_finished_with_stop_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_with_stop_ouray_in_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_ouray
   id: 91298
   absolute_time: 2014-07-11 22:43:00.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 38580.0
   lap: 1
   pacer:
@@ -5226,11 +5226,11 @@ hardrock_2014_finished_with_stop_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_ouray_out_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_ouray
   id: 91299
   absolute_time: 2014-07-11 22:46:00.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 38760.0
   lap: 1
   pacer:
@@ -5239,11 +5239,11 @@ hardrock_2014_finished_with_stop_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_with_stop_grouse_in_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_grouse
   id: 91302
   absolute_time: 2014-07-12 02:56:00.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 53760.0
   lap: 1
   pacer:
@@ -5252,11 +5252,11 @@ hardrock_2014_finished_with_stop_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_grouse_out_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_grouse
   id: 91303
   absolute_time: 2014-07-12 03:06:00.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 54360.0
   lap: 1
   pacer:
@@ -5265,11 +5265,11 @@ hardrock_2014_finished_with_stop_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_with_stop_sherman_in_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_sherman
   id: 91306
   absolute_time: 2014-07-12 07:05:00.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 68700.0
   lap: 1
   pacer:
@@ -5278,11 +5278,11 @@ hardrock_2014_finished_with_stop_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_sherman_out_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_sherman
   id: 91307
   absolute_time: 2014-07-12 07:15:00.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 69300.0
   lap: 1
   pacer:
@@ -5291,11 +5291,11 @@ hardrock_2014_finished_with_stop_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_with_stop_cunningham_in_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_cunningham
   id: 91312
   absolute_time: 2014-07-12 13:43:00.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 92580.0
   lap: 1
   pacer:
@@ -5304,11 +5304,11 @@ hardrock_2014_finished_with_stop_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_with_stop_cunningham_out_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_cunningham
   id: 91313
   absolute_time: 2014-07-12 13:46:00.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 92760.0
   lap: 1
   pacer:
@@ -5317,11 +5317,11 @@ hardrock_2014_finished_with_stop_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_with_stop_finish_1:
+  effort: hardrock_2014_finished_with_stop
   split: hardrock_cw_finish
   id: 91314
   absolute_time: 2014-07-12 16:23:42.000000000 Z
   data_status:
-  effort_id: 4173
   elapsed_seconds: 102222.0
   lap: 1
   pacer:
@@ -5330,11 +5330,11 @@ hardrock_2014_finished_with_stop_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_start_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_start
   id: 91315
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -5343,11 +5343,11 @@ hardrock_2014_finished_without_stop_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_telluride_in_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_telluride
   id: 91320
   absolute_time: 2014-07-11 18:53:00.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 24780.0
   lap: 1
   pacer:
@@ -5356,11 +5356,11 @@ hardrock_2014_finished_without_stop_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_telluride_out_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_telluride
   id: 91321
   absolute_time: 2014-07-11 18:56:00.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 24960.0
   lap: 1
   pacer:
@@ -5369,11 +5369,11 @@ hardrock_2014_finished_without_stop_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_without_stop_ouray_in_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_ouray
   id: 91326
   absolute_time: 2014-07-11 22:43:00.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 38580.0
   lap: 1
   pacer:
@@ -5382,11 +5382,11 @@ hardrock_2014_finished_without_stop_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_ouray_out_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_ouray
   id: 91327
   absolute_time: 2014-07-11 22:50:00.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 39000.0
   lap: 1
   pacer:
@@ -5395,11 +5395,11 @@ hardrock_2014_finished_without_stop_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_without_stop_grouse_in_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_grouse
   id: 91330
   absolute_time: 2014-07-12 03:10:00.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 54600.0
   lap: 1
   pacer:
@@ -5408,11 +5408,11 @@ hardrock_2014_finished_without_stop_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_grouse_out_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_grouse
   id: 91331
   absolute_time: 2014-07-12 03:15:00.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 54900.0
   lap: 1
   pacer:
@@ -5421,11 +5421,11 @@ hardrock_2014_finished_without_stop_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_without_stop_sherman_in_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_sherman
   id: 91334
   absolute_time: 2014-07-12 07:15:00.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 69300.0
   lap: 1
   pacer:
@@ -5434,11 +5434,11 @@ hardrock_2014_finished_without_stop_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_sherman_out_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_sherman
   id: 91335
   absolute_time: 2014-07-12 07:23:59.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 69839.0
   lap: 1
   pacer:
@@ -5447,11 +5447,11 @@ hardrock_2014_finished_without_stop_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_without_stop_cunningham_in_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_cunningham
   id: 91340
   absolute_time: 2014-07-12 14:04:00.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 93840.0
   lap: 1
   pacer:
@@ -5460,11 +5460,11 @@ hardrock_2014_finished_without_stop_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_finished_without_stop_cunningham_out_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_cunningham
   id: 91341
   absolute_time: 2014-07-12 14:04:00.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 93840.0
   lap: 1
   pacer:
@@ -5473,11 +5473,11 @@ hardrock_2014_finished_without_stop_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_finished_without_stop_finish_1:
+  effort: hardrock_2014_finished_without_stop
   split: hardrock_cw_finish
   id: 91342
   absolute_time: 2014-07-12 16:28:54.000000000 Z
   data_status:
-  effort_id: 4174
   elapsed_seconds: 102534.0
   lap: 1
   pacer:
@@ -5486,11 +5486,11 @@ hardrock_2014_finished_without_stop_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_start_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_start
   id: 91819
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -5499,11 +5499,11 @@ hardrock_2014_claudio_wunsch_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_telluride_in_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_telluride
   id: 91824
   absolute_time: 2014-07-11 19:00:00.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 25200.0
   lap: 1
   pacer:
@@ -5512,11 +5512,11 @@ hardrock_2014_claudio_wunsch_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_telluride_out_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_telluride
   id: 91825
   absolute_time: 2014-07-11 19:07:00.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 25620.0
   lap: 1
   pacer:
@@ -5525,11 +5525,11 @@ hardrock_2014_claudio_wunsch_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_claudio_wunsch_ouray_in_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_ouray
   id: 91830
   absolute_time: 2014-07-11 23:04:00.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 39840.0
   lap: 1
   pacer:
@@ -5538,11 +5538,11 @@ hardrock_2014_claudio_wunsch_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_ouray_out_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_ouray
   id: 91831
   absolute_time: 2014-07-11 23:24:00.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 41040.0
   lap: 1
   pacer:
@@ -5551,11 +5551,11 @@ hardrock_2014_claudio_wunsch_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_claudio_wunsch_grouse_in_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_grouse
   id: 91834
   absolute_time: 2014-07-12 03:55:00.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 57300.0
   lap: 1
   pacer:
@@ -5564,11 +5564,11 @@ hardrock_2014_claudio_wunsch_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_grouse_out_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_grouse
   id: 91835
   absolute_time: 2014-07-12 04:37:00.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 59820.0
   lap: 1
   pacer:
@@ -5577,11 +5577,11 @@ hardrock_2014_claudio_wunsch_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_claudio_wunsch_sherman_in_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_sherman
   id: 91838
   absolute_time: 2014-07-12 10:17:00.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 80220.0
   lap: 1
   pacer:
@@ -5590,11 +5590,11 @@ hardrock_2014_claudio_wunsch_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_sherman_out_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_sherman
   id: 91839
   absolute_time: 2014-07-12 10:33:00.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 81180.0
   lap: 1
   pacer:
@@ -5603,11 +5603,11 @@ hardrock_2014_claudio_wunsch_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_claudio_wunsch_cunningham_in_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_cunningham
   id: 91844
   absolute_time: 2014-07-12 19:19:00.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 112740.0
   lap: 1
   pacer:
@@ -5616,11 +5616,11 @@ hardrock_2014_claudio_wunsch_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_claudio_wunsch_cunningham_out_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_cunningham
   id: 91845
   absolute_time: 2014-07-12 19:34:00.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 113640.0
   lap: 1
   pacer:
@@ -5629,11 +5629,11 @@ hardrock_2014_claudio_wunsch_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_claudio_wunsch_finish_1:
+  effort: hardrock_2014_claudio_wunsch
   split: hardrock_cw_finish
   id: 91846
   absolute_time: 2014-07-12 23:58:21.000000000 Z
   data_status:
-  effort_id: 4192
   elapsed_seconds: 129501.0
   lap: 1
   pacer:
@@ -5642,11 +5642,11 @@ hardrock_2014_claudio_wunsch_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_start_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_start
   id: 92015
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -5655,11 +5655,11 @@ hardrock_2014_rachelle_eichmann_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_telluride_in_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_telluride
   id: 92020
   absolute_time: 2014-07-11 20:26:59.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 30419.0
   lap: 1
   pacer:
@@ -5668,11 +5668,11 @@ hardrock_2014_rachelle_eichmann_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_telluride_out_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_telluride
   id: 92021
   absolute_time: 2014-07-11 20:39:00.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 31140.0
   lap: 1
   pacer:
@@ -5681,11 +5681,11 @@ hardrock_2014_rachelle_eichmann_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_rachelle_eichmann_ouray_in_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_ouray
   id: 92026
   absolute_time: 2014-07-12 01:23:00.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 48180.0
   lap: 1
   pacer:
@@ -5694,11 +5694,11 @@ hardrock_2014_rachelle_eichmann_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_ouray_out_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_ouray
   id: 92027
   absolute_time: 2014-07-12 01:33:00.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 48780.0
   lap: 1
   pacer:
@@ -5707,11 +5707,11 @@ hardrock_2014_rachelle_eichmann_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_rachelle_eichmann_grouse_in_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_grouse
   id: 92030
   absolute_time: 2014-07-12 07:25:00.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 69900.0
   lap: 1
   pacer:
@@ -5720,11 +5720,11 @@ hardrock_2014_rachelle_eichmann_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_grouse_out_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_grouse
   id: 92031
   absolute_time: 2014-07-12 07:49:00.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 71340.0
   lap: 1
   pacer:
@@ -5733,11 +5733,11 @@ hardrock_2014_rachelle_eichmann_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_rachelle_eichmann_sherman_in_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_sherman
   id: 92034
   absolute_time: 2014-07-12 13:30:00.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 91800.0
   lap: 1
   pacer:
@@ -5746,11 +5746,11 @@ hardrock_2014_rachelle_eichmann_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_sherman_out_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_sherman
   id: 92035
   absolute_time: 2014-07-12 13:49:00.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 92940.0
   lap: 1
   pacer:
@@ -5759,11 +5759,11 @@ hardrock_2014_rachelle_eichmann_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_rachelle_eichmann_cunningham_in_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_cunningham
   id: 92040
   absolute_time: 2014-07-12 21:53:00.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 121980.0
   lap: 1
   pacer:
@@ -5772,11 +5772,11 @@ hardrock_2014_rachelle_eichmann_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_rachelle_eichmann_cunningham_out_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_cunningham
   id: 92041
   absolute_time: 2014-07-12 21:58:00.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 122280.0
   lap: 1
   pacer:
@@ -5785,11 +5785,11 @@ hardrock_2014_rachelle_eichmann_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_rachelle_eichmann_finish_1:
+  effort: hardrock_2014_rachelle_eichmann
   split: hardrock_cw_finish
   id: 92042
   absolute_time: 2014-07-13 01:39:17.000000000 Z
   data_status:
-  effort_id: 4199
   elapsed_seconds: 135557.0
   lap: 1
   pacer:
@@ -5798,11 +5798,11 @@ hardrock_2014_rachelle_eichmann_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_start_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_start
   id: 92211
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -5811,11 +5811,11 @@ hardrock_2014_keith_metz_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_telluride_in_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_telluride
   id: 92216
   absolute_time: 2014-07-11 20:30:00.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 30600.0
   lap: 1
   pacer:
@@ -5824,11 +5824,11 @@ hardrock_2014_keith_metz_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_telluride_out_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_telluride
   id: 92217
   absolute_time: 2014-07-11 20:42:00.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 31320.0
   lap: 1
   pacer:
@@ -5837,11 +5837,11 @@ hardrock_2014_keith_metz_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_keith_metz_ouray_in_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_ouray
   id: 92222
   absolute_time: 2014-07-12 01:27:00.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 48420.0
   lap: 1
   pacer:
@@ -5850,11 +5850,11 @@ hardrock_2014_keith_metz_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_ouray_out_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_ouray
   id: 92223
   absolute_time: 2014-07-12 01:43:00.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 49380.0
   lap: 1
   pacer:
@@ -5863,11 +5863,11 @@ hardrock_2014_keith_metz_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_keith_metz_grouse_in_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_grouse
   id: 92226
   absolute_time: 2014-07-12 07:30:00.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 70200.0
   lap: 1
   pacer:
@@ -5876,11 +5876,11 @@ hardrock_2014_keith_metz_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_grouse_out_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_grouse
   id: 92227
   absolute_time: 2014-07-12 07:56:00.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 71760.0
   lap: 1
   pacer:
@@ -5889,11 +5889,11 @@ hardrock_2014_keith_metz_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_keith_metz_sherman_in_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_sherman
   id: 92230
   absolute_time: 2014-07-12 14:03:00.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 93780.0
   lap: 1
   pacer:
@@ -5902,11 +5902,11 @@ hardrock_2014_keith_metz_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_sherman_out_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_sherman
   id: 92231
   absolute_time: 2014-07-12 14:22:00.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 94920.0
   lap: 1
   pacer:
@@ -5915,11 +5915,11 @@ hardrock_2014_keith_metz_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_keith_metz_cunningham_in_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_cunningham
   id: 92236
   absolute_time: 2014-07-12 23:19:00.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 127140.0
   lap: 1
   pacer:
@@ -5928,11 +5928,11 @@ hardrock_2014_keith_metz_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_keith_metz_cunningham_out_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_cunningham
   id: 92237
   absolute_time: 2014-07-12 23:30:00.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 127800.0
   lap: 1
   pacer:
@@ -5941,11 +5941,11 @@ hardrock_2014_keith_metz_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_keith_metz_finish_1:
+  effort: hardrock_2014_keith_metz
   split: hardrock_cw_finish
   id: 92238
   absolute_time: 2014-07-13 02:59:02.000000000 Z
   data_status:
-  effort_id: 4206
   elapsed_seconds: 140342.0
   lap: 1
   pacer:
@@ -5954,11 +5954,11 @@ hardrock_2014_keith_metz_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_start_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_start
   id: 92239
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -5967,11 +5967,11 @@ hardrock_2014_major_green_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_telluride_in_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_telluride
   id: 92244
   absolute_time: 2014-07-11 20:52:00.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 31920.0
   lap: 1
   pacer:
@@ -5980,11 +5980,11 @@ hardrock_2014_major_green_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_telluride_out_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_telluride
   id: 92245
   absolute_time: 2014-07-11 20:58:00.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 32280.0
   lap: 1
   pacer:
@@ -5993,11 +5993,11 @@ hardrock_2014_major_green_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_major_green_ouray_in_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_ouray
   id: 92250
   absolute_time: 2014-07-12 02:00:00.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 50400.0
   lap: 1
   pacer:
@@ -6006,11 +6006,11 @@ hardrock_2014_major_green_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_ouray_out_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_ouray
   id: 92251
   absolute_time: 2014-07-12 02:12:00.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 51120.0
   lap: 1
   pacer:
@@ -6019,11 +6019,11 @@ hardrock_2014_major_green_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_major_green_grouse_in_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_grouse
   id: 92254
   absolute_time: 2014-07-12 08:07:00.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 72420.0
   lap: 1
   pacer:
@@ -6032,11 +6032,11 @@ hardrock_2014_major_green_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_grouse_out_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_grouse
   id: 92255
   absolute_time: 2014-07-12 08:18:00.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 73080.0
   lap: 1
   pacer:
@@ -6045,11 +6045,11 @@ hardrock_2014_major_green_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_major_green_sherman_in_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_sherman
   id: 92258
   absolute_time: 2014-07-12 14:25:00.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 95100.0
   lap: 1
   pacer:
@@ -6058,11 +6058,11 @@ hardrock_2014_major_green_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_sherman_out_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_sherman
   id: 92259
   absolute_time: 2014-07-12 14:40:00.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 96000.0
   lap: 1
   pacer:
@@ -6071,11 +6071,11 @@ hardrock_2014_major_green_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_major_green_cunningham_in_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_cunningham
   id: 92264
   absolute_time: 2014-07-12 23:13:00.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 126780.0
   lap: 1
   pacer:
@@ -6084,11 +6084,11 @@ hardrock_2014_major_green_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_major_green_cunningham_out_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_cunningham
   id: 92265
   absolute_time: 2014-07-12 23:23:00.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 127380.0
   lap: 1
   pacer:
@@ -6097,11 +6097,11 @@ hardrock_2014_major_green_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_major_green_finish_1:
+  effort: hardrock_2014_major_green
   split: hardrock_cw_finish
   id: 92266
   absolute_time: 2014-07-13 03:03:41.000000000 Z
   data_status:
-  effort_id: 4207
   elapsed_seconds: 140621.0
   lap: 1
   pacer:
@@ -6110,11 +6110,11 @@ hardrock_2014_major_green_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_start_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_start
   id: 92631
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -6123,11 +6123,11 @@ hardrock_2014_humberto_adams_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_telluride_in_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_telluride
   id: 92636
   absolute_time: 2014-07-11 20:54:59.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 32099.0
   lap: 1
   pacer:
@@ -6136,11 +6136,11 @@ hardrock_2014_humberto_adams_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_telluride_out_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_telluride
   id: 92637
   absolute_time: 2014-07-11 21:58:00.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 35880.0
   lap: 1
   pacer:
@@ -6149,11 +6149,11 @@ hardrock_2014_humberto_adams_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_humberto_adams_ouray_in_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_ouray
   id: 92642
   absolute_time: 2014-07-12 01:56:59.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 50219.0
   lap: 1
   pacer:
@@ -6162,11 +6162,11 @@ hardrock_2014_humberto_adams_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_ouray_out_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_ouray
   id: 92643
   absolute_time: 2014-07-12 02:20:00.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 51600.0
   lap: 1
   pacer:
@@ -6175,11 +6175,11 @@ hardrock_2014_humberto_adams_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_humberto_adams_grouse_in_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_grouse
   id: 92646
   absolute_time: 2014-07-12 09:36:00.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 77760.0
   lap: 1
   pacer:
@@ -6188,11 +6188,11 @@ hardrock_2014_humberto_adams_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_grouse_out_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_grouse
   id: 92647
   absolute_time: 2014-07-12 10:22:00.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 80520.0
   lap: 1
   pacer:
@@ -6201,11 +6201,11 @@ hardrock_2014_humberto_adams_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_humberto_adams_sherman_in_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_sherman
   id: 92650
   absolute_time: 2014-07-12 16:25:00.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 102300.0
   lap: 1
   pacer:
@@ -6214,11 +6214,11 @@ hardrock_2014_humberto_adams_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_sherman_out_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_sherman
   id: 92651
   absolute_time: 2014-07-12 16:45:00.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 103500.0
   lap: 1
   pacer:
@@ -6227,11 +6227,11 @@ hardrock_2014_humberto_adams_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_humberto_adams_cunningham_in_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_cunningham
   id: 92656
   absolute_time: 2014-07-13 01:18:00.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 134280.0
   lap: 1
   pacer:
@@ -6240,11 +6240,11 @@ hardrock_2014_humberto_adams_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_humberto_adams_cunningham_out_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_cunningham
   id: 92657
   absolute_time: 2014-07-13 01:30:00.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 135000.0
   lap: 1
   pacer:
@@ -6253,11 +6253,11 @@ hardrock_2014_humberto_adams_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_humberto_adams_finish_1:
+  effort: hardrock_2014_humberto_adams
   split: hardrock_cw_finish
   id: 92658
   absolute_time: 2014-07-13 05:40:21.000000000 Z
   data_status:
-  effort_id: 4221
   elapsed_seconds: 150021.0
   lap: 1
   pacer:
@@ -6266,11 +6266,11 @@ hardrock_2014_humberto_adams_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_start_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_start
   id: 93331
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -6279,11 +6279,11 @@ hardrock_2014_omer_yundt_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_telluride_in_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_telluride
   id: 93336
   absolute_time: 2014-07-11 21:34:00.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 34440.0
   lap: 1
   pacer:
@@ -6292,11 +6292,11 @@ hardrock_2014_omer_yundt_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_telluride_out_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_telluride
   id: 93337
   absolute_time: 2014-07-11 22:06:00.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 36360.0
   lap: 1
   pacer:
@@ -6305,11 +6305,11 @@ hardrock_2014_omer_yundt_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_omer_yundt_ouray_in_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_ouray
   id: 93342
   absolute_time: 2014-07-12 03:38:00.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 56280.0
   lap: 1
   pacer:
@@ -6318,11 +6318,11 @@ hardrock_2014_omer_yundt_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_ouray_out_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_ouray
   id: 93343
   absolute_time: 2014-07-12 04:26:00.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 59160.0
   lap: 1
   pacer:
@@ -6331,11 +6331,11 @@ hardrock_2014_omer_yundt_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_omer_yundt_grouse_in_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_grouse
   id: 93346
   absolute_time: 2014-07-12 10:33:00.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 81180.0
   lap: 1
   pacer:
@@ -6344,11 +6344,11 @@ hardrock_2014_omer_yundt_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_grouse_out_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_grouse
   id: 93347
   absolute_time: 2014-07-12 11:34:00.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 84840.0
   lap: 1
   pacer:
@@ -6357,11 +6357,11 @@ hardrock_2014_omer_yundt_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_omer_yundt_sherman_in_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_sherman
   id: 93350
   absolute_time: 2014-07-12 17:22:00.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 105720.0
   lap: 1
   pacer:
@@ -6370,11 +6370,11 @@ hardrock_2014_omer_yundt_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_sherman_out_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_sherman
   id: 93351
   absolute_time: 2014-07-12 18:00:00.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 108000.0
   lap: 1
   pacer:
@@ -6383,11 +6383,11 @@ hardrock_2014_omer_yundt_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_omer_yundt_cunningham_in_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_cunningham
   id: 93356
   absolute_time: 2014-07-13 02:14:00.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 137640.0
   lap: 1
   pacer:
@@ -6396,11 +6396,11 @@ hardrock_2014_omer_yundt_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_omer_yundt_cunningham_out_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_cunningham
   id: 93357
   absolute_time: 2014-07-13 02:33:00.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 138780.0
   lap: 1
   pacer:
@@ -6409,11 +6409,11 @@ hardrock_2014_omer_yundt_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_omer_yundt_finish_1:
+  effort: hardrock_2014_omer_yundt
   split: hardrock_cw_finish
   id: 93358
   absolute_time: 2014-07-13 08:48:15.000000000 Z
   data_status:
-  effort_id: 4246
   elapsed_seconds: 161295.0
   lap: 1
   pacer:
@@ -6422,11 +6422,11 @@ hardrock_2014_omer_yundt_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_start_1:
+  effort: hardrock_2014_pat_schaden
   split: hardrock_cw_start
   id: 93359
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 4247
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -6435,11 +6435,11 @@ hardrock_2014_pat_schaden_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_telluride_in_1:
+  effort: hardrock_2014_pat_schaden
   split: hardrock_cw_telluride
   id: 93364
   absolute_time: 2014-07-11 22:35:00.000000000 Z
   data_status: 2
-  effort_id: 4247
   elapsed_seconds: 38100.0
   lap: 1
   pacer:
@@ -6448,11 +6448,11 @@ hardrock_2014_pat_schaden_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_telluride_out_1:
+  effort: hardrock_2014_pat_schaden
   split: hardrock_cw_telluride
   id: 93365
   absolute_time: 2014-07-11 22:47:00.000000000 Z
   data_status: 2
-  effort_id: 4247
   elapsed_seconds: 38820.0
   lap: 1
   pacer:
@@ -6461,11 +6461,11 @@ hardrock_2014_pat_schaden_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_pat_schaden_ouray_in_1:
+  effort: hardrock_2014_pat_schaden
   split: hardrock_cw_ouray
   id: 93370
   absolute_time: 2014-07-12 04:44:00.000000000 Z
   data_status: 2
-  effort_id: 4247
   elapsed_seconds: 60240.0
   lap: 1
   pacer:
@@ -6474,11 +6474,11 @@ hardrock_2014_pat_schaden_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_ouray_out_1:
+  effort: hardrock_2014_pat_schaden
   split: hardrock_cw_ouray
   id: 93371
   absolute_time: 2014-07-12 05:16:00.000000000 Z
   data_status: 2
-  effort_id: 4247
   elapsed_seconds: 62160.0
   lap: 1
   pacer:
@@ -6487,11 +6487,11 @@ hardrock_2014_pat_schaden_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_pat_schaden_grouse_in_1:
+  effort: hardrock_2014_pat_schaden
   split: hardrock_cw_grouse
   id: 93374
   absolute_time: 2014-07-12 12:27:00.000000000 Z
   data_status: 2
-  effort_id: 4247
   elapsed_seconds: 88020.0
   lap: 1
   pacer:
@@ -6500,11 +6500,11 @@ hardrock_2014_pat_schaden_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_grouse_out_1:
+  effort: hardrock_2014_pat_schaden
   split: hardrock_cw_grouse
   id: 93375
   absolute_time: 2014-07-12 12:48:00.000000000 Z
   data_status: 2
-  effort_id: 4247
   elapsed_seconds: 89280.0
   lap: 1
   pacer:
@@ -6513,11 +6513,11 @@ hardrock_2014_pat_schaden_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_pat_schaden_sherman_in_1:
+  effort: hardrock_2014_pat_schaden
   split: hardrock_cw_sherman
   id: 93378
   absolute_time: 2014-07-12 18:29:00.000000000 Z
   data_status: 2
-  effort_id: 4247
   elapsed_seconds: 109740.0
   lap: 1
   pacer:
@@ -6526,11 +6526,11 @@ hardrock_2014_pat_schaden_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_pat_schaden_sherman_out_1:
+  effort: hardrock_2014_pat_schaden
   split: hardrock_cw_sherman
   id: 93379
   absolute_time: 2014-07-12 18:52:00.000000000 Z
   data_status: 2
-  effort_id: 4247
   elapsed_seconds: 111120.0
   lap: 1
   pacer:
@@ -6539,11 +6539,11 @@ hardrock_2014_pat_schaden_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_pat_schaden_cunningham_in_1:
+  effort: hardrock_2014_pat_schaden
   split: hardrock_cw_cunningham
   id: 93384
   absolute_time: 2014-07-13 04:14:00.000000000 Z
   data_status: 2
-  effort_id: 4247
   elapsed_seconds: 144840.0
   lap: 1
   pacer:
@@ -6552,11 +6552,11 @@ hardrock_2014_pat_schaden_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_start_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_start
   id: 93415
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -6565,11 +6565,11 @@ hardrock_2014_clarence_goyette_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_telluride_in_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_telluride
   id: 93420
   absolute_time: 2014-07-11 22:05:00.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 36300.0
   lap: 1
   pacer:
@@ -6578,11 +6578,11 @@ hardrock_2014_clarence_goyette_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_telluride_out_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_telluride
   id: 93421
   absolute_time: 2014-07-11 22:14:00.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 36840.0
   lap: 1
   pacer:
@@ -6591,11 +6591,11 @@ hardrock_2014_clarence_goyette_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_clarence_goyette_ouray_in_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_ouray
   id: 93426
   absolute_time: 2014-07-12 04:32:00.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 59520.0
   lap: 1
   pacer:
@@ -6604,11 +6604,11 @@ hardrock_2014_clarence_goyette_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_ouray_out_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_ouray
   id: 93427
   absolute_time: 2014-07-12 05:02:00.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 61320.0
   lap: 1
   pacer:
@@ -6617,11 +6617,11 @@ hardrock_2014_clarence_goyette_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_clarence_goyette_grouse_in_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_grouse
   id: 93430
   absolute_time: 2014-07-12 11:19:00.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 83940.0
   lap: 1
   pacer:
@@ -6630,11 +6630,11 @@ hardrock_2014_clarence_goyette_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_grouse_out_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_grouse
   id: 93431
   absolute_time: 2014-07-12 11:59:00.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 86340.0
   lap: 1
   pacer:
@@ -6643,11 +6643,11 @@ hardrock_2014_clarence_goyette_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_clarence_goyette_sherman_in_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_sherman
   id: 93434
   absolute_time: 2014-07-12 18:06:00.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 108360.0
   lap: 1
   pacer:
@@ -6656,11 +6656,11 @@ hardrock_2014_clarence_goyette_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_sherman_out_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_sherman
   id: 93435
   absolute_time: 2014-07-12 18:32:00.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 109920.0
   lap: 1
   pacer:
@@ -6669,11 +6669,11 @@ hardrock_2014_clarence_goyette_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_clarence_goyette_cunningham_in_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_cunningham
   id: 93440
   absolute_time: 2014-07-13 04:02:00.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 144120.0
   lap: 1
   pacer:
@@ -6682,11 +6682,11 @@ hardrock_2014_clarence_goyette_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_clarence_goyette_cunningham_out_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_cunningham
   id: 93441
   absolute_time: 2014-07-13 04:32:00.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 145920.0
   lap: 1
   pacer:
@@ -6695,11 +6695,11 @@ hardrock_2014_clarence_goyette_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_clarence_goyette_finish_1:
+  effort: hardrock_2014_clarence_goyette
   split: hardrock_cw_finish
   id: 93442
   absolute_time: 2014-07-13 09:21:28.000000000 Z
   data_status:
-  effort_id: 4249
   elapsed_seconds: 163288.0
   lap: 1
   pacer:
@@ -6708,11 +6708,11 @@ hardrock_2014_clarence_goyette_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_start_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_start
   id: 93471
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -6721,11 +6721,11 @@ hardrock_2014_irvin_corkery_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_telluride_in_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_telluride
   id: 93476
   absolute_time: 2014-07-11 20:21:00.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 30060.0
   lap: 1
   pacer:
@@ -6734,11 +6734,11 @@ hardrock_2014_irvin_corkery_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_telluride_out_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_telluride
   id: 93477
   absolute_time: 2014-07-11 20:32:00.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 30720.0
   lap: 1
   pacer:
@@ -6747,11 +6747,11 @@ hardrock_2014_irvin_corkery_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_irvin_corkery_ouray_in_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_ouray
   id: 93482
   absolute_time: 2014-07-12 01:25:00.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 48300.0
   lap: 1
   pacer:
@@ -6760,11 +6760,11 @@ hardrock_2014_irvin_corkery_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_ouray_out_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_ouray
   id: 93483
   absolute_time: 2014-07-12 01:45:00.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 49500.0
   lap: 1
   pacer:
@@ -6773,11 +6773,11 @@ hardrock_2014_irvin_corkery_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_irvin_corkery_grouse_in_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_grouse
   id: 93486
   absolute_time: 2014-07-12 07:39:00.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 70740.0
   lap: 1
   pacer:
@@ -6786,11 +6786,11 @@ hardrock_2014_irvin_corkery_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_grouse_out_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_grouse
   id: 93487
   absolute_time: 2014-07-12 08:12:59.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 72779.0
   lap: 1
   pacer:
@@ -6799,11 +6799,11 @@ hardrock_2014_irvin_corkery_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_irvin_corkery_sherman_in_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_sherman
   id: 93490
   absolute_time: 2014-07-12 15:59:00.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 100740.0
   lap: 1
   pacer:
@@ -6812,11 +6812,11 @@ hardrock_2014_irvin_corkery_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_sherman_out_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_sherman
   id: 93491
   absolute_time: 2014-07-12 16:35:00.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 102900.0
   lap: 1
   pacer:
@@ -6825,11 +6825,11 @@ hardrock_2014_irvin_corkery_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_irvin_corkery_cunningham_in_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_cunningham
   id: 93496
   absolute_time: 2014-07-13 03:38:00.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 142680.0
   lap: 1
   pacer:
@@ -6838,11 +6838,11 @@ hardrock_2014_irvin_corkery_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_irvin_corkery_cunningham_out_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_cunningham
   id: 93497
   absolute_time: 2014-07-13 03:54:00.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 143640.0
   lap: 1
   pacer:
@@ -6851,11 +6851,11 @@ hardrock_2014_irvin_corkery_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_irvin_corkery_finish_1:
+  effort: hardrock_2014_irvin_corkery
   split: hardrock_cw_finish
   id: 93498
   absolute_time: 2014-07-13 09:25:16.000000000 Z
   data_status:
-  effort_id: 4251
   elapsed_seconds: 163516.0
   lap: 1
   pacer:
@@ -6864,11 +6864,11 @@ hardrock_2014_irvin_corkery_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_start_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_start
   id: 93527
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -6877,11 +6877,11 @@ hardrock_2014_willis_murray_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_telluride_in_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_telluride
   id: 93532
   absolute_time: 2014-07-11 22:05:00.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 36300.0
   lap: 1
   pacer:
@@ -6890,11 +6890,11 @@ hardrock_2014_willis_murray_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_telluride_out_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_telluride
   id: 93533
   absolute_time: 2014-07-11 22:20:00.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 37200.0
   lap: 1
   pacer:
@@ -6903,11 +6903,11 @@ hardrock_2014_willis_murray_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_willis_murray_ouray_in_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_ouray
   id: 93538
   absolute_time: 2014-07-12 03:53:00.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 57180.0
   lap: 1
   pacer:
@@ -6916,11 +6916,11 @@ hardrock_2014_willis_murray_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_ouray_out_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_ouray
   id: 93539
   absolute_time: 2014-07-12 04:31:00.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 59460.0
   lap: 1
   pacer:
@@ -6929,11 +6929,11 @@ hardrock_2014_willis_murray_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_willis_murray_grouse_in_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_grouse
   id: 93542
   absolute_time: 2014-07-12 11:49:00.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 85740.0
   lap: 1
   pacer:
@@ -6942,11 +6942,11 @@ hardrock_2014_willis_murray_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_grouse_out_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_grouse
   id: 93543
   absolute_time: 2014-07-12 12:18:00.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 87480.0
   lap: 1
   pacer:
@@ -6955,11 +6955,11 @@ hardrock_2014_willis_murray_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_willis_murray_sherman_in_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_sherman
   id: 93546
   absolute_time: 2014-07-12 18:11:00.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 108660.0
   lap: 1
   pacer:
@@ -6968,11 +6968,11 @@ hardrock_2014_willis_murray_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_sherman_out_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_sherman
   id: 93547
   absolute_time: 2014-07-12 18:46:00.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 110760.0
   lap: 1
   pacer:
@@ -6981,11 +6981,11 @@ hardrock_2014_willis_murray_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_willis_murray_cunningham_in_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_cunningham
   id: 93552
   absolute_time: 2014-07-13 04:11:00.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 144660.0
   lap: 1
   pacer:
@@ -6994,11 +6994,11 @@ hardrock_2014_willis_murray_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_willis_murray_cunningham_out_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_cunningham
   id: 93553
   absolute_time: 2014-07-13 04:38:00.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 146280.0
   lap: 1
   pacer:
@@ -7007,11 +7007,11 @@ hardrock_2014_willis_murray_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_willis_murray_finish_1:
+  effort: hardrock_2014_willis_murray
   split: hardrock_cw_finish
   id: 93554
   absolute_time: 2014-07-13 09:40:40.000000000 Z
   data_status:
-  effort_id: 4253
   elapsed_seconds: 164440.0
   lap: 1
   pacer:
@@ -7020,11 +7020,11 @@ hardrock_2014_willis_murray_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_start_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_start
   id: 93611
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -7033,11 +7033,11 @@ hardrock_2014_ken_bradtke_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_telluride_in_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_telluride
   id: 93616
   absolute_time: 2014-07-11 21:58:00.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 35880.0
   lap: 1
   pacer:
@@ -7046,11 +7046,11 @@ hardrock_2014_ken_bradtke_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_telluride_out_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_telluride
   id: 93617
   absolute_time: 2014-07-11 22:11:00.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 36660.0
   lap: 1
   pacer:
@@ -7059,11 +7059,11 @@ hardrock_2014_ken_bradtke_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_ken_bradtke_ouray_in_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_ouray
   id: 93622
   absolute_time: 2014-07-12 04:48:00.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 60480.0
   lap: 1
   pacer:
@@ -7072,11 +7072,11 @@ hardrock_2014_ken_bradtke_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_ouray_out_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_ouray
   id: 93623
   absolute_time: 2014-07-12 05:31:00.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 63060.0
   lap: 1
   pacer:
@@ -7085,11 +7085,11 @@ hardrock_2014_ken_bradtke_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_ken_bradtke_grouse_in_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_grouse
   id: 93626
   absolute_time: 2014-07-12 12:07:00.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 86820.0
   lap: 1
   pacer:
@@ -7098,11 +7098,11 @@ hardrock_2014_ken_bradtke_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_grouse_out_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_grouse
   id: 93627
   absolute_time: 2014-07-12 12:24:00.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 87840.0
   lap: 1
   pacer:
@@ -7111,11 +7111,11 @@ hardrock_2014_ken_bradtke_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_ken_bradtke_sherman_in_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_sherman
   id: 93630
   absolute_time: 2014-07-12 18:02:00.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 108120.0
   lap: 1
   pacer:
@@ -7124,11 +7124,11 @@ hardrock_2014_ken_bradtke_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_sherman_out_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_sherman
   id: 93631
   absolute_time: 2014-07-12 18:37:00.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 110220.0
   lap: 1
   pacer:
@@ -7137,11 +7137,11 @@ hardrock_2014_ken_bradtke_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_ken_bradtke_cunningham_in_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_cunningham
   id: 93636
   absolute_time: 2014-07-13 04:54:00.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 147240.0
   lap: 1
   pacer:
@@ -7150,11 +7150,11 @@ hardrock_2014_ken_bradtke_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_ken_bradtke_cunningham_out_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_cunningham
   id: 93637
   absolute_time: 2014-07-13 05:08:00.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 148080.0
   lap: 1
   pacer:
@@ -7163,11 +7163,11 @@ hardrock_2014_ken_bradtke_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_ken_bradtke_finish_1:
+  effort: hardrock_2014_ken_bradtke
   split: hardrock_cw_finish
   id: 93638
   absolute_time: 2014-07-13 10:23:44.000000000 Z
   data_status:
-  effort_id: 4256
   elapsed_seconds: 167024.0
   lap: 1
   pacer:
@@ -7176,11 +7176,11 @@ hardrock_2014_ken_bradtke_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_start_1:
+  effort: hardrock_2014_progress_sherman
   split: hardrock_cw_start
   id: 94155
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 4277
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -7189,11 +7189,11 @@ hardrock_2014_progress_sherman_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_telluride_in_1:
+  effort: hardrock_2014_progress_sherman
   split: hardrock_cw_telluride
   id: 94160
   absolute_time: 2014-07-11 23:07:00.000000000 Z
   data_status: 2
-  effort_id: 4277
   elapsed_seconds: 40020.0
   lap: 1
   pacer:
@@ -7202,11 +7202,11 @@ hardrock_2014_progress_sherman_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_telluride_out_1:
+  effort: hardrock_2014_progress_sherman
   split: hardrock_cw_telluride
   id: 94161
   absolute_time: 2014-07-11 23:16:00.000000000 Z
   data_status: 2
-  effort_id: 4277
   elapsed_seconds: 40560.0
   lap: 1
   pacer:
@@ -7215,11 +7215,11 @@ hardrock_2014_progress_sherman_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_progress_sherman_ouray_in_1:
+  effort: hardrock_2014_progress_sherman
   split: hardrock_cw_ouray
   id: 94166
   absolute_time: 2014-07-12 05:57:59.000000000 Z
   data_status: 2
-  effort_id: 4277
   elapsed_seconds: 64679.0
   lap: 1
   pacer:
@@ -7228,11 +7228,11 @@ hardrock_2014_progress_sherman_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_ouray_out_1:
+  effort: hardrock_2014_progress_sherman
   split: hardrock_cw_ouray
   id: 94167
   absolute_time: 2014-07-12 06:16:00.000000000 Z
   data_status: 2
-  effort_id: 4277
   elapsed_seconds: 65760.0
   lap: 1
   pacer:
@@ -7241,11 +7241,11 @@ hardrock_2014_progress_sherman_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_progress_sherman_grouse_in_1:
+  effort: hardrock_2014_progress_sherman
   split: hardrock_cw_grouse
   id: 94170
   absolute_time: 2014-07-12 13:40:00.000000000 Z
   data_status: 2
-  effort_id: 4277
   elapsed_seconds: 92400.0
   lap: 1
   pacer:
@@ -7254,11 +7254,11 @@ hardrock_2014_progress_sherman_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_grouse_out_1:
+  effort: hardrock_2014_progress_sherman
   split: hardrock_cw_grouse
   id: 94171
   absolute_time: 2014-07-12 14:06:00.000000000 Z
   data_status: 2
-  effort_id: 4277
   elapsed_seconds: 93960.0
   lap: 1
   pacer:
@@ -7267,11 +7267,11 @@ hardrock_2014_progress_sherman_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_progress_sherman_sherman_in_1:
+  effort: hardrock_2014_progress_sherman
   split: hardrock_cw_sherman
   id: 94174
   absolute_time: 2014-07-12 21:13:00.000000000 Z
   data_status: 2
-  effort_id: 4277
   elapsed_seconds: 119580.0
   lap: 1
   pacer:
@@ -7280,11 +7280,11 @@ hardrock_2014_progress_sherman_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_progress_sherman_sherman_out_1:
+  effort: hardrock_2014_progress_sherman
   split: hardrock_cw_sherman
   id: 94175
   absolute_time: 2014-07-12 21:28:00.000000000 Z
   data_status: 2
-  effort_id: 4277
   elapsed_seconds: 120480.0
   lap: 1
   pacer:
@@ -7293,11 +7293,11 @@ hardrock_2014_progress_sherman_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_multiple_stops_start_1:
+  effort: hardrock_2014_multiple_stops
   split: hardrock_cw_start
   id: 94437
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status:
-  effort_id: 4293
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -7306,11 +7306,11 @@ hardrock_2014_multiple_stops_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_multiple_stops_telluride_in_1:
+  effort: hardrock_2014_multiple_stops
   split: hardrock_cw_telluride
   id: 94442
   absolute_time: 2014-07-11 22:36:00.000000000 Z
   data_status:
-  effort_id: 4293
   elapsed_seconds: 38160.0
   lap: 1
   pacer:
@@ -7319,11 +7319,11 @@ hardrock_2014_multiple_stops_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_multiple_stops_telluride_out_1:
+  effort: hardrock_2014_multiple_stops
   split: hardrock_cw_telluride
   id: 94443
   absolute_time: 2014-07-11 22:52:00.000000000 Z
   data_status:
-  effort_id: 4293
   elapsed_seconds: 39120.0
   lap: 1
   pacer:
@@ -7332,11 +7332,11 @@ hardrock_2014_multiple_stops_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_multiple_stops_ouray_in_1:
+  effort: hardrock_2014_multiple_stops
   split: hardrock_cw_ouray
   id: 94448
   absolute_time: 2014-07-12 05:20:00.000000000 Z
   data_status:
-  effort_id: 4293
   elapsed_seconds: 62400.0
   lap: 1
   pacer:
@@ -7345,11 +7345,11 @@ hardrock_2014_multiple_stops_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_multiple_stops_ouray_out_1:
+  effort: hardrock_2014_multiple_stops
   split: hardrock_cw_ouray
   id: 94449
   absolute_time: 2014-07-12 05:48:00.000000000 Z
   data_status:
-  effort_id: 4293
   elapsed_seconds: 64080.0
   lap: 1
   pacer:
@@ -7358,11 +7358,11 @@ hardrock_2014_multiple_stops_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_multiple_stops_grouse_in_1:
+  effort: hardrock_2014_multiple_stops
   split: hardrock_cw_grouse
   id: 94452
   absolute_time: 2014-07-12 13:10:00.000000000 Z
   data_status:
-  effort_id: 4293
   elapsed_seconds: 90600.0
   lap: 1
   pacer:
@@ -7371,11 +7371,11 @@ hardrock_2014_multiple_stops_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_multiple_stops_grouse_out_1:
+  effort: hardrock_2014_multiple_stops
   split: hardrock_cw_grouse
   id: 94453
   absolute_time: 2014-07-12 13:10:00.000000000 Z
   data_status:
-  effort_id: 4293
   elapsed_seconds: 90600.0
   lap: 1
   pacer:
@@ -7384,11 +7384,11 @@ hardrock_2014_multiple_stops_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_without_start_telluride_in_1:
+  effort: hardrock_2014_without_start
   split: hardrock_cw_telluride
   id: 94459
   absolute_time: 2014-07-11 23:17:00.000000000 Z
   data_status: 2
-  effort_id: 4294
   elapsed_seconds:
   lap: 1
   pacer:
@@ -7397,11 +7397,11 @@ hardrock_2014_without_start_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_without_start_telluride_out_1:
+  effort: hardrock_2014_without_start
   split: hardrock_cw_telluride
   id: 94460
   absolute_time: 2014-07-11 23:27:00.000000000 Z
   data_status: 2
-  effort_id: 4294
   elapsed_seconds:
   lap: 1
   pacer:
@@ -7410,11 +7410,11 @@ hardrock_2014_without_start_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_without_start_ouray_in_1:
+  effort: hardrock_2014_without_start
   split: hardrock_cw_ouray
   id: 94465
   absolute_time: 2014-07-12 06:06:00.000000000 Z
   data_status: 2
-  effort_id: 4294
   elapsed_seconds:
   lap: 1
   pacer:
@@ -7423,11 +7423,11 @@ hardrock_2014_without_start_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_without_start_ouray_out_1:
+  effort: hardrock_2014_without_start
   split: hardrock_cw_ouray
   id: 94466
   absolute_time: 2014-07-12 06:29:00.000000000 Z
   data_status: 2
-  effort_id: 4294
   elapsed_seconds:
   lap: 1
   pacer:
@@ -7436,11 +7436,11 @@ hardrock_2014_without_start_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_without_start_grouse_in_1:
+  effort: hardrock_2014_without_start
   split: hardrock_cw_grouse
   id: 94469
   absolute_time: 2014-07-12 13:56:00.000000000 Z
   data_status: 2
-  effort_id: 4294
   elapsed_seconds:
   lap: 1
   pacer:
@@ -7449,11 +7449,11 @@ hardrock_2014_without_start_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_without_start_grouse_out_1:
+  effort: hardrock_2014_without_start
   split: hardrock_cw_grouse
   id: 94470
   absolute_time: 2014-07-12 13:56:00.000000000 Z
   data_status: 2
-  effort_id: 4294
   elapsed_seconds:
   lap: 1
   pacer:
@@ -7462,11 +7462,11 @@ hardrock_2014_without_start_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_drop_ouray_start_1:
+  effort: hardrock_2014_drop_ouray
   split: hardrock_cw_start
   id: 94471
   absolute_time: 2014-07-11 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 4295
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -7475,11 +7475,11 @@ hardrock_2014_drop_ouray_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_drop_ouray_telluride_in_1:
+  effort: hardrock_2014_drop_ouray
   split: hardrock_cw_telluride
   id: 94476
   absolute_time: 2014-07-11 23:42:00.000000000 Z
   data_status: 2
-  effort_id: 4295
   elapsed_seconds: 42120.0
   lap: 1
   pacer:
@@ -7488,11 +7488,11 @@ hardrock_2014_drop_ouray_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_drop_ouray_telluride_out_1:
+  effort: hardrock_2014_drop_ouray
   split: hardrock_cw_telluride
   id: 94477
   absolute_time: 2014-07-11 23:54:00.000000000 Z
   data_status: 2
-  effort_id: 4295
   elapsed_seconds: 42840.0
   lap: 1
   pacer:
@@ -7501,11 +7501,11 @@ hardrock_2014_drop_ouray_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2014_drop_ouray_ouray_in_1:
+  effort: hardrock_2014_drop_ouray
   split: hardrock_cw_ouray
   id: 94482
   absolute_time: 2014-07-12 06:24:00.000000000 Z
   data_status: 2
-  effort_id: 4295
   elapsed_seconds: 66240.0
   lap: 1
   pacer:
@@ -7514,11 +7514,11 @@ hardrock_2014_drop_ouray_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2014_drop_ouray_ouray_out_1:
+  effort: hardrock_2014_drop_ouray
   split: hardrock_cw_ouray
   id: 94483
   absolute_time: 2014-07-12 06:28:00.000000000 Z
   data_status: 2
-  effort_id: 4295
   elapsed_seconds: 66480.0
   lap: 1
   pacer:
@@ -7527,11 +7527,11 @@ hardrock_2014_drop_ouray_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_telluride_in_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_telluride
   id: 101536
   absolute_time: 2015-07-11 21:05:00.000000000 Z
   data_status: 1
-  effort_id: 138
   elapsed_seconds: 119100.0
   lap: 1
   pacer: true
@@ -7540,11 +7540,11 @@ hardrock_2015_bad_status_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_telluride_out_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_telluride
   id: 101537
   absolute_time: 2015-07-11 21:30:00.000000000 Z
   data_status: 1
-  effort_id: 138
   elapsed_seconds: 120600.0
   lap: 1
   pacer: true
@@ -7553,11 +7553,11 @@ hardrock_2015_bad_status_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_irvin_harber_telluride_in_1:
+  effort: hardrock_2015_irvin_harber
   split: hardrock_ccw_telluride
   id: 101540
   absolute_time: 2015-07-11 11:00:00.000000000 Z
   data_status: 2
-  effort_id: 141
   elapsed_seconds: 82800.0
   lap: 1
   pacer: true
@@ -7566,11 +7566,11 @@ hardrock_2015_irvin_harber_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_irvin_harber_telluride_out_1:
+  effort: hardrock_2015_irvin_harber
   split: hardrock_ccw_telluride
   id: 101541
   absolute_time: 2015-07-11 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 141
   elapsed_seconds: 86400.0
   lap: 1
   pacer: true
@@ -7579,11 +7579,11 @@ hardrock_2015_irvin_harber_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2015_bad_status_putnam_in_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_putnam
   id: 101555
   absolute_time: 2015-07-12 01:00:00.000000000 Z
   data_status: 0
-  effort_id: 138
   elapsed_seconds: 133200.0
   lap: 1
   pacer: true
@@ -7592,11 +7592,11 @@ hardrock_2015_bad_status_putnam_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_bad_status_putnam_out_1:
+  effort: hardrock_2015_bad_status
   split: hardrock_ccw_putnam
   id: 101556
   absolute_time: 2015-07-12 01:05:00.000000000 Z
   data_status: 0
-  effort_id: 138
   elapsed_seconds: 133500.0
   lap: 1
   pacer: true
@@ -7605,11 +7605,11 @@ hardrock_2015_bad_status_putnam_out_1:
   sub_split_bitkey: 64
   status_reason:
 rufa_2016_finished_first_start_1:
+  effort: rufa_2016_finished_first
   split: rufa_course_start
   id: 132044
   absolute_time: 2016-02-13 13:00:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -7618,11 +7618,11 @@ rufa_2016_finished_first_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_1:
+  effort: rufa_2016_finished_first
   split: rufa_course_grandeur_peak
   id: 132045
   absolute_time: 2016-02-13 13:59:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 3540.0
   lap: 1
   pacer:
@@ -7631,11 +7631,11 @@ rufa_2016_finished_first_grandeur_peak_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_2:
+  effort: rufa_2016_finished_first
   split: rufa_course_grandeur_peak
   id: 132046
   absolute_time: 2016-02-13 15:39:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 9540.0
   lap: 2
   pacer:
@@ -7644,11 +7644,11 @@ rufa_2016_finished_first_grandeur_peak_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_finish_2:
+  effort: rufa_2016_finished_first
   split: rufa_course_finish
   id: 132047
   absolute_time: 2016-02-13 16:12:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 11520.0
   lap: 2
   pacer:
@@ -7657,11 +7657,11 @@ rufa_2016_finished_first_finish_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_3:
+  effort: rufa_2016_finished_first
   split: rufa_course_grandeur_peak
   id: 132048
   absolute_time: 2016-02-13 17:29:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 16140.0
   lap: 3
   pacer:
@@ -7670,11 +7670,11 @@ rufa_2016_finished_first_grandeur_peak_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_4:
+  effort: rufa_2016_finished_first
   split: rufa_course_grandeur_peak
   id: 132049
   absolute_time: 2016-02-13 19:30:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 23400.0
   lap: 4
   pacer:
@@ -7683,11 +7683,11 @@ rufa_2016_finished_first_grandeur_peak_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_finish_4:
+  effort: rufa_2016_finished_first
   split: rufa_course_finish
   id: 132050
   absolute_time: 2016-02-13 20:04:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 25440.0
   lap: 4
   pacer:
@@ -7696,11 +7696,11 @@ rufa_2016_finished_first_finish_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_start_5:
+  effort: rufa_2016_finished_first
   split: rufa_course_start
   id: 132051
   absolute_time: 2016-02-13 20:09:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 25740.0
   lap: 5
   pacer:
@@ -7709,11 +7709,11 @@ rufa_2016_finished_first_start_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_5:
+  effort: rufa_2016_finished_first
   split: rufa_course_grandeur_peak
   id: 132052
   absolute_time: 2016-02-13 21:22:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 30120.0
   lap: 5
   pacer:
@@ -7722,11 +7722,11 @@ rufa_2016_finished_first_grandeur_peak_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_finish_5:
+  effort: rufa_2016_finished_first
   split: rufa_course_finish
   id: 132053
   absolute_time: 2016-02-13 21:59:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 32340.0
   lap: 5
   pacer:
@@ -7735,11 +7735,11 @@ rufa_2016_finished_first_finish_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_start_6:
+  effort: rufa_2016_finished_first
   split: rufa_course_start
   id: 132054
   absolute_time: 2016-02-13 22:07:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 32820.0
   lap: 6
   pacer:
@@ -7748,11 +7748,11 @@ rufa_2016_finished_first_start_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_6:
+  effort: rufa_2016_finished_first
   split: rufa_course_grandeur_peak
   id: 132055
   absolute_time: 2016-02-13 23:26:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 37560.0
   lap: 6
   pacer:
@@ -7761,11 +7761,11 @@ rufa_2016_finished_first_grandeur_peak_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_finish_6:
+  effort: rufa_2016_finished_first
   split: rufa_course_finish
   id: 132056
   absolute_time: 2016-02-14 00:07:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 40020.0
   lap: 6
   pacer:
@@ -7774,11 +7774,11 @@ rufa_2016_finished_first_finish_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_start_7:
+  effort: rufa_2016_finished_first
   split: rufa_course_start
   id: 132057
   absolute_time: 2016-02-14 00:55:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 42900.0
   lap: 7
   pacer:
@@ -7787,11 +7787,11 @@ rufa_2016_finished_first_start_7:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_grandeur_peak_7:
+  effort: rufa_2016_finished_first
   split: rufa_course_grandeur_peak
   id: 132058
   absolute_time: 2016-02-14 02:17:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 47820.0
   lap: 7
   pacer:
@@ -7800,11 +7800,11 @@ rufa_2016_finished_first_grandeur_peak_7:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_first_finish_7:
+  effort: rufa_2016_finished_first
   split: rufa_course_finish
   id: 132059
   absolute_time: 2016-02-14 03:01:00.000000000 Z
   data_status: 2
-  effort_id: 6518
   elapsed_seconds: 50460.0
   lap: 7
   pacer:
@@ -7813,11 +7813,11 @@ rufa_2016_finished_first_finish_7:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_start_1:
+  effort: rufa_2016_finished_second
   split: rufa_course_start
   id: 132075
   absolute_time: 2016-02-13 13:00:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -7826,11 +7826,11 @@ rufa_2016_finished_second_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_1:
+  effort: rufa_2016_finished_second
   split: rufa_course_grandeur_peak
   id: 132076
   absolute_time: 2016-02-13 13:47:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 2820.0
   lap: 1
   pacer:
@@ -7839,11 +7839,11 @@ rufa_2016_finished_second_grandeur_peak_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_1:
+  effort: rufa_2016_finished_second
   split: rufa_course_finish
   id: 132077
   absolute_time: 2016-02-13 14:13:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 4380.0
   lap: 1
   pacer:
@@ -7852,11 +7852,11 @@ rufa_2016_finished_second_finish_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_start_2:
+  effort: rufa_2016_finished_second
   split: rufa_course_start
   id: 132078
   absolute_time: 2016-02-13 14:16:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 4560.0
   lap: 2
   pacer:
@@ -7865,11 +7865,11 @@ rufa_2016_finished_second_start_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_2:
+  effort: rufa_2016_finished_second
   split: rufa_course_grandeur_peak
   id: 132079
   absolute_time: 2016-02-13 15:03:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 7380.0
   lap: 2
   pacer:
@@ -7878,11 +7878,11 @@ rufa_2016_finished_second_grandeur_peak_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_2:
+  effort: rufa_2016_finished_second
   split: rufa_course_finish
   id: 132080
   absolute_time: 2016-02-13 15:29:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 8940.0
   lap: 2
   pacer:
@@ -7891,11 +7891,11 @@ rufa_2016_finished_second_finish_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_3:
+  effort: rufa_2016_finished_second
   split: rufa_course_grandeur_peak
   id: 132081
   absolute_time: 2016-02-13 16:22:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 12120.0
   lap: 3
   pacer:
@@ -7904,11 +7904,11 @@ rufa_2016_finished_second_grandeur_peak_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_3:
+  effort: rufa_2016_finished_second
   split: rufa_course_finish
   id: 132082
   absolute_time: 2016-02-13 16:47:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 13620.0
   lap: 3
   pacer:
@@ -7917,11 +7917,11 @@ rufa_2016_finished_second_finish_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_start_4:
+  effort: rufa_2016_finished_second
   split: rufa_course_start
   id: 132083
   absolute_time: 2016-02-13 16:51:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 13860.0
   lap: 4
   pacer:
@@ -7930,11 +7930,11 @@ rufa_2016_finished_second_start_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_4:
+  effort: rufa_2016_finished_second
   split: rufa_course_grandeur_peak
   id: 132084
   absolute_time: 2016-02-13 17:45:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 17100.0
   lap: 4
   pacer:
@@ -7943,11 +7943,11 @@ rufa_2016_finished_second_grandeur_peak_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_4:
+  effort: rufa_2016_finished_second
   split: rufa_course_finish
   id: 132085
   absolute_time: 2016-02-13 18:12:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 18720.0
   lap: 4
   pacer:
@@ -7956,11 +7956,11 @@ rufa_2016_finished_second_finish_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_5:
+  effort: rufa_2016_finished_second
   split: rufa_course_grandeur_peak
   id: 132086
   absolute_time: 2016-02-13 19:18:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 22680.0
   lap: 5
   pacer:
@@ -7969,11 +7969,11 @@ rufa_2016_finished_second_grandeur_peak_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_5:
+  effort: rufa_2016_finished_second
   split: rufa_course_finish
   id: 132087
   absolute_time: 2016-02-13 19:49:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 24540.0
   lap: 5
   pacer:
@@ -7982,11 +7982,11 @@ rufa_2016_finished_second_finish_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_start_6:
+  effort: rufa_2016_finished_second
   split: rufa_course_start
   id: 132088
   absolute_time: 2016-02-13 19:56:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 24960.0
   lap: 6
   pacer:
@@ -7995,11 +7995,11 @@ rufa_2016_finished_second_start_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_grandeur_peak_6:
+  effort: rufa_2016_finished_second
   split: rufa_course_grandeur_peak
   id: 132089
   absolute_time: 2016-02-13 20:58:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 28680.0
   lap: 6
   pacer:
@@ -8008,11 +8008,11 @@ rufa_2016_finished_second_grandeur_peak_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_finished_second_finish_6:
+  effort: rufa_2016_finished_second
   split: rufa_course_finish
   id: 132090
   absolute_time: 2016-02-13 21:28:00.000000000 Z
   data_status: 2
-  effort_id: 6520
   elapsed_seconds: 30480.0
   lap: 6
   pacer:
@@ -8021,11 +8021,11 @@ rufa_2016_finished_second_finish_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_progress_lap1_start_1:
+  effort: rufa_2016_progress_lap1
   split: rufa_course_start
   id: 132438
   absolute_time: 2016-02-13 13:00:00.000000000 Z
   data_status: 2
-  effort_id: 6560
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -8034,11 +8034,11 @@ rufa_2016_progress_lap1_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2016_progress_lap1_grandeur_peak_1:
+  effort: rufa_2016_progress_lap1
   split: rufa_course_grandeur_peak
   id: 132439
   absolute_time: 2016-02-13 14:25:00.000000000 Z
   data_status: 2
-  effort_id: 6560
   elapsed_seconds: 5100.0
   lap: 1
   pacer:
@@ -8047,11 +8047,11 @@ rufa_2016_progress_lap1_grandeur_peak_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_1:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_start
   id: 133963
   absolute_time: 2017-02-11 13:10:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -8060,11 +8060,11 @@ rufa_2017_24h_finished_first_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_1:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_grandeur_peak
   id: 133964
   absolute_time: 2017-02-11 14:23:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 4380.0
   lap: 1
   pacer:
@@ -8073,11 +8073,11 @@ rufa_2017_24h_finished_first_grandeur_peak_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_1:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
   id: 133965
   absolute_time: 2017-02-11 15:05:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 6900.0
   lap: 1
   pacer:
@@ -8086,11 +8086,11 @@ rufa_2017_24h_finished_first_finish_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_2:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_start
   id: 133966
   absolute_time: 2017-02-11 15:05:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 6900.0
   lap: 2
   pacer:
@@ -8099,11 +8099,11 @@ rufa_2017_24h_finished_first_start_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_2:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_grandeur_peak
   id: 133967
   absolute_time: 2017-02-11 16:36:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 12360.0
   lap: 2
   pacer:
@@ -8112,11 +8112,11 @@ rufa_2017_24h_finished_first_grandeur_peak_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_2:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
   id: 133968
   absolute_time: 2017-02-11 17:12:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 14520.0
   lap: 2
   pacer:
@@ -8125,11 +8125,11 @@ rufa_2017_24h_finished_first_finish_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_3:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_start
   id: 133969
   absolute_time: 2017-02-11 17:19:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 14940.0
   lap: 3
   pacer:
@@ -8138,11 +8138,11 @@ rufa_2017_24h_finished_first_start_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_3:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_grandeur_peak
   id: 133970
   absolute_time: 2017-02-11 18:47:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 20220.0
   lap: 3
   pacer:
@@ -8151,11 +8151,11 @@ rufa_2017_24h_finished_first_grandeur_peak_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_3:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
   id: 133971
   absolute_time: 2017-02-11 19:24:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 22440.0
   lap: 3
   pacer:
@@ -8164,11 +8164,11 @@ rufa_2017_24h_finished_first_finish_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_4:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_start
   id: 133972
   absolute_time: 2017-02-11 19:31:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 22860.0
   lap: 4
   pacer:
@@ -8177,11 +8177,11 @@ rufa_2017_24h_finished_first_start_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_4:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_grandeur_peak
   id: 133973
   absolute_time: 2017-02-11 21:05:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 28500.0
   lap: 4
   pacer:
@@ -8190,11 +8190,11 @@ rufa_2017_24h_finished_first_grandeur_peak_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_4:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
   id: 133974
   absolute_time: 2017-02-11 21:46:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 30960.0
   lap: 4
   pacer:
@@ -8203,11 +8203,11 @@ rufa_2017_24h_finished_first_finish_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_5:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_start
   id: 133975
   absolute_time: 2017-02-11 22:06:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 32160.0
   lap: 5
   pacer:
@@ -8216,11 +8216,11 @@ rufa_2017_24h_finished_first_start_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_5:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_grandeur_peak
   id: 133976
   absolute_time: 2017-02-11 23:40:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 37800.0
   lap: 5
   pacer:
@@ -8229,11 +8229,11 @@ rufa_2017_24h_finished_first_grandeur_peak_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_5:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
   id: 133977
   absolute_time: 2017-02-12 00:20:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 40200.0
   lap: 5
   pacer:
@@ -8242,11 +8242,11 @@ rufa_2017_24h_finished_first_finish_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_6:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_start
   id: 133978
   absolute_time: 2017-02-12 00:50:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 42000.0
   lap: 6
   pacer:
@@ -8255,11 +8255,11 @@ rufa_2017_24h_finished_first_start_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_6:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_grandeur_peak
   id: 133979
   absolute_time: 2017-02-12 02:25:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 47700.0
   lap: 6
   pacer:
@@ -8268,11 +8268,11 @@ rufa_2017_24h_finished_first_grandeur_peak_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_6:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
   id: 133980
   absolute_time: 2017-02-12 03:15:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 50700.0
   lap: 6
   pacer:
@@ -8281,11 +8281,11 @@ rufa_2017_24h_finished_first_finish_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_start_7:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_start
   id: 133981
   absolute_time: 2017-02-12 03:38:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 52080.0
   lap: 7
   pacer:
@@ -8294,11 +8294,11 @@ rufa_2017_24h_finished_first_start_7:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_7:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_grandeur_peak
   id: 133982
   absolute_time: 2017-02-12 05:19:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 58140.0
   lap: 7
   pacer:
@@ -8307,11 +8307,11 @@ rufa_2017_24h_finished_first_grandeur_peak_7:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_first_finish_7:
+  effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
   id: 133983
   absolute_time: 2017-02-12 06:08:00.000000000 Z
   data_status: 2
-  effort_id: 6693
   elapsed_seconds: 61080.0
   lap: 7
   pacer:
@@ -8320,11 +8320,11 @@ rufa_2017_24h_finished_first_finish_7:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_1:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_start
   id: 134001
   absolute_time: 2017-02-11 15:00:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -8333,11 +8333,11 @@ rufa_2017_24h_progress_lap6_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_1:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_grandeur_peak
   id: 134002
   absolute_time: 2017-02-11 15:57:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 3420.0
   lap: 1
   pacer:
@@ -8346,11 +8346,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_1:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
   id: 134003
   absolute_time: 2017-02-11 16:28:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 5280.0
   lap: 1
   pacer:
@@ -8359,11 +8359,11 @@ rufa_2017_24h_progress_lap6_finish_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_2:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_start
   id: 134004
   absolute_time: 2017-02-11 16:28:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 5280.0
   lap: 2
   pacer:
@@ -8372,11 +8372,11 @@ rufa_2017_24h_progress_lap6_start_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_2:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_grandeur_peak
   id: 134005
   absolute_time: 2017-02-11 17:29:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 8940.0
   lap: 2
   pacer:
@@ -8385,11 +8385,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_2:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
   id: 134006
   absolute_time: 2017-02-11 18:01:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 10860.0
   lap: 2
   pacer:
@@ -8398,11 +8398,11 @@ rufa_2017_24h_progress_lap6_finish_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_3:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_start
   id: 134007
   absolute_time: 2017-02-11 18:02:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 10920.0
   lap: 3
   pacer:
@@ -8411,11 +8411,11 @@ rufa_2017_24h_progress_lap6_start_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_3:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_grandeur_peak
   id: 134008
   absolute_time: 2017-02-11 19:13:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 15180.0
   lap: 3
   pacer:
@@ -8424,11 +8424,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_3:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
   id: 134009
   absolute_time: 2017-02-11 19:46:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 17160.0
   lap: 3
   pacer:
@@ -8437,11 +8437,11 @@ rufa_2017_24h_progress_lap6_finish_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_4:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_start
   id: 134010
   absolute_time: 2017-02-11 19:48:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 17280.0
   lap: 4
   pacer:
@@ -8450,11 +8450,11 @@ rufa_2017_24h_progress_lap6_start_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_4:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_grandeur_peak
   id: 134011
   absolute_time: 2017-02-11 21:01:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 21660.0
   lap: 4
   pacer:
@@ -8463,11 +8463,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_4:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
   id: 134012
   absolute_time: 2017-02-11 21:36:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 23760.0
   lap: 4
   pacer:
@@ -8476,11 +8476,11 @@ rufa_2017_24h_progress_lap6_finish_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_5:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_start
   id: 134013
   absolute_time: 2017-02-11 21:39:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 23940.0
   lap: 5
   pacer:
@@ -8489,11 +8489,11 @@ rufa_2017_24h_progress_lap6_start_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_5:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_grandeur_peak
   id: 134014
   absolute_time: 2017-02-11 22:53:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 28380.0
   lap: 5
   pacer:
@@ -8502,11 +8502,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_5:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
   id: 134015
   absolute_time: 2017-02-11 23:27:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 30420.0
   lap: 5
   pacer:
@@ -8515,11 +8515,11 @@ rufa_2017_24h_progress_lap6_finish_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_start_6:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_start
   id: 134016
   absolute_time: 2017-02-11 23:30:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 30600.0
   lap: 6
   pacer:
@@ -8528,11 +8528,11 @@ rufa_2017_24h_progress_lap6_start_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_grandeur_peak_6:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_grandeur_peak
   id: 134017
   absolute_time: 2017-02-12 00:49:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 35340.0
   lap: 6
   pacer:
@@ -8541,11 +8541,11 @@ rufa_2017_24h_progress_lap6_grandeur_peak_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap6_finish_6:
+  effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
   id: 134018
   absolute_time: 2017-02-12 01:20:00.000000000 Z
   data_status: 2
-  effort_id: 6695
   elapsed_seconds: 37200.0
   lap: 6
   pacer:
@@ -8554,11 +8554,11 @@ rufa_2017_24h_progress_lap6_finish_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_start_1:
+  effort: rufa_2017_24h_multiple_stops
   split: rufa_course_start
   id: 134805
   absolute_time: 2017-02-11 15:00:00.000000000 Z
   data_status: 2
-  effort_id: 6756
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -8567,11 +8567,11 @@ rufa_2017_24h_multiple_stops_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_grandeur_peak_1:
+  effort: rufa_2017_24h_multiple_stops
   split: rufa_course_grandeur_peak
   id: 134806
   absolute_time: 2017-02-11 16:05:00.000000000 Z
   data_status: 2
-  effort_id: 6756
   elapsed_seconds: 3900.0
   lap: 1
   pacer:
@@ -8580,11 +8580,11 @@ rufa_2017_24h_multiple_stops_grandeur_peak_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_finish_1:
+  effort: rufa_2017_24h_multiple_stops
   split: rufa_course_finish
   id: 134807
   absolute_time: 2017-02-11 16:40:00.000000000 Z
   data_status: 2
-  effort_id: 6756
   elapsed_seconds: 6000.0
   lap: 1
   pacer:
@@ -8593,11 +8593,11 @@ rufa_2017_24h_multiple_stops_finish_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_start_2:
+  effort: rufa_2017_24h_multiple_stops
   split: rufa_course_start
   id: 134808
   absolute_time: 2017-02-11 16:40:00.000000000 Z
   data_status: 2
-  effort_id: 6756
   elapsed_seconds: 6000.0
   lap: 2
   pacer:
@@ -8606,11 +8606,11 @@ rufa_2017_24h_multiple_stops_start_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_grandeur_peak_2:
+  effort: rufa_2017_24h_multiple_stops
   split: rufa_course_grandeur_peak
   id: 134809
   absolute_time: 2017-02-11 17:52:00.000000000 Z
   data_status: 2
-  effort_id: 6756
   elapsed_seconds: 10320.0
   lap: 2
   pacer:
@@ -8619,11 +8619,11 @@ rufa_2017_24h_multiple_stops_grandeur_peak_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_finish_2:
+  effort: rufa_2017_24h_multiple_stops
   split: rufa_course_finish
   id: 134810
   absolute_time: 2017-02-11 18:24:00.000000000 Z
   data_status: 2
-  effort_id: 6756
   elapsed_seconds: 12240.0
   lap: 2
   pacer:
@@ -8632,11 +8632,11 @@ rufa_2017_24h_multiple_stops_finish_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_grandeur_peak_3:
+  effort: rufa_2017_24h_multiple_stops
   split: rufa_course_grandeur_peak
   id: 134811
   absolute_time: 2017-02-11 19:55:00.000000000 Z
   data_status: 2
-  effort_id: 6756
   elapsed_seconds: 17700.0
   lap: 3
   pacer:
@@ -8645,11 +8645,11 @@ rufa_2017_24h_multiple_stops_grandeur_peak_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_multiple_stops_finish_3:
+  effort: rufa_2017_24h_multiple_stops
   split: rufa_course_finish
   id: 134812
   absolute_time: 2017-02-11 20:42:00.000000000 Z
   data_status: 2
-  effort_id: 6756
   elapsed_seconds: 20520.0
   lap: 3
   pacer:
@@ -8658,11 +8658,11 @@ rufa_2017_24h_multiple_stops_finish_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_start_1:
+  effort: rufa_2017_24h_finished_last
   split: rufa_course_start
   id: 135007
   absolute_time: 2017-02-11 15:00:00.000000000 Z
   data_status: 2
-  effort_id: 6780
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -8671,11 +8671,11 @@ rufa_2017_24h_finished_last_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_grandeur_peak_1:
+  effort: rufa_2017_24h_finished_last
   split: rufa_course_grandeur_peak
   id: 135008
   absolute_time: 2017-02-11 16:17:00.000000000 Z
   data_status: 2
-  effort_id: 6780
   elapsed_seconds: 4620.0
   lap: 1
   pacer:
@@ -8684,11 +8684,11 @@ rufa_2017_24h_finished_last_grandeur_peak_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_finish_1:
+  effort: rufa_2017_24h_finished_last
   split: rufa_course_finish
   id: 135009
   absolute_time: 2017-02-11 16:54:00.000000000 Z
   data_status: 2
-  effort_id: 6780
   elapsed_seconds: 6840.0
   lap: 1
   pacer:
@@ -8697,11 +8697,11 @@ rufa_2017_24h_finished_last_finish_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_start_2:
+  effort: rufa_2017_24h_finished_last
   split: rufa_course_start
   id: 135010
   absolute_time: 2017-02-11 16:58:00.000000000 Z
   data_status: 2
-  effort_id: 6780
   elapsed_seconds: 7080.0
   lap: 2
   pacer:
@@ -8710,11 +8710,11 @@ rufa_2017_24h_finished_last_start_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_grandeur_peak_2:
+  effort: rufa_2017_24h_finished_last
   split: rufa_course_grandeur_peak
   id: 135011
   absolute_time: 2017-02-11 18:21:00.000000000 Z
   data_status: 2
-  effort_id: 6780
   elapsed_seconds: 12060.0
   lap: 2
   pacer:
@@ -8723,11 +8723,11 @@ rufa_2017_24h_finished_last_grandeur_peak_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_finished_last_finish_2:
+  effort: rufa_2017_24h_finished_last
   split: rufa_course_finish
   id: 135012
   absolute_time: 2017-02-11 18:57:00.000000000 Z
   data_status: 2
-  effort_id: 6780
   elapsed_seconds: 14220.0
   lap: 2
   pacer:
@@ -8736,11 +8736,11 @@ rufa_2017_24h_finished_last_finish_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap1_start_1:
+  effort: rufa_2017_24h_progress_lap1
   split: rufa_course_start
   id: 135132
   absolute_time: 2017-02-11 16:00:00.000000000 Z
   data_status: 2
-  effort_id: 6805
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -8749,11 +8749,11 @@ rufa_2017_24h_progress_lap1_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap1_grandeur_peak_1:
+  effort: rufa_2017_24h_progress_lap1
   split: rufa_course_grandeur_peak
   id: 135133
   absolute_time: 2017-02-11 17:27:00.000000000 Z
   data_status: 2
-  effort_id: 6805
   elapsed_seconds: 5220.0
   lap: 1
   pacer:
@@ -8762,11 +8762,11 @@ rufa_2017_24h_progress_lap1_grandeur_peak_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_24h_progress_lap1_finish_1:
+  effort: rufa_2017_24h_progress_lap1
   split: rufa_course_finish
   id: 135134
   absolute_time: 2017-02-11 18:53:00.000000000 Z
   data_status: 1
-  effort_id: 6805
   elapsed_seconds: 10380.0
   lap: 1
   pacer:
@@ -8775,11 +8775,11 @@ rufa_2017_24h_progress_lap1_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_start_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_start
   id: 146923
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -8788,11 +8788,11 @@ hardrock_2016_lavon_paucek_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_telluride_in_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_telluride
   id: 146928
   absolute_time: 2016-07-15 18:36:00.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 23760.0
   lap: 1
   pacer:
@@ -8801,11 +8801,11 @@ hardrock_2016_lavon_paucek_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_telluride_out_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_telluride
   id: 146929
   absolute_time: 2016-07-15 18:38:00.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 23880.0
   lap: 1
   pacer:
@@ -8814,11 +8814,11 @@ hardrock_2016_lavon_paucek_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_lavon_paucek_ouray_in_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_ouray
   id: 146934
   absolute_time: 2016-07-15 22:11:00.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 36660.0
   lap: 1
   pacer:
@@ -8827,11 +8827,11 @@ hardrock_2016_lavon_paucek_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_ouray_out_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_ouray
   id: 146935
   absolute_time: 2016-07-15 22:16:00.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 36960.0
   lap: 1
   pacer:
@@ -8840,11 +8840,11 @@ hardrock_2016_lavon_paucek_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_lavon_paucek_grouse_in_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_grouse
   id: 146938
   absolute_time: 2016-07-16 02:36:00.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 52560.0
   lap: 1
   pacer:
@@ -8853,11 +8853,11 @@ hardrock_2016_lavon_paucek_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_grouse_out_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_grouse
   id: 146939
   absolute_time: 2016-07-16 02:36:00.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 52560.0
   lap: 1
   pacer:
@@ -8866,11 +8866,11 @@ hardrock_2016_lavon_paucek_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_lavon_paucek_sherman_in_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_sherman
   id: 146942
   absolute_time: 2016-07-16 07:02:00.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 68520.0
   lap: 1
   pacer:
@@ -8879,11 +8879,11 @@ hardrock_2016_lavon_paucek_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_sherman_out_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_sherman
   id: 146943
   absolute_time: 2016-07-16 07:09:00.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 68940.0
   lap: 1
   pacer:
@@ -8892,11 +8892,11 @@ hardrock_2016_lavon_paucek_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_lavon_paucek_cunningham_in_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_cunningham
   id: 146948
   absolute_time: 2016-07-16 14:11:00.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 94260.0
   lap: 1
   pacer:
@@ -8905,11 +8905,11 @@ hardrock_2016_lavon_paucek_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_lavon_paucek_cunningham_out_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_cunningham
   id: 146949
   absolute_time: 2016-07-16 14:13:00.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 94380.0
   lap: 1
   pacer:
@@ -8918,11 +8918,11 @@ hardrock_2016_lavon_paucek_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_lavon_paucek_finish_1:
+  effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_finish
   id: 146950
   absolute_time: 2016-07-16 17:02:09.000000000 Z
   data_status: 2
-  effort_id: 7270
   elapsed_seconds: 104529.0
   lap: 1
   pacer:
@@ -8931,11 +8931,11 @@ hardrock_2016_lavon_paucek_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_start_1:
+  effort: hardrock_2016_vesta_borer
   split: hardrock_cw_start
   id: 147315
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7284
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -8944,11 +8944,11 @@ hardrock_2016_vesta_borer_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_telluride_in_1:
+  effort: hardrock_2016_vesta_borer
   split: hardrock_cw_telluride
   id: 147320
   absolute_time: 2016-07-15 20:17:00.000000000 Z
   data_status: 2
-  effort_id: 7284
   elapsed_seconds: 29820.0
   lap: 1
   pacer:
@@ -8957,11 +8957,11 @@ hardrock_2016_vesta_borer_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_telluride_out_1:
+  effort: hardrock_2016_vesta_borer
   split: hardrock_cw_telluride
   id: 147321
   absolute_time: 2016-07-15 20:22:00.000000000 Z
   data_status: 2
-  effort_id: 7284
   elapsed_seconds: 30120.0
   lap: 1
   pacer:
@@ -8970,11 +8970,11 @@ hardrock_2016_vesta_borer_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_vesta_borer_ouray_in_1:
+  effort: hardrock_2016_vesta_borer
   split: hardrock_cw_ouray
   id: 147326
   absolute_time: 2016-07-16 00:49:00.000000000 Z
   data_status: 2
-  effort_id: 7284
   elapsed_seconds: 46140.0
   lap: 1
   pacer:
@@ -8983,11 +8983,11 @@ hardrock_2016_vesta_borer_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_ouray_out_1:
+  effort: hardrock_2016_vesta_borer
   split: hardrock_cw_ouray
   id: 147327
   absolute_time: 2016-07-16 00:58:00.000000000 Z
   data_status: 2
-  effort_id: 7284
   elapsed_seconds: 46680.0
   lap: 1
   pacer:
@@ -8996,11 +8996,11 @@ hardrock_2016_vesta_borer_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_vesta_borer_grouse_in_1:
+  effort: hardrock_2016_vesta_borer
   split: hardrock_cw_grouse
   id: 147330
   absolute_time: 2016-07-16 06:14:00.000000000 Z
   data_status: 2
-  effort_id: 7284
   elapsed_seconds: 65640.0
   lap: 1
   pacer:
@@ -9009,11 +9009,11 @@ hardrock_2016_vesta_borer_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_grouse_out_1:
+  effort: hardrock_2016_vesta_borer
   split: hardrock_cw_grouse
   id: 147331
   absolute_time: 2016-07-16 06:24:00.000000000 Z
   data_status: 2
-  effort_id: 7284
   elapsed_seconds: 66240.0
   lap: 1
   pacer:
@@ -9022,11 +9022,11 @@ hardrock_2016_vesta_borer_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_vesta_borer_sherman_in_1:
+  effort: hardrock_2016_vesta_borer
   split: hardrock_cw_sherman
   id: 147334
   absolute_time: 2016-07-16 11:23:00.000000000 Z
   data_status: 2
-  effort_id: 7284
   elapsed_seconds: 84180.0
   lap: 1
   pacer:
@@ -9035,11 +9035,11 @@ hardrock_2016_vesta_borer_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_sherman_out_1:
+  effort: hardrock_2016_vesta_borer
   split: hardrock_cw_sherman
   id: 147335
   absolute_time: 2016-07-16 11:41:00.000000000 Z
   data_status: 2
-  effort_id: 7284
   elapsed_seconds: 85260.0
   lap: 1
   pacer:
@@ -9048,11 +9048,11 @@ hardrock_2016_vesta_borer_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_vesta_borer_cunningham_in_1:
+  effort: hardrock_2016_vesta_borer
   split: hardrock_cw_cunningham
   id: 147340
   absolute_time: 2016-07-16 19:00:00.000000000 Z
   data_status: 2
-  effort_id: 7284
   elapsed_seconds: 111600.0
   lap: 1
   pacer:
@@ -9061,11 +9061,11 @@ hardrock_2016_vesta_borer_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_vesta_borer_cunningham_out_1:
+  effort: hardrock_2016_vesta_borer
   split: hardrock_cw_cunningham
   id: 147341
   absolute_time: 2016-07-16 19:05:00.000000000 Z
   data_status: 2
-  effort_id: 7284
   elapsed_seconds: 111900.0
   lap: 1
   pacer:
@@ -9074,11 +9074,11 @@ hardrock_2016_vesta_borer_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kory_kulas_start_1:
+  effort: hardrock_2016_kory_kulas
   split: hardrock_cw_start
   id: 147455
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7289
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -9087,11 +9087,11 @@ hardrock_2016_kory_kulas_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_telluride_in_1:
+  effort: hardrock_2016_kory_kulas
   split: hardrock_cw_telluride
   id: 147460
   absolute_time: 2016-07-15 20:16:00.000000000 Z
   data_status: 2
-  effort_id: 7289
   elapsed_seconds: 29760.0
   lap: 1
   pacer:
@@ -9100,11 +9100,11 @@ hardrock_2016_kory_kulas_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_telluride_out_1:
+  effort: hardrock_2016_kory_kulas
   split: hardrock_cw_telluride
   id: 147461
   absolute_time: 2016-07-15 20:25:00.000000000 Z
   data_status: 2
-  effort_id: 7289
   elapsed_seconds: 30300.0
   lap: 1
   pacer:
@@ -9113,11 +9113,11 @@ hardrock_2016_kory_kulas_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kory_kulas_ouray_in_1:
+  effort: hardrock_2016_kory_kulas
   split: hardrock_cw_ouray
   id: 147466
   absolute_time: 2016-07-16 01:05:00.000000000 Z
   data_status: 2
-  effort_id: 7289
   elapsed_seconds: 47100.0
   lap: 1
   pacer:
@@ -9126,11 +9126,11 @@ hardrock_2016_kory_kulas_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_ouray_out_1:
+  effort: hardrock_2016_kory_kulas
   split: hardrock_cw_ouray
   id: 147467
   absolute_time: 2016-07-16 01:16:00.000000000 Z
   data_status: 2
-  effort_id: 7289
   elapsed_seconds: 47760.0
   lap: 1
   pacer:
@@ -9139,11 +9139,11 @@ hardrock_2016_kory_kulas_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kory_kulas_grouse_in_1:
+  effort: hardrock_2016_kory_kulas
   split: hardrock_cw_grouse
   id: 147470
   absolute_time: 2016-07-16 07:30:00.000000000 Z
   data_status: 2
-  effort_id: 7289
   elapsed_seconds: 70200.0
   lap: 1
   pacer:
@@ -9152,11 +9152,11 @@ hardrock_2016_kory_kulas_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_grouse_out_1:
+  effort: hardrock_2016_kory_kulas
   split: hardrock_cw_grouse
   id: 147471
   absolute_time: 2016-07-16 07:55:00.000000000 Z
   data_status: 2
-  effort_id: 7289
   elapsed_seconds: 71700.0
   lap: 1
   pacer:
@@ -9165,11 +9165,11 @@ hardrock_2016_kory_kulas_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kory_kulas_sherman_in_1:
+  effort: hardrock_2016_kory_kulas
   split: hardrock_cw_sherman
   id: 147474
   absolute_time: 2016-07-16 13:00:00.000000000 Z
   data_status: 2
-  effort_id: 7289
   elapsed_seconds: 90000.0
   lap: 1
   pacer:
@@ -9178,11 +9178,11 @@ hardrock_2016_kory_kulas_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_sherman_out_1:
+  effort: hardrock_2016_kory_kulas
   split: hardrock_cw_sherman
   id: 147475
   absolute_time: 2016-07-16 13:08:00.000000000 Z
   data_status: 2
-  effort_id: 7289
   elapsed_seconds: 90480.0
   lap: 1
   pacer:
@@ -9191,11 +9191,11 @@ hardrock_2016_kory_kulas_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kory_kulas_cunningham_in_1:
+  effort: hardrock_2016_kory_kulas
   split: hardrock_cw_cunningham
   id: 147480
   absolute_time: 2016-07-16 20:51:00.000000000 Z
   data_status: 2
-  effort_id: 7289
   elapsed_seconds: 118260.0
   lap: 1
   pacer:
@@ -9204,11 +9204,11 @@ hardrock_2016_kory_kulas_cunningham_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kory_kulas_cunningham_out_1:
+  effort: hardrock_2016_kory_kulas
   split: hardrock_cw_cunningham
   id: 147481
   absolute_time: 2016-07-16 20:58:00.000000000 Z
   data_status: 2
-  effort_id: 7289
   elapsed_seconds: 118680.0
   lap: 1
   pacer:
@@ -9217,11 +9217,11 @@ hardrock_2016_kory_kulas_cunningham_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_shad_hirthe_start_1:
+  effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_start
   id: 147679
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7297
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -9230,11 +9230,11 @@ hardrock_2016_shad_hirthe_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_shad_hirthe_telluride_in_1:
+  effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_telluride
   id: 147684
   absolute_time: 2016-07-15 19:59:00.000000000 Z
   data_status: 2
-  effort_id: 7297
   elapsed_seconds: 28740.0
   lap: 1
   pacer:
@@ -9243,11 +9243,11 @@ hardrock_2016_shad_hirthe_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_shad_hirthe_telluride_out_1:
+  effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_telluride
   id: 147685
   absolute_time: 2016-07-15 20:07:00.000000000 Z
   data_status: 2
-  effort_id: 7297
   elapsed_seconds: 29220.0
   lap: 1
   pacer:
@@ -9256,11 +9256,11 @@ hardrock_2016_shad_hirthe_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_shad_hirthe_ouray_in_1:
+  effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_ouray
   id: 147690
   absolute_time: 2016-07-16 00:35:00.000000000 Z
   data_status: 2
-  effort_id: 7297
   elapsed_seconds: 45300.0
   lap: 1
   pacer:
@@ -9269,11 +9269,11 @@ hardrock_2016_shad_hirthe_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_shad_hirthe_ouray_out_1:
+  effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_ouray
   id: 147691
   absolute_time: 2016-07-16 00:47:00.000000000 Z
   data_status: 2
-  effort_id: 7297
   elapsed_seconds: 46020.0
   lap: 1
   pacer:
@@ -9282,11 +9282,11 @@ hardrock_2016_shad_hirthe_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_shad_hirthe_grouse_in_1:
+  effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_grouse
   id: 147694
   absolute_time: 2016-07-16 06:28:00.000000000 Z
   data_status: 2
-  effort_id: 7297
   elapsed_seconds: 66480.0
   lap: 1
   pacer:
@@ -9295,11 +9295,11 @@ hardrock_2016_shad_hirthe_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_shad_hirthe_grouse_out_1:
+  effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_grouse
   id: 147695
   absolute_time: 2016-07-16 06:47:00.000000000 Z
   data_status: 2
-  effort_id: 7297
   elapsed_seconds: 67620.0
   lap: 1
   pacer:
@@ -9308,11 +9308,11 @@ hardrock_2016_shad_hirthe_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_shad_hirthe_sherman_in_1:
+  effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_sherman
   id: 147698
   absolute_time: 2016-07-16 12:35:00.000000000 Z
   data_status: 2
-  effort_id: 7297
   elapsed_seconds: 88500.0
   lap: 1
   pacer:
@@ -9321,11 +9321,11 @@ hardrock_2016_shad_hirthe_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_shad_hirthe_sherman_out_1:
+  effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_sherman
   id: 147699
   absolute_time: 2016-07-16 12:59:00.000000000 Z
   data_status: 2
-  effort_id: 7297
   elapsed_seconds: 89940.0
   lap: 1
   pacer:
@@ -9334,11 +9334,11 @@ hardrock_2016_shad_hirthe_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_douglas_vandervort_start_1:
+  effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_start
   id: 147819
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7302
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -9347,11 +9347,11 @@ hardrock_2016_douglas_vandervort_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_douglas_vandervort_telluride_in_1:
+  effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_telluride
   id: 147824
   absolute_time: 2016-07-15 20:16:00.000000000 Z
   data_status: 2
-  effort_id: 7302
   elapsed_seconds: 29760.0
   lap: 1
   pacer:
@@ -9360,11 +9360,11 @@ hardrock_2016_douglas_vandervort_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_douglas_vandervort_telluride_out_1:
+  effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_telluride
   id: 147825
   absolute_time: 2016-07-15 20:27:00.000000000 Z
   data_status: 2
-  effort_id: 7302
   elapsed_seconds: 30420.0
   lap: 1
   pacer:
@@ -9373,11 +9373,11 @@ hardrock_2016_douglas_vandervort_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_douglas_vandervort_ouray_in_1:
+  effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_ouray
   id: 147830
   absolute_time: 2016-07-16 01:19:00.000000000 Z
   data_status: 2
-  effort_id: 7302
   elapsed_seconds: 47940.0
   lap: 1
   pacer:
@@ -9386,11 +9386,11 @@ hardrock_2016_douglas_vandervort_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_douglas_vandervort_ouray_out_1:
+  effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_ouray
   id: 147831
   absolute_time: 2016-07-16 01:46:00.000000000 Z
   data_status: 2
-  effort_id: 7302
   elapsed_seconds: 49560.0
   lap: 1
   pacer:
@@ -9399,11 +9399,11 @@ hardrock_2016_douglas_vandervort_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_douglas_vandervort_grouse_in_1:
+  effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_grouse
   id: 147834
   absolute_time: 2016-07-16 08:00:00.000000000 Z
   data_status: 2
-  effort_id: 7302
   elapsed_seconds: 72000.0
   lap: 1
   pacer:
@@ -9412,11 +9412,11 @@ hardrock_2016_douglas_vandervort_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_douglas_vandervort_grouse_out_1:
+  effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_grouse
   id: 147835
   absolute_time: 2016-07-16 08:27:00.000000000 Z
   data_status: 2
-  effort_id: 7302
   elapsed_seconds: 73620.0
   lap: 1
   pacer:
@@ -9425,11 +9425,11 @@ hardrock_2016_douglas_vandervort_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_douglas_vandervort_sherman_in_1:
+  effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_sherman
   id: 147838
   absolute_time: 2016-07-16 13:49:00.000000000 Z
   data_status: 2
-  effort_id: 7302
   elapsed_seconds: 92940.0
   lap: 1
   pacer:
@@ -9438,11 +9438,11 @@ hardrock_2016_douglas_vandervort_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_douglas_vandervort_sherman_out_1:
+  effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_sherman
   id: 147839
   absolute_time: 2016-07-16 14:19:00.000000000 Z
   data_status: 2
-  effort_id: 7302
   elapsed_seconds: 94740.0
   lap: 1
   pacer:
@@ -9451,11 +9451,11 @@ hardrock_2016_douglas_vandervort_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_missing_telluride_out_start_1:
+  effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_start
   id: 147987
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7308
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -9464,11 +9464,11 @@ hardrock_2016_missing_telluride_out_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_missing_telluride_out_telluride_in_1:
+  effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_telluride
   id: 147992
   absolute_time: 2016-07-15 21:41:00.000000000 Z
   data_status: 2
-  effort_id: 7308
   elapsed_seconds: 34860.0
   lap: 1
   pacer:
@@ -9477,11 +9477,11 @@ hardrock_2016_missing_telluride_out_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_missing_telluride_out_ouray_in_1:
+  effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_ouray
   id: 147998
   absolute_time: 2016-07-16 02:54:00.000000000 Z
   data_status: 2
-  effort_id: 7308
   elapsed_seconds: 53640.0
   lap: 1
   pacer:
@@ -9490,11 +9490,11 @@ hardrock_2016_missing_telluride_out_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_missing_telluride_out_ouray_out_1:
+  effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_ouray
   id: 147999
   absolute_time: 2016-07-16 03:10:00.000000000 Z
   data_status: 2
-  effort_id: 7308
   elapsed_seconds: 54600.0
   lap: 1
   pacer:
@@ -9503,11 +9503,11 @@ hardrock_2016_missing_telluride_out_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_missing_telluride_out_grouse_in_1:
+  effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_grouse
   id: 148002
   absolute_time: 2016-07-16 09:04:00.000000000 Z
   data_status: 2
-  effort_id: 7308
   elapsed_seconds: 75840.0
   lap: 1
   pacer:
@@ -9516,11 +9516,11 @@ hardrock_2016_missing_telluride_out_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_missing_telluride_out_grouse_out_1:
+  effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_grouse
   id: 148003
   absolute_time: 2016-07-16 09:16:00.000000000 Z
   data_status: 2
-  effort_id: 7308
   elapsed_seconds: 76560.0
   lap: 1
   pacer:
@@ -9529,11 +9529,11 @@ hardrock_2016_missing_telluride_out_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_missing_telluride_out_sherman_in_1:
+  effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_sherman
   id: 148006
   absolute_time: 2016-07-16 14:51:00.000000000 Z
   data_status: 2
-  effort_id: 7308
   elapsed_seconds: 96660.0
   lap: 1
   pacer:
@@ -9542,11 +9542,11 @@ hardrock_2016_missing_telluride_out_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_missing_telluride_out_sherman_out_1:
+  effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_sherman
   id: 148007
   absolute_time: 2016-07-16 15:13:00.000000000 Z
   data_status: 2
-  effort_id: 7308
   elapsed_seconds: 97980.0
   lap: 1
   pacer:
@@ -9555,11 +9555,11 @@ hardrock_2016_missing_telluride_out_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_junior_lesch_start_1:
+  effort: hardrock_2016_junior_lesch
   split: hardrock_cw_start
   id: 148071
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7311
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -9568,11 +9568,11 @@ hardrock_2016_junior_lesch_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_junior_lesch_telluride_in_1:
+  effort: hardrock_2016_junior_lesch
   split: hardrock_cw_telluride
   id: 148076
   absolute_time: 2016-07-15 20:10:00.000000000 Z
   data_status: 2
-  effort_id: 7311
   elapsed_seconds: 29400.0
   lap: 1
   pacer:
@@ -9581,11 +9581,11 @@ hardrock_2016_junior_lesch_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_junior_lesch_telluride_out_1:
+  effort: hardrock_2016_junior_lesch
   split: hardrock_cw_telluride
   id: 148077
   absolute_time: 2016-07-15 20:17:00.000000000 Z
   data_status: 2
-  effort_id: 7311
   elapsed_seconds: 29820.0
   lap: 1
   pacer:
@@ -9594,11 +9594,11 @@ hardrock_2016_junior_lesch_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_junior_lesch_ouray_in_1:
+  effort: hardrock_2016_junior_lesch
   split: hardrock_cw_ouray
   id: 148082
   absolute_time: 2016-07-16 00:57:00.000000000 Z
   data_status: 2
-  effort_id: 7311
   elapsed_seconds: 46620.0
   lap: 1
   pacer:
@@ -9607,11 +9607,11 @@ hardrock_2016_junior_lesch_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_junior_lesch_ouray_out_1:
+  effort: hardrock_2016_junior_lesch
   split: hardrock_cw_ouray
   id: 148083
   absolute_time: 2016-07-16 01:20:00.000000000 Z
   data_status: 2
-  effort_id: 7311
   elapsed_seconds: 48000.0
   lap: 1
   pacer:
@@ -9620,11 +9620,11 @@ hardrock_2016_junior_lesch_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_junior_lesch_grouse_in_1:
+  effort: hardrock_2016_junior_lesch
   split: hardrock_cw_grouse
   id: 148086
   absolute_time: 2016-07-16 07:31:00.000000000 Z
   data_status: 2
-  effort_id: 7311
   elapsed_seconds: 70260.0
   lap: 1
   pacer:
@@ -9633,11 +9633,11 @@ hardrock_2016_junior_lesch_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_junior_lesch_grouse_out_1:
+  effort: hardrock_2016_junior_lesch
   split: hardrock_cw_grouse
   id: 148087
   absolute_time: 2016-07-16 08:42:00.000000000 Z
   data_status: 2
-  effort_id: 7311
   elapsed_seconds: 74520.0
   lap: 1
   pacer:
@@ -9646,11 +9646,11 @@ hardrock_2016_junior_lesch_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_junior_lesch_sherman_in_1:
+  effort: hardrock_2016_junior_lesch
   split: hardrock_cw_sherman
   id: 148090
   absolute_time: 2016-07-16 15:10:00.000000000 Z
   data_status: 2
-  effort_id: 7311
   elapsed_seconds: 97800.0
   lap: 1
   pacer:
@@ -9659,11 +9659,11 @@ hardrock_2016_junior_lesch_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_junior_lesch_sherman_out_1:
+  effort: hardrock_2016_junior_lesch
   split: hardrock_cw_sherman
   id: 148091
   absolute_time: 2016-07-16 15:44:00.000000000 Z
   data_status: 2
-  effort_id: 7311
   elapsed_seconds: 99840.0
   lap: 1
   pacer:
@@ -9672,11 +9672,11 @@ hardrock_2016_junior_lesch_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_eddy_goldner_start_1:
+  effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_start
   id: 148183
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7315
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -9685,11 +9685,11 @@ hardrock_2016_eddy_goldner_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_eddy_goldner_telluride_in_1:
+  effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_telluride
   id: 148188
   absolute_time: 2016-07-15 19:41:00.000000000 Z
   data_status: 2
-  effort_id: 7315
   elapsed_seconds: 27660.0
   lap: 1
   pacer:
@@ -9698,11 +9698,11 @@ hardrock_2016_eddy_goldner_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_eddy_goldner_telluride_out_1:
+  effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_telluride
   id: 148189
   absolute_time: 2016-07-15 19:54:00.000000000 Z
   data_status: 2
-  effort_id: 7315
   elapsed_seconds: 28440.0
   lap: 1
   pacer:
@@ -9711,11 +9711,11 @@ hardrock_2016_eddy_goldner_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_eddy_goldner_ouray_in_1:
+  effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_ouray
   id: 148194
   absolute_time: 2016-07-16 00:48:00.000000000 Z
   data_status: 2
-  effort_id: 7315
   elapsed_seconds: 46080.0
   lap: 1
   pacer:
@@ -9724,11 +9724,11 @@ hardrock_2016_eddy_goldner_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_eddy_goldner_ouray_out_1:
+  effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_ouray
   id: 148195
   absolute_time: 2016-07-16 01:05:00.000000000 Z
   data_status: 2
-  effort_id: 7315
   elapsed_seconds: 47100.0
   lap: 1
   pacer:
@@ -9737,11 +9737,11 @@ hardrock_2016_eddy_goldner_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_eddy_goldner_grouse_in_1:
+  effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_grouse
   id: 148198
   absolute_time: 2016-07-16 07:42:00.000000000 Z
   data_status: 2
-  effort_id: 7315
   elapsed_seconds: 70920.0
   lap: 1
   pacer:
@@ -9750,11 +9750,11 @@ hardrock_2016_eddy_goldner_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_eddy_goldner_grouse_out_1:
+  effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_grouse
   id: 148199
   absolute_time: 2016-07-16 08:25:00.000000000 Z
   data_status: 2
-  effort_id: 7315
   elapsed_seconds: 73500.0
   lap: 1
   pacer:
@@ -9763,11 +9763,11 @@ hardrock_2016_eddy_goldner_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_eddy_goldner_sherman_in_1:
+  effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_sherman
   id: 148202
   absolute_time: 2016-07-16 14:24:00.000000000 Z
   data_status: 2
-  effort_id: 7315
   elapsed_seconds: 95040.0
   lap: 1
   pacer:
@@ -9776,11 +9776,11 @@ hardrock_2016_eddy_goldner_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_eddy_goldner_sherman_out_1:
+  effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_sherman
   id: 148203
   absolute_time: 2016-07-16 15:00:00.000000000 Z
   data_status: 2
-  effort_id: 7315
   elapsed_seconds: 97200.0
   lap: 1
   pacer:
@@ -9789,11 +9789,11 @@ hardrock_2016_eddy_goldner_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_progress_sherman_start_1:
+  effort: hardrock_2016_progress_sherman
   split: hardrock_cw_start
   id: 148547
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7328
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -9802,11 +9802,11 @@ hardrock_2016_progress_sherman_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_progress_sherman_telluride_in_1:
+  effort: hardrock_2016_progress_sherman
   split: hardrock_cw_telluride
   id: 148552
   absolute_time: 2016-07-15 19:44:00.000000000 Z
   data_status: 2
-  effort_id: 7328
   elapsed_seconds: 27840.0
   lap: 1
   pacer:
@@ -9815,11 +9815,11 @@ hardrock_2016_progress_sherman_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_progress_sherman_telluride_out_1:
+  effort: hardrock_2016_progress_sherman
   split: hardrock_cw_telluride
   id: 148553
   absolute_time: 2016-07-15 19:47:00.000000000 Z
   data_status: 2
-  effort_id: 7328
   elapsed_seconds: 28020.0
   lap: 1
   pacer:
@@ -9828,11 +9828,11 @@ hardrock_2016_progress_sherman_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_progress_sherman_ouray_in_1:
+  effort: hardrock_2016_progress_sherman
   split: hardrock_cw_ouray
   id: 148558
   absolute_time: 2016-07-16 00:03:00.000000000 Z
   data_status: 2
-  effort_id: 7328
   elapsed_seconds: 43380.0
   lap: 1
   pacer:
@@ -9841,11 +9841,11 @@ hardrock_2016_progress_sherman_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_progress_sherman_ouray_out_1:
+  effort: hardrock_2016_progress_sherman
   split: hardrock_cw_ouray
   id: 148559
   absolute_time: 2016-07-16 00:09:00.000000000 Z
   data_status: 2
-  effort_id: 7328
   elapsed_seconds: 43740.0
   lap: 1
   pacer:
@@ -9854,11 +9854,11 @@ hardrock_2016_progress_sherman_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_progress_sherman_grouse_in_1:
+  effort: hardrock_2016_progress_sherman
   split: hardrock_cw_grouse
   id: 148562
   absolute_time: 2016-07-16 05:08:00.000000000 Z
   data_status: 2
-  effort_id: 7328
   elapsed_seconds: 61680.0
   lap: 1
   pacer:
@@ -9867,11 +9867,11 @@ hardrock_2016_progress_sherman_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_progress_sherman_grouse_out_1:
+  effort: hardrock_2016_progress_sherman
   split: hardrock_cw_grouse
   id: 148563
   absolute_time: 2016-07-16 05:32:00.000000000 Z
   data_status: 2
-  effort_id: 7328
   elapsed_seconds: 63120.0
   lap: 1
   pacer:
@@ -9880,11 +9880,11 @@ hardrock_2016_progress_sherman_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_progress_sherman_sherman_in_1:
+  effort: hardrock_2016_progress_sherman
   split: hardrock_cw_sherman
   id: 148566
   absolute_time: 2016-07-16 11:27:00.000000000 Z
   data_status: 2
-  effort_id: 7328
   elapsed_seconds: 84420.0
   lap: 1
   pacer:
@@ -9893,11 +9893,11 @@ hardrock_2016_progress_sherman_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_progress_sherman_sherman_out_1:
+  effort: hardrock_2016_progress_sherman
   split: hardrock_cw_sherman
   id: 148567
   absolute_time: 2016-07-16 11:52:00.000000000 Z
   data_status: 2
-  effort_id: 7328
   elapsed_seconds: 85920.0
   lap: 1
   pacer:
@@ -9906,11 +9906,11 @@ hardrock_2016_progress_sherman_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_benito_moen_start_1:
+  effort: hardrock_2016_benito_moen
   split: hardrock_cw_start
   id: 148799
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7337
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -9919,11 +9919,11 @@ hardrock_2016_benito_moen_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_benito_moen_telluride_in_1:
+  effort: hardrock_2016_benito_moen
   split: hardrock_cw_telluride
   id: 148804
   absolute_time: 2016-07-15 20:42:00.000000000 Z
   data_status: 2
-  effort_id: 7337
   elapsed_seconds: 31320.0
   lap: 1
   pacer:
@@ -9932,11 +9932,11 @@ hardrock_2016_benito_moen_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_benito_moen_telluride_out_1:
+  effort: hardrock_2016_benito_moen
   split: hardrock_cw_telluride
   id: 148805
   absolute_time: 2016-07-15 20:54:00.000000000 Z
   data_status: 2
-  effort_id: 7337
   elapsed_seconds: 32040.0
   lap: 1
   pacer:
@@ -9945,11 +9945,11 @@ hardrock_2016_benito_moen_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_benito_moen_ouray_in_1:
+  effort: hardrock_2016_benito_moen
   split: hardrock_cw_ouray
   id: 148810
   absolute_time: 2016-07-16 02:32:00.000000000 Z
   data_status: 2
-  effort_id: 7337
   elapsed_seconds: 52320.0
   lap: 1
   pacer:
@@ -9958,11 +9958,11 @@ hardrock_2016_benito_moen_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_benito_moen_ouray_out_1:
+  effort: hardrock_2016_benito_moen
   split: hardrock_cw_ouray
   id: 148811
   absolute_time: 2016-07-16 03:32:00.000000000 Z
   data_status: 2
-  effort_id: 7337
   elapsed_seconds: 55920.0
   lap: 1
   pacer:
@@ -9971,11 +9971,11 @@ hardrock_2016_benito_moen_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_benito_moen_grouse_in_1:
+  effort: hardrock_2016_benito_moen
   split: hardrock_cw_grouse
   id: 148814
   absolute_time: 2016-07-16 10:02:00.000000000 Z
   data_status: 2
-  effort_id: 7337
   elapsed_seconds: 79320.0
   lap: 1
   pacer:
@@ -9984,11 +9984,11 @@ hardrock_2016_benito_moen_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_benito_moen_grouse_out_1:
+  effort: hardrock_2016_benito_moen
   split: hardrock_cw_grouse
   id: 148815
   absolute_time: 2016-07-16 11:05:00.000000000 Z
   data_status: 2
-  effort_id: 7337
   elapsed_seconds: 83100.0
   lap: 1
   pacer:
@@ -9997,11 +9997,11 @@ hardrock_2016_benito_moen_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_benito_moen_sherman_in_1:
+  effort: hardrock_2016_benito_moen
   split: hardrock_cw_sherman
   id: 148818
   absolute_time: 2016-07-16 16:45:00.000000000 Z
   data_status: 2
-  effort_id: 7337
   elapsed_seconds: 103500.0
   lap: 1
   pacer:
@@ -10010,11 +10010,11 @@ hardrock_2016_benito_moen_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_benito_moen_sherman_out_1:
+  effort: hardrock_2016_benito_moen
   split: hardrock_cw_sherman
   id: 148819
   absolute_time: 2016-07-16 17:27:00.000000000 Z
   data_status: 2
-  effort_id: 7337
   elapsed_seconds: 106020.0
   lap: 1
   pacer:
@@ -10023,11 +10023,11 @@ hardrock_2016_benito_moen_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kendall_koch_start_1:
+  effort: hardrock_2016_kendall_koch
   split: hardrock_cw_start
   id: 148883
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7340
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10036,11 +10036,11 @@ hardrock_2016_kendall_koch_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kendall_koch_telluride_in_1:
+  effort: hardrock_2016_kendall_koch
   split: hardrock_cw_telluride
   id: 148888
   absolute_time: 2016-07-15 21:44:00.000000000 Z
   data_status: 2
-  effort_id: 7340
   elapsed_seconds: 35040.0
   lap: 1
   pacer:
@@ -10049,11 +10049,11 @@ hardrock_2016_kendall_koch_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kendall_koch_telluride_out_1:
+  effort: hardrock_2016_kendall_koch
   split: hardrock_cw_telluride
   id: 148889
   absolute_time: 2016-07-15 21:54:00.000000000 Z
   data_status: 2
-  effort_id: 7340
   elapsed_seconds: 35640.0
   lap: 1
   pacer:
@@ -10062,11 +10062,11 @@ hardrock_2016_kendall_koch_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kendall_koch_ouray_in_1:
+  effort: hardrock_2016_kendall_koch
   split: hardrock_cw_ouray
   id: 148894
   absolute_time: 2016-07-16 03:43:00.000000000 Z
   data_status: 2
-  effort_id: 7340
   elapsed_seconds: 56580.0
   lap: 1
   pacer:
@@ -10075,11 +10075,11 @@ hardrock_2016_kendall_koch_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kendall_koch_ouray_out_1:
+  effort: hardrock_2016_kendall_koch
   split: hardrock_cw_ouray
   id: 148895
   absolute_time: 2016-07-16 03:46:00.000000000 Z
   data_status: 2
-  effort_id: 7340
   elapsed_seconds: 56760.0
   lap: 1
   pacer:
@@ -10088,11 +10088,11 @@ hardrock_2016_kendall_koch_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kendall_koch_grouse_in_1:
+  effort: hardrock_2016_kendall_koch
   split: hardrock_cw_grouse
   id: 148898
   absolute_time: 2016-07-16 10:18:00.000000000 Z
   data_status: 2
-  effort_id: 7340
   elapsed_seconds: 80280.0
   lap: 1
   pacer:
@@ -10101,11 +10101,11 @@ hardrock_2016_kendall_koch_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kendall_koch_grouse_out_1:
+  effort: hardrock_2016_kendall_koch
   split: hardrock_cw_grouse
   id: 148899
   absolute_time: 2016-07-16 10:22:00.000000000 Z
   data_status: 2
-  effort_id: 7340
   elapsed_seconds: 80520.0
   lap: 1
   pacer:
@@ -10114,11 +10114,11 @@ hardrock_2016_kendall_koch_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_kendall_koch_sherman_in_1:
+  effort: hardrock_2016_kendall_koch
   split: hardrock_cw_sherman
   id: 148902
   absolute_time: 2016-07-16 17:08:00.000000000 Z
   data_status: 2
-  effort_id: 7340
   elapsed_seconds: 104880.0
   lap: 1
   pacer:
@@ -10127,11 +10127,11 @@ hardrock_2016_kendall_koch_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_kendall_koch_sherman_out_1:
+  effort: hardrock_2016_kendall_koch
   split: hardrock_cw_sherman
   id: 148903
   absolute_time: 2016-07-16 17:32:00.000000000 Z
   data_status: 2
-  effort_id: 7340
   elapsed_seconds: 106320.0
   lap: 1
   pacer:
@@ -10140,11 +10140,11 @@ hardrock_2016_kendall_koch_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_charlie_mueller_start_1:
+  effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_start
   id: 148967
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7343
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10153,11 +10153,11 @@ hardrock_2016_charlie_mueller_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_charlie_mueller_telluride_in_1:
+  effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_telluride
   id: 148972
   absolute_time: 2016-07-15 21:45:00.000000000 Z
   data_status: 2
-  effort_id: 7343
   elapsed_seconds: 35100.0
   lap: 1
   pacer:
@@ -10166,11 +10166,11 @@ hardrock_2016_charlie_mueller_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_charlie_mueller_telluride_out_1:
+  effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_telluride
   id: 148973
   absolute_time: 2016-07-15 22:00:00.000000000 Z
   data_status: 2
-  effort_id: 7343
   elapsed_seconds: 36000.0
   lap: 1
   pacer:
@@ -10179,11 +10179,11 @@ hardrock_2016_charlie_mueller_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_charlie_mueller_ouray_in_1:
+  effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_ouray
   id: 148978
   absolute_time: 2016-07-16 03:38:00.000000000 Z
   data_status: 2
-  effort_id: 7343
   elapsed_seconds: 56280.0
   lap: 1
   pacer:
@@ -10192,11 +10192,11 @@ hardrock_2016_charlie_mueller_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_charlie_mueller_ouray_out_1:
+  effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_ouray
   id: 148979
   absolute_time: 2016-07-16 04:00:00.000000000 Z
   data_status: 2
-  effort_id: 7343
   elapsed_seconds: 57600.0
   lap: 1
   pacer:
@@ -10205,11 +10205,11 @@ hardrock_2016_charlie_mueller_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_charlie_mueller_grouse_in_1:
+  effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_grouse
   id: 148982
   absolute_time: 2016-07-16 10:15:00.000000000 Z
   data_status: 2
-  effort_id: 7343
   elapsed_seconds: 80100.0
   lap: 1
   pacer:
@@ -10218,11 +10218,11 @@ hardrock_2016_charlie_mueller_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_charlie_mueller_grouse_out_1:
+  effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_grouse
   id: 148983
   absolute_time: 2016-07-16 10:27:00.000000000 Z
   data_status: 2
-  effort_id: 7343
   elapsed_seconds: 80820.0
   lap: 1
   pacer:
@@ -10231,11 +10231,11 @@ hardrock_2016_charlie_mueller_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_charlie_mueller_sherman_in_1:
+  effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_sherman
   id: 148986
   absolute_time: 2016-07-16 16:45:00.000000000 Z
   data_status: 2
-  effort_id: 7343
   elapsed_seconds: 103500.0
   lap: 1
   pacer:
@@ -10244,11 +10244,11 @@ hardrock_2016_charlie_mueller_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_charlie_mueller_sherman_out_1:
+  effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_sherman
   id: 148987
   absolute_time: 2016-07-16 17:05:00.000000000 Z
   data_status: 2
-  effort_id: 7343
   elapsed_seconds: 104700.0
   lap: 1
   pacer:
@@ -10257,11 +10257,11 @@ hardrock_2016_charlie_mueller_sherman_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_brinda_fisher_start_1:
+  effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_start
   id: 149891
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7376
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10270,11 +10270,11 @@ hardrock_2016_brinda_fisher_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_brinda_fisher_telluride_in_1:
+  effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_telluride
   id: 149896
   absolute_time: 2016-07-15 22:57:00.000000000 Z
   data_status: 2
-  effort_id: 7376
   elapsed_seconds: 39420.0
   lap: 1
   pacer:
@@ -10283,11 +10283,11 @@ hardrock_2016_brinda_fisher_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_brinda_fisher_telluride_out_1:
+  effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_telluride
   id: 149897
   absolute_time: 2016-07-15 23:00:00.000000000 Z
   data_status: 2
-  effort_id: 7376
   elapsed_seconds: 39600.0
   lap: 1
   pacer:
@@ -10296,11 +10296,11 @@ hardrock_2016_brinda_fisher_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_brinda_fisher_ouray_in_1:
+  effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_ouray
   id: 149902
   absolute_time: 2016-07-16 05:56:00.000000000 Z
   data_status: 2
-  effort_id: 7376
   elapsed_seconds: 64560.0
   lap: 1
   pacer:
@@ -10309,11 +10309,11 @@ hardrock_2016_brinda_fisher_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_brinda_fisher_ouray_out_1:
+  effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_ouray
   id: 149903
   absolute_time: 2016-07-16 06:25:00.000000000 Z
   data_status: 2
-  effort_id: 7376
   elapsed_seconds: 66300.0
   lap: 1
   pacer:
@@ -10322,11 +10322,11 @@ hardrock_2016_brinda_fisher_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_brinda_fisher_grouse_in_1:
+  effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_grouse
   id: 149906
   absolute_time: 2016-07-16 14:05:00.000000000 Z
   data_status: 2
-  effort_id: 7376
   elapsed_seconds: 93900.0
   lap: 1
   pacer:
@@ -10335,11 +10335,11 @@ hardrock_2016_brinda_fisher_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_brinda_fisher_grouse_out_1:
+  effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_grouse
   id: 149907
   absolute_time: 2016-07-16 14:19:00.000000000 Z
   data_status: 2
-  effort_id: 7376
   elapsed_seconds: 94740.0
   lap: 1
   pacer:
@@ -10348,11 +10348,11 @@ hardrock_2016_brinda_fisher_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rene_mclaughlin_start_1:
+  effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_start
   id: 149997
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7380
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10361,11 +10361,11 @@ hardrock_2016_rene_mclaughlin_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rene_mclaughlin_telluride_in_1:
+  effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_telluride
   id: 150002
   absolute_time: 2016-07-15 22:06:00.000000000 Z
   data_status: 2
-  effort_id: 7380
   elapsed_seconds: 36360.0
   lap: 1
   pacer:
@@ -10374,11 +10374,11 @@ hardrock_2016_rene_mclaughlin_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rene_mclaughlin_telluride_out_1:
+  effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_telluride
   id: 150003
   absolute_time: 2016-07-15 22:20:00.000000000 Z
   data_status: 2
-  effort_id: 7380
   elapsed_seconds: 37200.0
   lap: 1
   pacer:
@@ -10387,11 +10387,11 @@ hardrock_2016_rene_mclaughlin_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rene_mclaughlin_ouray_in_1:
+  effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_ouray
   id: 150008
   absolute_time: 2016-07-16 04:34:00.000000000 Z
   data_status: 2
-  effort_id: 7380
   elapsed_seconds: 59640.0
   lap: 1
   pacer:
@@ -10400,11 +10400,11 @@ hardrock_2016_rene_mclaughlin_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rene_mclaughlin_ouray_out_1:
+  effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_ouray
   id: 150009
   absolute_time: 2016-07-16 04:55:00.000000000 Z
   data_status: 2
-  effort_id: 7380
   elapsed_seconds: 60900.0
   lap: 1
   pacer:
@@ -10413,11 +10413,11 @@ hardrock_2016_rene_mclaughlin_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rene_mclaughlin_grouse_in_1:
+  effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_grouse
   id: 150012
   absolute_time: 2016-07-16 12:07:00.000000000 Z
   data_status: 2
-  effort_id: 7380
   elapsed_seconds: 86820.0
   lap: 1
   pacer:
@@ -10426,11 +10426,11 @@ hardrock_2016_rene_mclaughlin_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rene_mclaughlin_grouse_out_1:
+  effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_grouse
   id: 150013
   absolute_time: 2016-07-16 13:37:00.000000000 Z
   data_status: 2
-  effort_id: 7380
   elapsed_seconds: 92220.0
   lap: 1
   pacer:
@@ -10439,11 +10439,11 @@ hardrock_2016_rene_mclaughlin_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rene_mclaughlin_sherman_in_1:
+  effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_sherman
   id: 150016
   absolute_time: 2016-07-16 20:41:00.000000000 Z
   data_status: 2
-  effort_id: 7380
   elapsed_seconds: 117660.0
   lap: 1
   pacer:
@@ -10452,11 +10452,11 @@ hardrock_2016_rene_mclaughlin_sherman_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_dropped_grouse_start_1:
+  effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_start
   id: 150319
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7396
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10465,11 +10465,11 @@ hardrock_2016_dropped_grouse_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_dropped_grouse_telluride_in_1:
+  effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_telluride
   id: 150324
   absolute_time: 2016-07-15 18:35:00.000000000 Z
   data_status: 2
-  effort_id: 7396
   elapsed_seconds: 23700.0
   lap: 1
   pacer:
@@ -10478,11 +10478,11 @@ hardrock_2016_dropped_grouse_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_dropped_grouse_telluride_out_1:
+  effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_telluride
   id: 150325
   absolute_time: 2016-07-15 18:39:00.000000000 Z
   data_status: 2
-  effort_id: 7396
   elapsed_seconds: 23940.0
   lap: 1
   pacer:
@@ -10491,11 +10491,11 @@ hardrock_2016_dropped_grouse_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_dropped_grouse_ouray_in_1:
+  effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_ouray
   id: 150330
   absolute_time: 2016-07-15 22:06:00.000000000 Z
   data_status: 2
-  effort_id: 7396
   elapsed_seconds: 36360.0
   lap: 1
   pacer:
@@ -10504,11 +10504,11 @@ hardrock_2016_dropped_grouse_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_dropped_grouse_ouray_out_1:
+  effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_ouray
   id: 150331
   absolute_time: 2016-07-15 22:12:00.000000000 Z
   data_status: 2
-  effort_id: 7396
   elapsed_seconds: 36720.0
   lap: 1
   pacer:
@@ -10517,11 +10517,11 @@ hardrock_2016_dropped_grouse_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_dropped_grouse_grouse_in_1:
+  effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_grouse
   id: 150334
   absolute_time: 2016-07-16 02:40:00.000000000 Z
   data_status: 2
-  effort_id: 7396
   elapsed_seconds: 52800.0
   lap: 1
   pacer:
@@ -10530,11 +10530,11 @@ hardrock_2016_dropped_grouse_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_dropped_grouse_grouse_out_1:
+  effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_grouse
   id: 150335
   absolute_time: 2016-07-16 02:40:00.000000000 Z
   data_status: 2
-  effort_id: 7396
   elapsed_seconds: 52800.0
   lap: 1
   pacer:
@@ -10543,11 +10543,11 @@ hardrock_2016_dropped_grouse_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_mervin_smitham_start_1:
+  effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_start
   id: 150387
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7400
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10556,11 +10556,11 @@ hardrock_2016_mervin_smitham_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_mervin_smitham_telluride_in_1:
+  effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_telluride
   id: 150392
   absolute_time: 2016-07-15 21:07:00.000000000 Z
   data_status: 2
-  effort_id: 7400
   elapsed_seconds: 32820.0
   lap: 1
   pacer:
@@ -10569,11 +10569,11 @@ hardrock_2016_mervin_smitham_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_mervin_smitham_telluride_out_1:
+  effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_telluride
   id: 150393
   absolute_time: 2016-07-15 21:25:00.000000000 Z
   data_status: 2
-  effort_id: 7400
   elapsed_seconds: 33900.0
   lap: 1
   pacer:
@@ -10582,11 +10582,11 @@ hardrock_2016_mervin_smitham_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_mervin_smitham_ouray_in_1:
+  effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_ouray
   id: 150398
   absolute_time: 2016-07-16 03:00:00.000000000 Z
   data_status: 2
-  effort_id: 7400
   elapsed_seconds: 54000.0
   lap: 1
   pacer:
@@ -10595,11 +10595,11 @@ hardrock_2016_mervin_smitham_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_mervin_smitham_ouray_out_1:
+  effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_ouray
   id: 150399
   absolute_time: 2016-07-16 03:59:00.000000000 Z
   data_status: 2
-  effort_id: 7400
   elapsed_seconds: 57540.0
   lap: 1
   pacer:
@@ -10608,11 +10608,11 @@ hardrock_2016_mervin_smitham_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_mervin_smitham_grouse_in_1:
+  effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_grouse
   id: 150402
   absolute_time: 2016-07-16 11:53:00.000000000 Z
   data_status: 2
-  effort_id: 7400
   elapsed_seconds: 85980.0
   lap: 1
   pacer:
@@ -10621,11 +10621,11 @@ hardrock_2016_mervin_smitham_grouse_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_mervin_smitham_grouse_out_1:
+  effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_grouse
   id: 150403
   absolute_time: 2016-07-16 11:53:00.000000000 Z
   data_status: 2
-  effort_id: 7400
   elapsed_seconds: 85980.0
   lap: 1
   pacer:
@@ -10634,11 +10634,11 @@ hardrock_2016_mervin_smitham_grouse_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rhett_auer_start_1:
+  effort: hardrock_2016_rhett_auer
   split: hardrock_cw_start
   id: 150455
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7404
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10647,11 +10647,11 @@ hardrock_2016_rhett_auer_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rhett_auer_telluride_in_1:
+  effort: hardrock_2016_rhett_auer
   split: hardrock_cw_telluride
   id: 150460
   absolute_time: 2016-07-15 18:04:00.000000000 Z
   data_status: 2
-  effort_id: 7404
   elapsed_seconds: 21840.0
   lap: 1
   pacer:
@@ -10660,11 +10660,11 @@ hardrock_2016_rhett_auer_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rhett_auer_telluride_out_1:
+  effort: hardrock_2016_rhett_auer
   split: hardrock_cw_telluride
   id: 150461
   absolute_time: 2016-07-15 18:06:00.000000000 Z
   data_status: 2
-  effort_id: 7404
   elapsed_seconds: 21960.0
   lap: 1
   pacer:
@@ -10673,11 +10673,11 @@ hardrock_2016_rhett_auer_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_rhett_auer_ouray_in_1:
+  effort: hardrock_2016_rhett_auer
   split: hardrock_cw_ouray
   id: 150466
   absolute_time: 2016-07-15 21:40:00.000000000 Z
   data_status: 2
-  effort_id: 7404
   elapsed_seconds: 34800.0
   lap: 1
   pacer:
@@ -10686,11 +10686,11 @@ hardrock_2016_rhett_auer_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_rhett_auer_ouray_out_1:
+  effort: hardrock_2016_rhett_auer
   split: hardrock_cw_ouray
   id: 150467
   absolute_time: 2016-07-15 21:53:00.000000000 Z
   data_status: 2
-  effort_id: 7404
   elapsed_seconds: 35580.0
   lap: 1
   pacer:
@@ -10699,11 +10699,11 @@ hardrock_2016_rhett_auer_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_hoyt_macejkovic_start_1:
+  effort: hardrock_2016_hoyt_macejkovic
   split: hardrock_cw_start
   id: 150494
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7407
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10712,11 +10712,11 @@ hardrock_2016_hoyt_macejkovic_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_hoyt_macejkovic_telluride_in_1:
+  effort: hardrock_2016_hoyt_macejkovic
   split: hardrock_cw_telluride
   id: 150499
   absolute_time: 2016-07-15 21:56:00.000000000 Z
   data_status: 2
-  effort_id: 7407
   elapsed_seconds: 35760.0
   lap: 1
   pacer:
@@ -10725,11 +10725,11 @@ hardrock_2016_hoyt_macejkovic_telluride_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_hoyt_macejkovic_telluride_out_1:
+  effort: hardrock_2016_hoyt_macejkovic
   split: hardrock_cw_telluride
   id: 150500
   absolute_time: 2016-07-15 22:11:00.000000000 Z
   data_status: 2
-  effort_id: 7407
   elapsed_seconds: 36660.0
   lap: 1
   pacer:
@@ -10738,11 +10738,11 @@ hardrock_2016_hoyt_macejkovic_telluride_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_hoyt_macejkovic_ouray_in_1:
+  effort: hardrock_2016_hoyt_macejkovic
   split: hardrock_cw_ouray
   id: 150505
   absolute_time: 2016-07-16 04:44:00.000000000 Z
   data_status: 2
-  effort_id: 7407
   elapsed_seconds: 60240.0
   lap: 1
   pacer:
@@ -10751,11 +10751,11 @@ hardrock_2016_hoyt_macejkovic_ouray_in_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2016_hoyt_macejkovic_ouray_out_1:
+  effort: hardrock_2016_hoyt_macejkovic
   split: hardrock_cw_ouray
   id: 150506
   absolute_time: 2016-07-16 05:46:00.000000000 Z
   data_status: 2
-  effort_id: 7407
   elapsed_seconds: 63960.0
   lap: 1
   pacer:
@@ -10764,11 +10764,11 @@ hardrock_2016_hoyt_macejkovic_ouray_out_1:
   sub_split_bitkey: 64
   status_reason:
 ggd30_50k_finished_first_start_1:
+  effort: ggd30_50k_finished_first
   split: d30_50k_course_start
   id: 184081
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status:
-  effort_id: 15626
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10777,11 +10777,11 @@ ggd30_50k_finished_first_start_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_aid_1_1:
+  effort: ggd30_50k_finished_first
   split: d30_50k_course_aid_1
   id: 184082
   absolute_time: 2017-06-03 13:46:48.170000000 Z
   data_status:
-  effort_id: 15626
   elapsed_seconds: 2808.17
   lap: 1
   pacer:
@@ -10790,11 +10790,11 @@ ggd30_50k_finished_first_aid_1_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_aid_2_1:
+  effort: ggd30_50k_finished_first
   split: d30_50k_course_aid_2
   id: 184083
   absolute_time: 2017-06-03 14:54:09.710000000 Z
   data_status:
-  effort_id: 15626
   elapsed_seconds: 6849.71
   lap: 1
   pacer:
@@ -10803,11 +10803,11 @@ ggd30_50k_finished_first_aid_2_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_aid_3_1:
+  effort: ggd30_50k_finished_first
   split: d30_50k_course_aid_3
   id: 184084
   absolute_time: 2017-06-03 15:53:16.010000000 Z
   data_status:
-  effort_id: 15626
   elapsed_seconds: 10396.01
   lap: 1
   pacer:
@@ -10816,11 +10816,11 @@ ggd30_50k_finished_first_aid_3_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_start_1:
+  effort: ggd30_50k_bad_finish
   split: d30_50k_course_start
   id: 184337
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
-  effort_id: 15664
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10829,11 +10829,11 @@ ggd30_50k_bad_finish_start_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_aid_1_1:
+  effort: ggd30_50k_bad_finish
   split: d30_50k_course_aid_1
   id: 184338
   absolute_time: 2017-06-03 13:49:00.820000000 Z
   data_status: 2
-  effort_id: 15664
   elapsed_seconds: 2940.82
   lap: 1
   pacer:
@@ -10842,11 +10842,11 @@ ggd30_50k_bad_finish_aid_1_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_aid_2_1:
+  effort: ggd30_50k_bad_finish
   split: d30_50k_course_aid_2
   id: 184339
   absolute_time: 2017-06-03 15:05:22.760000000 Z
   data_status: 2
-  effort_id: 15664
   elapsed_seconds: 7522.76
   lap: 1
   pacer:
@@ -10855,11 +10855,11 @@ ggd30_50k_bad_finish_aid_2_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_aid_3_1:
+  effort: ggd30_50k_bad_finish
   split: d30_50k_course_aid_3
   id: 184340
   absolute_time: 2017-06-03 16:15:30.090000000 Z
   data_status: 2
-  effort_id: 15664
   elapsed_seconds: 11730.09
   lap: 1
   pacer:
@@ -10868,11 +10868,11 @@ ggd30_50k_bad_finish_aid_3_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid4_start_1:
+  effort: ggd30_50k_progress_aid4
   split: d30_50k_course_start
   id: 185898
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status:
-  effort_id: 15891
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10881,11 +10881,11 @@ ggd30_50k_progress_aid4_start_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid4_aid_1_1:
+  effort: ggd30_50k_progress_aid4
   split: d30_50k_course_aid_1
   id: 185899
   absolute_time: 2017-06-03 14:13:10.900000000 Z
   data_status:
-  effort_id: 15891
   elapsed_seconds: 4390.9
   lap: 1
   pacer:
@@ -10894,11 +10894,11 @@ ggd30_50k_progress_aid4_aid_1_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid4_aid_2_1:
+  effort: ggd30_50k_progress_aid4
   split: d30_50k_course_aid_2
   id: 185900
   absolute_time: 2017-06-03 15:59:30.110000000 Z
   data_status:
-  effort_id: 15891
   elapsed_seconds: 10770.11
   lap: 1
   pacer:
@@ -10907,11 +10907,11 @@ ggd30_50k_progress_aid4_aid_2_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid3_start_1:
+  effort: ggd30_50k_progress_aid3
   split: d30_50k_course_start
   id: 185965
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
-  effort_id: 15901
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10920,11 +10920,11 @@ ggd30_50k_progress_aid3_start_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid3_aid_1_1:
+  effort: ggd30_50k_progress_aid3
   split: d30_50k_course_aid_1
   id: 185966
   absolute_time: 2017-06-03 14:11:47.000000000 Z
   data_status: 2
-  effort_id: 15901
   elapsed_seconds: 4307.0
   lap: 1
   pacer:
@@ -10933,11 +10933,11 @@ ggd30_50k_progress_aid3_aid_1_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid3_aid_2_1:
+  effort: ggd30_50k_progress_aid3
   split: d30_50k_course_aid_2
   id: 185967
   absolute_time: 2017-06-03 15:56:58.000000000 Z
   data_status: 2
-  effort_id: 15901
   elapsed_seconds: 10618.0
   lap: 1
   pacer:
@@ -10946,11 +10946,11 @@ ggd30_50k_progress_aid3_aid_2_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_drop_aid4_start_1:
+  effort: ggd30_50k_drop_aid4
   split: d30_50k_course_start
   id: 186151
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
-  effort_id: 15931
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -10959,11 +10959,11 @@ ggd30_50k_drop_aid4_start_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_drop_aid4_aid_1_1:
+  effort: ggd30_50k_drop_aid4
   split: d30_50k_course_aid_1
   id: 186152
   absolute_time: 2017-06-03 14:01:33.780000000 Z
   data_status: 2
-  effort_id: 15931
   elapsed_seconds: 3693.78
   lap: 1
   pacer:
@@ -10972,11 +10972,11 @@ ggd30_50k_drop_aid4_aid_1_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_drop_aid4_aid_2_1:
+  effort: ggd30_50k_drop_aid4
   split: d30_50k_course_aid_2
   id: 186153
   absolute_time: 2017-06-03 15:35:56.730000000 Z
   data_status: 2
-  effort_id: 15931
   elapsed_seconds: 9356.73
   lap: 1
   pacer:
@@ -10985,11 +10985,11 @@ ggd30_50k_drop_aid4_aid_2_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_aid_4_1:
+  effort: ggd30_50k_finished_first
   split: d30_50k_course_aid_4
   id: 188949
   absolute_time: 2017-06-03 17:11:12.540000000 Z
   data_status:
-  effort_id: 15626
   elapsed_seconds: 15072.54
   lap: 1
   pacer:
@@ -10998,11 +10998,11 @@ ggd30_50k_finished_first_aid_4_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_aid_5_1:
+  effort: ggd30_50k_finished_first
   split: d30_50k_course_aid_5
   id: 188950
   absolute_time: 2017-06-03 18:09:59.140000000 Z
   data_status:
-  effort_id: 15626
   elapsed_seconds: 18599.14
   lap: 1
   pacer:
@@ -11011,11 +11011,11 @@ ggd30_50k_finished_first_aid_5_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_first_finish_1:
+  effort: ggd30_50k_finished_first
   split: d30_50k_course_finish
   id: 188951
   absolute_time: 2017-06-03 18:29:47.410000000 Z
   data_status:
-  effort_id: 15626
   elapsed_seconds: 19787.41
   lap: 1
   pacer:
@@ -11024,11 +11024,11 @@ ggd30_50k_finished_first_finish_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_aid_4_1:
+  effort: ggd30_50k_bad_finish
   split: d30_50k_course_aid_4
   id: 189053
   absolute_time: 2017-06-03 17:49:35.620000000 Z
   data_status: 2
-  effort_id: 15664
   elapsed_seconds: 17375.62
   lap: 1
   pacer:
@@ -11037,11 +11037,11 @@ ggd30_50k_bad_finish_aid_4_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_aid_5_1:
+  effort: ggd30_50k_bad_finish
   split: d30_50k_course_aid_5
   id: 189054
   absolute_time: 2017-06-03 19:40:01.980000000 Z
   data_status: 2
-  effort_id: 15664
   elapsed_seconds: 24001.98
   lap: 1
   pacer:
@@ -11050,11 +11050,11 @@ ggd30_50k_bad_finish_aid_5_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_bad_finish_finish_1:
+  effort: ggd30_50k_bad_finish
   split: d30_50k_course_finish
   id: 189055
   absolute_time: 2017-06-03 19:24:16.590000000 Z
   data_status: 0
-  effort_id: 15664
   elapsed_seconds: 23056.59
   lap: 1
   pacer:
@@ -11063,11 +11063,11 @@ ggd30_50k_bad_finish_finish_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid4_aid_3_1:
+  effort: ggd30_50k_progress_aid4
   split: d30_50k_course_aid_3
   id: 189813
   absolute_time: 2017-06-03 17:38:48.070000000 Z
   data_status:
-  effort_id: 15891
   elapsed_seconds: 16728.07
   lap: 1
   pacer:
@@ -11076,11 +11076,11 @@ ggd30_50k_progress_aid4_aid_3_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid4_aid_4_1:
+  effort: ggd30_50k_progress_aid4
   split: d30_50k_course_aid_4
   id: 189814
   absolute_time: 2017-06-03 19:46:07.330000000 Z
   data_status:
-  effort_id: 15891
   elapsed_seconds: 24367.33
   lap: 1
   pacer:
@@ -11089,11 +11089,11 @@ ggd30_50k_progress_aid4_aid_4_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_progress_aid3_aid_3_1:
+  effort: ggd30_50k_progress_aid3
   split: d30_50k_course_aid_3
   id: 189850
   absolute_time: 2017-06-03 17:39:00.000000000 Z
   data_status: 2
-  effort_id: 15901
   elapsed_seconds: 16740.0
   lap: 1
   pacer:
@@ -11102,11 +11102,11 @@ ggd30_50k_progress_aid3_aid_3_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_drop_aid4_aid_3_1:
+  effort: ggd30_50k_drop_aid4
   split: d30_50k_course_aid_3
   id: 189951
   absolute_time: 2017-06-03 17:11:07.470000000 Z
   data_status: 2
-  effort_id: 15931
   elapsed_seconds: 15067.47
   lap: 1
   pacer:
@@ -11115,11 +11115,11 @@ ggd30_50k_drop_aid4_aid_3_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_drop_aid4_aid_4_1:
+  effort: ggd30_50k_drop_aid4
   split: d30_50k_course_aid_4
   id: 189952
   absolute_time: 2017-06-03 19:47:10.550000000 Z
   data_status: 2
-  effort_id: 15931
   elapsed_seconds: 24430.55
   lap: 1
   pacer:
@@ -11128,11 +11128,11 @@ ggd30_50k_drop_aid4_aid_4_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_finished_first_start_1:
+  effort: ggd30_12m_finished_first
   split: d30_12m_course_start
   id: 190116
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status:
-  effort_id: 16173
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11141,11 +11141,11 @@ ggd30_12m_finished_first_start_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_finished_first_finish_1:
+  effort: ggd30_12m_finished_first
   split: d30_12m_course_finish
   id: 190117
   absolute_time: 2017-06-03 17:48:09.280000000 Z
   data_status:
-  effort_id: 16173
   elapsed_seconds: 6489.28
   lap: 1
   pacer:
@@ -11154,11 +11154,11 @@ ggd30_12m_finished_first_finish_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_finished_second_start_1:
+  effort: ggd30_12m_finished_second
   split: d30_12m_course_start
   id: 190272
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status:
-  effort_id: 16107
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11167,11 +11167,11 @@ ggd30_12m_finished_second_start_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_finished_second_finish_1:
+  effort: ggd30_12m_finished_second
   split: d30_12m_course_finish
   id: 190273
   absolute_time: 2017-06-03 18:54:56.690000000 Z
   data_status:
-  effort_id: 16107
   elapsed_seconds: 10496.69
   lap: 1
   pacer:
@@ -11180,11 +11180,11 @@ ggd30_12m_finished_second_finish_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_cedric_windler_start_1:
+  effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_start
   id: 190477
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 50
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11193,11 +11193,11 @@ hardrock_2015_cedric_windler_start_1:
   sub_split_bitkey: 1
   status_reason:
 hardrock_2015_tuan_jacobs_start_1:
+  effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_start
   id: 190478
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
-  effort_id: 7
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11206,11 +11206,11 @@ hardrock_2015_tuan_jacobs_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_start_1:
+  effort: sum_55k_finished_first
   split: sum_55k_course_start
   id: 190499
   absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status: 2
-  effort_id: 16227
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11219,11 +11219,11 @@ sum_55k_finished_first_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_molas_pass_aid1_in_1:
+  effort: sum_55k_finished_first
   split: sum_55k_course_molas_pass_aid1
   id: 190500
   absolute_time: 2017-10-07 18:20:36.000000000 Z
   data_status: 2
-  effort_id: 16227
   elapsed_seconds: 12036.0
   lap: 1
   pacer:
@@ -11232,11 +11232,11 @@ sum_55k_finished_first_molas_pass_aid1_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_molas_pass_aid1_out_1:
+  effort: sum_55k_finished_first
   split: sum_55k_course_molas_pass_aid1
   id: 190501
   absolute_time: 2017-10-07 18:22:10.000000000 Z
   data_status: 2
-  effort_id: 16227
   elapsed_seconds: 12130.0
   lap: 1
   pacer:
@@ -11245,11 +11245,11 @@ sum_55k_finished_first_molas_pass_aid1_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_first_rolling_pass_aid2_in_1:
+  effort: sum_55k_finished_first
   split: sum_55k_course_rolling_pass_aid2
   id: 190502
   absolute_time: 2017-10-07 20:48:20.000000000 Z
   data_status: 2
-  effort_id: 16227
   elapsed_seconds: 20900.0
   lap: 1
   pacer:
@@ -11258,11 +11258,11 @@ sum_55k_finished_first_rolling_pass_aid2_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_rolling_pass_aid2_out_1:
+  effort: sum_55k_finished_first
   split: sum_55k_course_rolling_pass_aid2
   id: 190503
   absolute_time: 2017-10-07 20:50:20.000000000 Z
   data_status: 2
-  effort_id: 16227
   elapsed_seconds: 21020.0
   lap: 1
   pacer:
@@ -11271,11 +11271,11 @@ sum_55k_finished_first_rolling_pass_aid2_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_first_bandera_mine_aid5_in_1:
+  effort: sum_55k_finished_first
   split: sum_55k_course_bandera_mine_aid5
   id: 190504
   absolute_time: 2017-10-07 21:28:20.000000000 Z
   data_status: 2
-  effort_id: 16227
   elapsed_seconds: 23300.0
   lap: 1
   pacer:
@@ -11284,11 +11284,11 @@ sum_55k_finished_first_bandera_mine_aid5_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_bandera_mine_aid5_out_1:
+  effort: sum_55k_finished_first
   split: sum_55k_course_bandera_mine_aid5
   id: 190505
   absolute_time: 2017-10-07 21:28:20.000000000 Z
   data_status: 2
-  effort_id: 16227
   elapsed_seconds: 23300.0
   lap: 1
   pacer:
@@ -11297,11 +11297,11 @@ sum_55k_finished_first_bandera_mine_aid5_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_first_anvil_cg_aid6_in_1:
+  effort: sum_55k_finished_first
   split: sum_55k_course_anvil_cg_aid6
   id: 190506
   absolute_time: 2017-10-07 22:43:35.000000000 Z
   data_status: 2
-  effort_id: 16227
   elapsed_seconds: 27815.0
   lap: 1
   pacer:
@@ -11310,11 +11310,11 @@ sum_55k_finished_first_anvil_cg_aid6_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_first_anvil_cg_aid6_out_1:
+  effort: sum_55k_finished_first
   split: sum_55k_course_anvil_cg_aid6
   id: 190507
   absolute_time: 2017-10-07 22:51:27.000000000 Z
   data_status: 2
-  effort_id: 16227
   elapsed_seconds: 28287.0
   lap: 1
   pacer:
@@ -11323,11 +11323,11 @@ sum_55k_finished_first_anvil_cg_aid6_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_first_finish_1:
+  effort: sum_55k_finished_first
   split: sum_55k_course_finish
   id: 190508
   absolute_time: 2017-10-07 23:58:06.000000000 Z
   data_status: 2
-  effort_id: 16227
   elapsed_seconds: 32286.0
   lap: 1
   pacer:
@@ -11336,11 +11336,11 @@ sum_55k_finished_first_finish_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_start_1:
+  effort: sum_55k_finished_second
   split: sum_55k_course_start
   id: 190519
   absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status: 2
-  effort_id: 16229
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11349,11 +11349,11 @@ sum_55k_finished_second_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_molas_pass_aid1_in_1:
+  effort: sum_55k_finished_second
   split: sum_55k_course_molas_pass_aid1
   id: 190520
   absolute_time: 2017-10-07 18:30:31.000000000 Z
   data_status: 2
-  effort_id: 16229
   elapsed_seconds: 12631.0
   lap: 1
   pacer:
@@ -11362,11 +11362,11 @@ sum_55k_finished_second_molas_pass_aid1_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_molas_pass_aid1_out_1:
+  effort: sum_55k_finished_second
   split: sum_55k_course_molas_pass_aid1
   id: 190521
   absolute_time: 2017-10-07 18:31:46.000000000 Z
   data_status: 2
-  effort_id: 16229
   elapsed_seconds: 12706.0
   lap: 1
   pacer:
@@ -11375,11 +11375,11 @@ sum_55k_finished_second_molas_pass_aid1_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_second_rolling_pass_aid2_in_1:
+  effort: sum_55k_finished_second
   split: sum_55k_course_rolling_pass_aid2
   id: 190522
   absolute_time: 2017-10-07 21:13:00.000000000 Z
   data_status: 2
-  effort_id: 16229
   elapsed_seconds: 22380.0
   lap: 1
   pacer: false
@@ -11388,11 +11388,11 @@ sum_55k_finished_second_rolling_pass_aid2_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_rolling_pass_aid2_out_1:
+  effort: sum_55k_finished_second
   split: sum_55k_course_rolling_pass_aid2
   id: 190523
   absolute_time: 2017-10-07 21:18:00.000000000 Z
   data_status: 2
-  effort_id: 16229
   elapsed_seconds: 22680.0
   lap: 1
   pacer: false
@@ -11401,11 +11401,11 @@ sum_55k_finished_second_rolling_pass_aid2_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_second_bandera_mine_aid5_in_1:
+  effort: sum_55k_finished_second
   split: sum_55k_course_bandera_mine_aid5
   id: 190524
   absolute_time: 2017-10-07 22:04:20.000000000 Z
   data_status: 2
-  effort_id: 16229
   elapsed_seconds: 25460.0
   lap: 1
   pacer:
@@ -11414,11 +11414,11 @@ sum_55k_finished_second_bandera_mine_aid5_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_bandera_mine_aid5_out_1:
+  effort: sum_55k_finished_second
   split: sum_55k_course_bandera_mine_aid5
   id: 190525
   absolute_time: 2017-10-07 22:05:20.000000000 Z
   data_status: 2
-  effort_id: 16229
   elapsed_seconds: 25520.0
   lap: 1
   pacer:
@@ -11427,11 +11427,11 @@ sum_55k_finished_second_bandera_mine_aid5_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_second_anvil_cg_aid6_in_1:
+  effort: sum_55k_finished_second
   split: sum_55k_course_anvil_cg_aid6
   id: 190526
   absolute_time: 2017-10-07 23:13:46.000000000 Z
   data_status: 2
-  effort_id: 16229
   elapsed_seconds: 29626.0
   lap: 1
   pacer:
@@ -11440,11 +11440,11 @@ sum_55k_finished_second_anvil_cg_aid6_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_finished_second_anvil_cg_aid6_out_1:
+  effort: sum_55k_finished_second
   split: sum_55k_course_anvil_cg_aid6
   id: 190527
   absolute_time: 2017-10-07 23:13:50.000000000 Z
   data_status: 2
-  effort_id: 16229
   elapsed_seconds: 29630.0
   lap: 1
   pacer:
@@ -11453,11 +11453,11 @@ sum_55k_finished_second_anvil_cg_aid6_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_finished_second_finish_1:
+  effort: sum_55k_finished_second
   split: sum_55k_course_finish
   id: 190528
   absolute_time: 2017-10-08 00:07:38.000000000 Z
   data_status: 2
-  effort_id: 16229
   elapsed_seconds: 32858.0
   lap: 1
   pacer:
@@ -11466,11 +11466,11 @@ sum_55k_finished_second_finish_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_progress_rolling_start_1:
+  effort: sum_55k_progress_rolling
   split: sum_55k_course_start
   id: 190668
   absolute_time: 2017-10-07 13:00:00.000000000 Z
   data_status: 2
-  effort_id: 16244
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11479,11 +11479,11 @@ sum_55k_progress_rolling_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_progress_rolling_molas_pass_aid1_in_1:
+  effort: sum_55k_progress_rolling
   split: sum_55k_course_molas_pass_aid1
   id: 190669
   absolute_time: 2017-10-07 15:12:00.000000000 Z
   data_status: 2
-  effort_id: 16244
   elapsed_seconds: 7920.0
   lap: 1
   pacer:
@@ -11492,11 +11492,11 @@ sum_55k_progress_rolling_molas_pass_aid1_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_progress_rolling_molas_pass_aid1_out_1:
+  effort: sum_55k_progress_rolling
   split: sum_55k_course_molas_pass_aid1
   id: 190670
   absolute_time: 2017-10-07 15:19:00.000000000 Z
   data_status: 2
-  effort_id: 16244
   elapsed_seconds: 8340.0
   lap: 1
   pacer:
@@ -11505,11 +11505,11 @@ sum_55k_progress_rolling_molas_pass_aid1_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_progress_rolling_rolling_pass_aid2_in_1:
+  effort: sum_55k_progress_rolling
   split: sum_55k_course_rolling_pass_aid2
   id: 190671
   absolute_time: 2017-10-07 17:05:00.000000000 Z
   data_status: 2
-  effort_id: 16244
   elapsed_seconds: 14700.0
   lap: 1
   pacer:
@@ -11518,11 +11518,11 @@ sum_55k_progress_rolling_rolling_pass_aid2_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_progress_rolling_rolling_pass_aid2_out_1:
+  effort: sum_55k_progress_rolling
   split: sum_55k_course_rolling_pass_aid2
   id: 190672
   absolute_time: 2017-10-07 17:15:00.000000000 Z
   data_status: 2
-  effort_id: 16244
   elapsed_seconds: 15300.0
   lap: 1
   pacer:
@@ -11531,11 +11531,11 @@ sum_55k_progress_rolling_rolling_pass_aid2_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_drop_bandera_start_1:
+  effort: sum_55k_drop_bandera
   split: sum_55k_course_start
   id: 190678
   absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status: 2
-  effort_id: 16245
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11544,11 +11544,11 @@ sum_55k_drop_bandera_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_drop_bandera_molas_pass_aid1_in_1:
+  effort: sum_55k_drop_bandera
   split: sum_55k_course_molas_pass_aid1
   id: 190679
   absolute_time: 2017-10-07 19:12:27.000000000 Z
   data_status: 2
-  effort_id: 16245
   elapsed_seconds: 15147.0
   lap: 1
   pacer:
@@ -11557,11 +11557,11 @@ sum_55k_drop_bandera_molas_pass_aid1_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_drop_bandera_molas_pass_aid1_out_1:
+  effort: sum_55k_drop_bandera
   split: sum_55k_course_molas_pass_aid1
   id: 190680
   absolute_time: 2017-10-07 19:19:02.000000000 Z
   data_status: 2
-  effort_id: 16245
   elapsed_seconds: 15542.0
   lap: 1
   pacer:
@@ -11570,11 +11570,11 @@ sum_55k_drop_bandera_molas_pass_aid1_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_drop_bandera_rolling_pass_aid2_in_1:
+  effort: sum_55k_drop_bandera
   split: sum_55k_course_rolling_pass_aid2
   id: 190681
   absolute_time: 2017-10-07 22:27:20.000000000 Z
   data_status: 2
-  effort_id: 16245
   elapsed_seconds: 26840.0
   lap: 1
   pacer:
@@ -11583,11 +11583,11 @@ sum_55k_drop_bandera_rolling_pass_aid2_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_drop_bandera_rolling_pass_aid2_out_1:
+  effort: sum_55k_drop_bandera
   split: sum_55k_course_rolling_pass_aid2
   id: 190682
   absolute_time: 2017-10-07 22:54:20.000000000 Z
   data_status:
-  effort_id: 16245
   elapsed_seconds: 28460.0
   lap: 1
   pacer:
@@ -11596,11 +11596,11 @@ sum_55k_drop_bandera_rolling_pass_aid2_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_drop_bandera_bandera_mine_aid5_in_1:
+  effort: sum_55k_drop_bandera
   split: sum_55k_course_bandera_mine_aid5
   id: 190683
   absolute_time: 2017-10-08 00:21:20.000000000 Z
   data_status: 2
-  effort_id: 16245
   elapsed_seconds: 33680.0
   lap: 1
   pacer:
@@ -11609,11 +11609,11 @@ sum_55k_drop_bandera_bandera_mine_aid5_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_anvil_cg_aid6_in_1:
+  effort: sum_100k_drop_anvil
   split: sum_100k_course_anvil_cg_aid6
   id: 190694
   absolute_time: 2017-09-24 03:11:00.000000000 Z
   data_status:
-  effort_id: 16247
   elapsed_seconds: 51060.0
   lap: 1
   pacer: false
@@ -11622,11 +11622,11 @@ sum_100k_drop_anvil_anvil_cg_aid6_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_anvil_cg_aid6_out_1:
+  effort: sum_100k_drop_anvil
   split: sum_100k_course_anvil_cg_aid6
   id: 190695
   absolute_time: 2017-09-24 03:21:00.000000000 Z
   data_status:
-  effort_id: 16247
   elapsed_seconds: 51660.0
   lap: 1
   pacer: false
@@ -11635,11 +11635,11 @@ sum_100k_drop_anvil_anvil_cg_aid6_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_100k_drop_anvil_rolling_pass_aid2_in_1:
+  effort: sum_100k_drop_anvil
   split: sum_100k_course_rolling_pass_aid2
   id: 190696
   absolute_time: 2017-09-23 15:09:00.000000000 Z
   data_status:
-  effort_id: 16247
   elapsed_seconds: 7740.0
   lap: 1
   pacer: false
@@ -11648,11 +11648,11 @@ sum_100k_drop_anvil_rolling_pass_aid2_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_rolling_pass_aid2_out_1:
+  effort: sum_100k_drop_anvil
   split: sum_100k_course_rolling_pass_aid2
   id: 190697
   absolute_time: 2017-09-24 07:03:05.000000000 Z
   data_status:
-  effort_id: 16247
   elapsed_seconds: 64985.0
   lap: 1
   pacer:
@@ -11661,11 +11661,11 @@ sum_100k_drop_anvil_rolling_pass_aid2_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_100k_drop_anvil_start_1:
+  effort: sum_100k_drop_anvil
   split: sum_100k_course_start
   id: 190698
   absolute_time: 2017-09-23 13:00:00.000000000 Z
   data_status:
-  effort_id: 16247
   elapsed_seconds: 0.0
   lap: 1
   pacer: false
@@ -11674,11 +11674,11 @@ sum_100k_drop_anvil_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_molas_pass_aid1_in_1:
+  effort: sum_100k_drop_anvil
   split: sum_100k_course_molas_pass_aid1
   id: 190699
   absolute_time: 2017-09-23 14:30:00.000000000 Z
   data_status:
-  effort_id: 16247
   elapsed_seconds: 5400.0
   lap: 1
   pacer: false
@@ -11687,11 +11687,11 @@ sum_100k_drop_anvil_molas_pass_aid1_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_molas_pass_aid1_out_1:
+  effort: sum_100k_drop_anvil
   split: sum_100k_course_molas_pass_aid1
   id: 190700
   absolute_time: 2017-09-23 14:32:00.000000000 Z
   data_status:
-  effort_id: 16247
   elapsed_seconds: 5520.0
   lap: 1
   pacer: false
@@ -11700,11 +11700,11 @@ sum_100k_drop_anvil_molas_pass_aid1_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_100k_drop_anvil_cascade_creek_rd_aid3_in_1:
+  effort: sum_100k_drop_anvil
   split: sum_100k_course_cascade_creek_rd_aid3
   id: 190701
   absolute_time: 2017-09-24 07:24:00.000000000 Z
   data_status:
-  effort_id: 16247
   elapsed_seconds: 66240.0
   lap: 1
   pacer: false
@@ -11713,11 +11713,11 @@ sum_100k_drop_anvil_cascade_creek_rd_aid3_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_cascade_creek_rd_aid3_out_1:
+  effort: sum_100k_drop_anvil
   split: sum_100k_course_cascade_creek_rd_aid3
   id: 190702
   absolute_time: 2017-09-24 07:28:00.000000000 Z
   data_status:
-  effort_id: 16247
   elapsed_seconds: 66480.0
   lap: 1
   pacer: false
@@ -11726,11 +11726,11 @@ sum_100k_drop_anvil_cascade_creek_rd_aid3_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_100k_drop_anvil_engineer_mtn_th_aid4_in_1:
+  effort: sum_100k_drop_anvil
   split: sum_100k_course_engineer_mtn_th_aid4
   id: 190703
   absolute_time: 2017-09-24 15:09:00.000000000 Z
   data_status:
-  effort_id: 16247
   elapsed_seconds: 94140.0
   lap: 1
   pacer: false
@@ -11739,11 +11739,11 @@ sum_100k_drop_anvil_engineer_mtn_th_aid4_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_engineer_mtn_th_aid4_out_1:
+  effort: sum_100k_drop_anvil
   split: sum_100k_course_engineer_mtn_th_aid4
   id: 190704
   absolute_time: 2017-09-24 15:09:09.000000000 Z
   data_status:
-  effort_id: 16247
   elapsed_seconds: 94149.0
   lap: 1
   pacer: false
@@ -11752,11 +11752,11 @@ sum_100k_drop_anvil_engineer_mtn_th_aid4_out_1:
   sub_split_bitkey: 64
   status_reason:
 ggd30_12m_start_only_start_1:
+  effort: ggd30_12m_start_only
   split: d30_12m_course_start
   id: 190731
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status:
-  effort_id: 16094
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11765,11 +11765,11 @@ ggd30_12m_start_only_start_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_start_only_start_1:
+  effort: ggd30_50k_start_only
   split: d30_50k_course_start
   id: 190761
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status:
-  effort_id: 16023
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11778,11 +11778,11 @@ ggd30_50k_start_only_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_start_only_start_1:
+  effort: sum_55k_start_only
   split: sum_55k_course_start
   id: 190816
   absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status:
-  effort_id: 16246
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11791,11 +11791,11 @@ sum_55k_start_only_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_1:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_start
   id: 192182
   absolute_time: 2017-02-11 14:00:00.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11804,11 +11804,11 @@ rufa_2017_12h_finished_first_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_1:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_finish
   id: 192183
   absolute_time: 2017-02-11 15:33:52.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 5632.0
   lap: 1
   pacer:
@@ -11817,11 +11817,11 @@ rufa_2017_12h_finished_first_finish_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_2:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_start
   id: 192184
   absolute_time: 2017-02-11 15:40:32.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 6032.0
   lap: 2
   pacer:
@@ -11830,11 +11830,11 @@ rufa_2017_12h_finished_first_start_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_2:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_grandeur_peak
   id: 192185
   absolute_time: 2017-02-11 16:43:26.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 9806.0
   lap: 2
   pacer:
@@ -11843,11 +11843,11 @@ rufa_2017_12h_finished_first_grandeur_peak_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_2:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_finish
   id: 192186
   absolute_time: 2017-02-11 17:10:10.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 11410.0
   lap: 2
   pacer:
@@ -11856,11 +11856,11 @@ rufa_2017_12h_finished_first_finish_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_3:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_start
   id: 192187
   absolute_time: 2017-02-11 17:18:26.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 11906.0
   lap: 3
   pacer:
@@ -11869,11 +11869,11 @@ rufa_2017_12h_finished_first_start_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_3:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_grandeur_peak
   id: 192188
   absolute_time: 2017-02-11 18:15:00.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 15300.0
   lap: 3
   pacer:
@@ -11882,11 +11882,11 @@ rufa_2017_12h_finished_first_grandeur_peak_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_3:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_finish
   id: 192189
   absolute_time: 2017-02-11 18:41:05.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 16865.0
   lap: 3
   pacer:
@@ -11895,11 +11895,11 @@ rufa_2017_12h_finished_first_finish_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_4:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_start
   id: 192190
   absolute_time: 2017-02-11 18:44:57.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 17097.0
   lap: 4
   pacer:
@@ -11908,11 +11908,11 @@ rufa_2017_12h_finished_first_start_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_4:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_grandeur_peak
   id: 192191
   absolute_time: 2017-02-11 19:43:15.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 20595.0
   lap: 4
   pacer:
@@ -11921,11 +11921,11 @@ rufa_2017_12h_finished_first_grandeur_peak_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_4:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_finish
   id: 192192
   absolute_time: 2017-02-11 20:10:39.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 22239.0
   lap: 4
   pacer:
@@ -11934,11 +11934,11 @@ rufa_2017_12h_finished_first_finish_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_5:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_start
   id: 192193
   absolute_time: 2017-02-11 20:16:40.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 22600.0
   lap: 5
   pacer:
@@ -11947,11 +11947,11 @@ rufa_2017_12h_finished_first_start_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_5:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_grandeur_peak
   id: 192194
   absolute_time: 2017-02-11 21:19:28.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 26368.0
   lap: 5
   pacer:
@@ -11960,11 +11960,11 @@ rufa_2017_12h_finished_first_grandeur_peak_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_5:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_finish
   id: 192195
   absolute_time: 2017-02-11 21:50:23.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 28223.0
   lap: 5
   pacer:
@@ -11973,11 +11973,11 @@ rufa_2017_12h_finished_first_finish_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_6:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_start
   id: 192196
   absolute_time: 2017-02-11 21:59:13.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 28753.0
   lap: 6
   pacer:
@@ -11986,11 +11986,11 @@ rufa_2017_12h_finished_first_start_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_6:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_grandeur_peak
   id: 192197
   absolute_time: 2017-02-11 23:07:18.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 32838.0
   lap: 6
   pacer:
@@ -11999,11 +11999,11 @@ rufa_2017_12h_finished_first_grandeur_peak_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_6:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_finish
   id: 192198
   absolute_time: 2017-02-11 23:38:34.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 34714.0
   lap: 6
   pacer:
@@ -12012,11 +12012,11 @@ rufa_2017_12h_finished_first_finish_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_start_7:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_start
   id: 192199
   absolute_time: 2017-02-11 23:52:03.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 35523.0
   lap: 7
   pacer:
@@ -12025,11 +12025,11 @@ rufa_2017_12h_finished_first_start_7:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_grandeur_peak_7:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_grandeur_peak
   id: 192200
   absolute_time: 2017-02-12 01:01:00.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 39660.0
   lap: 7
   pacer:
@@ -12038,11 +12038,11 @@ rufa_2017_12h_finished_first_grandeur_peak_7:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_first_finish_7:
+  effort: rufa_2017_12h_finished_first
   split: rufa_course_finish
   id: 192201
   absolute_time: 2017-02-12 01:35:12.000000000 Z
   data_status:
-  effort_id: 16643
   elapsed_seconds: 41712.0
   lap: 7
   pacer:
@@ -12051,11 +12051,11 @@ rufa_2017_12h_finished_first_finish_7:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_1:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_start
   id: 192278
   absolute_time: 2017-02-11 14:00:00.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12064,11 +12064,11 @@ rufa_2017_12h_finished_lap6_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_1:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_grandeur_peak
   id: 192279
   absolute_time: 2017-02-11 14:58:53.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 3533.0
   lap: 1
   pacer:
@@ -12077,11 +12077,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_1:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_finish
   id: 192280
   absolute_time: 2017-02-11 15:30:50.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 5450.0
   lap: 1
   pacer:
@@ -12090,11 +12090,11 @@ rufa_2017_12h_finished_lap6_finish_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_2:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_start
   id: 192281
   absolute_time: 2017-02-11 15:33:13.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 5593.0
   lap: 2
   pacer:
@@ -12103,11 +12103,11 @@ rufa_2017_12h_finished_lap6_start_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_2:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_grandeur_peak
   id: 192282
   absolute_time: 2017-02-11 16:38:35.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 9515.0
   lap: 2
   pacer:
@@ -12116,11 +12116,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_2:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_finish
   id: 192283
   absolute_time: 2017-02-11 17:10:32.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 11432.0
   lap: 2
   pacer:
@@ -12129,11 +12129,11 @@ rufa_2017_12h_finished_lap6_finish_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_3:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_start
   id: 192284
   absolute_time: 2017-02-11 17:21:18.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 12078.0
   lap: 3
   pacer:
@@ -12142,11 +12142,11 @@ rufa_2017_12h_finished_lap6_start_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_3:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_grandeur_peak
   id: 192285
   absolute_time: 2017-02-11 18:31:00.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 16260.0
   lap: 3
   pacer:
@@ -12155,11 +12155,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_3:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_finish
   id: 192286
   absolute_time: 2017-02-11 19:04:24.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 18264.0
   lap: 3
   pacer:
@@ -12168,11 +12168,11 @@ rufa_2017_12h_finished_lap6_finish_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_4:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_start
   id: 192287
   absolute_time: 2017-02-11 19:12:11.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 18731.0
   lap: 4
   pacer:
@@ -12181,11 +12181,11 @@ rufa_2017_12h_finished_lap6_start_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_4:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_grandeur_peak
   id: 192288
   absolute_time: 2017-02-11 20:23:51.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 23031.0
   lap: 4
   pacer:
@@ -12194,11 +12194,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_4:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_finish
   id: 192289
   absolute_time: 2017-02-11 21:02:55.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 25375.0
   lap: 4
   pacer:
@@ -12207,11 +12207,11 @@ rufa_2017_12h_finished_lap6_finish_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_5:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_start
   id: 192290
   absolute_time: 2017-02-11 21:25:05.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 26705.0
   lap: 5
   pacer:
@@ -12220,11 +12220,11 @@ rufa_2017_12h_finished_lap6_start_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_5:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_grandeur_peak
   id: 192291
   absolute_time: 2017-02-11 22:42:57.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 31377.0
   lap: 5
   pacer:
@@ -12233,11 +12233,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_5:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_finish
   id: 192292
   absolute_time: 2017-02-11 23:20:36.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 33636.0
   lap: 5
   pacer:
@@ -12246,11 +12246,11 @@ rufa_2017_12h_finished_lap6_finish_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_start_6:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_start
   id: 192293
   absolute_time: 2017-02-11 23:35:51.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 34551.0
   lap: 6
   pacer:
@@ -12259,11 +12259,11 @@ rufa_2017_12h_finished_lap6_start_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_grandeur_peak_6:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_grandeur_peak
   id: 192294
   absolute_time: 2017-02-12 00:51:18.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 39078.0
   lap: 6
   pacer:
@@ -12272,11 +12272,11 @@ rufa_2017_12h_finished_lap6_grandeur_peak_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_finished_lap6_finish_6:
+  effort: rufa_2017_12h_finished_lap6
   split: rufa_course_finish
   id: 192295
   absolute_time: 2017-02-12 01:27:38.000000000 Z
   data_status:
-  effort_id: 16648
   elapsed_seconds: 41258.0
   lap: 6
   pacer:
@@ -12285,11 +12285,11 @@ rufa_2017_12h_finished_lap6_finish_6:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_start_1:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_start
   id: 192420
   absolute_time: 2017-02-11 14:00:00.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12298,11 +12298,11 @@ rufa_2017_12h_progress_lap5_partial_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_1:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_grandeur_peak
   id: 192421
   absolute_time: 2017-02-11 15:08:31.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 4111.0
   lap: 1
   pacer:
@@ -12311,11 +12311,11 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_finish_1:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_finish
   id: 192422
   absolute_time: 2017-02-11 15:44:16.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 6256.0
   lap: 1
   pacer:
@@ -12324,11 +12324,11 @@ rufa_2017_12h_progress_lap5_partial_finish_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_start_2:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_start
   id: 192423
   absolute_time: 2017-02-11 15:47:17.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 6437.0
   lap: 2
   pacer:
@@ -12337,11 +12337,11 @@ rufa_2017_12h_progress_lap5_partial_start_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_2:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_grandeur_peak
   id: 192424
   absolute_time: 2017-02-11 17:07:41.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 11261.0
   lap: 2
   pacer:
@@ -12350,11 +12350,11 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_finish_2:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_finish
   id: 192425
   absolute_time: 2017-02-11 17:45:17.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 13517.0
   lap: 2
   pacer:
@@ -12363,11 +12363,11 @@ rufa_2017_12h_progress_lap5_partial_finish_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_start_3:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_start
   id: 192426
   absolute_time: 2017-02-11 17:51:49.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 13909.0
   lap: 3
   pacer:
@@ -12376,11 +12376,11 @@ rufa_2017_12h_progress_lap5_partial_start_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_3:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_grandeur_peak
   id: 192427
   absolute_time: 2017-02-11 19:16:00.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 18960.0
   lap: 3
   pacer:
@@ -12389,11 +12389,11 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_finish_3:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_finish
   id: 192428
   absolute_time: 2017-02-11 19:57:00.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 21420.0
   lap: 3
   pacer:
@@ -12402,11 +12402,11 @@ rufa_2017_12h_progress_lap5_partial_finish_3:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_start_4:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_start
   id: 192429
   absolute_time: 2017-02-11 20:06:16.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 21976.0
   lap: 4
   pacer:
@@ -12415,11 +12415,11 @@ rufa_2017_12h_progress_lap5_partial_start_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_4:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_grandeur_peak
   id: 192430
   absolute_time: 2017-02-11 21:36:13.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 27373.0
   lap: 4
   pacer:
@@ -12428,11 +12428,11 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_finish_4:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_finish
   id: 192431
   absolute_time: 2017-02-11 22:26:23.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 30383.0
   lap: 4
   pacer:
@@ -12441,11 +12441,11 @@ rufa_2017_12h_progress_lap5_partial_finish_4:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_start_5:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_start
   id: 192432
   absolute_time: 2017-02-11 22:47:18.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 31638.0
   lap: 5
   pacer:
@@ -12454,11 +12454,11 @@ rufa_2017_12h_progress_lap5_partial_start_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap5_partial_grandeur_peak_5:
+  effort: rufa_2017_12h_progress_lap5_partial
   split: rufa_course_grandeur_peak
   id: 192433
   absolute_time: 2017-02-12 00:29:17.000000000 Z
   data_status: 2
-  effort_id: 16657
   elapsed_seconds: 37757.0
   lap: 5
   pacer:
@@ -12467,11 +12467,11 @@ rufa_2017_12h_progress_lap5_partial_grandeur_peak_5:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_start_1:
+  effort: rufa_2017_12h_progress_lap2
   split: rufa_course_start
   id: 192497
   absolute_time: 2017-02-11 14:00:00.000000000 Z
   data_status: 2
-  effort_id: 16663
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12480,11 +12480,11 @@ rufa_2017_12h_progress_lap2_start_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_grandeur_peak_1:
+  effort: rufa_2017_12h_progress_lap2
   split: rufa_course_grandeur_peak
   id: 192498
   absolute_time: 2017-02-11 15:13:16.000000000 Z
   data_status: 2
-  effort_id: 16663
   elapsed_seconds: 4396.0
   lap: 1
   pacer:
@@ -12493,11 +12493,11 @@ rufa_2017_12h_progress_lap2_grandeur_peak_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_finish_1:
+  effort: rufa_2017_12h_progress_lap2
   split: rufa_course_finish
   id: 192499
   absolute_time: 2017-02-11 16:03:44.000000000 Z
   data_status: 2
-  effort_id: 16663
   elapsed_seconds: 7424.0
   lap: 1
   pacer:
@@ -12506,11 +12506,11 @@ rufa_2017_12h_progress_lap2_finish_1:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_start_2:
+  effort: rufa_2017_12h_progress_lap2
   split: rufa_course_start
   id: 192500
   absolute_time: 2017-02-11 16:05:43.000000000 Z
   data_status: 2
-  effort_id: 16663
   elapsed_seconds: 7543.0
   lap: 2
   pacer:
@@ -12519,11 +12519,11 @@ rufa_2017_12h_progress_lap2_start_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_grandeur_peak_2:
+  effort: rufa_2017_12h_progress_lap2
   split: rufa_course_grandeur_peak
   id: 192501
   absolute_time: 2017-02-11 17:25:36.000000000 Z
   data_status: 2
-  effort_id: 16663
   elapsed_seconds: 12336.0
   lap: 2
   pacer:
@@ -12532,11 +12532,11 @@ rufa_2017_12h_progress_lap2_grandeur_peak_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_progress_lap2_finish_2:
+  effort: rufa_2017_12h_progress_lap2
   split: rufa_course_finish
   id: 192502
   absolute_time: 2017-02-11 18:13:54.000000000 Z
   data_status: 2
-  effort_id: 16663
   elapsed_seconds: 15234.0
   lap: 2
   pacer:
@@ -12545,11 +12545,11 @@ rufa_2017_12h_progress_lap2_finish_2:
   sub_split_bitkey: 1
   status_reason:
 rufa_2017_12h_start_only_start_1:
+  effort: rufa_2017_12h_start_only
   split: rufa_course_start
   id: 192542
   absolute_time: 2017-02-11 14:00:00.000000000 Z
   data_status: 2
-  effort_id: 16667
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12558,11 +12558,11 @@ rufa_2017_12h_start_only_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_progress_cascade_start_1:
+  effort: sum_100k_progress_cascade
   split: sum_100k_course_start
   id: 192697
   absolute_time: 2017-09-23 13:00:00.000000000 Z
   data_status: 2
-  effort_id: 16248
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12571,11 +12571,11 @@ sum_100k_progress_cascade_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_progress_cascade_molas_pass_aid1_in_1:
+  effort: sum_100k_progress_cascade
   split: sum_100k_course_molas_pass_aid1
   id: 192698
   absolute_time: 2017-09-23 15:20:00.000000000 Z
   data_status:
-  effort_id: 16248
   elapsed_seconds: 8400.0
   lap: 1
   pacer:
@@ -12584,11 +12584,11 @@ sum_100k_progress_cascade_molas_pass_aid1_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_progress_cascade_molas_pass_aid1_out_1:
+  effort: sum_100k_progress_cascade
   split: sum_100k_course_molas_pass_aid1
   id: 192699
   absolute_time: 2017-09-23 15:25:00.000000000 Z
   data_status:
-  effort_id: 16248
   elapsed_seconds: 8700.0
   lap: 1
   pacer:
@@ -12597,11 +12597,11 @@ sum_100k_progress_cascade_molas_pass_aid1_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_100k_progress_cascade_rolling_pass_aid2_in_1:
+  effort: sum_100k_progress_cascade
   split: sum_100k_course_rolling_pass_aid2
   id: 192700
   absolute_time: 2017-09-23 17:11:00.000000000 Z
   data_status:
-  effort_id: 16248
   elapsed_seconds: 15060.0
   lap: 1
   pacer:
@@ -12610,11 +12610,11 @@ sum_100k_progress_cascade_rolling_pass_aid2_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_progress_cascade_rolling_pass_aid2_out_1:
+  effort: sum_100k_progress_cascade
   split: sum_100k_course_rolling_pass_aid2
   id: 192701
   absolute_time: 2017-09-23 17:22:00.000000000 Z
   data_status:
-  effort_id: 16248
   elapsed_seconds: 15720.0
   lap: 1
   pacer:
@@ -12623,11 +12623,11 @@ sum_100k_progress_cascade_rolling_pass_aid2_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_100k_progress_cascade_cascade_creek_rd_aid3_in_1:
+  effort: sum_100k_progress_cascade
   split: sum_100k_course_cascade_creek_rd_aid3
   id: 192703
   absolute_time: 2017-09-23 19:50:00.000000000 Z
   data_status:
-  effort_id: 16248
   elapsed_seconds: 24600.0
   lap: 1
   pacer:
@@ -12636,11 +12636,11 @@ sum_100k_progress_cascade_cascade_creek_rd_aid3_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_progress_cascade_cascade_creek_rd_aid3_out_1:
+  effort: sum_100k_progress_cascade
   split: sum_100k_course_cascade_creek_rd_aid3
   id: 192704
   absolute_time: 2017-09-23 20:14:00.000000000 Z
   data_status:
-  effort_id: 16248
   elapsed_seconds: 26040.0
   lap: 1
   pacer:
@@ -12649,11 +12649,11 @@ sum_100k_progress_cascade_cascade_creek_rd_aid3_out_1:
   sub_split_bitkey: 64
   status_reason:
 hardrock_2016_start_only_start_1:
+  effort: hardrock_2016_start_only
   split: hardrock_cw_start
   id: 192705
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status:
-  effort_id: 7411
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12662,11 +12662,11 @@ hardrock_2016_start_only_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_on_dst_change_start_1:
+  effort: sum_100k_on_dst_change
   split: sum_100k_course_start
   id: 192708
   absolute_time: 2017-11-05 14:00:00.000000000 Z
   data_status: 2
-  effort_id: 16684
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12675,11 +12675,11 @@ sum_100k_on_dst_change_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_across_dst_change_start_1:
+  effort: sum_100k_across_dst_change
   split: sum_100k_course_start
   id: 192709
   absolute_time: 2017-11-05 06:30:00.000000000 Z
   data_status: 2
-  effort_id: 16685
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12688,11 +12688,11 @@ sum_100k_across_dst_change_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_across_dst_change_molas_pass_aid1_in_1:
+  effort: sum_100k_across_dst_change
   split: sum_100k_course_molas_pass_aid1
   id: 192710
   absolute_time: 2017-11-05 09:30:00.000000000 Z
   data_status: 2
-  effort_id: 16685
   elapsed_seconds: 10800.0
   lap: 1
   pacer:
@@ -12701,11 +12701,11 @@ sum_100k_across_dst_change_molas_pass_aid1_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_100k_on_dst_change_molas_pass_aid1_in_1:
+  effort: sum_100k_on_dst_change
   split: sum_100k_course_molas_pass_aid1
   id: 192715
   absolute_time: 2017-11-05 16:25:00.000000000 Z
   data_status: 2
-  effort_id: 16684
   elapsed_seconds: 8700.0
   lap: 1
   pacer:
@@ -12714,11 +12714,11 @@ sum_100k_on_dst_change_molas_pass_aid1_in_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_start_1:
+  effort: ggd30_50k_finished_second
   split: d30_50k_course_start
   id: 192716
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
-  effort_id: 16686
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12727,11 +12727,11 @@ ggd30_50k_finished_second_start_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_aid_1_1:
+  effort: ggd30_50k_finished_second
   split: d30_50k_course_aid_1
   id: 192717
   absolute_time: 2017-06-03 13:52:00.000000000 Z
   data_status: 2
-  effort_id: 16686
   elapsed_seconds: 3120.0
   lap: 1
   pacer:
@@ -12740,11 +12740,11 @@ ggd30_50k_finished_second_aid_1_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_aid_2_1:
+  effort: ggd30_50k_finished_second
   split: d30_50k_course_aid_2
   id: 192718
   absolute_time: 2017-06-03 15:01:00.000000000 Z
   data_status: 2
-  effort_id: 16686
   elapsed_seconds: 7260.0
   lap: 1
   pacer:
@@ -12753,11 +12753,11 @@ ggd30_50k_finished_second_aid_2_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_aid_3_1:
+  effort: ggd30_50k_finished_second
   split: d30_50k_course_aid_3
   id: 192719
   absolute_time: 2017-06-03 16:15:00.000000000 Z
   data_status: 2
-  effort_id: 16686
   elapsed_seconds: 11700.0
   lap: 1
   pacer:
@@ -12766,11 +12766,11 @@ ggd30_50k_finished_second_aid_3_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_aid_4_1:
+  effort: ggd30_50k_finished_second
   split: d30_50k_course_aid_4
   id: 192720
   absolute_time: 2017-06-03 17:48:00.000000000 Z
   data_status: 2
-  effort_id: 16686
   elapsed_seconds: 17280.0
   lap: 1
   pacer:
@@ -12779,11 +12779,11 @@ ggd30_50k_finished_second_aid_4_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_aid_5_1:
+  effort: ggd30_50k_finished_second
   split: d30_50k_course_aid_5
   id: 192721
   absolute_time: 2017-06-03 18:50:00.000000000 Z
   data_status:
-  effort_id: 16686
   elapsed_seconds: 21000.0
   lap: 1
   pacer:
@@ -12792,11 +12792,11 @@ ggd30_50k_finished_second_aid_5_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_50k_finished_second_finish_1:
+  effort: ggd30_50k_finished_second
   split: d30_50k_course_finish
   id: 192722
   absolute_time: 2017-06-03 19:12:00.000000000 Z
   data_status:
-  effort_id: 16686
   elapsed_seconds: 22320.0
   lap: 1
   pacer:
@@ -12805,11 +12805,11 @@ ggd30_50k_finished_second_finish_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_series_finisher_start_1:
+  effort: ggd30_12m_series_finisher
   split: d30_12m_course_start
   id: 192723
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status: 2
-  effort_id: 16687
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12818,11 +12818,11 @@ ggd30_12m_series_finisher_start_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_series_finisher_finish_1:
+  effort: ggd30_12m_series_finisher
   split: d30_12m_course_finish
   id: 192724
   absolute_time: 2017-06-03 18:55:00.000000000 Z
   data_status:
-  effort_id: 16687
   elapsed_seconds: 10500.0
   lap: 1
   pacer:
@@ -12831,11 +12831,11 @@ ggd30_12m_series_finisher_finish_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_start_1:
+  effort: sum_55k_series_finisher
   split: sum_55k_course_start
   id: 192725
   absolute_time: 2017-09-23 15:00:00.000000000 Z
   data_status: 2
-  effort_id: 16688
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12844,11 +12844,11 @@ sum_55k_series_finisher_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_molas_pass_aid1_in_1:
+  effort: sum_55k_series_finisher
   split: sum_55k_course_molas_pass_aid1
   id: 192726
   absolute_time: 2017-09-23 17:30:00.000000000 Z
   data_status: 2
-  effort_id: 16688
   elapsed_seconds: 9000.0
   lap: 1
   pacer:
@@ -12857,11 +12857,11 @@ sum_55k_series_finisher_molas_pass_aid1_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_molas_pass_aid1_out_1:
+  effort: sum_55k_series_finisher
   split: sum_55k_course_molas_pass_aid1
   id: 192727
   absolute_time: 2017-09-23 17:35:00.000000000 Z
   data_status: 2
-  effort_id: 16688
   elapsed_seconds: 9300.0
   lap: 1
   pacer:
@@ -12870,11 +12870,11 @@ sum_55k_series_finisher_molas_pass_aid1_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_series_finisher_rolling_pass_aid2_in_1:
+  effort: sum_55k_series_finisher
   split: sum_55k_course_rolling_pass_aid2
   id: 192728
   absolute_time: 2017-09-23 20:20:00.000000000 Z
   data_status: 2
-  effort_id: 16688
   elapsed_seconds: 19200.0
   lap: 1
   pacer:
@@ -12883,11 +12883,11 @@ sum_55k_series_finisher_rolling_pass_aid2_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_rolling_pass_aid2_out_1:
+  effort: sum_55k_series_finisher
   split: sum_55k_course_rolling_pass_aid2
   id: 192729
   absolute_time: 2017-09-23 20:30:00.000000000 Z
   data_status: 2
-  effort_id: 16688
   elapsed_seconds: 19800.0
   lap: 1
   pacer:
@@ -12896,11 +12896,11 @@ sum_55k_series_finisher_rolling_pass_aid2_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_series_finisher_bandera_mine_aid5_in_1:
+  effort: sum_55k_series_finisher
   split: sum_55k_course_bandera_mine_aid5
   id: 192730
   absolute_time: 2017-09-23 22:30:00.000000000 Z
   data_status: 2
-  effort_id: 16688
   elapsed_seconds: 27000.0
   lap: 1
   pacer:
@@ -12909,11 +12909,11 @@ sum_55k_series_finisher_bandera_mine_aid5_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_bandera_mine_aid5_out_1:
+  effort: sum_55k_series_finisher
   split: sum_55k_course_bandera_mine_aid5
   id: 192731
   absolute_time: 2017-09-23 22:44:00.000000000 Z
   data_status:
-  effort_id: 16688
   elapsed_seconds: 27840.0
   lap: 1
   pacer:
@@ -12922,11 +12922,11 @@ sum_55k_series_finisher_bandera_mine_aid5_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_series_finisher_anvil_cg_aid6_in_1:
+  effort: sum_55k_series_finisher
   split: sum_55k_course_anvil_cg_aid6
   id: 192732
   absolute_time: 2017-09-24 00:15:00.000000000 Z
   data_status:
-  effort_id: 16688
   elapsed_seconds: 33300.0
   lap: 1
   pacer:
@@ -12935,11 +12935,11 @@ sum_55k_series_finisher_anvil_cg_aid6_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_series_finisher_anvil_cg_aid6_out_1:
+  effort: sum_55k_series_finisher
   split: sum_55k_course_anvil_cg_aid6
   id: 192733
   absolute_time: 2017-09-24 00:25:00.000000000 Z
   data_status:
-  effort_id: 16688
   elapsed_seconds: 33900.0
   lap: 1
   pacer:
@@ -12948,11 +12948,11 @@ sum_55k_series_finisher_anvil_cg_aid6_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_series_finisher_finish_1:
+  effort: sum_55k_series_finisher
   split: sum_55k_course_finish
   id: 192734
   absolute_time: 2017-09-24 01:20:00.000000000 Z
   data_status:
-  effort_id: 16688
   elapsed_seconds: 37200.0
   lap: 1
   pacer:
@@ -12961,11 +12961,11 @@ sum_55k_series_finisher_finish_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_start_1:
+  effort: sum_55k_slow_finisher
   split: sum_55k_course_start
   id: 192735
   absolute_time: 2017-09-23 15:00:00.000000000 Z
   data_status: 2
-  effort_id: 16689
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12974,11 +12974,11 @@ sum_55k_slow_finisher_start_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_molas_pass_aid1_in_1:
+  effort: sum_55k_slow_finisher
   split: sum_55k_course_molas_pass_aid1
   id: 192736
   absolute_time: 2017-09-23 18:10:00.000000000 Z
   data_status: 2
-  effort_id: 16689
   elapsed_seconds: 11400.0
   lap: 1
   pacer:
@@ -12987,11 +12987,11 @@ sum_55k_slow_finisher_molas_pass_aid1_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_molas_pass_aid1_out_1:
+  effort: sum_55k_slow_finisher
   split: sum_55k_course_molas_pass_aid1
   id: 192737
   absolute_time: 2017-09-23 18:20:00.000000000 Z
   data_status: 2
-  effort_id: 16689
   elapsed_seconds: 12000.0
   lap: 1
   pacer:
@@ -13000,11 +13000,11 @@ sum_55k_slow_finisher_molas_pass_aid1_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_slow_finisher_rolling_pass_aid2_in_1:
+  effort: sum_55k_slow_finisher
   split: sum_55k_course_rolling_pass_aid2
   id: 192738
   absolute_time: 2017-09-23 21:35:00.000000000 Z
   data_status: 2
-  effort_id: 16689
   elapsed_seconds: 23700.0
   lap: 1
   pacer:
@@ -13013,11 +13013,11 @@ sum_55k_slow_finisher_rolling_pass_aid2_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_rolling_pass_aid2_out_1:
+  effort: sum_55k_slow_finisher
   split: sum_55k_course_rolling_pass_aid2
   id: 192739
   absolute_time: 2017-09-23 21:45:00.000000000 Z
   data_status: 2
-  effort_id: 16689
   elapsed_seconds: 24300.0
   lap: 1
   pacer:
@@ -13026,11 +13026,11 @@ sum_55k_slow_finisher_rolling_pass_aid2_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_slow_finisher_bandera_mine_aid5_in_1:
+  effort: sum_55k_slow_finisher
   split: sum_55k_course_bandera_mine_aid5
   id: 192740
   absolute_time: 2017-09-23 23:20:00.000000000 Z
   data_status: 2
-  effort_id: 16689
   elapsed_seconds: 30000.0
   lap: 1
   pacer:
@@ -13039,11 +13039,11 @@ sum_55k_slow_finisher_bandera_mine_aid5_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_bandera_mine_aid5_out_1:
+  effort: sum_55k_slow_finisher
   split: sum_55k_course_bandera_mine_aid5
   id: 192741
   absolute_time: 2017-09-23 23:40:00.000000000 Z
   data_status: 2
-  effort_id: 16689
   elapsed_seconds: 31200.0
   lap: 1
   pacer:
@@ -13052,11 +13052,11 @@ sum_55k_slow_finisher_bandera_mine_aid5_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_slow_finisher_anvil_cg_aid6_in_1:
+  effort: sum_55k_slow_finisher
   split: sum_55k_course_anvil_cg_aid6
   id: 192742
   absolute_time: 2017-09-24 01:33:00.000000000 Z
   data_status: 2
-  effort_id: 16689
   elapsed_seconds: 37980.0
   lap: 1
   pacer:
@@ -13065,11 +13065,11 @@ sum_55k_slow_finisher_anvil_cg_aid6_in_1:
   sub_split_bitkey: 1
   status_reason:
 sum_55k_slow_finisher_anvil_cg_aid6_out_1:
+  effort: sum_55k_slow_finisher
   split: sum_55k_course_anvil_cg_aid6
   id: 192743
   absolute_time: 2017-09-24 01:55:00.000000000 Z
   data_status: 2
-  effort_id: 16689
   elapsed_seconds: 39300.0
   lap: 1
   pacer:
@@ -13078,11 +13078,11 @@ sum_55k_slow_finisher_anvil_cg_aid6_out_1:
   sub_split_bitkey: 64
   status_reason:
 sum_55k_slow_finisher_finish_1:
+  effort: sum_55k_slow_finisher
   split: sum_55k_course_finish
   id: 192744
   absolute_time: 2017-09-24 03:21:21.000000000 Z
   data_status: 2
-  effort_id: 16689
   elapsed_seconds: 44481.0
   lap: 1
   pacer:
@@ -13091,11 +13091,11 @@ sum_55k_slow_finisher_finish_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_slow_finisher_start_1:
+  effort: ggd30_12m_slow_finisher
   split: d30_12m_course_start
   id: 192745
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status: 2
-  effort_id: 16690
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -13104,11 +13104,11 @@ ggd30_12m_slow_finisher_start_1:
   sub_split_bitkey: 1
   status_reason:
 ggd30_12m_slow_finisher_finish_1:
+  effort: ggd30_12m_slow_finisher
   split: d30_12m_course_finish
   id: 192746
   absolute_time: 2017-06-03 20:32:10.000000000 Z
   data_status:
-  effort_id: 16690
   elapsed_seconds: 16330.0
   lap: 1
   pacer:

--- a/spec/fixtures/subscriptions.yml
+++ b/spec/fixtures/subscriptions.yml
@@ -1,17 +1,15 @@
 ---
 subscription_0001:
   user: admin_user
+  subscribable: rufa_2017_12h_not_started (Effort)
   id: 2
   endpoint:
   protocol: 1
   resource_key: arn:aws:sns:us-west-2:998989370925:d-follow-rufa-2017-12h-not-started:c7853bd1-f4c2-44e8-bb25-e814aafdf134
-  subscribable_id: 16673
-  subscribable_type: Effort
 subscription_0002:
   user: admin_user
+  subscribable: rufa_2017_12h_not_started (Effort)
   id: 4
   endpoint:
   protocol: 0
   resource_key: arn:aws:sns:us-west-2:998989370925:d-follow-rufa-2017-12h-not-started:c7853bd1-f4c2-44e8-bb25-e814aafdf134
-  subscribable_id: 16673
-  subscribable_type: Effort

--- a/spec/lib/exporter/export_service_spec.rb
+++ b/spec/lib/exporter/export_service_spec.rb
@@ -95,8 +95,8 @@ RSpec.describe ::Exporter::ExportService do
 
         expect(::Effort.count).to be > stubbed_batch_size
         expect(resulting_lines.count).to eq(::Effort.count + 1)
-        expect(resulting_lines.second.chomp).to eq("121,Susanna,Abshire,CO")
-        expect(resulting_lines.last.chomp).to eq("4246,Omer,Yundt,CO")
+        expect(resulting_lines.second.chomp).to eq("#{efforts(:hardrock_2015_susanna_abshire).id},Susanna,Abshire,CO")
+        expect(resulting_lines.last.chomp).to eq("#{efforts(:hardrock_2014_omer_yundt).id},Omer,Yundt,CO")
       end
     end
   end

--- a/spec/models/efforts_together_in_aid_spec.rb
+++ b/spec/models/efforts_together_in_aid_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe EffortsTogetherInAid, type: :model do
       it "returns rows containing effort ids together in aid at various lap splits" do
         expect(subject.size).to eq(4)
         grouse_etia = subject.find { |etia| etia.lap == 1 && etia.split_id == grouse.id }
-        expect(grouse_etia.together_effort_ids).to match_array([31, 50, 59, 141])
+        expected_ids = %i[hardrock_2015_gilberto_mckenzie hardrock_2015_cedric_windler hardrock_2015_rachelle_eichmann hardrock_2015_irvin_harber].map { |label| efforts(label).id }
+        expect(grouse_etia.together_effort_ids).to match_array(expected_ids)
       end
     end
   end

--- a/spec/models/raw_time_spec.rb
+++ b/spec/models/raw_time_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe RawTime, type: :model do
 
   describe "#split_time" do
     let(:event) { events(:sum_100k) }
-    let(:effort) { event.efforts.first }
+    let(:effort) { efforts(:sum_100k_drop_anvil) }
     let(:event_group) { event_groups(:sum) }
     let(:split) { event.ordered_splits.second }
     let(:split_time) { effort.ordered_split_times.second }

--- a/spec/system/courses/course_best_efforts_flow_spec.rb
+++ b/spec/system/courses/course_best_efforts_flow_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe "Visit the best efforts page and search for an effort" do
   let(:event_group) { event.event_group }
   let(:organization) { event_group.organization }
 
-  let(:effort_1) { event.efforts.ranking_subquery.first }
+  # Pin to a finished effort, which is what the best_efforts page actually displays.
+  # `event.efforts.ranking_subquery.first` is brittle: with hash-assigned ids it can land
+  # on a non-finished effort that the page does not render, making verify_link_present fail.
+  let(:effort_1) { efforts(:hardrock_2016_lavon_paucek) }
   let(:other_efforts) { event.efforts.where.not(id: effort_1.id) }
 
   # rubocop:disable RSpec/BeforeAfterAll
@@ -37,7 +40,7 @@ RSpec.describe "Visit the best efforts page and search for an effort" do
   context "when hidden efforts exist for the course" do
     let(:hidden_event) { events(:hardrock_2014) }
     let(:hidden_event_group) { hidden_event.event_group }
-    let(:hidden_effort_1) { hidden_event.efforts.ranking_subquery.first }
+    let(:hidden_effort_1) { efforts(:hardrock_2014_finished_first) }
     let(:other_hidden_efforts) { hidden_event.efforts.where.not(id: hidden_effort_1.id) }
 
     let(:user) { users(:third_user) }


### PR DESCRIPTION
## Summary

Continues the "Make X a portable fixture table" series. Efforts now use Rails-assigned (label-hashed) ids; other fixtures reference them by label.

### Changes
- Add `:efforts` to `PORTABLE_FIXTURE_TABLES`. efforts is slugged, so no `ORDER_BY_MAP` entry is needed.
- `spec/fixtures/efforts.yml`: drop the explicit `id:` from every entry (115); reorder by slug.
- Replace `effort_id: <int>` with `effort: <label>` in three referencing fixtures:
  - `notifications.yml` (81 rows) — inserted at top (Notification's only belongs_to).
  - `split_times.yml` (1009 rows) — inserted before `split:` (SplitTime declares `:effort` then `:split`).
  - `subscriptions.yml`: the two polymorphic refs to effort 16673 become `subscribable: rufa_2017_12h_not_started (Effort)`.

The bare-integer `efforts.final_split_time_id` column is preserved as a literal — split_times is not yet portable, so the ids still resolve. When split_times becomes portable in a future PR, that column will need a `belongs_to :final_split_time, class_name: "SplitTime", optional: true` first (same precedent as #2086 for ProjectionAssessmentRun's split FKs).

### Spec fix-up

Fixed a latent fixture-order trap in `raw_time_spec` (`#split_time` describe block): it used `event.efforts.first` to pick an effort, which previously happened to land on one with split_times. With efforts ids now hash-assigned, `event.efforts.first` is `sum_100k_un_started` (0 split_times), so `ordered_split_times.second` is nil. Pinned to `efforts(:sum_100k_drop_anvil)` (11 split_times) — same test intent, robust to id order.

Other specs using bare `event.efforts.first`/`.second` (event_spec, effort_progress_row_spec, assign_bibs system spec, etc.) all pass — they treat "any effort" as their input and don't care about identity.

## Testing

Ran a focused local selection (~660 examples covering Effort, Event, EventGroup, RawTime, SplitTime, Split, Subscription, IntervalSplitTraffic, the API controllers, SubmitRawTimeRows, ProgressNotifier, the projection runner, plus the system specs that use bare effort accessors) — all green. Relying on CI for the full suite.

Part of #2065
