### PR TITLE
Make event_series a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -43,6 +43,7 @@ module FixtureHelper
     :credentials,
     :efforts,
     :event_groups,
+    :event_series,
     :events,
     :historical_facts,
     :lotteries,

--- a/spec/fixtures/event_series.yml
+++ b/spec/fixtures/event_series.yml
@@ -2,14 +2,12 @@
 d30_50k_series:
   organization: dirty_30_running
   results_template: simple
-  id: 1
   name: D30 50K Series
   scoring_method: 0
   slug: d30-50k-series
 d30_short_series:
   organization: dirty_30_running
   results_template: simple
-  id: 2
   name: D30 Short Series
   scoring_method: 0
   slug: d30-short-series

--- a/spec/fixtures/event_series_events.yml
+++ b/spec/fixtures/event_series_events.yml
@@ -1,17 +1,17 @@
 ---
 event_series_event_0001:
+  event_series: d30_50k_series
   event: ggd30_50k
   id: 1
-  event_series_id: 1
 event_series_event_0002:
+  event_series: d30_50k_series
   event: sum_55k
   id: 2
-  event_series_id: 1
 event_series_event_0003:
+  event_series: d30_short_series
   event: ggd30_12m
   id: 3
-  event_series_id: 2
 event_series_event_0004:
+  event_series: d30_short_series
   event: sum_55k
   id: 4
-  event_series_id: 2


### PR DESCRIPTION
## Summary

Smallest possible portability conversion in the series. event_series now uses Rails-assigned (label-hashed) ids; `event_series_events` references it by label.

### Changes
- Add `:event_series` to `PORTABLE_FIXTURE_TABLES`. Slugged, so no `ORDER_BY_MAP` entry is needed.
- `spec/fixtures/event_series.yml`: drop the explicit `id:` from the two entries.
- `spec/fixtures/event_series_events.yml`: rewrite `event_series_id: <int>` as `event_series: <label>` (4 rows), inserted at the top of each entry to match EventSeriesEvent's `:event_series, :event` declaration order.

No model changes needed — EventSeries's FKs (organization, results_template) are already portable, and there's no Auditable `created_by`.

## Testing

Ran the EventSeries-touching specs (~100 examples covering EventSeries model, Results::SeriesEffort, Event, EventGroup, Organization) — all green. Relying on CI for the full suite.

Part of #2065
