### PR TITLE
Make aid_stations a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -38,6 +38,7 @@ module FixtureHelper
   # Portable fixture tables are assigned an :id by Rails and are referenced by title
   # rather than id in other fixture tables.
   PORTABLE_FIXTURE_TABLES = [
+    :aid_stations,
     :course_groups,
     :courses,
     :credentials,
@@ -62,6 +63,7 @@ module FixtureHelper
   # column could become an unexpected sort key, scrambling every label and FK reference).
   # Pick columns that uniquely identify a row by its real-world identity.
   ORDER_BY_MAP = {
+    aid_stations: "event_id, split_id",
     credentials: "service_identifier, key, user_id",
     historical_facts: "last_name, first_name, year, kind, personal_info_hash",
     partners: "partnerable_type, partnerable_id, name",

--- a/spec/fixtures/aid_stations.yml
+++ b/spec/fixtures/aid_stations.yml
@@ -1,225 +1,169 @@
 ---
 aid_station_0001:
   event: hardrock_2015
-  split: hardrock_ccw_start
-  id: 5
+  split: hardrock_ccw_sherman
 aid_station_0002:
   event: hardrock_2015
-  split: hardrock_ccw_cunningham
-  id: 6
+  split: hardrock_ccw_start
 aid_station_0003:
   event: hardrock_2015
-  split: hardrock_ccw_sherman
-  id: 12
+  split: hardrock_ccw_cunningham
 aid_station_0004:
   event: hardrock_2015
-  split: hardrock_ccw_grouse
-  id: 16
+  split: hardrock_ccw_telluride
 aid_station_0005:
   event: hardrock_2015
-  split: hardrock_ccw_telluride
-  id: 26
+  split: hardrock_ccw_ouray
 aid_station_0006:
   event: hardrock_2015
-  split: hardrock_ccw_putnam
-  id: 32
+  split: hardrock_ccw_finish
 aid_station_0007:
   event: hardrock_2015
-  split: hardrock_ccw_finish
-  id: 34
+  split: hardrock_ccw_putnam
 aid_station_0008:
-  event: ramble
-  split: ramble_even_course_start
-  id: 140
+  event: hardrock_2015
+  split: hardrock_ccw_grouse
 aid_station_0009:
+  event: hardrock_2016
+  split: hardrock_cw_sherman
+aid_station_0010:
+  event: hardrock_2016
+  split: hardrock_cw_telluride
+aid_station_0011:
+  event: hardrock_2016
+  split: hardrock_cw_cunningham
+aid_station_0012:
+  event: hardrock_2016
+  split: hardrock_cw_start
+aid_station_0013:
+  event: hardrock_2016
+  split: hardrock_cw_finish
+aid_station_0014:
+  event: hardrock_2016
+  split: hardrock_cw_ouray
+aid_station_0015:
+  event: hardrock_2016
+  split: hardrock_cw_grouse
+aid_station_0016:
+  event: sum_100k
+  split: sum_100k_course_anvil_cg_aid6
+aid_station_0017:
+  event: sum_100k
+  split: sum_100k_course_molas_pass_aid1
+aid_station_0018:
+  event: sum_100k
+  split: sum_100k_course_finish
+aid_station_0019:
+  event: sum_100k
+  split: sum_100k_course_cascade_creek_rd_aid3
+aid_station_0020:
+  event: sum_100k
+  split: sum_100k_course_bandera_mine_aid5
+aid_station_0021:
+  event: sum_100k
+  split: sum_100k_course_engineer_mtn_th_aid4
+aid_station_0022:
+  event: sum_100k
+  split: sum_100k_course_start
+aid_station_0023:
+  event: sum_100k
+  split: sum_100k_course_rolling_pass_aid2
+aid_station_0024:
   event: ramble
   split: ramble_even_course_finish
-  id: 141
-aid_station_0010:
-  event: hardrock_2014
-  split: hardrock_cw_start
-  id: 202
-aid_station_0011:
-  event: hardrock_2014
-  split: hardrock_cw_finish
-  id: 203
-aid_station_0012:
-  event: hardrock_2014
-  split: hardrock_cw_telluride
-  id: 208
-aid_station_0013:
-  event: hardrock_2014
-  split: hardrock_cw_ouray
-  id: 214
-aid_station_0014:
-  event: hardrock_2014
-  split: hardrock_cw_grouse
-  id: 218
-aid_station_0015:
-  event: hardrock_2014
-  split: hardrock_cw_sherman
-  id: 222
-aid_station_0016:
-  event: hardrock_2014
-  split: hardrock_cw_cunningham
-  id: 228
-aid_station_0017:
-  event: rufa_2016
-  split: rufa_course_start
-  id: 458
-aid_station_0018:
-  event: rufa_2016
-  split: rufa_course_finish
-  id: 459
-aid_station_0019:
-  event: rufa_2016
-  split: rufa_course_grandeur_peak
-  id: 460
-aid_station_0020:
-  event: rufa_2017_24h
-  split: rufa_course_grandeur_peak
-  id: 476
-aid_station_0021:
-  event: rufa_2017_24h
-  split: rufa_course_start
-  id: 477
-aid_station_0022:
-  event: rufa_2017_24h
-  split: rufa_course_finish
-  id: 478
-aid_station_0023:
-  event: hardrock_2016
-  split: hardrock_cw_start
-  id: 479
-aid_station_0024:
-  event: hardrock_2016
-  split: hardrock_cw_telluride
-  id: 482
 aid_station_0025:
-  event: hardrock_2016
-  split: hardrock_cw_ouray
-  id: 485
+  event: ramble
+  split: ramble_even_course_start
 aid_station_0026:
-  event: hardrock_2016
-  split: hardrock_cw_grouse
-  id: 487
+  event: rufa_2017_12h
+  split: rufa_course_start
 aid_station_0027:
-  event: hardrock_2016
-  split: hardrock_cw_sherman
-  id: 489
+  event: rufa_2017_12h
+  split: rufa_course_grandeur_peak
 aid_station_0028:
-  event: hardrock_2016
-  split: hardrock_cw_cunningham
-  id: 492
+  event: rufa_2017_12h
+  split: rufa_course_finish
 aid_station_0029:
-  event: hardrock_2016
-  split: hardrock_cw_finish
-  id: 493
+  event: ggd30_50k
+  split: d30_50k_course_aid_4
 aid_station_0030:
-  event: hardrock_2015
-  split: hardrock_ccw_ouray
-  id: 513
+  event: ggd30_50k
+  split: d30_50k_course_aid_3
 aid_station_0031:
   event: ggd30_50k
   split: d30_50k_course_start
-  id: 570
 aid_station_0032:
   event: ggd30_50k
-  split: d30_50k_course_finish
-  id: 571
+  split: d30_50k_course_aid_2
 aid_station_0033:
   event: ggd30_50k
-  split: d30_50k_course_aid_1
-  id: 572
+  split: d30_50k_course_finish
 aid_station_0034:
   event: ggd30_50k
-  split: d30_50k_course_aid_3
-  id: 574
+  split: d30_50k_course_aid_1
 aid_station_0035:
   event: ggd30_50k
-  split: d30_50k_course_aid_4
-  id: 575
-aid_station_0036:
-  event: ggd30_50k
   split: d30_50k_course_aid_5
-  id: 576
-aid_station_0037:
-  event: ggd30_50k
-  split: d30_50k_course_aid_2
-  id: 577
-aid_station_0038:
-  event: ggd30_12m
-  split: d30_12m_course_finish
-  id: 578
-aid_station_0039:
+aid_station_0036:
   event: ggd30_12m
   split: d30_12m_course_start
-  id: 579
-aid_station_0040:
-  event: sum_100k
-  split: sum_100k_course_finish
-  id: 626
-aid_station_0041:
-  event: sum_100k
-  split: sum_100k_course_start
-  id: 627
-aid_station_0042:
-  event: sum_100k
-  split: sum_100k_course_rolling_pass_aid2
-  id: 629
-aid_station_0043:
-  event: sum_100k
-  split: sum_100k_course_cascade_creek_rd_aid3
-  id: 630
-aid_station_0044:
-  event: sum_100k
-  split: sum_100k_course_engineer_mtn_th_aid4
-  id: 631
-aid_station_0045:
-  event: sum_100k
-  split: sum_100k_course_bandera_mine_aid5
-  id: 632
-aid_station_0046:
-  event: sum_55k
-  split: sum_55k_course_finish
-  id: 634
-aid_station_0047:
-  event: sum_55k
-  split: sum_55k_course_start
-  id: 635
-aid_station_0048:
-  event: sum_55k
-  split: sum_55k_course_molas_pass_aid1
-  id: 636
-aid_station_0049:
+aid_station_0037:
+  event: ggd30_12m
+  split: d30_12m_course_finish
+aid_station_0038:
   event: sum_55k
   split: sum_55k_course_rolling_pass_aid2
-  id: 637
-aid_station_0050:
+aid_station_0039:
   event: sum_55k
   split: sum_55k_course_bandera_mine_aid5
-  id: 638
-aid_station_0051:
+aid_station_0040:
   event: sum_55k
   split: sum_55k_course_anvil_cg_aid6
-  id: 639
-aid_station_0052:
-  event: sum_100k
-  split: sum_100k_course_molas_pass_aid1
-  id: 725
-aid_station_0053:
-  event: sum_100k
-  split: sum_100k_course_anvil_cg_aid6
-  id: 726
-aid_station_0054:
-  event: rufa_2017_12h
-  split: rufa_course_grandeur_peak
-  id: 753
-aid_station_0055:
-  event: rufa_2017_12h
-  split: rufa_course_finish
-  id: 754
-aid_station_0056:
-  event: rufa_2017_12h
+aid_station_0041:
+  event: sum_55k
+  split: sum_55k_course_finish
+aid_station_0042:
+  event: sum_55k
+  split: sum_55k_course_start
+aid_station_0043:
+  event: sum_55k
+  split: sum_55k_course_molas_pass_aid1
+aid_station_0044:
+  event: hardrock_2014
+  split: hardrock_cw_sherman
+aid_station_0045:
+  event: hardrock_2014
+  split: hardrock_cw_telluride
+aid_station_0046:
+  event: hardrock_2014
+  split: hardrock_cw_cunningham
+aid_station_0047:
+  event: hardrock_2014
+  split: hardrock_cw_start
+aid_station_0048:
+  event: hardrock_2014
+  split: hardrock_cw_finish
+aid_station_0049:
+  event: hardrock_2014
+  split: hardrock_cw_ouray
+aid_station_0050:
+  event: hardrock_2014
+  split: hardrock_cw_grouse
+aid_station_0051:
+  event: rufa_2016
   split: rufa_course_start
-  id: 755
+aid_station_0052:
+  event: rufa_2016
+  split: rufa_course_grandeur_peak
+aid_station_0053:
+  event: rufa_2016
+  split: rufa_course_finish
+aid_station_0054:
+  event: rufa_2017_24h
+  split: rufa_course_start
+aid_station_0055:
+  event: rufa_2017_24h
+  split: rufa_course_grandeur_peak
+aid_station_0056:
+  event: rufa_2017_24h
+  split: rufa_course_finish


### PR DESCRIPTION
## Summary

Continues the series. aid_stations now uses hash-assigned ids; rows are sorted by `(event_id, split_id)` on dump.

### Changes
- Add `:aid_stations` to `PORTABLE_FIXTURE_TABLES`.
- Add `aid_stations: "event_id, split_id"` to `ORDER_BY_MAP`. This matches the model's `validates_uniqueness_of :split_id, scope: :event_id`, so the ordering uniquely identifies each row by its real-world identity.
- `spec/fixtures/aid_stations.yml`: drop explicit `id:` from all 56 entries; reorder rows to match what the dump will produce (sorted by `(event_id, split_id)` on the now-hash-assigned ids of the portable event and split parents). Labels renumbered `aid_station_NNNN` in the new order.

No referencing fixtures, no Auditable column, no polymorphic refs. Both FKs (event, split) are already portable.

## Testing

Ran the AidStation-touching specs (~270 examples covering AidStation model, Event, EventGroup, Split, the aid_stations + events API controllers, and SubmitRawTimeRows interactor) — all green, rubocop clean. Relying on CI for the full suite.

Part of #2065
