### PR TITLE
Make stewardships a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -55,6 +55,7 @@ module FixtureHelper
     :results_templates,
     :results_template_categories,
     :splits,
+    :stewardships,
     :users,
   ].freeze
 
@@ -68,6 +69,7 @@ module FixtureHelper
     historical_facts: "last_name, first_name, year, kind, personal_info_hash",
     partners: "partnerable_type, partnerable_id, name",
     results_template_categories: "results_template_id, position, results_category_id",
+    stewardships: "user_id, organization_id",
   }.freeze
 
   ATTRIBUTES_TO_IGNORE = [


### PR DESCRIPTION
## Summary

Smallest possible portability change — a 2-line addition to the helper. The current `stewardships.yml` is empty (`--- {}`), so no fixture file is touched. Future regenerations will produce label-referenced entries.

### Changes
- Add `:stewardships` to `PORTABLE_FIXTURE_TABLES`.
- Add `stewardships: "user_id, organization_id"` to `ORDER_BY_MAP` — the natural unique combination per Stewardship's `validates_uniqueness_of :user_id, scope: :organization_id`.

Both FKs (user, organization) are already portable. No model changes, no fixture changes, no spec changes.

## Sidebar: notifications skipped for now

I tried `notifications` first since it looked easier (single FK to effort), but the data has genuine duplicates: 46 of 81 rows share the same (effort_id, distance, bitkey), and even adding `follower_ids` leaves 19 pairs with all-nil content columns and empty follower arrays. There's no semantic discriminator suitable for `ORDER_BY_MAP`. Skipping for now — likely needs a fixture-deduplication step before it can go portable.

## Testing

Ran `stewardship_spec` and `organization_usages_controller_spec` (17 examples) — all green, rubocop clean.

Part of #2065
