### PR TITLE
Make event_series_events a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -45,6 +45,7 @@ module FixtureHelper
     :efforts,
     :event_groups,
     :event_series,
+    :event_series_events,
     :events,
     :historical_facts,
     :lotteries,
@@ -66,6 +67,7 @@ module FixtureHelper
   ORDER_BY_MAP = {
     aid_stations: "event_id, split_id",
     credentials: "service_identifier, key, user_id",
+    event_series_events: "event_series_id, event_id",
     historical_facts: "last_name, first_name, year, kind, personal_info_hash",
     partners: "partnerable_type, partnerable_id, name",
     results_template_categories: "results_template_id, position, results_category_id",

--- a/spec/fixtures/event_series_events.yml
+++ b/spec/fixtures/event_series_events.yml
@@ -1,17 +1,13 @@
 ---
 event_series_event_0001:
-  event_series: d30_50k_series
-  event: ggd30_50k
-  id: 1
-event_series_event_0002:
-  event_series: d30_50k_series
-  event: sum_55k
-  id: 2
-event_series_event_0003:
   event_series: d30_short_series
   event: ggd30_12m
-  id: 3
-event_series_event_0004:
+event_series_event_0002:
   event_series: d30_short_series
   event: sum_55k
-  id: 4
+event_series_event_0003:
+  event_series: d30_50k_series
+  event: ggd30_50k
+event_series_event_0004:
+  event_series: d30_50k_series
+  event: sum_55k


### PR DESCRIPTION
## Summary

Tiny conversion. event_series_events is a 4-row join table; both FKs are already portable.

### Changes
- Add `:event_series_events` to `PORTABLE_FIXTURE_TABLES`.
- Add `event_series_events: "event_series_id, event_id"` to `ORDER_BY_MAP` — the natural unique combination for the join table.
- `event_series_events.yml`: drop explicit `id:` from the 4 entries and reorder to match the new sort produced by hash-assigned parent ids.

No model changes, no spec changes, no downstream consumers.

## Testing

Ran `event_series_spec` and `results/series_effort_spec` (3 examples) — all green, rubocop clean.

Part of #2065
