### PR TITLE
Make projection_assessment_runs a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -52,6 +52,7 @@ module FixtureHelper
     :organizations,
     :partners,
     :people,
+    :projection_assessment_runs,
     :results_categories,
     :results_templates,
     :results_template_categories,
@@ -70,6 +71,9 @@ module FixtureHelper
     event_series_events: "event_series_id, event_id",
     historical_facts: "last_name, first_name, year, kind, personal_info_hash",
     partners: "partnerable_type, partnerable_id, name",
+    projection_assessment_runs:
+      "event_id, completed_lap, completed_split_id, completed_bitkey, " \
+      "projected_lap, projected_split_id, projected_bitkey",
     results_template_categories: "results_template_id, position, results_category_id",
     stewardships: "user_id, organization_id",
   }.freeze

--- a/spec/fixtures/projection_assessment_runs.yml
+++ b/spec/fixtures/projection_assessment_runs.yml
@@ -3,7 +3,6 @@ projection_assessment_run_0001:
   event: ramble
   completed_split: ramble_even_course_start
   projected_split: ramble_even_course_finish
-  id: 269964004
   completed_bitkey: 1
   completed_lap: 1
   elapsed_time:


### PR DESCRIPTION
## Summary

Single-row conversion. All three FKs (event, completed_split, projected_split) are already portable — the latter two via the belongs_to associations added in #2086.

### Changes
- Add `:projection_assessment_runs` to `PORTABLE_FIXTURE_TABLES`.
- Add an `ORDER_BY_MAP` entry: `event_id, completed_lap, completed_split_id, completed_bitkey, projected_lap, projected_split_id, projected_bitkey` — the natural unique combination of an event plus the two time_points that identify each assessment run.
- `projection_assessment_runs.yml`: drop the explicit `id:` from the single entry.

The only consumer in specs (`runner_job_spec`) references `projection_assessment_run_0001`, which stays stable since there is only one row.

## Testing

Ran `runner_job_spec` and `runner_spec` (6 examples) — all green, rubocop clean.

Part of #2065
