### PR TITLE
Make monetary_donations a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -49,6 +49,7 @@ module FixtureHelper
     :events,
     :historical_facts,
     :lotteries,
+    :monetary_donations,
     :organizations,
     :partners,
     :people,
@@ -70,6 +71,7 @@ module FixtureHelper
     credentials: "service_identifier, key, user_id",
     event_series_events: "event_series_id, event_id",
     historical_facts: "last_name, first_name, year, kind, personal_info_hash",
+    monetary_donations: "received_on, organization_id, amount, source",
     partners: "partnerable_type, partnerable_id, name",
     projection_assessment_runs:
       "event_id, completed_lap, completed_split_id, completed_bitkey, " \

--- a/spec/fixtures/monetary_donations.yml
+++ b/spec/fixtures/monetary_donations.yml
@@ -1,22 +1,19 @@
 ---
 monetary_donation_0001:
   organization: hardrock
-  id: 1
   received_on: 2024-09-12
   amount: !ruby/object:BigDecimal 9:0.25e3
   source: paypal
   note: PayPal transaction ABC123
 monetary_donation_0002:
-  organization: hardrock
-  id: 2
-  received_on: 2025-03-04
-  amount: !ruby/object:BigDecimal 9:0.5e3
-  source: check
-  note: Check
-monetary_donation_0003:
   organization: running_up_for_air
-  id: 3
   received_on: 2025-02-15
   amount: !ruby/object:BigDecimal 9:0.1e3
   source: bitpay
   note:
+monetary_donation_0003:
+  organization: hardrock
+  received_on: 2025-03-04
+  amount: !ruby/object:BigDecimal 9:0.5e3
+  source: check
+  note: Check


### PR DESCRIPTION
## Summary

Small conversion. 3 rows, single FK to organization (portable).

### Changes
- Add `:monetary_donations` to `PORTABLE_FIXTURE_TABLES`.
- Add `monetary_donations: "received_on, organization_id, amount, source"` to `ORDER_BY_MAP` — a date-first natural identity.
- `monetary_donations.yml`: drop the explicit `id:` from the 3 entries.

### Why date-first ordering

Two specs reference `monetary_donations(:monetary_donation_0001)` directly:
- `monetary_donation_spec` asserts hardrock has donation 0001.
- `madmin/monetary_donations_controller_spec` asserts the index page shows "paypal" (the 0001 source).

Picking `received_on` as the primary sort key keeps the hardrock-paypal donation (received 2024-09-12, the earliest date) as `monetary_donation_0001`, so both specs pass unmodified. Rows 0002 and 0003 swap content (the running_up_for_air bitpay donation becomes 0002; the hardrock check donation becomes 0003); no spec references those labels.

Organization-first ordering (matching the existing schema index `["organization_id", "received_on"]`) would have been equally valid but would have rotated 0001 to a running_up_for_air row, requiring spec updates.

## Testing

Ran `monetary_donation_spec` and `madmin/monetary_donations_controller_spec` (15 examples) — all green, rubocop clean.

Part of #2065
