### PR TITLE
Make subscriptions a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -59,6 +59,7 @@ module FixtureHelper
     :results_template_categories,
     :splits,
     :stewardships,
+    :subscriptions,
     :users,
   ].freeze
 
@@ -78,6 +79,7 @@ module FixtureHelper
       "projected_lap, projected_split_id, projected_bitkey",
     results_template_categories: "results_template_id, position, results_category_id",
     stewardships: "user_id, organization_id",
+    subscriptions: "user_id, subscribable_type, subscribable_id, protocol, endpoint",
   }.freeze
 
   ATTRIBUTES_TO_IGNORE = [

--- a/spec/fixtures/subscriptions.yml
+++ b/spec/fixtures/subscriptions.yml
@@ -2,14 +2,12 @@
 subscription_0001:
   user: admin_user
   subscribable: rufa_2017_12h_not_started (Effort)
-  id: 2
   endpoint:
-  protocol: 1
+  protocol: 0
   resource_key: arn:aws:sns:us-west-2:998989370925:d-follow-rufa-2017-12h-not-started:c7853bd1-f4c2-44e8-bb25-e814aafdf134
 subscription_0002:
   user: admin_user
   subscribable: rufa_2017_12h_not_started (Effort)
-  id: 4
   endpoint:
-  protocol: 0
+  protocol: 1
   resource_key: arn:aws:sns:us-west-2:998989370925:d-follow-rufa-2017-12h-not-started:c7853bd1-f4c2-44e8-bb25-e814aafdf134


### PR DESCRIPTION
## Summary

2-row conversion. FK to user (portable), polymorphic to Effort (portable).

### Changes
- Add `:subscriptions` to `PORTABLE_FIXTURE_TABLES`.
- Add `subscriptions: "user_id, subscribable_type, subscribable_id, protocol, endpoint"` to `ORDER_BY_MAP` — matches the existing unique index `index_subscriptions_on_unique_fields_with_endpoint`.
- `subscriptions.yml`: drop explicit `id:` from both entries; reorder by the new key. Both rows share the same user (admin_user) and subscribable (rufa_2017_12h_not_started Effort) and differ only by protocol; under the new sort they swap (protocol 0 first, protocol 1 second).

The one consumer (`refresh_pending_subscription_job_spec`) references `subscription_0002` as "some subscription" without asserting a specific protocol value, so the swap is invisible to it.

## Testing

Ran `subscription_spec`, `refresh_pending_subscription_job_spec`, `subscriptions/button_spec`, `subscription_mailer_spec` (29 examples) — all green, rubocop clean.

Part of #2065
