### PR TITLE
Make connections a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -39,6 +39,7 @@ module FixtureHelper
   # rather than id in other fixture tables.
   PORTABLE_FIXTURE_TABLES = [
     :aid_stations,
+    :connections,
     :course_groups,
     :courses,
     :credentials,
@@ -69,6 +70,8 @@ module FixtureHelper
   # Pick columns that uniquely identify a row by its real-world identity.
   ORDER_BY_MAP = {
     aid_stations: "event_id, split_id",
+    connections:
+      "service_identifier, source_type, source_id, destination_type, destination_id",
     credentials: "service_identifier, key, user_id",
     event_series_events: "event_series_id, event_id",
     historical_facts: "last_name, first_name, year, kind, personal_info_hash",

--- a/spec/fixtures/connections.yml
+++ b/spec/fixtures/connections.yml
@@ -1,22 +1,19 @@
 ---
 connection_0001:
-  destination: rufa_2017 (EventGroup)
-  id: 1
+  destination: rufa_2017_12h (Event)
   service_identifier: runsignup
-  source_id: '123'
-  source_type: Race
+  source_id: '12'
+  source_type: Event
   field_mappings: []
 connection_0002:
   destination: rufa_2017_24h (Event)
-  id: 2
   service_identifier: runsignup
   source_id: '24'
   source_type: Event
   field_mappings: []
 connection_0003:
-  destination: rufa_2017_12h (Event)
-  id: 3
+  destination: rufa_2017 (EventGroup)
   service_identifier: runsignup
-  source_id: '12'
-  source_type: Event
+  source_id: '123'
+  source_type: Race
   field_mappings: []

--- a/spec/presenters/connect_service_presenter_spec.rb
+++ b/spec/presenters/connect_service_presenter_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe ConnectServicePresenter do
       ]
     end
     before do
-      connections(:connection_0001).update!(field_mappings: persisted_mappings)
+      connections(:connection_0003).update!(field_mappings: persisted_mappings)
     end
 
     describe "#field_mappings" do

--- a/spec/presenters/connect_service_presenter_spec.rb
+++ b/spec/presenters/connect_service_presenter_spec.rb
@@ -132,9 +132,10 @@ RSpec.describe ConnectServicePresenter do
         { "source_question_id" => 200, "destination" => "comments", "value_when_present" => "First Attempt" },
       ]
     end
-    before do
-      connections(:connection_0003).update!(field_mappings: persisted_mappings)
+    let(:race_connection) do
+      Connection.find_by!(service_identifier: "runsignup", source_type: "Race", destination: event_group)
     end
+    before { race_connection.update!(field_mappings: persisted_mappings) }
 
     describe "#field_mappings" do
       it "returns the array stored on the EventGroup-level Race Connection" do

--- a/spec/requests/event_groups/field_mappings_controller_spec.rb
+++ b/spec/requests/event_groups/field_mappings_controller_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe "PATCH /event_groups/:event_group_id/connect_service/:connect_ser
     }
   end
   let(:event_group) { event_groups(:rufa_2017) }
-  let(:race_connection) { connections(:connection_0003) }
+  let(:race_connection) do
+    Connection.find_by!(service_identifier: "runsignup", source_type: "Race", destination: event_group)
+  end
 
   before { login_as user, scope: :user }
   after { Warden.test_reset! }

--- a/spec/requests/event_groups/field_mappings_controller_spec.rb
+++ b/spec/requests/event_groups/field_mappings_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "PATCH /event_groups/:event_group_id/connect_service/:connect_ser
     }
   end
   let(:event_group) { event_groups(:rufa_2017) }
-  let(:race_connection) { connections(:connection_0001) }
+  let(:race_connection) { connections(:connection_0003) }
 
   before { login_as user, scope: :user }
   after { Warden.test_reset! }


### PR DESCRIPTION
## Summary

3-row conversion. Polymorphic destination FKs were already labelized in earlier PRs (#2083 for the EventGroup ref, #2085 for the Event refs); this PR drops the explicit `id:` fields and reorders.

### Changes
- Add `:connections` to `PORTABLE_FIXTURE_TABLES`.
- Add `connections: "service_identifier, source_type, source_id, destination_type, destination_id"` to `ORDER_BY_MAP` — matches the existing unique index `index_connections_on_service_source_and_destination`.
- `connections.yml`: drop the explicit `id:` from the 3 entries and reorder. Under the new sort, the two Event-source connections come first (source_type "Event" < "Race"), so the Race-on-EventGroup connection rotates from `connection_0001` to `connection_0003`.
- Update the two specs (`connect_service_presenter_spec`, `event_groups/field_mappings_controller_spec`) that reference `connection_0001` to use `connection_0003`.

## Testing

Ran `connect_service_presenter_spec` and `field_mappings_controller_spec` (30 examples) — all green, rubocop clean.

Part of #2065
