### PR TITLE
Make lottery_divisions a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -50,6 +50,7 @@ module FixtureHelper
     :events,
     :historical_facts,
     :lotteries,
+    :lottery_divisions,
     :monetary_donations,
     :organizations,
     :partners,
@@ -75,6 +76,7 @@ module FixtureHelper
     credentials: "service_identifier, key, user_id",
     event_series_events: "event_series_id, event_id",
     historical_facts: "last_name, first_name, year, kind, personal_info_hash",
+    lottery_divisions: "lottery_id, name",
     monetary_donations: "received_on, organization_id, amount, source",
     partners: "partnerable_type, partnerable_id, name",
     projection_assessment_runs:

--- a/spec/fixtures/lottery_divisions.yml
+++ b/spec/fixtures/lottery_divisions.yml
@@ -1,31 +1,26 @@
 ---
 lottery_division_0001:
   lottery: lottery_with_tickets_and_draws
-  id: 1
-  maximum_entries: 3
-  maximum_wait_list: 2
-  name: Never Ever Evers
-lottery_division_0002:
-  lottery: lottery_with_tickets_and_draws
-  id: 2
-  maximum_entries: 3
-  maximum_wait_list: 3
-  name: Veterans
-lottery_division_0003:
-  lottery: lottery_without_tickets
-  id: 6
-  maximum_entries: 5
-  maximum_wait_list: 3
-  name: Fast People
-lottery_division_0004:
-  lottery: lottery_without_tickets
-  id: 7
-  maximum_entries: 5
-  maximum_wait_list: 3
-  name: Slow People
-lottery_division_0005:
-  lottery: lottery_with_tickets_and_draws
-  id: 8
   maximum_entries: 3
   maximum_wait_list: 5
   name: Elses
+lottery_division_0002:
+  lottery: lottery_with_tickets_and_draws
+  maximum_entries: 3
+  maximum_wait_list: 2
+  name: Never Ever Evers
+lottery_division_0003:
+  lottery: lottery_with_tickets_and_draws
+  maximum_entries: 3
+  maximum_wait_list: 3
+  name: Veterans
+lottery_division_0004:
+  lottery: lottery_without_tickets
+  maximum_entries: 5
+  maximum_wait_list: 3
+  name: Fast People
+lottery_division_0005:
+  lottery: lottery_without_tickets
+  maximum_entries: 5
+  maximum_wait_list: 3
+  name: Slow People

--- a/spec/fixtures/lottery_draws.yml
+++ b/spec/fixtures/lottery_draws.yml
@@ -1,50 +1,50 @@
 ---
 lottery_draw_0001:
+  division: lottery_division_0002
   id: 110
   created_at: 2021-10-02 16:24:20.181722000 Z
-  lottery_division_id: 1
   lottery_id:
   lottery_ticket_id: 18
   position:
 lottery_draw_0002:
+  division: lottery_division_0002
   id: 111
   created_at: 2021-10-02 16:29:20.183865000 Z
-  lottery_division_id: 1
   lottery_id:
   lottery_ticket_id: 10
   position:
 lottery_draw_0003:
+  division: lottery_division_0002
   id: 112
   created_at: 2021-10-02 16:43:20.186126000 Z
-  lottery_division_id: 1
   lottery_id:
   lottery_ticket_id: 17
   position:
 lottery_draw_0004:
+  division: lottery_division_0002
   id: 113
   created_at: 2021-10-02 16:46:20.188331000 Z
-  lottery_division_id: 1
   lottery_id:
   lottery_ticket_id: 13
   position:
 lottery_draw_0005:
+  division: lottery_division_0002
   id: 114
   created_at: 2021-10-02 16:45:20.190595000 Z
-  lottery_division_id: 1
   lottery_id:
   lottery_ticket_id: 9
   position:
 lottery_draw_0006:
+  division: lottery_division_0001
   id: 119
   created_at: 2021-10-02 16:28:20.202115000 Z
-  lottery_division_id: 8
   lottery_id:
   lottery_ticket_id: 3
   position:
 lottery_draw_0007:
+  division: lottery_division_0001
   id: 124
   created_at: 2021-10-02 17:25:58.420681000 Z
-  lottery_division_id: 8
   lottery_id:
   lottery_ticket_id: 6
   position:

--- a/spec/fixtures/lottery_entrants.yml
+++ b/spec/fixtures/lottery_entrants.yml
@@ -1,6 +1,7 @@
 ---
 lottery_entrant_0001:
   person:
+  division: lottery_division_0002
   id: 4
   birthdate: '2000-01-09'
   city: Amadashire
@@ -12,7 +13,6 @@ lottery_entrant_0001:
   first_name: Emeline
   gender: 0
   last_name: Runolfsson
-  lottery_division_id: 1
   number_of_tickets: 1
   phone:
   pre_selected: false
@@ -22,6 +22,7 @@ lottery_entrant_0001:
   withdrawn: false
 lottery_entrant_0002:
   person:
+  division: lottery_division_0002
   id: 5
   birthdate: '1976-05-14'
   city: O'Connertown
@@ -33,7 +34,6 @@ lottery_entrant_0002:
   first_name: Norris
   gender: 0
   last_name: Wilkinson
-  lottery_division_id: 1
   number_of_tickets: 5
   phone:
   pre_selected: false
@@ -43,6 +43,7 @@ lottery_entrant_0002:
   withdrawn: false
 lottery_entrant_0003:
   person:
+  division: lottery_division_0003
   id: 6
   birthdate: '1983-01-09'
   city: Port Brandaburgh
@@ -54,7 +55,6 @@ lottery_entrant_0003:
   first_name: Jerrold
   gender: 0
   last_name: Treutel
-  lottery_division_id: 2
   number_of_tickets: 3
   phone:
   pre_selected: false
@@ -64,6 +64,7 @@ lottery_entrant_0003:
   withdrawn: false
 lottery_entrant_0004:
   person:
+  division: lottery_division_0002
   id: 7
   birthdate: '1993-06-06'
   city: West Vicentafurt
@@ -75,7 +76,6 @@ lottery_entrant_0004:
   first_name: Jospeh
   gender: 1
   last_name: Barrows
-  lottery_division_id: 1
   number_of_tickets: 1
   phone:
   pre_selected: false
@@ -85,6 +85,7 @@ lottery_entrant_0004:
   withdrawn: false
 lottery_entrant_0005:
   person:
+  division: lottery_division_0003
   id: 8
   birthdate: '1981-05-12'
   city: Caroleeville
@@ -96,7 +97,6 @@ lottery_entrant_0005:
   first_name: Ivette
   gender: 1
   last_name: Kuhn
-  lottery_division_id: 2
   number_of_tickets: 1
   phone:
   pre_selected: false
@@ -106,6 +106,7 @@ lottery_entrant_0005:
   withdrawn: false
 lottery_entrant_0006:
   person:
+  division: lottery_division_0002
   id: 9
   birthdate: '1971-11-07'
   city: Hungborough
@@ -117,7 +118,6 @@ lottery_entrant_0006:
   first_name: Nenita
   gender: 0
   last_name: Heaney
-  lottery_division_id: 1
   number_of_tickets: 1
   phone:
   pre_selected: false
@@ -127,6 +127,7 @@ lottery_entrant_0006:
   withdrawn: false
 lottery_entrant_0007:
   person:
+  division: lottery_division_0003
   id: 10
   birthdate: '1976-08-30'
   city: East Lauraport
@@ -138,7 +139,6 @@ lottery_entrant_0007:
   first_name: Veola
   gender: 0
   last_name: Cassin
-  lottery_division_id: 2
   number_of_tickets: 2
   phone:
   pre_selected: false
@@ -148,6 +148,7 @@ lottery_entrant_0007:
   withdrawn: false
 lottery_entrant_0008:
   person:
+  division: lottery_division_0002
   id: 11
   birthdate: '1986-08-22'
   city: Lebsackville
@@ -159,7 +160,6 @@ lottery_entrant_0008:
   first_name: Modesta
   gender: 1
   last_name: Raynor
-  lottery_division_id: 1
   number_of_tickets: 2
   phone:
   pre_selected: false
@@ -169,6 +169,7 @@ lottery_entrant_0008:
   withdrawn: false
 lottery_entrant_0009:
   person:
+  division: lottery_division_0003
   id: 12
   birthdate: '1994-03-08'
   city: Lake Nickyberg
@@ -180,7 +181,6 @@ lottery_entrant_0009:
   first_name: Blythe
   gender: 0
   last_name: Hintz
-  lottery_division_id: 2
   number_of_tickets: 1
   phone:
   pre_selected: false
@@ -190,6 +190,7 @@ lottery_entrant_0009:
   withdrawn: false
 lottery_entrant_0010:
   person:
+  division: lottery_division_0002
   id: 13
   birthdate: '1986-10-23'
   city: Beerbury
@@ -201,7 +202,6 @@ lottery_entrant_0010:
   first_name: Mitsuko
   gender: 1
   last_name: Wilkinson
-  lottery_division_id: 1
   number_of_tickets: 1
   phone:
   pre_selected: false
@@ -211,6 +211,7 @@ lottery_entrant_0010:
   withdrawn: false
 lottery_entrant_0011:
   person:
+  division: lottery_division_0004
   id: 21
   birthdate: '1994-05-31'
   city: Port Glennis
@@ -222,7 +223,6 @@ lottery_entrant_0011:
   first_name: Gricelda
   gender: 1
   last_name: Crona
-  lottery_division_id: 6
   number_of_tickets: 2
   phone:
   pre_selected: false
@@ -232,6 +232,7 @@ lottery_entrant_0011:
   withdrawn: false
 lottery_entrant_0012:
   person:
+  division: lottery_division_0005
   id: 22
   birthdate: '1997-10-15'
   city: West Rebecka
@@ -243,7 +244,6 @@ lottery_entrant_0012:
   first_name: Deb
   gender: 1
   last_name: Swaniawski
-  lottery_division_id: 7
   number_of_tickets: 1
   phone:
   pre_selected: false
@@ -253,6 +253,7 @@ lottery_entrant_0012:
   withdrawn: false
 lottery_entrant_0013:
   person:
+  division: lottery_division_0005
   id: 23
   birthdate: '1997-11-08'
   city: Prohaskaside
@@ -264,7 +265,6 @@ lottery_entrant_0013:
   first_name: Bernetta
   gender: 1
   last_name: Gerlach
-  lottery_division_id: 7
   number_of_tickets: 1
   phone:
   pre_selected: false
@@ -274,6 +274,7 @@ lottery_entrant_0013:
   withdrawn: false
 lottery_entrant_0014:
   person:
+  division: lottery_division_0001
   id: 24
   birthdate: '1991-07-22'
   city: Piamouth
@@ -285,7 +286,6 @@ lottery_entrant_0014:
   first_name: Denisha
   gender: 1
   last_name: Carter
-  lottery_division_id: 8
   number_of_tickets: 2
   phone:
   pre_selected: false
@@ -295,6 +295,7 @@ lottery_entrant_0014:
   withdrawn: false
 lottery_entrant_0015:
   person:
+  division: lottery_division_0001
   id: 25
   birthdate: '1978-08-19'
   city: Lake Antonialand
@@ -306,7 +307,6 @@ lottery_entrant_0015:
   first_name: Shenika
   gender: 0
   last_name: O'Kon
-  lottery_division_id: 8
   number_of_tickets: 1
   phone:
   pre_selected: false
@@ -316,6 +316,7 @@ lottery_entrant_0015:
   withdrawn: false
 lottery_entrant_0016:
   person:
+  division: lottery_division_0001
   id: 26
   birthdate: '1977-05-09'
   city: West Virgenborough
@@ -327,7 +328,6 @@ lottery_entrant_0016:
   first_name: Maud
   gender: 0
   last_name: Boyer
-  lottery_division_id: 8
   number_of_tickets: 1
   phone:
   pre_selected: false
@@ -337,6 +337,7 @@ lottery_entrant_0016:
   withdrawn: false
 lottery_entrant_0017:
   person:
+  division: lottery_division_0001
   id: 27
   birthdate: '1972-12-18'
   city: North Jessia
@@ -348,7 +349,6 @@ lottery_entrant_0017:
   first_name: Melina
   gender: 1
   last_name: Conroy
-  lottery_division_id: 8
   number_of_tickets: 3
   phone:
   pre_selected: false
@@ -358,6 +358,7 @@ lottery_entrant_0017:
   withdrawn: false
 lottery_entrant_0018:
   person:
+  division: lottery_division_0001
   id: 28
   birthdate: '1992-08-29'
   city: Refugialand
@@ -369,7 +370,6 @@ lottery_entrant_0018:
   first_name: Abraham
   gender: 1
   last_name: Balistreri
-  lottery_division_id: 8
   number_of_tickets: 1
   phone:
   pre_selected: false

--- a/spec/fixtures/lottery_tickets.yml
+++ b/spec/fixtures/lottery_tickets.yml
@@ -1,157 +1,157 @@
 ---
 lottery_ticket_0001:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0001
   id: 1
-  lottery_division_id: 8
   lottery_entrant_id: 28
   reference_number: 10000
 lottery_ticket_0002:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0002
   id: 2
-  lottery_division_id: 1
   lottery_entrant_id: 5
   reference_number: 10001
 lottery_ticket_0003:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0001
   id: 3
-  lottery_division_id: 8
   lottery_entrant_id: 27
   reference_number: 10002
 lottery_ticket_0004:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0003
   id: 4
-  lottery_division_id: 2
   lottery_entrant_id: 12
   reference_number: 10003
 lottery_ticket_0005:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0003
   id: 5
-  lottery_division_id: 2
   lottery_entrant_id: 6
   reference_number: 10004
 lottery_ticket_0006:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0001
   id: 6
-  lottery_division_id: 8
   lottery_entrant_id: 24
   reference_number: 10005
 lottery_ticket_0007:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0002
   id: 7
-  lottery_division_id: 1
   lottery_entrant_id: 5
   reference_number: 10006
 lottery_ticket_0008:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0001
   id: 8
-  lottery_division_id: 8
   lottery_entrant_id: 25
   reference_number: 10007
 lottery_ticket_0009:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0002
   id: 9
-  lottery_division_id: 1
   lottery_entrant_id: 4
   reference_number: 10008
 lottery_ticket_0010:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0002
   id: 10
-  lottery_division_id: 1
   lottery_entrant_id: 7
   reference_number: 10009
 lottery_ticket_0011:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0002
   id: 11
-  lottery_division_id: 1
   lottery_entrant_id: 5
   reference_number: 10010
 lottery_ticket_0012:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0001
   id: 12
-  lottery_division_id: 8
   lottery_entrant_id: 26
   reference_number: 10011
 lottery_ticket_0013:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0002
   id: 13
-  lottery_division_id: 1
   lottery_entrant_id: 11
   reference_number: 10012
 lottery_ticket_0014:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0003
   id: 14
-  lottery_division_id: 2
   lottery_entrant_id: 8
   reference_number: 10013
 lottery_ticket_0015:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0001
   id: 15
-  lottery_division_id: 8
   lottery_entrant_id: 27
   reference_number: 10014
 lottery_ticket_0016:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0002
   id: 16
-  lottery_division_id: 1
   lottery_entrant_id: 5
   reference_number: 10015
 lottery_ticket_0017:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0002
   id: 17
-  lottery_division_id: 1
   lottery_entrant_id: 9
   reference_number: 10016
 lottery_ticket_0018:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0002
   id: 18
-  lottery_division_id: 1
   lottery_entrant_id: 13
   reference_number: 10017
 lottery_ticket_0019:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0001
   id: 19
-  lottery_division_id: 8
   lottery_entrant_id: 27
   reference_number: 10018
 lottery_ticket_0020:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0002
   id: 20
-  lottery_division_id: 1
   lottery_entrant_id: 11
   reference_number: 10019
 lottery_ticket_0021:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0003
   id: 21
-  lottery_division_id: 2
   lottery_entrant_id: 10
   reference_number: 10020
 lottery_ticket_0022:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0001
   id: 22
-  lottery_division_id: 8
   lottery_entrant_id: 24
   reference_number: 10021
 lottery_ticket_0023:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0002
   id: 23
-  lottery_division_id: 1
   lottery_entrant_id: 5
   reference_number: 10022
 lottery_ticket_0024:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0003
   id: 24
-  lottery_division_id: 2
   lottery_entrant_id: 10
   reference_number: 10023
 lottery_ticket_0025:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0003
   id: 25
-  lottery_division_id: 2
   lottery_entrant_id: 6
   reference_number: 10024
 lottery_ticket_0026:
   lottery: lottery_with_tickets_and_draws
+  division: lottery_division_0003
   id: 26
-  lottery_division_id: 2
   lottery_entrant_id: 6
   reference_number: 10025

--- a/spec/models/lottery_entrant_spec.rb
+++ b/spec/models/lottery_entrant_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe LotteryEntrant, type: :model do
     describe ".belonging_to_user" do
       let(:result) { existing_scope.belonging_to_user(user) }
       let(:user) { users(:fifth_user) }
-      let(:division) { lottery_divisions(:lottery_division_0001) }
+      let(:division) { LotteryDivision.find_by!(name: "Never Ever Evers") }
       let(:entrant_1) { lottery_entrants(:lottery_entrant_0001) }
       let(:entrant_2) { lottery_entrants(:lottery_entrant_0002) }
       let(:person) { people(:bruno_fadel) }
@@ -212,13 +212,14 @@ RSpec.describe LotteryEntrant, type: :model do
 
   describe "#draw_ticket!" do
     subject { lottery.entrants.find_by(last_name: "Crona") }
+
     let(:lottery) { lotteries(:lottery_without_tickets) }
     let(:division) { lottery.divisions.first }
     let(:execute_method) { subject.draw_ticket! }
 
     context "when the entrant has no tickets" do
       it "does not create a draw" do
-        expect { execute_method }.not_to change { LotteryDraw.count }
+        expect { execute_method }.not_to(change(LotteryDraw, :count))
       end
 
       it "returns nil" do
@@ -228,8 +229,9 @@ RSpec.describe LotteryEntrant, type: :model do
 
     context "when the entrant has tickets that have not been drawn" do
       before { lottery.delete_and_insert_tickets! }
+
       it "creates a draw" do
-        expect { execute_method }.to change { LotteryDraw.count }.by(1)
+        expect { execute_method }.to change(LotteryDraw, :count).by(1)
       end
 
       it "returns the draw" do
@@ -244,7 +246,7 @@ RSpec.describe LotteryEntrant, type: :model do
       end
 
       it "does not create a draw" do
-        expect { execute_method }.not_to change { LotteryDraw.count }
+        expect { execute_method }.not_to(change(LotteryDraw, :count))
       end
 
       it "returns nil" do
@@ -255,6 +257,7 @@ RSpec.describe LotteryEntrant, type: :model do
 
   describe "#drawn?" do
     subject { lottery.entrants.find_by(last_name: "Crona") }
+
     let(:lottery) { lotteries(:lottery_without_tickets) }
     let(:division) { lottery.divisions.first }
     let(:result) { subject.drawn? }
@@ -265,6 +268,7 @@ RSpec.describe LotteryEntrant, type: :model do
 
     context "when the entrant has tickets that have not been drawn" do
       before { lottery.delete_and_insert_tickets! }
+
       it { expect(result).to eq(false) }
     end
 


### PR DESCRIPTION
## Summary

Starts the lottery-chain portability conversion. lottery_divisions has 5 rows and a single FK to lottery (already portable). Three downstream fixtures (lottery_tickets, lottery_entrants, lottery_draws) get their `lottery_division_id: <int>` rewritten to `division: <label>`.

### Changes
- Add `:lottery_divisions` to `PORTABLE_FIXTURE_TABLES`.
- Add `lottery_divisions: "lottery_id, name"` to `ORDER_BY_MAP` — matches the model's `validates_uniqueness_of :name, ..., scope: :lottery`.
- `lottery_divisions.yml`: drop the 5 `id:` fields and reorder. Labels rotate (e.g. `lottery_division_0001` was "Never Ever Evers", now "Elses").
- `lottery_tickets.yml` (26 rows), `lottery_entrants.yml` (18 rows), `lottery_draws.yml` (7 rows): rewrite `lottery_division_id: <int>` as `division: <label>`, positioned per each model's `belongs_to` declaration order.
- `lottery_entrant_spec`: switch from `lottery_divisions(:lottery_division_0001)` to `LotteryDivision.find_by!(name: "Never Ever Evers")` — content lookups don't break on row reordering (the pattern from #2096).
- Clean up 9 pre-existing rubocop offenses in the touched spec file (`-A` autocorrect).

## Testing

Ran the lottery model specs (~80 examples across LotteryDivision, LotteryEntrant, LotteryTicket, LotteryDraw, Lottery) — all green, rubocop clean.

Part of #2065
