### PR TITLE
Make lottery_simulation_runs a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -51,6 +51,7 @@ module FixtureHelper
     :historical_facts,
     :lotteries,
     :lottery_divisions,
+    :lottery_simulation_runs,
     :monetary_donations,
     :organizations,
     :partners,
@@ -77,6 +78,7 @@ module FixtureHelper
     event_series_events: "event_series_id, event_id",
     historical_facts: "last_name, first_name, year, kind, personal_info_hash",
     lottery_divisions: "lottery_id, name",
+    lottery_simulation_runs: "lottery_id, started_at, name",
     monetary_donations: "received_on, organization_id, amount, source",
     partners: "partnerable_type, partnerable_id, name",
     projection_assessment_runs:

--- a/spec/fixtures/lottery_simulation_runs.yml
+++ b/spec/fixtures/lottery_simulation_runs.yml
@@ -1,7 +1,6 @@
 ---
 lottery_simulation_run_0001:
   lottery: lottery_without_tickets
-  id: 813529981
   context:
   elapsed_time:
   error_message:


### PR DESCRIPTION
## Summary

Single-row conversion. FK to lottery (already portable).

### Changes
- Add `:lottery_simulation_runs` to `PORTABLE_FIXTURE_TABLES`.
- Add `lottery_simulation_runs: "lottery_id, started_at, name"` to `ORDER_BY_MAP` — group by lottery, then chronologically by start time, with `name` as a tiebreaker.
- `lottery_simulation_runs.yml`: drop the explicit `id:` from the single entry.

The one consumer (`runner_job_spec`) references `lottery_simulation_run_0001`, which stays stable since there is only one row.

## Testing

Ran `runner_job_spec` and `lottery_simulation_run_spec` (9 examples) — all green, rubocop clean.

Part of #2065
