### PR TITLE
Make course_group_courses a portable fixture table

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -40,6 +40,7 @@ module FixtureHelper
   PORTABLE_FIXTURE_TABLES = [
     :aid_stations,
     :connections,
+    :course_group_courses,
     :course_groups,
     :courses,
     :credentials,
@@ -77,6 +78,7 @@ module FixtureHelper
     aid_stations: "event_id, split_id",
     connections:
       "service_identifier, source_type, source_id, destination_type, destination_id",
+    course_group_courses: "course_group_id, course_id",
     credentials: "service_identifier, key, user_id",
     event_series_events: "event_series_id, event_id",
     historical_facts: "last_name, first_name, year, kind, personal_info_hash",

--- a/spec/fixtures/course_group_courses.yml
+++ b/spec/fixtures/course_group_courses.yml
@@ -2,8 +2,6 @@
 course_group_course_0001:
   course_group: both_directions
   course: hardrock_ccw
-  id: 4
 course_group_course_0002:
   course_group: both_directions
   course: hardrock_cw
-  id: 6


### PR DESCRIPTION
## Summary

Makes the `course_group_courses` join table portable (2 rows).

### Changes
- Add `:course_group_courses` to `PORTABLE_FIXTURE_TABLES`.
- Add `course_group_courses: "course_group_id, course_id"` to `ORDER_BY_MAP` — the table has no slug and no explicit unique index, but `(course_group_id, course_id)` is the natural composite identity for a join.
- `course_group_courses.yml`: drop the 2 `id:` fields. Labels stay assigned to the same rows — `Zlib.crc32` of `hardrock_ccw` (497M) < `hardrock_cw` (586M), so the existing order matches the new ORDER_BY.

Both belongs_to sides (`course_group`, `course`) are already portable, so the dump format is unchanged otherwise. Nothing externally references `CourseGroupCourse` by id, and no spec used the `course_group_courses(:label)` accessor.

### Verified
- 44 examples pass (Course model, CourseGroupBestEffortsDisplay presenter, course_group system specs).
- `rubocop lib/tasks/db/fixture_helper.rb` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2065
