### PR TITLE
Add Effort belongs_to associations for final/stopped split_time

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -31,6 +31,8 @@ class Effort < ApplicationRecord
 
   belongs_to :event, counter_cache: true, touch: true
   belongs_to :person, optional: true
+  belongs_to :final_split_time, class_name: "SplitTime", optional: true
+  belongs_to :stopped_split_time, class_name: "SplitTime", optional: true
 
   scope :standard_includes, -> { includes(:person) }
 


### PR DESCRIPTION
## Summary

Adds `belongs_to :final_split_time` and `belongs_to :stopped_split_time` (both `class_name: "SplitTime", optional: true`) on `Effort`. Both already exist as integer FK columns on the `efforts` table — this PR just declares the associations.

Precursor to making `split_times` a portable fixture table: the `db:to_fixtures` dumper rewrites a FK column to an association label only if the model has a `belongs_to` pointing at the (soon-to-be-)portable table. Without these associations, `final_split_time_id` / `stopped_split_time_id` in `efforts.yml` would dangle once split_times gets hash-assigned ids.

### Notes
- The existing manual `Effort#stopped_split_time` method (line 355, in-memory traversal via `ordered_split_times.rfind(&:stopped_here)`) is left alone. Ruby method-definition order means the explicit `def` overrides the belongs_to getter, preserving the autosave-friendly in-memory-traversal behavior its 4 specs verify. The belongs_to is only there to satisfy the dumper's `reflect_on_all_associations(:belongs_to)` scan; setter/foreign_key plumbing still gets defined.
- No new `def final_split_time` exists, so for that one the belongs_to getter is the only definition.

### Verified
- 193 examples pass (Effort + SplitTime model specs, including the 4 `#stopped_split_time` scenarios).
- `rubocop app/models/effort.rb` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2065
