### PR TITLE
Make split_times a portable fixture table

### DIFF
--- a/app/models/split_time.rb
+++ b/app/models/split_time.rb
@@ -97,6 +97,10 @@ class SplitTime < ApplicationRecord
     "#{effort || '[unknown effort]'} at #{split || '[unknown split]'}"
   end
 
+  def slug
+    "#{effort.slug.underscore}_#{split.name(sub_split_bitkey).parameterize.underscore}_#{lap}"
+  end
+
   def course_is_consistent
     return unless effort&.event && split && (effort.event.course_id != split.course_id)
 

--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -66,6 +66,7 @@ module FixtureHelper
     :results_categories,
     :results_templates,
     :results_template_categories,
+    :split_times,
     :splits,
     :stewardships,
     :subscriptions,
@@ -99,6 +100,7 @@ module FixtureHelper
       "event_group_id, source, bib_number, parameterized_split_name, bitkey, " \
       "entered_time, absolute_time",
     results_template_categories: "results_template_id, position, results_category_id",
+    split_times: "effort_id, lap, split_id, sub_split_bitkey",
     stewardships: "user_id, organization_id",
     subscriptions: "user_id, subscribable_type, subscribable_id, protocol, endpoint",
   }.freeze

--- a/spec/fixtures/efforts.yml
+++ b/spec/fixtures/efforts.yml
@@ -2,6 +2,8 @@
 ggd30_12m_finished_first:
   event: ggd30_12m
   person: finished_first_france
+  final_split_time: ggd30_12m_finished_first_finish_1
+  stopped_split_time:
   age: 23
   beacon_url:
   beyond_start: true
@@ -19,7 +21,6 @@ ggd30_12m_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 190117
   finished: true
   first_name: Finished
   gender: 0
@@ -33,13 +34,14 @@ ggd30_12m_finished_first:
   state_code: ARA
   state_name: Auvergne-Rhône-Alpes
   stopped: true
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_12m_finished_second:
   event: ggd30_12m
   person: finished_second_colorado_us
+  final_split_time: ggd30_12m_finished_second_finish_1
+  stopped_split_time:
   age: 43
   beacon_url:
   beyond_start: true
@@ -57,7 +59,6 @@ ggd30_12m_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 190273
   finished: true
   first_name: Finished
   gender: 1
@@ -71,13 +72,14 @@ ggd30_12m_finished_second:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_12m_not_started:
   event: ggd30_12m
   person: not_started_colorado_us
+  final_split_time:
+  stopped_split_time:
   age: 22
   beacon_url:
   beyond_start: false
@@ -95,7 +97,6 @@ ggd30_12m_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id:
   finished: false
   first_name: Not
   gender: 1
@@ -109,13 +110,14 @@ ggd30_12m_not_started:
   state_code: CO
   state_name: Colorado
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_12m_series_finisher:
   event: ggd30_12m
   person: series_finisher
+  final_split_time: ggd30_12m_series_finisher_finish_1
+  stopped_split_time:
   age: 34
   beacon_url:
   beyond_start: true
@@ -133,7 +135,6 @@ ggd30_12m_series_finisher:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192724
   finished: true
   first_name: Series
   gender: 0
@@ -147,13 +148,14 @@ ggd30_12m_series_finisher:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_12m_slow_finisher:
   event: ggd30_12m
   person: slow_finisher
+  final_split_time: ggd30_12m_slow_finisher_finish_1
+  stopped_split_time:
   age: 64
   beacon_url:
   beyond_start: true
@@ -171,7 +173,6 @@ ggd30_12m_slow_finisher:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192746
   finished: true
   first_name: Slow
   gender: 0
@@ -185,13 +186,14 @@ ggd30_12m_slow_finisher:
   state_code: UT
   state_name:
   stopped: true
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_12m_start_only:
   event: ggd30_12m
   person: start_only_colorado_us
+  final_split_time: ggd30_12m_start_only_start_1
+  stopped_split_time:
   age: 27
   beacon_url:
   beyond_start: false
@@ -209,7 +211,6 @@ ggd30_12m_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 190731
   finished: false
   first_name: Start
   gender: 1
@@ -223,13 +224,14 @@ ggd30_12m_start_only:
   state_code: CO
   state_name: Colorado
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_50k_bad_finish:
   event: ggd30_50k
   person: bad_finish
+  final_split_time: ggd30_50k_bad_finish_finish_1
+  stopped_split_time:
   age: 21
   beacon_url:
   beyond_start: true
@@ -247,7 +249,6 @@ ggd30_50k_bad_finish:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 189055
   finished: true
   first_name: Bad
   gender: 0
@@ -261,13 +262,14 @@ ggd30_50k_bad_finish:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_50k_drop_aid4:
   event: ggd30_50k
   person: drop_aid4
+  final_split_time: ggd30_50k_drop_aid4_aid_4_1
+  stopped_split_time: ggd30_50k_drop_aid4_aid_4_1
   age: 18
   beacon_url:
   beyond_start: true
@@ -285,7 +287,6 @@ ggd30_50k_drop_aid4:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 189952
   finished: false
   first_name: Drop
   gender: 0
@@ -299,13 +300,14 @@ ggd30_50k_drop_aid4:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id: 189952
   synced_at:
   topic_resource_key:
   wave:
 ggd30_50k_finished_first:
   event: ggd30_50k
   person: finished_first_colorado_us
+  final_split_time: ggd30_50k_finished_first_finish_1
+  stopped_split_time:
   age: 44
   beacon_url:
   beyond_start: true
@@ -323,7 +325,6 @@ ggd30_50k_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 188951
   finished: true
   first_name: Finished
   gender: 0
@@ -337,13 +338,14 @@ ggd30_50k_finished_first:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_50k_finished_second:
   event: ggd30_50k
   person:
+  final_split_time: ggd30_50k_finished_second_finish_1
+  stopped_split_time:
   age: 43
   beacon_url:
   beyond_start: true
@@ -361,7 +363,6 @@ ggd30_50k_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192722
   finished: true
   first_name: Finished
   gender: 1
@@ -375,13 +376,14 @@ ggd30_50k_finished_second:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_50k_not_started:
   event: ggd30_50k
   person: not_started
+  final_split_time:
+  stopped_split_time:
   age: 31
   beacon_url:
   beyond_start: false
@@ -399,7 +401,6 @@ ggd30_50k_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id:
   finished: false
   first_name: Not
   gender: 0
@@ -413,13 +414,14 @@ ggd30_50k_not_started:
   state_code:
   state_name:
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_50k_progress_aid3:
   event: ggd30_50k
   person: progress_aid3
+  final_split_time: ggd30_50k_progress_aid3_aid_3_1
+  stopped_split_time:
   age: 31
   beacon_url:
   beyond_start: true
@@ -437,7 +439,6 @@ ggd30_50k_progress_aid3:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 189850
   finished: false
   first_name: Progress
   gender: 0
@@ -451,13 +452,14 @@ ggd30_50k_progress_aid3:
   state_code:
   state_name:
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_50k_progress_aid4:
   event: ggd30_50k
   person: progress_aid4
+  final_split_time: ggd30_50k_progress_aid4_aid_4_1
+  stopped_split_time:
   age: 35
   beacon_url:
   beyond_start: true
@@ -475,7 +477,6 @@ ggd30_50k_progress_aid4:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 189814
   finished: false
   first_name: Progress
   gender: 1
@@ -489,13 +490,14 @@ ggd30_50k_progress_aid4:
   state_code:
   state_name:
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ggd30_50k_start_only:
   event: ggd30_50k
   person: start_only_2019_02_01_07_19_53
+  final_split_time: ggd30_50k_start_only_start_1
+  stopped_split_time:
   age: 31
   beacon_url:
   beyond_start: false
@@ -513,7 +515,6 @@ ggd30_50k_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 190761
   finished: false
   first_name: Start
   gender: 1
@@ -527,13 +528,14 @@ ggd30_50k_start_only:
   state_code:
   state_name:
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_clarence_goyette:
   event: hardrock_2014
   person: clarence_goyette
+  final_split_time: hardrock_2014_clarence_goyette_finish_1
+  stopped_split_time: hardrock_2014_clarence_goyette_finish_1
   age: 52
   beacon_url:
   beyond_start: true
@@ -551,7 +553,6 @@ hardrock_2014_clarence_goyette:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 93442
   finished: true
   first_name: Clarence
   gender: 0
@@ -565,13 +566,14 @@ hardrock_2014_clarence_goyette:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 93442
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_claudio_wunsch:
   event: hardrock_2014
   person: claudio_wunsch
+  final_split_time: hardrock_2014_claudio_wunsch_finish_1
+  stopped_split_time: hardrock_2014_claudio_wunsch_finish_1
   age: 33
   beacon_url:
   beyond_start: true
@@ -589,7 +591,6 @@ hardrock_2014_claudio_wunsch:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 91846
   finished: true
   first_name: Claudio
   gender: 0
@@ -603,13 +604,14 @@ hardrock_2014_claudio_wunsch:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id: 91846
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_drop_ouray:
   event: hardrock_2014
   person: drop_ouray
+  final_split_time: hardrock_2014_drop_ouray_ouray_out_1
+  stopped_split_time: hardrock_2014_drop_ouray_ouray_out_1
   age: 40
   beacon_url:
   beyond_start: true
@@ -627,7 +629,6 @@ hardrock_2014_drop_ouray:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 94483
   finished: false
   first_name: Drop
   gender: 1
@@ -641,13 +642,14 @@ hardrock_2014_drop_ouray:
   state_code: CA
   state_name: California
   stopped: true
-  stopped_split_time_id: 94483
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_finished_first:
   event: hardrock_2014
   person: finished_first_japan
+  final_split_time: hardrock_2014_finished_first_finish_1
+  stopped_split_time: hardrock_2014_finished_first_finish_1
   age: 19
   beacon_url:
   beyond_start: true
@@ -665,7 +667,6 @@ hardrock_2014_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 91286
   finished: true
   first_name: Finished
   gender: 0
@@ -679,13 +680,14 @@ hardrock_2014_finished_first:
   state_code: '01'
   state_name: Hokkaido
   stopped: true
-  stopped_split_time_id: 91286
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_finished_with_stop:
   event: hardrock_2014
   person: finished_with_stop
+  final_split_time: hardrock_2014_finished_with_stop_finish_1
+  stopped_split_time: hardrock_2014_finished_with_stop_finish_1
   age: 40
   beacon_url:
   beyond_start: true
@@ -703,7 +705,6 @@ hardrock_2014_finished_with_stop:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 91314
   finished: true
   first_name: Finished
   gender: 0
@@ -717,13 +718,14 @@ hardrock_2014_finished_with_stop:
   state_code: UT
   state_name: Utah
   stopped: true
-  stopped_split_time_id: 91314
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_finished_without_stop:
   event: hardrock_2014
   person: finished_without_stop
+  final_split_time: hardrock_2014_finished_without_stop_finish_1
+  stopped_split_time:
   age: 25
   beacon_url:
   beyond_start: true
@@ -741,7 +743,6 @@ hardrock_2014_finished_without_stop:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 91342
   finished: true
   first_name: Finished
   gender: 0
@@ -755,13 +756,14 @@ hardrock_2014_finished_without_stop:
   state_code: UT
   state_name: Utah
   stopped: true
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_humberto_adams:
   event: hardrock_2014
   person: humberto_adams
+  final_split_time: hardrock_2014_humberto_adams_finish_1
+  stopped_split_time: hardrock_2014_humberto_adams_finish_1
   age: 24
   beacon_url:
   beyond_start: true
@@ -779,7 +781,6 @@ hardrock_2014_humberto_adams:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 92658
   finished: true
   first_name: Humberto
   gender: 0
@@ -793,13 +794,14 @@ hardrock_2014_humberto_adams:
   state_code: NM
   state_name: New Mexico
   stopped: true
-  stopped_split_time_id: 92658
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_irvin_corkery:
   event: hardrock_2014
   person: irvin_corkery
+  final_split_time: hardrock_2014_irvin_corkery_finish_1
+  stopped_split_time: hardrock_2014_irvin_corkery_finish_1
   age: 22
   beacon_url:
   beyond_start: true
@@ -817,7 +819,6 @@ hardrock_2014_irvin_corkery:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 93498
   finished: true
   first_name: Irvin
   gender: 0
@@ -831,13 +832,14 @@ hardrock_2014_irvin_corkery:
   state_code: DC
   state_name: District of Columbia
   stopped: true
-  stopped_split_time_id: 93498
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_keith_metz:
   event: hardrock_2014
   person: keith_metz
+  final_split_time: hardrock_2014_keith_metz_finish_1
+  stopped_split_time: hardrock_2014_keith_metz_finish_1
   age: 42
   beacon_url:
   beyond_start: true
@@ -855,7 +857,6 @@ hardrock_2014_keith_metz:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 92238
   finished: true
   first_name: Keith
   gender: 0
@@ -869,13 +870,14 @@ hardrock_2014_keith_metz:
   state_code: UT
   state_name: Utah
   stopped: true
-  stopped_split_time_id: 92238
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_ken_bradtke:
   event: hardrock_2014
   person: ken_bradtke
+  final_split_time: hardrock_2014_ken_bradtke_finish_1
+  stopped_split_time: hardrock_2014_ken_bradtke_finish_1
   age: 47
   beacon_url:
   beyond_start: true
@@ -893,7 +895,6 @@ hardrock_2014_ken_bradtke:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 93638
   finished: true
   first_name: Ken
   gender: 0
@@ -907,13 +908,14 @@ hardrock_2014_ken_bradtke:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 93638
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_major_green:
   event: hardrock_2014
   person: major_green
+  final_split_time: hardrock_2014_major_green_finish_1
+  stopped_split_time: hardrock_2014_major_green_finish_1
   age: 58
   beacon_url:
   beyond_start: true
@@ -931,7 +933,6 @@ hardrock_2014_major_green:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 92266
   finished: true
   first_name: Major
   gender: 0
@@ -945,13 +946,14 @@ hardrock_2014_major_green:
   state_code: NC
   state_name: North Carolina
   stopped: true
-  stopped_split_time_id: 92266
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_multiple_stops:
   event: hardrock_2014
   person: multiple_stops
+  final_split_time: hardrock_2014_multiple_stops_grouse_out_1
+  stopped_split_time: hardrock_2014_multiple_stops_grouse_out_1
   age: 60
   beacon_url:
   beyond_start: true
@@ -969,7 +971,6 @@ hardrock_2014_multiple_stops:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 94453
   finished: false
   first_name: Multiple
   gender: 1
@@ -983,13 +984,14 @@ hardrock_2014_multiple_stops:
   state_code: HI
   state_name: Hawaii
   stopped: true
-  stopped_split_time_id: 94453
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_not_started:
   event: hardrock_2014
   person: not_started
+  final_split_time:
+  stopped_split_time:
   age: 28
   beacon_url:
   beyond_start: false
@@ -1007,7 +1009,6 @@ hardrock_2014_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id:
   finished: false
   first_name: Not
   gender: 0
@@ -1021,13 +1022,14 @@ hardrock_2014_not_started:
   state_code: CO
   state_name: Colorado
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_omer_yundt:
   event: hardrock_2014
   person: omer_yundt
+  final_split_time: hardrock_2014_omer_yundt_finish_1
+  stopped_split_time: hardrock_2014_omer_yundt_finish_1
   age: 40
   beacon_url:
   beyond_start: true
@@ -1045,7 +1047,6 @@ hardrock_2014_omer_yundt:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 93358
   finished: true
   first_name: Omer
   gender: 0
@@ -1059,13 +1060,14 @@ hardrock_2014_omer_yundt:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 93358
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_pat_schaden:
   event: hardrock_2014
   person: pat_schaden
+  final_split_time: hardrock_2014_pat_schaden_cunningham_in_1
+  stopped_split_time: hardrock_2014_pat_schaden_cunningham_in_1
   age: 53
   beacon_url:
   beyond_start: true
@@ -1083,7 +1085,6 @@ hardrock_2014_pat_schaden:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 93384
   finished: false
   first_name: Pat
   gender: 0
@@ -1097,13 +1098,14 @@ hardrock_2014_pat_schaden:
   state_code: AZ
   state_name: Arizona
   stopped: true
-  stopped_split_time_id: 93384
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_progress_sherman:
   event: hardrock_2014
   person: progress_sherman_colorado_us
+  final_split_time: hardrock_2014_progress_sherman_sherman_out_1
+  stopped_split_time:
   age: 36
   beacon_url:
   beyond_start: true
@@ -1121,7 +1123,6 @@ hardrock_2014_progress_sherman:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 94175
   finished: false
   first_name: Progress
   gender: 0
@@ -1135,13 +1136,14 @@ hardrock_2014_progress_sherman:
   state_code: CO
   state_name: Colorado
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_rachelle_eichmann:
   event: hardrock_2014
   person: rachelle_eichmann
+  final_split_time: hardrock_2014_rachelle_eichmann_finish_1
+  stopped_split_time: hardrock_2014_rachelle_eichmann_finish_1
   age: 22
   beacon_url:
   beyond_start: true
@@ -1159,7 +1161,6 @@ hardrock_2014_rachelle_eichmann:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 92042
   finished: true
   first_name: Rachelle
   gender: 1
@@ -1173,13 +1174,14 @@ hardrock_2014_rachelle_eichmann:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 92042
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_willis_murray:
   event: hardrock_2014
   person: willis_murray
+  final_split_time: hardrock_2014_willis_murray_finish_1
+  stopped_split_time: hardrock_2014_willis_murray_finish_1
   age: 16
   beacon_url:
   beyond_start: true
@@ -1197,7 +1199,6 @@ hardrock_2014_willis_murray:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 93554
   finished: true
   first_name: Willis
   gender: 0
@@ -1211,13 +1212,14 @@ hardrock_2014_willis_murray:
   state_code: GA
   state_name: Georgia
   stopped: true
-  stopped_split_time_id: 93554
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2014_without_start:
   event: hardrock_2014
   person: without_start
+  final_split_time: hardrock_2014_without_start_grouse_out_1
+  stopped_split_time: hardrock_2014_without_start_grouse_out_1
   age: 49
   beacon_url:
   beyond_start: true
@@ -1235,7 +1237,6 @@ hardrock_2014_without_start:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 94470
   finished: false
   first_name: Without
   gender: 0
@@ -1249,13 +1250,14 @@ hardrock_2014_without_start:
   state_code: MT
   state_name: Montana
   stopped: true
-  stopped_split_time_id: 94470
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_bad_status:
   event: hardrock_2015
   person: bad_status
+  final_split_time: hardrock_2015_bad_status_putnam_out_1
+  stopped_split_time: hardrock_2015_bad_status_putnam_out_1
   age: 21
   beacon_url:
   beyond_start: true
@@ -1273,7 +1275,6 @@ hardrock_2015_bad_status:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 101556
   finished: false
   first_name: Bad
   gender: 0
@@ -1287,13 +1288,14 @@ hardrock_2015_bad_status:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 101556
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_benedict_davis:
   event: hardrock_2015
   person: benedict_davis
+  final_split_time: hardrock_2015_benedict_davis_finish_1
+  stopped_split_time: hardrock_2015_benedict_davis_finish_1
   age: 32
   beacon_url:
   beyond_start: true
@@ -1311,7 +1313,6 @@ hardrock_2015_benedict_davis:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 3702
   finished: true
   first_name: Benedict
   gender: 0
@@ -1325,13 +1326,14 @@ hardrock_2015_benedict_davis:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 3702
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_bruno_fadel:
   event: hardrock_2015
   person: bruno_fadel
+  final_split_time: hardrock_2015_bruno_fadel_finish_1
+  stopped_split_time: hardrock_2015_bruno_fadel_finish_1
   age: 27
   beacon_url:
   beyond_start: true
@@ -1349,7 +1351,6 @@ hardrock_2015_bruno_fadel:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 3312
   finished: true
   first_name: Bruno
   gender: 0
@@ -1363,13 +1364,14 @@ hardrock_2015_bruno_fadel:
   state_code: CA
   state_name: California
   stopped: true
-  stopped_split_time_id: 3312
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_carmine_adams:
   event: hardrock_2015
   person: carmine_adams
+  final_split_time: hardrock_2015_carmine_adams_finish_1
+  stopped_split_time: hardrock_2015_carmine_adams_finish_1
   age: 18
   beacon_url:
   beyond_start: true
@@ -1387,7 +1389,6 @@ hardrock_2015_carmine_adams:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 432
   finished: true
   first_name: Carmine
   gender: 0
@@ -1401,13 +1402,14 @@ hardrock_2015_carmine_adams:
   state_code: WA
   state_name: Washington
   stopped: true
-  stopped_split_time_id: 432
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_cassondra_nienow:
   event: hardrock_2015
   person: cassondra_nienow
+  final_split_time: hardrock_2015_cassondra_nienow_sherman_out_1
+  stopped_split_time: hardrock_2015_cassondra_nienow_sherman_out_1
   age: 56
   beacon_url:
   beyond_start: true
@@ -1425,7 +1427,6 @@ hardrock_2015_cassondra_nienow:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 4198
   finished: false
   first_name: Cassondra
   gender: 1
@@ -1439,13 +1440,14 @@ hardrock_2015_cassondra_nienow:
   state_code: OH
   state_name: Ohio
   stopped: true
-  stopped_split_time_id: 4198
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_cedric_windler:
   event: hardrock_2015
   person: cedric_windler
+  final_split_time: hardrock_2015_cedric_windler_finish_1
+  stopped_split_time: hardrock_2015_cedric_windler_finish_1
   age: 36
   beacon_url:
   beyond_start: true
@@ -1463,7 +1465,6 @@ hardrock_2015_cedric_windler:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 1332
   finished: true
   first_name: Cedric
   gender: 0
@@ -1477,13 +1478,14 @@ hardrock_2015_cedric_windler:
   state_code: TN
   state_name: Tennessee
   stopped: true
-  stopped_split_time_id: 1332
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_chris_rempel:
   event: hardrock_2015
   person: chris_rempel
+  final_split_time: hardrock_2015_chris_rempel_finish_1
+  stopped_split_time: hardrock_2015_chris_rempel_finish_1
   age: 26
   beacon_url:
   beyond_start: true
@@ -1501,7 +1503,6 @@ hardrock_2015_chris_rempel:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 1512
   finished: true
   first_name: Chris
   gender: 0
@@ -1515,13 +1516,14 @@ hardrock_2015_chris_rempel:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 1512
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_darius_jacobson:
   event: hardrock_2015
   person: darius_jacobson
+  final_split_time: hardrock_2015_darius_jacobson_finish_1
+  stopped_split_time: hardrock_2015_darius_jacobson_finish_1
   age: 30
   beacon_url:
   beyond_start: true
@@ -1539,7 +1541,6 @@ hardrock_2015_darius_jacobson:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 582
   finished: true
   first_name: Darius
   gender: 0
@@ -1553,13 +1554,14 @@ hardrock_2015_darius_jacobson:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 582
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_demetrius_moen:
   event: hardrock_2015
   person: demetrius_moen
+  final_split_time: hardrock_2015_demetrius_moen_finish_1
+  stopped_split_time: hardrock_2015_demetrius_moen_finish_1
   age: 40
   beacon_url:
   beyond_start: true
@@ -1577,7 +1579,6 @@ hardrock_2015_demetrius_moen:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 2712
   finished: true
   first_name: Demetrius
   gender: 0
@@ -1591,13 +1592,14 @@ hardrock_2015_demetrius_moen:
   state_code: OR
   state_name: Oregon
   stopped: true
-  stopped_split_time_id: 2712
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_donn_mckenzie:
   event: hardrock_2015
   person: donn_mckenzie
+  final_split_time: hardrock_2015_donn_mckenzie_cunningham_out_1
+  stopped_split_time:
   age: 16
   beacon_url:
   beyond_start: true
@@ -1615,7 +1617,6 @@ hardrock_2015_donn_mckenzie:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 4219
   finished: false
   first_name: Donn
   gender: 0
@@ -1629,13 +1630,14 @@ hardrock_2015_donn_mckenzie:
   state_code: WY
   state_name: Wyoming
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_donte_spencer:
   event: hardrock_2015
   person: donte_spencer
+  final_split_time: hardrock_2015_donte_spencer_finish_1
+  stopped_split_time: hardrock_2015_donte_spencer_finish_1
   age: 30
   beacon_url:
   beyond_start: true
@@ -1653,7 +1655,6 @@ hardrock_2015_donte_spencer:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 3192
   finished: true
   first_name: Donte
   gender: 0
@@ -1667,13 +1668,14 @@ hardrock_2015_donte_spencer:
   state_code: UT
   state_name: Utah
   stopped: true
-  stopped_split_time_id: 3192
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_elden_morissette:
   event: hardrock_2015
   person: elden_morissette
+  final_split_time: hardrock_2015_elden_morissette_finish_1
+  stopped_split_time: hardrock_2015_elden_morissette_finish_1
   age: 42
   beacon_url:
   beyond_start: true
@@ -1691,7 +1693,6 @@ hardrock_2015_elden_morissette:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 1662
   finished: true
   first_name: Elden
   gender: 0
@@ -1705,13 +1706,14 @@ hardrock_2015_elden_morissette:
   state_code: WI
   state_name: Wisconsin
   stopped: true
-  stopped_split_time_id: 1662
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_erich_larson:
   event: hardrock_2015
   person: erich_larson
+  final_split_time: hardrock_2015_erich_larson_finish_1
+  stopped_split_time: hardrock_2015_erich_larson_finish_1
   age: 36
   beacon_url:
   beyond_start: true
@@ -1729,7 +1731,6 @@ hardrock_2015_erich_larson:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 72
   finished: true
   first_name: Erich
   gender: 0
@@ -1743,13 +1744,14 @@ hardrock_2015_erich_larson:
   state_code: MT
   state_name: Montana
   stopped: true
-  stopped_split_time_id: 72
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_garry_kuhlman:
   event: hardrock_2015
   person: garry_kuhlman
+  final_split_time: hardrock_2015_garry_kuhlman_finish_1
+  stopped_split_time: hardrock_2015_garry_kuhlman_finish_1
   age: 45
   beacon_url:
   beyond_start: true
@@ -1767,7 +1769,6 @@ hardrock_2015_garry_kuhlman:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 552
   finished: true
   first_name: Garry
   gender: 0
@@ -1781,13 +1782,14 @@ hardrock_2015_garry_kuhlman:
   state_code: MT
   state_name: Montana
   stopped: true
-  stopped_split_time_id: 552
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_gilberto_mckenzie:
   event: hardrock_2015
   person: gilberto_mckenzie
+  final_split_time: hardrock_2015_gilberto_mckenzie_finish_1
+  stopped_split_time: hardrock_2015_gilberto_mckenzie_finish_1
   age: 45
   beacon_url:
   beyond_start: true
@@ -1805,7 +1807,6 @@ hardrock_2015_gilberto_mckenzie:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 762
   finished: true
   first_name: Gilberto
   gender: 0
@@ -1819,13 +1820,14 @@ hardrock_2015_gilberto_mckenzie:
   state_code: WA
   state_name: Washington
   stopped: true
-  stopped_split_time_id: 762
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_gus_walker:
   event: hardrock_2015
   person: gus_walker
+  final_split_time: hardrock_2015_gus_walker_finish_1
+  stopped_split_time: hardrock_2015_gus_walker_finish_1
   age: 54
   beacon_url:
   beyond_start: true
@@ -1843,7 +1845,6 @@ hardrock_2015_gus_walker:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 3342
   finished: true
   first_name: Gus
   gender: 0
@@ -1857,13 +1858,14 @@ hardrock_2015_gus_walker:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 3342
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_irvin_harber:
   event: hardrock_2015
   person: irvin_harber
+  final_split_time: hardrock_2015_irvin_harber_telluride_out_1
+  stopped_split_time: hardrock_2015_irvin_harber_telluride_out_1
   age: 19
   beacon_url:
   beyond_start: true
@@ -1881,7 +1883,6 @@ hardrock_2015_irvin_harber:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 101541
   finished: false
   first_name: Irvin
   gender: 0
@@ -1895,13 +1896,14 @@ hardrock_2015_irvin_harber:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 101541
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_leandro_cole:
   event: hardrock_2015
   person: leandro_cole
+  final_split_time: hardrock_2015_leandro_cole_finish_1
+  stopped_split_time: hardrock_2015_leandro_cole_finish_1
   age: 45
   beacon_url:
   beyond_start: true
@@ -1919,7 +1921,6 @@ hardrock_2015_leandro_cole:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 3582
   finished: true
   first_name: Leandro
   gender: 0
@@ -1933,13 +1934,14 @@ hardrock_2015_leandro_cole:
   state_code: UT
   state_name: Utah
   stopped: true
-  stopped_split_time_id: 3582
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_leif_carter:
   event: hardrock_2015
   person: leif_carter
+  final_split_time: hardrock_2015_leif_carter_finish_1
+  stopped_split_time: hardrock_2015_leif_carter_finish_1
   age: 55
   beacon_url:
   beyond_start: true
@@ -1957,7 +1959,6 @@ hardrock_2015_leif_carter:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 282
   finished: true
   first_name: Leif
   gender: 0
@@ -1971,13 +1972,14 @@ hardrock_2015_leif_carter:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id: 282
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_leroy_leffler:
   event: hardrock_2015
   person: leroy_leffler
+  final_split_time: hardrock_2015_leroy_leffler_finish_1
+  stopped_split_time: hardrock_2015_leroy_leffler_finish_1
   age: 48
   beacon_url:
   beyond_start: true
@@ -1995,7 +1997,6 @@ hardrock_2015_leroy_leffler:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 1722
   finished: true
   first_name: Leroy
   gender: 0
@@ -2009,13 +2010,14 @@ hardrock_2015_leroy_leffler:
   state_code: NM
   state_name: New Mexico
   stopped: true
-  stopped_split_time_id: 1722
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_rachelle_eichmann:
   event: hardrock_2015
   person: rachelle_eichmann
+  final_split_time: hardrock_2015_rachelle_eichmann_finish_1
+  stopped_split_time: hardrock_2015_rachelle_eichmann_finish_1
   age: 23
   beacon_url:
   beyond_start: true
@@ -2033,7 +2035,6 @@ hardrock_2015_rachelle_eichmann:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 1602
   finished: true
   first_name: Rachelle
   gender: 1
@@ -2047,13 +2048,14 @@ hardrock_2015_rachelle_eichmann:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 1602
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_raphael_swift:
   event: hardrock_2015
   person: raphael_swift
+  final_split_time: hardrock_2015_raphael_swift_telluride_out_1
+  stopped_split_time:
   age: 40
   beacon_url:
   beyond_start: true
@@ -2071,7 +2073,6 @@ hardrock_2015_raphael_swift:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 3891
   finished: false
   first_name: Raphael
   gender: 0
@@ -2085,13 +2086,14 @@ hardrock_2015_raphael_swift:
   state_code: AR
   state_name: Arkansas
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_robby_gerlach:
   event: hardrock_2015
   person: robby_gerlach
+  final_split_time: hardrock_2015_robby_gerlach_finish_1
+  stopped_split_time: hardrock_2015_robby_gerlach_finish_1
   age: 45
   beacon_url:
   beyond_start: true
@@ -2109,7 +2111,6 @@ hardrock_2015_robby_gerlach:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 1542
   finished: true
   first_name: Robby
   gender: 0
@@ -2123,13 +2124,14 @@ hardrock_2015_robby_gerlach:
   state_code: VA
   state_name: Virginia
   stopped: true
-  stopped_split_time_id: 1542
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_robt_wintheiser:
   event: hardrock_2015
   person: robt_wintheiser
+  final_split_time: hardrock_2015_robt_wintheiser_finish_1
+  stopped_split_time: hardrock_2015_robt_wintheiser_finish_1
   age: 57
   beacon_url:
   beyond_start: true
@@ -2147,7 +2149,6 @@ hardrock_2015_robt_wintheiser:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 2652
   finished: true
   first_name: Robt
   gender: 0
@@ -2161,13 +2162,14 @@ hardrock_2015_robt_wintheiser:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 2652
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_samara_vandervort:
   event: hardrock_2015
   person: samara_vandervort
+  final_split_time: hardrock_2015_samara_vandervort_finish_1
+  stopped_split_time: hardrock_2015_samara_vandervort_finish_1
   age: 22
   beacon_url:
   beyond_start: true
@@ -2185,7 +2187,6 @@ hardrock_2015_samara_vandervort:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 2022
   finished: true
   first_name: Samara
   gender: 1
@@ -2199,13 +2200,14 @@ hardrock_2015_samara_vandervort:
   state_code: CA
   state_name: California
   stopped: true
-  stopped_split_time_id: 2022
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_santa_green:
   event: hardrock_2015
   person: santa_green
+  final_split_time: hardrock_2015_santa_green_finish_1
+  stopped_split_time: hardrock_2015_santa_green_finish_1
   age: 37
   beacon_url:
   beyond_start: true
@@ -2223,7 +2225,6 @@ hardrock_2015_santa_green:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 702
   finished: true
   first_name: Santa
   gender: 1
@@ -2237,13 +2238,14 @@ hardrock_2015_santa_green:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 702
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_susanna_abshire:
   event: hardrock_2015
   person: susanna_abshire
+  final_split_time: hardrock_2015_susanna_abshire_finish_1
+  stopped_split_time: hardrock_2015_susanna_abshire_finish_1
   age: 34
   beacon_url:
   beyond_start: true
@@ -2261,7 +2263,6 @@ hardrock_2015_susanna_abshire:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 3462
   finished: true
   first_name: Susanna
   gender: 1
@@ -2275,13 +2276,14 @@ hardrock_2015_susanna_abshire:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 3462
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_tuan_jacobs:
   event: hardrock_2015
   person: tuan_jacobs
+  final_split_time: hardrock_2015_tuan_jacobs_finish_1
+  stopped_split_time: hardrock_2015_tuan_jacobs_finish_1
   age: 17
   beacon_url:
   beyond_start: true
@@ -2299,7 +2301,6 @@ hardrock_2015_tuan_jacobs:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 42
   finished: true
   first_name: Tuan
   gender: 0
@@ -2313,13 +2314,14 @@ hardrock_2015_tuan_jacobs:
   state_code: AN
   state_name: Andalucía
   stopped: true
-  stopped_split_time_id: 42
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_vern_buckridge:
   event: hardrock_2015
   person: vern_buckridge
+  final_split_time: hardrock_2015_vern_buckridge_finish_1
+  stopped_split_time: hardrock_2015_vern_buckridge_finish_1
   age: 33
   beacon_url:
   beyond_start: true
@@ -2337,7 +2339,6 @@ hardrock_2015_vern_buckridge:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 2982
   finished: true
   first_name: Vern
   gender: 0
@@ -2351,13 +2352,14 @@ hardrock_2015_vern_buckridge:
   state_code: TX
   state_name: Texas
   stopped: true
-  stopped_split_time_id: 2982
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2015_vince_willms:
   event: hardrock_2015
   person: vince_willms
+  final_split_time: hardrock_2015_vince_willms_finish_1
+  stopped_split_time: hardrock_2015_vince_willms_finish_1
   age: 50
   beacon_url:
   beyond_start: true
@@ -2375,7 +2377,6 @@ hardrock_2015_vince_willms:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 1242
   finished: true
   first_name: Vince
   gender: 0
@@ -2389,13 +2390,14 @@ hardrock_2015_vince_willms:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 1242
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_benito_moen:
   event: hardrock_2016
   person: benito_moen
+  final_split_time: hardrock_2016_benito_moen_sherman_out_1
+  stopped_split_time:
   age: 52
   beacon_url:
   beyond_start: true
@@ -2413,7 +2415,6 @@ hardrock_2016_benito_moen:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 148819
   finished: false
   first_name: Benito
   gender: 0
@@ -2427,13 +2428,14 @@ hardrock_2016_benito_moen:
   state_code: OH
   state_name: Ohio
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_brinda_fisher:
   event: hardrock_2016
   person: brinda_fisher
+  final_split_time: hardrock_2016_brinda_fisher_grouse_out_1
+  stopped_split_time:
   age: 22
   beacon_url:
   beyond_start: true
@@ -2451,7 +2453,6 @@ hardrock_2016_brinda_fisher:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 149907
   finished: false
   first_name: Brinda
   gender: 1
@@ -2465,13 +2466,14 @@ hardrock_2016_brinda_fisher:
   state_code: SC
   state_name: South Carolina
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_charlie_mueller:
   event: hardrock_2016
   person: charlie_mueller
+  final_split_time: hardrock_2016_charlie_mueller_sherman_out_1
+  stopped_split_time:
   age: 27
   beacon_url:
   beyond_start: true
@@ -2489,7 +2491,6 @@ hardrock_2016_charlie_mueller:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 148987
   finished: false
   first_name: Charlie
   gender: 0
@@ -2503,13 +2504,14 @@ hardrock_2016_charlie_mueller:
   state_code: OR
   state_name: Oregon
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_douglas_vandervort:
   event: hardrock_2016
   person: douglas_vandervort
+  final_split_time: hardrock_2016_douglas_vandervort_sherman_out_1
+  stopped_split_time:
   age: 52
   beacon_url:
   beyond_start: true
@@ -2527,7 +2529,6 @@ hardrock_2016_douglas_vandervort:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 147839
   finished: false
   first_name: Douglas
   gender: 0
@@ -2541,13 +2542,14 @@ hardrock_2016_douglas_vandervort:
   state_code: CO
   state_name: Colorado
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_dropped_grouse:
   event: hardrock_2016
   person: dropped_grouse
+  final_split_time: hardrock_2016_dropped_grouse_grouse_out_1
+  stopped_split_time: hardrock_2016_dropped_grouse_grouse_out_1
   age: 47
   beacon_url:
   beyond_start: true
@@ -2565,7 +2567,6 @@ hardrock_2016_dropped_grouse:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 150335
   finished: false
   first_name: Dropped
   gender: 0
@@ -2579,13 +2580,14 @@ hardrock_2016_dropped_grouse:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 150335
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_eddy_goldner:
   event: hardrock_2016
   person: eddy_goldner
+  final_split_time: hardrock_2016_eddy_goldner_sherman_out_1
+  stopped_split_time:
   age: 18
   beacon_url:
   beyond_start: true
@@ -2603,7 +2605,6 @@ hardrock_2016_eddy_goldner:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 148203
   finished: false
   first_name: Eddy
   gender: 0
@@ -2617,13 +2618,14 @@ hardrock_2016_eddy_goldner:
   state_code: WA
   state_name: Washington
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_hoyt_macejkovic:
   event: hardrock_2016
   person: hoyt_macejkovic
+  final_split_time: hardrock_2016_hoyt_macejkovic_ouray_out_1
+  stopped_split_time: hardrock_2016_hoyt_macejkovic_ouray_out_1
   age: 55
   beacon_url:
   beyond_start: true
@@ -2641,7 +2643,6 @@ hardrock_2016_hoyt_macejkovic:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 150506
   finished: false
   first_name: Hoyt
   gender: 0
@@ -2655,13 +2656,14 @@ hardrock_2016_hoyt_macejkovic:
   state_code: MD
   state_name: Maryland
   stopped: true
-  stopped_split_time_id: 150506
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_junior_lesch:
   event: hardrock_2016
   person: junior_lesch
+  final_split_time: hardrock_2016_junior_lesch_sherman_out_1
+  stopped_split_time:
   age: 49
   beacon_url:
   beyond_start: true
@@ -2679,7 +2681,6 @@ hardrock_2016_junior_lesch:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 148091
   finished: false
   first_name: Junior
   gender: 0
@@ -2693,13 +2694,14 @@ hardrock_2016_junior_lesch:
   state_code: NM
   state_name: New Mexico
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_kendall_koch:
   event: hardrock_2016
   person: kendall_koch
+  final_split_time: hardrock_2016_kendall_koch_sherman_out_1
+  stopped_split_time:
   age: 40
   beacon_url:
   beyond_start: true
@@ -2717,7 +2719,6 @@ hardrock_2016_kendall_koch:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 148903
   finished: false
   first_name: Kendall
   gender: 0
@@ -2731,13 +2732,14 @@ hardrock_2016_kendall_koch:
   state_code: CO
   state_name: Colorado
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_kory_kulas:
   event: hardrock_2016
   person: kory_kulas
+  final_split_time: hardrock_2016_kory_kulas_cunningham_out_1
+  stopped_split_time:
   age: 42
   beacon_url:
   beyond_start: true
@@ -2755,7 +2757,6 @@ hardrock_2016_kory_kulas:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 147481
   finished: false
   first_name: Kory
   gender: 0
@@ -2769,13 +2770,14 @@ hardrock_2016_kory_kulas:
   state_code: CA
   state_name: California
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_lavon_paucek:
   event: hardrock_2016
   person: lavon_paucek
+  final_split_time: hardrock_2016_lavon_paucek_finish_1
+  stopped_split_time: hardrock_2016_lavon_paucek_finish_1
   age: 41
   beacon_url:
   beyond_start: true
@@ -2793,7 +2795,6 @@ hardrock_2016_lavon_paucek:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 146950
   finished: true
   first_name: Lavon
   gender: 1
@@ -2807,13 +2808,14 @@ hardrock_2016_lavon_paucek:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id: 146950
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_mervin_smitham:
   event: hardrock_2016
   person: mervin_smitham
+  final_split_time: hardrock_2016_mervin_smitham_grouse_out_1
+  stopped_split_time: hardrock_2016_mervin_smitham_grouse_out_1
   age: 24
   beacon_url:
   beyond_start: true
@@ -2831,7 +2833,6 @@ hardrock_2016_mervin_smitham:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 150403
   finished: false
   first_name: Mervin
   gender: 0
@@ -2845,13 +2846,14 @@ hardrock_2016_mervin_smitham:
   state_code: NM
   state_name: New Mexico
   stopped: true
-  stopped_split_time_id: 150403
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_missing_telluride_out:
   event: hardrock_2016
   person:
+  final_split_time: hardrock_2016_missing_telluride_out_sherman_out_1
+  stopped_split_time:
   age: 20
   beacon_url:
   beyond_start: true
@@ -2869,7 +2871,6 @@ hardrock_2016_missing_telluride_out:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 148007
   finished: false
   first_name: Missing
   gender: 0
@@ -2883,13 +2884,14 @@ hardrock_2016_missing_telluride_out:
   state_code: AK
   state_name: Alaska
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_progress_sherman:
   event: hardrock_2016
   person: progress_sherman
+  final_split_time: hardrock_2016_progress_sherman_sherman_out_1
+  stopped_split_time:
   age: 33
   beacon_url:
   beyond_start: true
@@ -2907,7 +2909,6 @@ hardrock_2016_progress_sherman:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 148567
   finished: false
   first_name: Progress
   gender: 0
@@ -2921,13 +2922,14 @@ hardrock_2016_progress_sherman:
   state_code: VA
   state_name: Virginia
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_rene_mclaughlin:
   event: hardrock_2016
   person: rene_mclaughlin
+  final_split_time: hardrock_2016_rene_mclaughlin_sherman_in_1
+  stopped_split_time:
   age: 32
   beacon_url:
   beyond_start: true
@@ -2945,7 +2947,6 @@ hardrock_2016_rene_mclaughlin:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 150016
   finished: false
   first_name: Rene
   gender: 0
@@ -2959,13 +2960,14 @@ hardrock_2016_rene_mclaughlin:
   state_code: TX
   state_name: Texas
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_rhett_auer:
   event: hardrock_2016
   person:
+  final_split_time: hardrock_2016_rhett_auer_ouray_out_1
+  stopped_split_time: hardrock_2016_rhett_auer_ouray_out_1
   age: 41
   beacon_url:
   beyond_start: true
@@ -2983,7 +2985,6 @@ hardrock_2016_rhett_auer:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 150467
   finished: false
   first_name: Rhett
   gender: 0
@@ -2997,13 +2998,14 @@ hardrock_2016_rhett_auer:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 150467
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_shad_hirthe:
   event: hardrock_2016
   person: shad_hirthe
+  final_split_time: hardrock_2016_shad_hirthe_sherman_out_1
+  stopped_split_time:
   age: 40
   beacon_url:
   beyond_start: true
@@ -3021,7 +3023,6 @@ hardrock_2016_shad_hirthe:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 147699
   finished: false
   first_name: Shad
   gender: 0
@@ -3035,13 +3036,14 @@ hardrock_2016_shad_hirthe:
   state_code: CO
   state_name: Colorado
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_start_only:
   event: hardrock_2016
   person: start_only_maine_us
+  final_split_time: hardrock_2016_start_only_start_1
+  stopped_split_time:
   age: 26
   beacon_url:
   beyond_start: false
@@ -3059,7 +3061,6 @@ hardrock_2016_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192705
   finished: false
   first_name: Start
   gender: 0
@@ -3073,13 +3074,14 @@ hardrock_2016_start_only:
   state_code: ME
   state_name: Maine
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 hardrock_2016_vesta_borer:
   event: hardrock_2016
   person: vesta_borer
+  final_split_time: hardrock_2016_vesta_borer_cunningham_out_1
+  stopped_split_time:
   age: 21
   beacon_url:
   beyond_start: true
@@ -3097,7 +3099,6 @@ hardrock_2016_vesta_borer:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 147341
   finished: false
   first_name: Vesta
   gender: 1
@@ -3111,13 +3112,14 @@ hardrock_2016_vesta_borer:
   state_code: UT
   state_name: Utah
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ramble_finished_first:
   event: ramble
   person: finished_first_2019_02_01
+  final_split_time: ramble_finished_first_finish_1
+  stopped_split_time: ramble_finished_first_finish_1
   age: 49
   beacon_url:
   beyond_start: true
@@ -3135,7 +3137,6 @@ ramble_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 15145
   finished: true
   first_name: Finished
   gender: 0
@@ -3149,13 +3150,14 @@ ramble_finished_first:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id: 15145
   synced_at:
   topic_resource_key:
   wave:
 ramble_finished_second:
   event: ramble
   person: finished_second_montana_us
+  final_split_time: ramble_finished_second_finish_1
+  stopped_split_time: ramble_finished_second_finish_1
   age: 12
   beacon_url:
   beyond_start: true
@@ -3173,7 +3175,6 @@ ramble_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 15161
   finished: true
   first_name: Finished
   gender: 1
@@ -3187,13 +3188,14 @@ ramble_finished_second:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id: 15161
   synced_at:
   topic_resource_key:
   wave:
 ramble_not_started:
   event: ramble
   person: not_started_2019_02_01
+  final_split_time:
+  stopped_split_time:
   age: 17
   beacon_url:
   beyond_start: false
@@ -3211,7 +3213,6 @@ ramble_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id:
   finished: false
   first_name: Not
   gender: 0
@@ -3225,13 +3226,14 @@ ramble_not_started:
   state_code:
   state_name:
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 ramble_start_only:
   event: ramble
   person: start_only_2019_02_01
+  final_split_time: ramble_start_only_start_1
+  stopped_split_time:
   age: 38
   beacon_url:
   beyond_start: false
@@ -3249,7 +3251,6 @@ ramble_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 15166
   finished: false
   first_name: Start
   gender: 1
@@ -3263,13 +3264,14 @@ ramble_start_only:
   state_code:
   state_name:
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 rufa_2016_finished_first:
   event: rufa_2016
   person:
+  final_split_time: rufa_2016_finished_first_finish_7
+  stopped_split_time: rufa_2016_finished_first_finish_7
   age: 35
   beacon_url:
   beyond_start: true
@@ -3287,7 +3289,6 @@ rufa_2016_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 132059
   finished: true
   first_name: Finished
   gender: 0
@@ -3301,13 +3302,14 @@ rufa_2016_finished_first:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id: 132059
   synced_at:
   topic_resource_key:
   wave:
 rufa_2016_finished_second:
   event: rufa_2016
   person:
+  final_split_time: rufa_2016_finished_second_finish_6
+  stopped_split_time: rufa_2016_finished_second_finish_6
   age: 32
   beacon_url:
   beyond_start: true
@@ -3325,7 +3327,6 @@ rufa_2016_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 132090
   finished: true
   first_name: Finished
   gender: 0
@@ -3339,13 +3340,14 @@ rufa_2016_finished_second:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id: 132090
   synced_at:
   topic_resource_key:
   wave:
 rufa_2016_not_started:
   event: rufa_2016
   person:
+  final_split_time:
+  stopped_split_time:
   age: 57
   beacon_url:
   beyond_start: false
@@ -3363,7 +3365,6 @@ rufa_2016_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id:
   finished: false
   first_name: Not
   gender: 1
@@ -3377,13 +3378,14 @@ rufa_2016_not_started:
   state_code:
   state_name:
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 rufa_2016_progress_lap1:
   event: rufa_2016
   person:
+  final_split_time: rufa_2016_progress_lap1_grandeur_peak_1
+  stopped_split_time:
   age: 25
   beacon_url:
   beyond_start: true
@@ -3401,7 +3403,6 @@ rufa_2016_progress_lap1:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 132439
   finished: false
   first_name: Progress
   gender: 0
@@ -3415,13 +3416,14 @@ rufa_2016_progress_lap1:
   state_code:
   state_name:
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_12h_finished_first:
   event: rufa_2017_12h
   person: finished_first
+  final_split_time: rufa_2017_12h_finished_first_finish_7
+  stopped_split_time: rufa_2017_12h_finished_first_finish_7
   age: 20
   beacon_url:
   beyond_start: true
@@ -3439,7 +3441,6 @@ rufa_2017_12h_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192201
   finished: true
   first_name: Finished
   gender: 0
@@ -3453,13 +3454,14 @@ rufa_2017_12h_finished_first:
   state_code: AZ
   state_name: Arizona
   stopped: true
-  stopped_split_time_id: 192201
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_12h_finished_lap6:
   event: rufa_2017_12h
   person: finished_lap6
+  final_split_time: rufa_2017_12h_finished_lap6_finish_6
+  stopped_split_time: rufa_2017_12h_finished_lap6_finish_6
   age: 53
   beacon_url:
   beyond_start: true
@@ -3477,7 +3479,6 @@ rufa_2017_12h_finished_lap6:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192295
   finished: true
   first_name: Finished
   gender: 0
@@ -3491,13 +3492,14 @@ rufa_2017_12h_finished_lap6:
   state_code: UT
   state_name: Utah
   stopped: true
-  stopped_split_time_id: 192295
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_12h_not_started:
   event: rufa_2017_12h
   person: not_started_utah_us
+  final_split_time:
+  stopped_split_time:
   age: 49
   beacon_url:
   beyond_start: false
@@ -3515,7 +3517,6 @@ rufa_2017_12h_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id:
   finished: false
   first_name: Not
   gender: 1
@@ -3529,13 +3530,14 @@ rufa_2017_12h_not_started:
   state_code: UT
   state_name: Utah
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_12h_progress_lap2:
   event: rufa_2017_12h
   person: progress_lap2
+  final_split_time: rufa_2017_12h_progress_lap2_finish_2
+  stopped_split_time:
   age: 24
   beacon_url:
   beyond_start: true
@@ -3553,7 +3555,6 @@ rufa_2017_12h_progress_lap2:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192502
   finished: false
   first_name: Progress
   gender: 1
@@ -3567,13 +3568,14 @@ rufa_2017_12h_progress_lap2:
   state_code: UT
   state_name: Utah
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_12h_progress_lap5_partial:
   event: rufa_2017_12h
   person: progress_lap5_partial
+  final_split_time: rufa_2017_12h_progress_lap5_partial_grandeur_peak_5
+  stopped_split_time:
   age: 28
   beacon_url:
   beyond_start: true
@@ -3591,7 +3593,6 @@ rufa_2017_12h_progress_lap5_partial:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192433
   finished: false
   first_name: Progress
   gender: 0
@@ -3605,13 +3606,14 @@ rufa_2017_12h_progress_lap5_partial:
   state_code: UT
   state_name: Utah
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_12h_start_only:
   event: rufa_2017_12h
   person: start_only
+  final_split_time: rufa_2017_12h_start_only_start_1
+  stopped_split_time:
   age: 44
   beacon_url:
   beyond_start: false
@@ -3629,7 +3631,6 @@ rufa_2017_12h_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192542
   finished: false
   first_name: Start
   gender: 0
@@ -3643,13 +3644,14 @@ rufa_2017_12h_start_only:
   state_code: UT
   state_name: Utah
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_24h_finished_first:
   event: rufa_2017_24h
   person: finished_first_utah_us
+  final_split_time: rufa_2017_24h_finished_first_finish_7
+  stopped_split_time: rufa_2017_24h_finished_first_finish_7
   age: 47
   beacon_url:
   beyond_start: true
@@ -3667,7 +3669,6 @@ rufa_2017_24h_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 133983
   finished: true
   first_name: Finished
   gender: 1
@@ -3681,13 +3682,14 @@ rufa_2017_24h_finished_first:
   state_code: UT
   state_name: Utah
   stopped: true
-  stopped_split_time_id: 133983
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_24h_finished_last:
   event: rufa_2017_24h
   person: finished_last
+  final_split_time: rufa_2017_24h_finished_last_finish_2
+  stopped_split_time: rufa_2017_24h_finished_last_finish_2
   age: 40
   beacon_url:
   beyond_start: true
@@ -3705,7 +3707,6 @@ rufa_2017_24h_finished_last:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 135012
   finished: true
   first_name: Finished
   gender: 0
@@ -3719,13 +3720,14 @@ rufa_2017_24h_finished_last:
   state_code: UT
   state_name: Utah
   stopped: true
-  stopped_split_time_id: 135012
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_24h_multiple_stops:
   event: rufa_2017_24h
   person: multiple_stops_utah_us
+  final_split_time: rufa_2017_24h_multiple_stops_finish_3
+  stopped_split_time: rufa_2017_24h_multiple_stops_finish_3
   age: 43
   beacon_url:
   beyond_start: true
@@ -3743,7 +3745,6 @@ rufa_2017_24h_multiple_stops:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 134812
   finished: true
   first_name: Multiple
   gender: 1
@@ -3757,13 +3758,14 @@ rufa_2017_24h_multiple_stops:
   state_code: UT
   state_name: Utah
   stopped: true
-  stopped_split_time_id: 134812
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_24h_not_started:
   event: rufa_2017_24h
   person: not_started
+  final_split_time:
+  stopped_split_time:
   age: 30
   beacon_url:
   beyond_start: false
@@ -3781,7 +3783,6 @@ rufa_2017_24h_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id:
   finished: false
   first_name: Not
   gender: 0
@@ -3795,13 +3796,14 @@ rufa_2017_24h_not_started:
   state_code: UT
   state_name: Utah
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_24h_progress_lap1:
   event: rufa_2017_24h
   person: progress_lap1
+  final_split_time: rufa_2017_24h_progress_lap1_finish_1
+  stopped_split_time:
   age: 49
   beacon_url:
   beyond_start: true
@@ -3819,7 +3821,6 @@ rufa_2017_24h_progress_lap1:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 135134
   finished: false
   first_name: Progress
   gender: 0
@@ -3833,13 +3834,14 @@ rufa_2017_24h_progress_lap1:
   state_code: UT
   state_name: Utah
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 rufa_2017_24h_progress_lap6:
   event: rufa_2017_24h
   person: progress_lap6
+  final_split_time: rufa_2017_24h_progress_lap6_finish_6
+  stopped_split_time:
   age: 33
   beacon_url:
   beyond_start: true
@@ -3857,7 +3859,6 @@ rufa_2017_24h_progress_lap6:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 134018
   finished: false
   first_name: Progress
   gender: 0
@@ -3871,13 +3872,14 @@ rufa_2017_24h_progress_lap6:
   state_code: UT
   state_name: Utah
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 sum_100k_across_dst_change:
   event: sum_100k
   person: across_dst_change
+  final_split_time: sum_100k_across_dst_change_molas_pass_aid1_in_1
+  stopped_split_time:
   age:
   beacon_url:
   beyond_start: true
@@ -3895,7 +3897,6 @@ sum_100k_across_dst_change:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192710
   finished: false
   first_name: Across
   gender: 1
@@ -3909,13 +3910,14 @@ sum_100k_across_dst_change:
   state_code:
   state_name:
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 sum_100k_drop_anvil:
   event: sum_100k
   person: drop_anvil
+  final_split_time: sum_100k_drop_anvil_anvil_cg_aid6_out_1
+  stopped_split_time: sum_100k_drop_anvil_anvil_cg_aid6_out_1
   age: 28
   beacon_url:
   beyond_start: true
@@ -3933,7 +3935,6 @@ sum_100k_drop_anvil:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 190695
   finished: false
   first_name: Drop
   gender: 0
@@ -3947,13 +3948,14 @@ sum_100k_drop_anvil:
   state_code: OH
   state_name: Ohio
   stopped: true
-  stopped_split_time_id: 190695
   synced_at:
   topic_resource_key:
   wave:
 sum_100k_on_dst_change:
   event: sum_100k
   person: on_dst_change
+  final_split_time: sum_100k_on_dst_change_molas_pass_aid1_in_1
+  stopped_split_time:
   age:
   beacon_url:
   beyond_start: true
@@ -3971,7 +3973,6 @@ sum_100k_on_dst_change:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192715
   finished: false
   first_name: 'On'
   gender: 1
@@ -3985,13 +3986,14 @@ sum_100k_on_dst_change:
   state_code:
   state_name:
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 sum_100k_progress_cascade:
   event: sum_100k
   person: progress_cascade
+  final_split_time: sum_100k_progress_cascade_cascade_creek_rd_aid3_out_1
+  stopped_split_time:
   age: 20
   beacon_url:
   beyond_start: true
@@ -4009,7 +4011,6 @@ sum_100k_progress_cascade:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192704
   finished: false
   first_name: Progress
   gender: 0
@@ -4023,13 +4024,14 @@ sum_100k_progress_cascade:
   state_code: UT
   state_name: Utah
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 sum_100k_un_started:
   event: sum_100k
   person: un_started
+  final_split_time:
+  stopped_split_time:
   age: 29
   beacon_url:
   beyond_start: false
@@ -4047,7 +4049,6 @@ sum_100k_un_started:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id:
   finished: false
   first_name: Un
   gender: 1
@@ -4061,13 +4062,14 @@ sum_100k_un_started:
   state_code: CO
   state_name: Colorado
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 sum_55k_drop_bandera:
   event: sum_55k
   person: drop_bandera
+  final_split_time: sum_55k_drop_bandera_bandera_mine_aid5_in_1
+  stopped_split_time: sum_55k_drop_bandera_bandera_mine_aid5_in_1
   age: 19
   beacon_url:
   beyond_start: true
@@ -4085,7 +4087,6 @@ sum_55k_drop_bandera:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 190683
   finished: false
   first_name: Drop
   gender: 1
@@ -4099,13 +4100,14 @@ sum_55k_drop_bandera:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 190683
   synced_at:
   topic_resource_key:
   wave:
 sum_55k_finished_first:
   event: sum_55k
   person: finished_first_colorado_us
+  final_split_time: sum_55k_finished_first_finish_1
+  stopped_split_time: sum_55k_finished_first_finish_1
   age: 44
   beacon_url:
   beyond_start: true
@@ -4123,7 +4125,6 @@ sum_55k_finished_first:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 190508
   finished: true
   first_name: Finished
   gender: 0
@@ -4137,13 +4138,14 @@ sum_55k_finished_first:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 190508
   synced_at:
   topic_resource_key:
   wave:
 sum_55k_finished_second:
   event: sum_55k
   person: finished_second_colorado_us
+  final_split_time: sum_55k_finished_second_finish_1
+  stopped_split_time: sum_55k_finished_second_finish_1
   age: 44
   beacon_url:
   beyond_start: true
@@ -4161,7 +4163,6 @@ sum_55k_finished_second:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 190528
   finished: true
   first_name: Finished
   gender: 1
@@ -4175,13 +4176,14 @@ sum_55k_finished_second:
   state_code: CO
   state_name: Colorado
   stopped: true
-  stopped_split_time_id: 190528
   synced_at:
   topic_resource_key:
   wave:
 sum_55k_not_started:
   event: sum_55k
   person: not_started_colorado_us_2019_02_01
+  final_split_time:
+  stopped_split_time:
   age: 36
   beacon_url:
   beyond_start: false
@@ -4199,7 +4201,6 @@ sum_55k_not_started:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id:
   finished: false
   first_name: Not
   gender: 2
@@ -4213,13 +4214,14 @@ sum_55k_not_started:
   state_code: CO
   state_name: Colorado
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 sum_55k_progress_rolling:
   event: sum_55k
   person: progress_rolling
+  final_split_time: sum_55k_progress_rolling_rolling_pass_aid2_out_1
+  stopped_split_time:
   age: 55
   beacon_url:
   beyond_start: true
@@ -4237,7 +4239,6 @@ sum_55k_progress_rolling:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 190672
   finished: false
   first_name: Progress
   gender: 1
@@ -4251,13 +4252,14 @@ sum_55k_progress_rolling:
   state_code: CA
   state_name: California
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 sum_55k_series_finisher:
   event: sum_55k
   person: series_finisher
+  final_split_time: sum_55k_series_finisher_finish_1
+  stopped_split_time:
   age: 34
   beacon_url:
   beyond_start: true
@@ -4275,7 +4277,6 @@ sum_55k_series_finisher:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192734
   finished: true
   first_name: Series
   gender: 0
@@ -4289,13 +4290,14 @@ sum_55k_series_finisher:
   state_code:
   state_name:
   stopped: true
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 sum_55k_slow_finisher:
   event: sum_55k
   person: slow_finisher
+  final_split_time: sum_55k_slow_finisher_finish_1
+  stopped_split_time:
   age: 64
   beacon_url:
   beyond_start: true
@@ -4313,7 +4315,6 @@ sum_55k_slow_finisher:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 192744
   finished: true
   first_name: Slow
   gender: 0
@@ -4327,13 +4328,14 @@ sum_55k_slow_finisher:
   state_code: UT
   state_name:
   stopped: true
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:
 sum_55k_start_only:
   event: sum_55k
   person: start_only_colorado_us_2019_02_01
+  final_split_time: sum_55k_start_only_start_1
+  stopped_split_time:
   age: 49
   beacon_url:
   beyond_start: false
@@ -4351,7 +4353,6 @@ sum_55k_start_only:
   email:
   emergency_contact:
   emergency_phone:
-  final_split_time_id: 190816
   finished: false
   first_name: Start
   gender: 0
@@ -4365,7 +4366,6 @@ sum_55k_start_only:
   state_code: CO
   state_name: Colorado
   stopped: false
-  stopped_split_time_id:
   synced_at:
   topic_resource_key:
   wave:

--- a/spec/fixtures/raw_times.yml
+++ b/spec/fixtures/raw_times.yml
@@ -1,6 +1,7 @@
 ---
 raw_time_0001:
   event_group: hardrock_2015
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time: 2017-07-07 16:31:00.000000000 Z
@@ -17,11 +18,11 @@ raw_time_0001:
   sortable_bib_number: 102
   source: internal
   split_name: Pole Creek
-  split_time_id:
   stopped_here:
   with_pacer:
 raw_time_0002:
   event_group: hardrock_2015
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time: 2017-07-07 20:20:00.000000000 Z
@@ -38,11 +39,11 @@ raw_time_0002:
   sortable_bib_number: 103
   source: internal
   split_name: Pole Creek
-  split_time_id:
   stopped_here:
   with_pacer:
 raw_time_0003:
   event_group: sum
+  split_time: sum_55k_finished_second_rolling_pass_aid2_in_1
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -59,11 +60,11 @@ raw_time_0003:
   sortable_bib_number: 101
   source: Live Entry (1)
   split_name: Rolling Pass (Aid2)
-  split_time_id: 190522
   stopped_here: false
   with_pacer: false
 raw_time_0004:
   event_group: sum
+  split_time: sum_55k_finished_second_rolling_pass_aid2_in_1
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -80,11 +81,11 @@ raw_time_0004:
   sortable_bib_number: 101
   source: Live Entry (1)
   split_name: Rolling Pass (Aid2)
-  split_time_id: 190522
   stopped_here: false
   with_pacer: false
 raw_time_0005:
   event_group: sum
+  split_time: sum_55k_finished_second_rolling_pass_aid2_out_1
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -101,11 +102,11 @@ raw_time_0005:
   sortable_bib_number: 101
   source: Live Entry (1)
   split_name: Rolling Pass (Aid2)
-  split_time_id: 190523
   stopped_here: false
   with_pacer: false
 raw_time_0006:
   event_group: sum
+  split_time: sum_55k_finished_second_rolling_pass_aid2_out_1
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -122,11 +123,11 @@ raw_time_0006:
   sortable_bib_number: 101
   source: Live Entry (1)
   split_name: Rolling Pass (Aid2)
-  split_time_id: 190523
   stopped_here: false
   with_pacer: false
 raw_time_0007:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -143,11 +144,11 @@ raw_time_0007:
   sortable_bib_number: 103
   source: Live Entry (1)
   split_name: Anvil CG (Aid6)
-  split_time_id:
   stopped_here: false
   with_pacer: false
 raw_time_0008:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -164,11 +165,11 @@ raw_time_0008:
   sortable_bib_number: 103
   source: Live Entry (1)
   split_name: Anvil CG (Aid6)
-  split_time_id:
   stopped_here: true
   with_pacer: false
 raw_time_0009:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -185,11 +186,11 @@ raw_time_0009:
   sortable_bib_number: 103
   source: Live Entry (1)
   split_name: Anvil CG (Aid6)
-  split_time_id:
   stopped_here: true
   with_pacer: false
 raw_time_0010:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -206,11 +207,11 @@ raw_time_0010:
   sortable_bib_number: 103
   source: Live Entry (1)
   split_name: Bandera Mine (Aid5)
-  split_time_id:
   stopped_here: false
   with_pacer: false
 raw_time_0011:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -227,11 +228,11 @@ raw_time_0011:
   sortable_bib_number: 114
   source: Live Entry (1)
   split_name: Start
-  split_time_id:
   stopped_here: false
   with_pacer: false
 raw_time_0012:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -248,11 +249,11 @@ raw_time_0012:
   sortable_bib_number: 130
   source: Live Entry (1)
   split_name: Rolling Pass (Aid2)
-  split_time_id:
   stopped_here: false
   with_pacer: false
 raw_time_0013:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -269,11 +270,11 @@ raw_time_0013:
   sortable_bib_number: 130
   source: another
   split_name: Rolling Pass (Aid2)
-  split_time_id:
   stopped_here: false
   with_pacer: false
 raw_time_0014:
   event_group: sum
+  split_time:
   creator:
   reviewer: admin_user
   absolute_time:
@@ -290,11 +291,11 @@ raw_time_0014:
   sortable_bib_number: 130
   source: another
   split_name: Rolling Pass (Aid2)
-  split_time_id:
   stopped_here: false
   with_pacer: false
 raw_time_0015:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -311,11 +312,11 @@ raw_time_0015:
   sortable_bib_number: 130
   source: another
   split_name: Rolling Pass (Aid2)
-  split_time_id:
   stopped_here: false
   with_pacer: false
 raw_time_0016:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time: 2018-06-30 13:00:00.000000000 Z
@@ -332,11 +333,11 @@ raw_time_0016:
   sortable_bib_number: 777
   source: internal
   split_name: Start
-  split_time_id:
   stopped_here: false
   with_pacer: false
 raw_time_0017:
   event_group: sum
+  split_time:
   creator:
   reviewer: admin_user
   absolute_time:
@@ -353,11 +354,11 @@ raw_time_0017:
   sortable_bib_number: 777
   source: internal
   split_name: Start
-  split_time_id:
   stopped_here: false
   with_pacer: false
 raw_time_0018:
   event_group: sum
+  split_time:
   creator:
   reviewer: admin_user
   absolute_time:
@@ -374,11 +375,11 @@ raw_time_0018:
   sortable_bib_number: 999
   source: internal
   split_name: Rolling Pass (Aid2)
-  split_time_id:
   stopped_here:
   with_pacer:
 raw_time_0019:
   event_group: sum
+  split_time:
   creator:
   reviewer: admin_user
   absolute_time:
@@ -395,11 +396,11 @@ raw_time_0019:
   sortable_bib_number: 999
   source: internal
   split_name: Rolling Pass (Aid2)
-  split_time_id:
   stopped_here:
   with_pacer:
 raw_time_0020:
   event_group: sum
+  split_time: sum_100k_drop_anvil_rolling_pass_aid2_out_1
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -416,11 +417,11 @@ raw_time_0020:
   sortable_bib_number: 999
   source: internal
   split_name: Rolling Pass (Aid2)
-  split_time_id: 190697
   stopped_here:
   with_pacer:
 raw_time_0021:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -437,11 +438,11 @@ raw_time_0021:
   sortable_bib_number: 101
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
-  split_time_id:
   stopped_here:
   with_pacer: false
 raw_time_0022:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -458,11 +459,11 @@ raw_time_0022:
   sortable_bib_number: 101
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
-  split_time_id:
   stopped_here:
   with_pacer: false
 raw_time_0023:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer:
   absolute_time:
@@ -479,11 +480,11 @@ raw_time_0023:
   sortable_bib_number: 130
   source: ost-live-entry
   split_name: Molas Pass (Aid1)
-  split_time_id:
   stopped_here:
   with_pacer: false
 raw_time_0024:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer:
   absolute_time:
@@ -500,11 +501,11 @@ raw_time_0024:
   sortable_bib_number: 130
   source: ost-live-entry
   split_name: Molas Pass (Aid1)
-  split_time_id:
   stopped_here:
   with_pacer: false
 raw_time_0025:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -521,11 +522,11 @@ raw_time_0025:
   sortable_bib_number: 130
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
-  split_time_id:
   stopped_here:
   with_pacer: false
 raw_time_0026:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer:
   absolute_time:
@@ -542,11 +543,11 @@ raw_time_0026:
   sortable_bib_number: 130
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
-  split_time_id:
   stopped_here: false
   with_pacer: false
 raw_time_0027:
   event_group: sum
+  split_time:
   creator: admin_user
   reviewer: admin_user
   absolute_time:
@@ -563,11 +564,11 @@ raw_time_0027:
   sortable_bib_number: 130
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
-  split_time_id:
   stopped_here:
   with_pacer: false
 raw_time_0028:
   event_group: sum
+  split_time: sum_100k_drop_anvil_anvil_cg_aid6_in_1
   creator: admin_user
   reviewer:
   absolute_time:
@@ -584,11 +585,11 @@ raw_time_0028:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Anvil CG (Aid6)
-  split_time_id: 190694
   stopped_here:
   with_pacer: false
 raw_time_0029:
   event_group: sum
+  split_time: sum_100k_drop_anvil_anvil_cg_aid6_out_1
   creator: admin_user
   reviewer:
   absolute_time:
@@ -605,11 +606,11 @@ raw_time_0029:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Anvil CG (Aid6)
-  split_time_id: 190695
   stopped_here:
   with_pacer: false
 raw_time_0030:
   event_group: sum
+  split_time: sum_100k_drop_anvil_cascade_creek_rd_aid3_in_1
   creator: admin_user
   reviewer:
   absolute_time:
@@ -626,11 +627,11 @@ raw_time_0030:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Cascade Creek Rd (Aid3)
-  split_time_id: 190701
   stopped_here:
   with_pacer: false
 raw_time_0031:
   event_group: sum
+  split_time: sum_100k_drop_anvil_cascade_creek_rd_aid3_out_1
   creator: admin_user
   reviewer:
   absolute_time:
@@ -647,11 +648,11 @@ raw_time_0031:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Cascade Creek Rd (Aid3)
-  split_time_id: 190702
   stopped_here:
   with_pacer: false
 raw_time_0032:
   event_group: sum
+  split_time: sum_100k_drop_anvil_engineer_mtn_th_aid4_in_1
   creator: admin_user
   reviewer:
   absolute_time:
@@ -668,11 +669,11 @@ raw_time_0032:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Engineer Mtn TH (Aid4)
-  split_time_id: 190703
   stopped_here:
   with_pacer: false
 raw_time_0033:
   event_group: sum
+  split_time: sum_100k_drop_anvil_engineer_mtn_th_aid4_out_1
   creator: admin_user
   reviewer:
   absolute_time:
@@ -689,11 +690,11 @@ raw_time_0033:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Engineer Mtn TH (Aid4)
-  split_time_id: 190704
   stopped_here:
   with_pacer: false
 raw_time_0034:
   event_group: sum
+  split_time: sum_100k_drop_anvil_molas_pass_aid1_in_1
   creator: admin_user
   reviewer:
   absolute_time:
@@ -710,11 +711,11 @@ raw_time_0034:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Molas Pass (Aid1)
-  split_time_id: 190699
   stopped_here:
   with_pacer: false
 raw_time_0035:
   event_group: sum
+  split_time: sum_100k_drop_anvil_molas_pass_aid1_out_1
   creator: admin_user
   reviewer:
   absolute_time:
@@ -731,11 +732,11 @@ raw_time_0035:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Molas Pass (Aid1)
-  split_time_id: 190700
   stopped_here:
   with_pacer: false
 raw_time_0036:
   event_group: sum
+  split_time: sum_100k_drop_anvil_rolling_pass_aid2_in_1
   creator: admin_user
   reviewer:
   absolute_time:
@@ -752,11 +753,11 @@ raw_time_0036:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
-  split_time_id: 190696
   stopped_here:
   with_pacer: false
 raw_time_0037:
   event_group: sum
+  split_time: sum_100k_drop_anvil_rolling_pass_aid2_out_1
   creator: admin_user
   reviewer:
   absolute_time:
@@ -773,11 +774,11 @@ raw_time_0037:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Rolling Pass (Aid2)
-  split_time_id: 190697
   stopped_here:
   with_pacer: false
 raw_time_0038:
   event_group: sum
+  split_time: sum_100k_drop_anvil_start_1
   creator: admin_user
   reviewer:
   absolute_time:
@@ -794,6 +795,5 @@ raw_time_0038:
   sortable_bib_number: 999
   source: ost-live-entry
   split_name: Start
-  split_time_id: 190698
   stopped_here:
   with_pacer: false

--- a/spec/fixtures/split_times.yml
+++ b/spec/fixtures/split_times.yml
@@ -1,8 +1,19 @@
 ---
+hardrock_2015_tuan_jacobs_start_1:
+  effort: hardrock_2015_tuan_jacobs
+  split: hardrock_ccw_start
+  absolute_time: 2015-07-10 12:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 hardrock_2015_tuan_jacobs_cunningham_in_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_cunningham
-  id: 14
   absolute_time: 2015-07-10 13:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 5880.0
@@ -15,7 +26,6 @@ hardrock_2015_tuan_jacobs_cunningham_in_1:
 hardrock_2015_tuan_jacobs_cunningham_out_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_cunningham
-  id: 15
   absolute_time: 2015-07-10 13:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 5880.0
@@ -28,7 +38,6 @@ hardrock_2015_tuan_jacobs_cunningham_out_1:
 hardrock_2015_tuan_jacobs_sherman_in_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_sherman
-  id: 20
   absolute_time: 2015-07-10 17:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 20280.0
@@ -41,7 +50,6 @@ hardrock_2015_tuan_jacobs_sherman_in_1:
 hardrock_2015_tuan_jacobs_sherman_out_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_sherman
-  id: 21
   absolute_time: 2015-07-10 17:39:00.000000000 Z
   data_status: 2
   elapsed_seconds: 20340.0
@@ -54,7 +62,6 @@ hardrock_2015_tuan_jacobs_sherman_out_1:
 hardrock_2015_tuan_jacobs_grouse_in_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_grouse
-  id: 24
   absolute_time: 2015-07-10 20:52:00.000000000 Z
   data_status: 2
   elapsed_seconds: 31920.0
@@ -67,7 +74,6 @@ hardrock_2015_tuan_jacobs_grouse_in_1:
 hardrock_2015_tuan_jacobs_grouse_out_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_grouse
-  id: 25
   absolute_time: 2015-07-10 20:57:00.000000000 Z
   data_status: 2
   elapsed_seconds: 32220.0
@@ -80,7 +86,6 @@ hardrock_2015_tuan_jacobs_grouse_out_1:
 hardrock_2015_tuan_jacobs_ouray_in_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_ouray
-  id: 28
   absolute_time: 2015-07-10 23:39:00.000000000 Z
   data_status: 2
   elapsed_seconds: 41940.0
@@ -93,7 +98,6 @@ hardrock_2015_tuan_jacobs_ouray_in_1:
 hardrock_2015_tuan_jacobs_ouray_out_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_ouray
-  id: 29
   absolute_time: 2015-07-10 23:45:00.000000000 Z
   data_status: 2
   elapsed_seconds: 42300.0
@@ -106,7 +110,6 @@ hardrock_2015_tuan_jacobs_ouray_out_1:
 hardrock_2015_tuan_jacobs_telluride_in_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_telluride
-  id: 34
   absolute_time: 2015-07-11 03:12:00.000000000 Z
   data_status: 2
   elapsed_seconds: 54720.0
@@ -119,7 +122,6 @@ hardrock_2015_tuan_jacobs_telluride_in_1:
 hardrock_2015_tuan_jacobs_telluride_out_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_telluride
-  id: 35
   absolute_time: 2015-07-11 03:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 55320.0
@@ -132,7 +134,6 @@ hardrock_2015_tuan_jacobs_telluride_out_1:
 hardrock_2015_tuan_jacobs_putnam_in_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_putnam
-  id: 40
   absolute_time: 2015-07-11 10:06:00.000000000 Z
   data_status: 2
   elapsed_seconds: 79560.0
@@ -145,7 +146,6 @@ hardrock_2015_tuan_jacobs_putnam_in_1:
 hardrock_2015_tuan_jacobs_putnam_out_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_putnam
-  id: 41
   absolute_time: 2015-07-11 10:06:00.000000000 Z
   data_status: 2
   elapsed_seconds: 79560.0
@@ -158,7 +158,6 @@ hardrock_2015_tuan_jacobs_putnam_out_1:
 hardrock_2015_tuan_jacobs_finish_1:
   effort: hardrock_2015_tuan_jacobs
   split: hardrock_ccw_finish
-  id: 42
   absolute_time: 2015-07-11 11:13:00.000000000 Z
   data_status: 2
   elapsed_seconds: 83580.0
@@ -171,7 +170,6 @@ hardrock_2015_tuan_jacobs_finish_1:
 hardrock_2015_erich_larson_start_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_start
-  id: 43
   absolute_time: 2015-07-10 12:00:11.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -184,7 +182,6 @@ hardrock_2015_erich_larson_start_1:
 hardrock_2015_erich_larson_cunningham_in_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_cunningham
-  id: 44
   absolute_time: 2015-07-10 14:00:22.000000000 Z
   data_status: 2
   elapsed_seconds: 7211.0
@@ -197,7 +194,6 @@ hardrock_2015_erich_larson_cunningham_in_1:
 hardrock_2015_erich_larson_cunningham_out_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_cunningham
-  id: 45
   absolute_time: 2015-07-10 14:01:33.000000000 Z
   data_status: 2
   elapsed_seconds: 7282.0
@@ -210,7 +206,6 @@ hardrock_2015_erich_larson_cunningham_out_1:
 hardrock_2015_erich_larson_sherman_in_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_sherman
-  id: 50
   absolute_time: 2015-07-10 18:06:50.000000000 Z
   data_status: 2
   elapsed_seconds: 21999.0
@@ -223,7 +218,6 @@ hardrock_2015_erich_larson_sherman_in_1:
 hardrock_2015_erich_larson_sherman_out_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_sherman
-  id: 51
   absolute_time: 2015-07-10 18:07:00.000000000 Z
   data_status: 2
   elapsed_seconds: 22009.0
@@ -236,7 +230,6 @@ hardrock_2015_erich_larson_sherman_out_1:
 hardrock_2015_erich_larson_grouse_in_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_grouse
-  id: 54
   absolute_time: 2015-07-10 21:21:00.000000000 Z
   data_status: 2
   elapsed_seconds: 33649.0
@@ -249,7 +242,6 @@ hardrock_2015_erich_larson_grouse_in_1:
 hardrock_2015_erich_larson_grouse_out_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_grouse
-  id: 55
   absolute_time: 2015-07-10 21:24:59.000000000 Z
   data_status: 2
   elapsed_seconds: 33888.0
@@ -262,7 +254,6 @@ hardrock_2015_erich_larson_grouse_out_1:
 hardrock_2015_erich_larson_ouray_in_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_ouray
-  id: 58
   absolute_time: 2015-07-11 00:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 44389.0
@@ -275,7 +266,6 @@ hardrock_2015_erich_larson_ouray_in_1:
 hardrock_2015_erich_larson_ouray_out_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_ouray
-  id: 59
   absolute_time: 2015-07-11 00:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 44629.0
@@ -288,7 +278,6 @@ hardrock_2015_erich_larson_ouray_out_1:
 hardrock_2015_erich_larson_telluride_in_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_telluride
-  id: 64
   absolute_time: 2015-07-11 04:29:00.000000000 Z
   data_status: 2
   elapsed_seconds: 59329.0
@@ -301,7 +290,6 @@ hardrock_2015_erich_larson_telluride_in_1:
 hardrock_2015_erich_larson_telluride_out_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_telluride
-  id: 65
   absolute_time: 2015-07-11 04:33:03.000000000 Z
   data_status: 2
   elapsed_seconds: 59572.0
@@ -314,7 +302,6 @@ hardrock_2015_erich_larson_telluride_out_1:
 hardrock_2015_erich_larson_putnam_in_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_putnam
-  id: 70
   absolute_time: 2015-07-11 12:39:05.000000000 Z
   data_status: 2
   elapsed_seconds: 88734.0
@@ -327,7 +314,6 @@ hardrock_2015_erich_larson_putnam_in_1:
 hardrock_2015_erich_larson_putnam_out_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_putnam
-  id: 71
   absolute_time: 2015-07-11 12:39:07.000000000 Z
   data_status: 2
   elapsed_seconds: 88736.0
@@ -340,7 +326,6 @@ hardrock_2015_erich_larson_putnam_out_1:
 hardrock_2015_erich_larson_finish_1:
   effort: hardrock_2015_erich_larson
   split: hardrock_ccw_finish
-  id: 72
   absolute_time: 2015-07-11 13:45:09.000000000 Z
   data_status: 2
   elapsed_seconds: 92698.0
@@ -353,7 +338,6 @@ hardrock_2015_erich_larson_finish_1:
 hardrock_2015_leif_carter_start_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_start
-  id: 253
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -366,7 +350,6 @@ hardrock_2015_leif_carter_start_1:
 hardrock_2015_leif_carter_cunningham_in_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_cunningham
-  id: 254
   absolute_time: 2015-07-10 13:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 6780.0
@@ -379,7 +362,6 @@ hardrock_2015_leif_carter_cunningham_in_1:
 hardrock_2015_leif_carter_cunningham_out_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_cunningham
-  id: 255
   absolute_time: 2015-07-10 13:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 6780.0
@@ -392,7 +374,6 @@ hardrock_2015_leif_carter_cunningham_out_1:
 hardrock_2015_leif_carter_sherman_in_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_sherman
-  id: 260
   absolute_time: 2015-07-10 18:06:00.000000000 Z
   data_status: 2
   elapsed_seconds: 21960.0
@@ -405,7 +386,6 @@ hardrock_2015_leif_carter_sherman_in_1:
 hardrock_2015_leif_carter_sherman_out_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_sherman
-  id: 261
   absolute_time: 2015-07-10 18:08:00.000000000 Z
   data_status: 2
   elapsed_seconds: 22080.0
@@ -418,7 +398,6 @@ hardrock_2015_leif_carter_sherman_out_1:
 hardrock_2015_leif_carter_grouse_in_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_grouse
-  id: 264
   absolute_time: 2015-07-10 21:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 34200.0
@@ -431,7 +410,6 @@ hardrock_2015_leif_carter_grouse_in_1:
 hardrock_2015_leif_carter_grouse_out_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_grouse
-  id: 265
   absolute_time: 2015-07-10 21:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 34560.0
@@ -444,7 +422,6 @@ hardrock_2015_leif_carter_grouse_out_1:
 hardrock_2015_leif_carter_ouray_in_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_ouray
-  id: 268
   absolute_time: 2015-07-11 00:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 45960.0
@@ -457,7 +434,6 @@ hardrock_2015_leif_carter_ouray_in_1:
 hardrock_2015_leif_carter_ouray_out_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_ouray
-  id: 269
   absolute_time: 2015-07-11 00:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 45960.0
@@ -470,7 +446,6 @@ hardrock_2015_leif_carter_ouray_out_1:
 hardrock_2015_leif_carter_telluride_in_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_telluride
-  id: 274
   absolute_time: 2015-07-11 05:18:00.000000000 Z
   data_status: 2
   elapsed_seconds: 62280.0
@@ -483,7 +458,6 @@ hardrock_2015_leif_carter_telluride_in_1:
 hardrock_2015_leif_carter_telluride_out_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_telluride
-  id: 275
   absolute_time: 2015-07-11 05:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 62640.0
@@ -496,7 +470,6 @@ hardrock_2015_leif_carter_telluride_out_1:
 hardrock_2015_leif_carter_putnam_in_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_putnam
-  id: 280
   absolute_time: 2015-07-11 15:02:00.000000000 Z
   data_status: 2
   elapsed_seconds: 97320.0
@@ -509,7 +482,6 @@ hardrock_2015_leif_carter_putnam_in_1:
 hardrock_2015_leif_carter_putnam_out_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_putnam
-  id: 281
   absolute_time: 2015-07-11 15:06:00.000000000 Z
   data_status: 2
   elapsed_seconds: 97560.0
@@ -522,7 +494,6 @@ hardrock_2015_leif_carter_putnam_out_1:
 hardrock_2015_leif_carter_finish_1:
   effort: hardrock_2015_leif_carter
   split: hardrock_ccw_finish
-  id: 282
   absolute_time: 2015-07-11 16:54:00.000000000 Z
   data_status: 2
   elapsed_seconds: 104040.0
@@ -535,7 +506,6 @@ hardrock_2015_leif_carter_finish_1:
 hardrock_2015_carmine_adams_start_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_start
-  id: 403
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -548,7 +518,6 @@ hardrock_2015_carmine_adams_start_1:
 hardrock_2015_carmine_adams_cunningham_in_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_cunningham
-  id: 404
   absolute_time: 2015-07-10 14:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8520.0
@@ -561,7 +530,6 @@ hardrock_2015_carmine_adams_cunningham_in_1:
 hardrock_2015_carmine_adams_cunningham_out_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_cunningham
-  id: 405
   absolute_time: 2015-07-10 14:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8520.0
@@ -574,7 +542,6 @@ hardrock_2015_carmine_adams_cunningham_out_1:
 hardrock_2015_carmine_adams_sherman_in_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_sherman
-  id: 410
   absolute_time: 2015-07-10 19:34:00.000000000 Z
   data_status: 2
   elapsed_seconds: 27240.0
@@ -587,7 +554,6 @@ hardrock_2015_carmine_adams_sherman_in_1:
 hardrock_2015_carmine_adams_sherman_out_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_sherman
-  id: 411
   absolute_time: 2015-07-10 19:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 27600.0
@@ -600,7 +566,6 @@ hardrock_2015_carmine_adams_sherman_out_1:
 hardrock_2015_carmine_adams_grouse_in_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_grouse
-  id: 414
   absolute_time: 2015-07-10 23:55:00.000000000 Z
   data_status: 2
   elapsed_seconds: 42900.0
@@ -613,7 +578,6 @@ hardrock_2015_carmine_adams_grouse_in_1:
 hardrock_2015_carmine_adams_grouse_out_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_grouse
-  id: 415
   absolute_time: 2015-07-11 00:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 43200.0
@@ -626,7 +590,6 @@ hardrock_2015_carmine_adams_grouse_out_1:
 hardrock_2015_carmine_adams_ouray_in_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_ouray
-  id: 418
   absolute_time: 2015-07-11 03:51:00.000000000 Z
   data_status: 2
   elapsed_seconds: 57060.0
@@ -639,7 +602,6 @@ hardrock_2015_carmine_adams_ouray_in_1:
 hardrock_2015_carmine_adams_ouray_out_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_ouray
-  id: 419
   absolute_time: 2015-07-11 04:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 57600.0
@@ -652,7 +614,6 @@ hardrock_2015_carmine_adams_ouray_out_1:
 hardrock_2015_carmine_adams_telluride_in_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_telluride
-  id: 424
   absolute_time: 2015-07-11 08:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 75540.0
@@ -665,7 +626,6 @@ hardrock_2015_carmine_adams_telluride_in_1:
 hardrock_2015_carmine_adams_telluride_out_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_telluride
-  id: 425
   absolute_time: 2015-07-11 09:09:00.000000000 Z
   data_status: 2
   elapsed_seconds: 76140.0
@@ -678,7 +638,6 @@ hardrock_2015_carmine_adams_telluride_out_1:
 hardrock_2015_carmine_adams_putnam_in_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_putnam
-  id: 430
   absolute_time: 2015-07-11 17:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 106800.0
@@ -691,7 +650,6 @@ hardrock_2015_carmine_adams_putnam_in_1:
 hardrock_2015_carmine_adams_putnam_out_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_putnam
-  id: 431
   absolute_time: 2015-07-11 17:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 106800.0
@@ -704,7 +662,6 @@ hardrock_2015_carmine_adams_putnam_out_1:
 hardrock_2015_carmine_adams_finish_1:
   effort: hardrock_2015_carmine_adams
   split: hardrock_ccw_finish
-  id: 432
   absolute_time: 2015-07-11 18:57:00.000000000 Z
   data_status: 2
   elapsed_seconds: 111420.0
@@ -717,7 +674,6 @@ hardrock_2015_carmine_adams_finish_1:
 hardrock_2015_garry_kuhlman_start_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_start
-  id: 523
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -730,7 +686,6 @@ hardrock_2015_garry_kuhlman_start_1:
 hardrock_2015_garry_kuhlman_cunningham_in_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_cunningham
-  id: 524
   absolute_time: 2015-07-10 14:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9000.0
@@ -743,7 +698,6 @@ hardrock_2015_garry_kuhlman_cunningham_in_1:
 hardrock_2015_garry_kuhlman_cunningham_out_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_cunningham
-  id: 525
   absolute_time: 2015-07-10 14:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9000.0
@@ -756,7 +710,6 @@ hardrock_2015_garry_kuhlman_cunningham_out_1:
 hardrock_2015_garry_kuhlman_sherman_in_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_sherman
-  id: 530
   absolute_time: 2015-07-10 19:52:00.000000000 Z
   data_status: 2
   elapsed_seconds: 28320.0
@@ -769,7 +722,6 @@ hardrock_2015_garry_kuhlman_sherman_in_1:
 hardrock_2015_garry_kuhlman_sherman_out_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_sherman
-  id: 531
   absolute_time: 2015-07-10 19:58:00.000000000 Z
   data_status: 2
   elapsed_seconds: 28680.0
@@ -782,7 +734,6 @@ hardrock_2015_garry_kuhlman_sherman_out_1:
 hardrock_2015_garry_kuhlman_grouse_in_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_grouse
-  id: 534
   absolute_time: 2015-07-10 23:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 42780.0
@@ -795,7 +746,6 @@ hardrock_2015_garry_kuhlman_grouse_in_1:
 hardrock_2015_garry_kuhlman_grouse_out_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_grouse
-  id: 535
   absolute_time: 2015-07-10 23:56:00.000000000 Z
   data_status: 2
   elapsed_seconds: 42960.0
@@ -808,7 +758,6 @@ hardrock_2015_garry_kuhlman_grouse_out_1:
 hardrock_2015_garry_kuhlman_ouray_in_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_ouray
-  id: 538
   absolute_time: 2015-07-11 03:42:00.000000000 Z
   data_status: 2
   elapsed_seconds: 56520.0
@@ -821,7 +770,6 @@ hardrock_2015_garry_kuhlman_ouray_in_1:
 hardrock_2015_garry_kuhlman_ouray_out_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_ouray
-  id: 539
   absolute_time: 2015-07-11 03:51:00.000000000 Z
   data_status: 2
   elapsed_seconds: 57060.0
@@ -834,7 +782,6 @@ hardrock_2015_garry_kuhlman_ouray_out_1:
 hardrock_2015_garry_kuhlman_telluride_in_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_telluride
-  id: 544
   absolute_time: 2015-07-11 08:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 75540.0
@@ -847,7 +794,6 @@ hardrock_2015_garry_kuhlman_telluride_in_1:
 hardrock_2015_garry_kuhlman_telluride_out_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_telluride
-  id: 545
   absolute_time: 2015-07-11 09:04:00.000000000 Z
   data_status: 2
   elapsed_seconds: 75840.0
@@ -860,7 +806,6 @@ hardrock_2015_garry_kuhlman_telluride_out_1:
 hardrock_2015_garry_kuhlman_putnam_in_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_putnam
-  id: 550
   absolute_time: 2015-07-11 18:11:00.000000000 Z
   data_status: 2
   elapsed_seconds: 108660.0
@@ -873,7 +818,6 @@ hardrock_2015_garry_kuhlman_putnam_in_1:
 hardrock_2015_garry_kuhlman_putnam_out_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_putnam
-  id: 551
   absolute_time: 2015-07-11 18:11:00.000000000 Z
   data_status: 2
   elapsed_seconds: 108660.0
@@ -886,7 +830,6 @@ hardrock_2015_garry_kuhlman_putnam_out_1:
 hardrock_2015_garry_kuhlman_finish_1:
   effort: hardrock_2015_garry_kuhlman
   split: hardrock_ccw_finish
-  id: 552
   absolute_time: 2015-07-11 19:39:00.000000000 Z
   data_status: 2
   elapsed_seconds: 113940.0
@@ -899,7 +842,6 @@ hardrock_2015_garry_kuhlman_finish_1:
 hardrock_2015_darius_jacobson_start_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_start
-  id: 553
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -912,7 +854,6 @@ hardrock_2015_darius_jacobson_start_1:
 hardrock_2015_darius_jacobson_cunningham_in_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_cunningham
-  id: 554
   absolute_time: 2015-07-10 14:18:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8280.0
@@ -925,7 +866,6 @@ hardrock_2015_darius_jacobson_cunningham_in_1:
 hardrock_2015_darius_jacobson_cunningham_out_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_cunningham
-  id: 555
   absolute_time: 2015-07-10 14:18:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8280.0
@@ -938,7 +878,6 @@ hardrock_2015_darius_jacobson_cunningham_out_1:
 hardrock_2015_darius_jacobson_sherman_in_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_sherman
-  id: 560
   absolute_time: 2015-07-10 19:09:00.000000000 Z
   data_status: 2
   elapsed_seconds: 25740.0
@@ -951,7 +890,6 @@ hardrock_2015_darius_jacobson_sherman_in_1:
 hardrock_2015_darius_jacobson_sherman_out_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_sherman
-  id: 561
   absolute_time: 2015-07-10 19:18:00.000000000 Z
   data_status: 2
   elapsed_seconds: 26280.0
@@ -964,7 +902,6 @@ hardrock_2015_darius_jacobson_sherman_out_1:
 hardrock_2015_darius_jacobson_grouse_in_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_grouse
-  id: 564
   absolute_time: 2015-07-10 23:17:00.000000000 Z
   data_status: 2
   elapsed_seconds: 40620.0
@@ -977,7 +914,6 @@ hardrock_2015_darius_jacobson_grouse_in_1:
 hardrock_2015_darius_jacobson_grouse_out_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_grouse
-  id: 565
   absolute_time: 2015-07-10 23:34:00.000000000 Z
   data_status: 2
   elapsed_seconds: 41640.0
@@ -990,7 +926,6 @@ hardrock_2015_darius_jacobson_grouse_out_1:
 hardrock_2015_darius_jacobson_telluride_in_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_telluride
-  id: 574
   absolute_time: 2015-07-11 08:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 74400.0
@@ -1003,7 +938,6 @@ hardrock_2015_darius_jacobson_telluride_in_1:
 hardrock_2015_darius_jacobson_telluride_out_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_telluride
-  id: 575
   absolute_time: 2015-07-11 08:54:00.000000000 Z
   data_status: 2
   elapsed_seconds: 75240.0
@@ -1016,7 +950,6 @@ hardrock_2015_darius_jacobson_telluride_out_1:
 hardrock_2015_darius_jacobson_putnam_in_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_putnam
-  id: 580
   absolute_time: 2015-07-11 18:26:00.000000000 Z
   data_status: 2
   elapsed_seconds: 109560.0
@@ -1029,7 +962,6 @@ hardrock_2015_darius_jacobson_putnam_in_1:
 hardrock_2015_darius_jacobson_putnam_out_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_putnam
-  id: 581
   absolute_time: 2015-07-11 18:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 109620.0
@@ -1042,7 +974,6 @@ hardrock_2015_darius_jacobson_putnam_out_1:
 hardrock_2015_darius_jacobson_finish_1:
   effort: hardrock_2015_darius_jacobson
   split: hardrock_ccw_finish
-  id: 582
   absolute_time: 2015-07-11 19:43:00.000000000 Z
   data_status: 2
   elapsed_seconds: 114180.0
@@ -1055,7 +986,6 @@ hardrock_2015_darius_jacobson_finish_1:
 hardrock_2015_santa_green_start_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_start
-  id: 673
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -1068,7 +998,6 @@ hardrock_2015_santa_green_start_1:
 hardrock_2015_santa_green_cunningham_in_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_cunningham
-  id: 674
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8640.0
@@ -1081,7 +1010,6 @@ hardrock_2015_santa_green_cunningham_in_1:
 hardrock_2015_santa_green_cunningham_out_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_cunningham
-  id: 675
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8640.0
@@ -1094,7 +1022,6 @@ hardrock_2015_santa_green_cunningham_out_1:
 hardrock_2015_santa_green_sherman_in_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_sherman
-  id: 680
   absolute_time: 2015-07-10 19:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 27360.0
@@ -1107,7 +1034,6 @@ hardrock_2015_santa_green_sherman_in_1:
 hardrock_2015_santa_green_sherman_out_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_sherman
-  id: 681
   absolute_time: 2015-07-10 19:42:00.000000000 Z
   data_status: 2
   elapsed_seconds: 27720.0
@@ -1120,7 +1046,6 @@ hardrock_2015_santa_green_sherman_out_1:
 hardrock_2015_santa_green_grouse_in_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_grouse
-  id: 684
   absolute_time: 2015-07-10 23:52:00.000000000 Z
   data_status: 2
   elapsed_seconds: 42720.0
@@ -1133,7 +1058,6 @@ hardrock_2015_santa_green_grouse_in_1:
 hardrock_2015_santa_green_grouse_out_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_grouse
-  id: 685
   absolute_time: 2015-07-10 23:52:00.000000000 Z
   data_status: 2
   elapsed_seconds: 42720.0
@@ -1146,7 +1070,6 @@ hardrock_2015_santa_green_grouse_out_1:
 hardrock_2015_santa_green_ouray_in_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_ouray
-  id: 688
   absolute_time: 2015-07-11 04:14:00.000000000 Z
   data_status: 2
   elapsed_seconds: 58440.0
@@ -1159,7 +1082,6 @@ hardrock_2015_santa_green_ouray_in_1:
 hardrock_2015_santa_green_ouray_out_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_ouray
-  id: 689
   absolute_time: 2015-07-11 04:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 59220.0
@@ -1172,7 +1094,6 @@ hardrock_2015_santa_green_ouray_out_1:
 hardrock_2015_santa_green_telluride_in_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_telluride
-  id: 694
   absolute_time: 2015-07-11 10:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 79500.0
@@ -1185,7 +1106,6 @@ hardrock_2015_santa_green_telluride_in_1:
 hardrock_2015_santa_green_telluride_out_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_telluride
-  id: 695
   absolute_time: 2015-07-11 10:14:00.000000000 Z
   data_status: 2
   elapsed_seconds: 80040.0
@@ -1198,7 +1118,6 @@ hardrock_2015_santa_green_telluride_out_1:
 hardrock_2015_santa_green_putnam_in_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_putnam
-  id: 700
   absolute_time: 2015-07-11 19:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 113880.0
@@ -1211,7 +1130,6 @@ hardrock_2015_santa_green_putnam_in_1:
 hardrock_2015_santa_green_putnam_out_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_putnam
-  id: 701
   absolute_time: 2015-07-11 19:43:00.000000000 Z
   data_status: 2
   elapsed_seconds: 114180.0
@@ -1224,7 +1142,6 @@ hardrock_2015_santa_green_putnam_out_1:
 hardrock_2015_santa_green_finish_1:
   effort: hardrock_2015_santa_green
   split: hardrock_ccw_finish
-  id: 702
   absolute_time: 2015-07-11 21:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 120120.0
@@ -1237,7 +1154,6 @@ hardrock_2015_santa_green_finish_1:
 hardrock_2015_gilberto_mckenzie_start_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_start
-  id: 733
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -1250,7 +1166,6 @@ hardrock_2015_gilberto_mckenzie_start_1:
 hardrock_2015_gilberto_mckenzie_cunningham_in_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_cunningham
-  id: 734
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8640.0
@@ -1263,7 +1178,6 @@ hardrock_2015_gilberto_mckenzie_cunningham_in_1:
 hardrock_2015_gilberto_mckenzie_cunningham_out_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_cunningham
-  id: 735
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8640.0
@@ -1276,7 +1190,6 @@ hardrock_2015_gilberto_mckenzie_cunningham_out_1:
 hardrock_2015_gilberto_mckenzie_sherman_in_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_sherman
-  id: 740
   absolute_time: 2015-07-10 19:56:00.000000000 Z
   data_status: 2
   elapsed_seconds: 28560.0
@@ -1289,7 +1202,6 @@ hardrock_2015_gilberto_mckenzie_sherman_in_1:
 hardrock_2015_gilberto_mckenzie_sherman_out_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_sherman
-  id: 741
   absolute_time: 2015-07-10 20:02:00.000000000 Z
   data_status: 2
   elapsed_seconds: 28920.0
@@ -1302,7 +1214,6 @@ hardrock_2015_gilberto_mckenzie_sherman_out_1:
 hardrock_2015_gilberto_mckenzie_grouse_in_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_grouse
-  id: 744
   absolute_time: 2015-07-11 00:58:00.000000000 Z
   data_status: 2
   elapsed_seconds: 46680.0
@@ -1315,7 +1226,6 @@ hardrock_2015_gilberto_mckenzie_grouse_in_1:
 hardrock_2015_gilberto_mckenzie_grouse_out_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_grouse
-  id: 745
   absolute_time: 2015-07-11 01:12:00.000000000 Z
   data_status: 2
   elapsed_seconds: 47520.0
@@ -1328,7 +1238,6 @@ hardrock_2015_gilberto_mckenzie_grouse_out_1:
 hardrock_2015_gilberto_mckenzie_ouray_in_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_ouray
-  id: 748
   absolute_time: 2015-07-11 05:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 64740.0
@@ -1341,7 +1250,6 @@ hardrock_2015_gilberto_mckenzie_ouray_in_1:
 hardrock_2015_gilberto_mckenzie_ouray_out_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_ouray
-  id: 749
   absolute_time: 2015-07-11 06:09:00.000000000 Z
   data_status: 2
   elapsed_seconds: 65340.0
@@ -1354,7 +1262,6 @@ hardrock_2015_gilberto_mckenzie_ouray_out_1:
 hardrock_2015_gilberto_mckenzie_telluride_in_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_telluride
-  id: 754
   absolute_time: 2015-07-11 11:33:00.000000000 Z
   data_status: 2
   elapsed_seconds: 84780.0
@@ -1367,7 +1274,6 @@ hardrock_2015_gilberto_mckenzie_telluride_in_1:
 hardrock_2015_gilberto_mckenzie_telluride_out_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_telluride
-  id: 755
   absolute_time: 2015-07-11 11:45:00.000000000 Z
   data_status: 2
   elapsed_seconds: 85500.0
@@ -1380,7 +1286,6 @@ hardrock_2015_gilberto_mckenzie_telluride_out_1:
 hardrock_2015_gilberto_mckenzie_putnam_in_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_putnam
-  id: 760
   absolute_time: 2015-07-11 21:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 121560.0
@@ -1393,7 +1298,6 @@ hardrock_2015_gilberto_mckenzie_putnam_in_1:
 hardrock_2015_gilberto_mckenzie_putnam_out_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_putnam
-  id: 761
   absolute_time: 2015-07-11 21:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 121560.0
@@ -1406,7 +1310,6 @@ hardrock_2015_gilberto_mckenzie_putnam_out_1:
 hardrock_2015_gilberto_mckenzie_finish_1:
   effort: hardrock_2015_gilberto_mckenzie
   split: hardrock_ccw_finish
-  id: 762
   absolute_time: 2015-07-11 23:18:00.000000000 Z
   data_status: 2
   elapsed_seconds: 127080.0
@@ -1419,7 +1322,6 @@ hardrock_2015_gilberto_mckenzie_finish_1:
 hardrock_2015_vince_willms_start_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_start
-  id: 1213
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -1432,7 +1334,6 @@ hardrock_2015_vince_willms_start_1:
 hardrock_2015_vince_willms_cunningham_in_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_cunningham
-  id: 1214
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8640.0
@@ -1445,7 +1346,6 @@ hardrock_2015_vince_willms_cunningham_in_1:
 hardrock_2015_vince_willms_cunningham_out_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_cunningham
-  id: 1215
   absolute_time: 2015-07-10 14:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8640.0
@@ -1458,7 +1358,6 @@ hardrock_2015_vince_willms_cunningham_out_1:
 hardrock_2015_vince_willms_sherman_in_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_sherman
-  id: 1220
   absolute_time: 2015-07-10 19:47:00.000000000 Z
   data_status: 2
   elapsed_seconds: 28020.0
@@ -1471,7 +1370,6 @@ hardrock_2015_vince_willms_sherman_in_1:
 hardrock_2015_vince_willms_sherman_out_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_sherman
-  id: 1221
   absolute_time: 2015-07-10 19:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 28740.0
@@ -1484,7 +1382,6 @@ hardrock_2015_vince_willms_sherman_out_1:
 hardrock_2015_vince_willms_grouse_in_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_grouse
-  id: 1224
   absolute_time: 2015-07-10 23:58:00.000000000 Z
   data_status: 2
   elapsed_seconds: 43080.0
@@ -1497,7 +1394,6 @@ hardrock_2015_vince_willms_grouse_in_1:
 hardrock_2015_vince_willms_grouse_out_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_grouse
-  id: 1225
   absolute_time: 2015-07-11 00:06:00.000000000 Z
   data_status: 2
   elapsed_seconds: 43560.0
@@ -1510,7 +1406,6 @@ hardrock_2015_vince_willms_grouse_out_1:
 hardrock_2015_vince_willms_ouray_in_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_ouray
-  id: 1228
   absolute_time: 2015-07-11 04:34:00.000000000 Z
   data_status: 2
   elapsed_seconds: 59640.0
@@ -1523,7 +1418,6 @@ hardrock_2015_vince_willms_ouray_in_1:
 hardrock_2015_vince_willms_ouray_out_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_ouray
-  id: 1229
   absolute_time: 2015-07-11 04:58:00.000000000 Z
   data_status: 2
   elapsed_seconds: 61080.0
@@ -1536,7 +1430,6 @@ hardrock_2015_vince_willms_ouray_out_1:
 hardrock_2015_vince_willms_telluride_in_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_telluride
-  id: 1234
   absolute_time: 2015-07-11 11:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 85200.0
@@ -1549,7 +1442,6 @@ hardrock_2015_vince_willms_telluride_in_1:
 hardrock_2015_vince_willms_telluride_out_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_telluride
-  id: 1235
   absolute_time: 2015-07-11 12:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 89580.0
@@ -1562,7 +1454,6 @@ hardrock_2015_vince_willms_telluride_out_1:
 hardrock_2015_vince_willms_putnam_in_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_putnam
-  id: 1240
   absolute_time: 2015-07-11 23:23:00.000000000 Z
   data_status: 2
   elapsed_seconds: 127380.0
@@ -1575,7 +1466,6 @@ hardrock_2015_vince_willms_putnam_in_1:
 hardrock_2015_vince_willms_putnam_out_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_putnam
-  id: 1241
   absolute_time: 2015-07-11 23:25:00.000000000 Z
   data_status: 2
   elapsed_seconds: 127500.0
@@ -1588,7 +1478,6 @@ hardrock_2015_vince_willms_putnam_out_1:
 hardrock_2015_vince_willms_finish_1:
   effort: hardrock_2015_vince_willms
   split: hardrock_ccw_finish
-  id: 1242
   absolute_time: 2015-07-12 00:58:00.000000000 Z
   data_status: 2
   elapsed_seconds: 133080.0
@@ -1598,10 +1487,21 @@ hardrock_2015_vince_willms_finish_1:
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
+hardrock_2015_cedric_windler_start_1:
+  effort: hardrock_2015_cedric_windler
+  split: hardrock_ccw_start
+  absolute_time: 2015-07-10 12:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 hardrock_2015_cedric_windler_cunningham_in_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_cunningham
-  id: 1304
   absolute_time: 2015-07-10 14:32:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9120.0
@@ -1614,7 +1514,6 @@ hardrock_2015_cedric_windler_cunningham_in_1:
 hardrock_2015_cedric_windler_cunningham_out_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_cunningham
-  id: 1305
   absolute_time: 2015-07-10 14:32:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9120.0
@@ -1627,7 +1526,6 @@ hardrock_2015_cedric_windler_cunningham_out_1:
 hardrock_2015_cedric_windler_sherman_in_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_sherman
-  id: 1310
   absolute_time: 2015-07-10 19:52:00.000000000 Z
   data_status: 2
   elapsed_seconds: 28320.0
@@ -1640,7 +1538,6 @@ hardrock_2015_cedric_windler_sherman_in_1:
 hardrock_2015_cedric_windler_sherman_out_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_sherman
-  id: 1311
   absolute_time: 2015-07-10 19:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 28740.0
@@ -1653,7 +1550,6 @@ hardrock_2015_cedric_windler_sherman_out_1:
 hardrock_2015_cedric_windler_grouse_in_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_grouse
-  id: 1314
   absolute_time: 2015-07-11 00:51:00.000000000 Z
   data_status: 2
   elapsed_seconds: 46260.0
@@ -1666,7 +1562,6 @@ hardrock_2015_cedric_windler_grouse_in_1:
 hardrock_2015_cedric_windler_grouse_out_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_grouse
-  id: 1315
   absolute_time: 2015-07-11 01:02:00.000000000 Z
   data_status: 2
   elapsed_seconds: 46920.0
@@ -1679,7 +1574,6 @@ hardrock_2015_cedric_windler_grouse_out_1:
 hardrock_2015_cedric_windler_ouray_in_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_ouray
-  id: 1318
   absolute_time: 2015-07-11 06:06:00.000000000 Z
   data_status: 2
   elapsed_seconds: 65160.0
@@ -1692,7 +1586,6 @@ hardrock_2015_cedric_windler_ouray_in_1:
 hardrock_2015_cedric_windler_ouray_out_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_ouray
-  id: 1319
   absolute_time: 2015-07-11 06:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 67980.0
@@ -1705,7 +1598,6 @@ hardrock_2015_cedric_windler_ouray_out_1:
 hardrock_2015_cedric_windler_telluride_in_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_telluride
-  id: 1324
   absolute_time: 2015-07-11 13:10:00.000000000 Z
   data_status: 2
   elapsed_seconds: 90600.0
@@ -1718,7 +1610,6 @@ hardrock_2015_cedric_windler_telluride_in_1:
 hardrock_2015_cedric_windler_telluride_out_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_telluride
-  id: 1325
   absolute_time: 2015-07-11 13:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 91200.0
@@ -1731,7 +1622,6 @@ hardrock_2015_cedric_windler_telluride_out_1:
 hardrock_2015_cedric_windler_putnam_in_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_putnam
-  id: 1330
   absolute_time: 2015-07-11 23:39:00.000000000 Z
   data_status: 2
   elapsed_seconds: 128340.0
@@ -1744,7 +1634,6 @@ hardrock_2015_cedric_windler_putnam_in_1:
 hardrock_2015_cedric_windler_putnam_out_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_putnam
-  id: 1331
   absolute_time: 2015-07-11 23:39:00.000000000 Z
   data_status: 2
   elapsed_seconds: 128340.0
@@ -1757,7 +1646,6 @@ hardrock_2015_cedric_windler_putnam_out_1:
 hardrock_2015_cedric_windler_finish_1:
   effort: hardrock_2015_cedric_windler
   split: hardrock_ccw_finish
-  id: 1332
   absolute_time: 2015-07-12 01:19:00.000000000 Z
   data_status: 2
   elapsed_seconds: 134340.0
@@ -1770,7 +1658,6 @@ hardrock_2015_cedric_windler_finish_1:
 hardrock_2015_chris_rempel_start_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_start
-  id: 1483
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -1783,7 +1670,6 @@ hardrock_2015_chris_rempel_start_1:
 hardrock_2015_chris_rempel_cunningham_in_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_cunningham
-  id: 1484
   absolute_time: 2015-07-10 14:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9360.0
@@ -1796,7 +1682,6 @@ hardrock_2015_chris_rempel_cunningham_in_1:
 hardrock_2015_chris_rempel_cunningham_out_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_cunningham
-  id: 1485
   absolute_time: 2015-07-10 14:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9360.0
@@ -1809,7 +1694,6 @@ hardrock_2015_chris_rempel_cunningham_out_1:
 hardrock_2015_chris_rempel_sherman_in_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_sherman
-  id: 1490
   absolute_time: 2015-07-10 20:12:00.000000000 Z
   data_status: 2
   elapsed_seconds: 29520.0
@@ -1822,7 +1706,6 @@ hardrock_2015_chris_rempel_sherman_in_1:
 hardrock_2015_chris_rempel_sherman_out_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_sherman
-  id: 1491
   absolute_time: 2015-07-10 20:23:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30180.0
@@ -1835,7 +1718,6 @@ hardrock_2015_chris_rempel_sherman_out_1:
 hardrock_2015_chris_rempel_grouse_in_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_grouse
-  id: 1494
   absolute_time: 2015-07-11 00:57:00.000000000 Z
   data_status: 2
   elapsed_seconds: 46620.0
@@ -1848,7 +1730,6 @@ hardrock_2015_chris_rempel_grouse_in_1:
 hardrock_2015_chris_rempel_grouse_out_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_grouse
-  id: 1495
   absolute_time: 2015-07-11 01:09:00.000000000 Z
   data_status: 2
   elapsed_seconds: 47340.0
@@ -1861,7 +1742,6 @@ hardrock_2015_chris_rempel_grouse_out_1:
 hardrock_2015_chris_rempel_ouray_in_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_ouray
-  id: 1498
   absolute_time: 2015-07-11 06:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 65100.0
@@ -1874,7 +1754,6 @@ hardrock_2015_chris_rempel_ouray_in_1:
 hardrock_2015_chris_rempel_ouray_out_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_ouray
-  id: 1499
   absolute_time: 2015-07-11 06:23:00.000000000 Z
   data_status: 2
   elapsed_seconds: 66180.0
@@ -1887,7 +1766,6 @@ hardrock_2015_chris_rempel_ouray_out_1:
 hardrock_2015_chris_rempel_telluride_in_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_telluride
-  id: 1504
   absolute_time: 2015-07-11 12:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 88800.0
@@ -1900,7 +1778,6 @@ hardrock_2015_chris_rempel_telluride_in_1:
 hardrock_2015_chris_rempel_telluride_out_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_telluride
-  id: 1505
   absolute_time: 2015-07-11 13:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 90000.0
@@ -1913,7 +1790,6 @@ hardrock_2015_chris_rempel_telluride_out_1:
 hardrock_2015_chris_rempel_putnam_in_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_putnam
-  id: 1510
   absolute_time: 2015-07-12 00:03:00.000000000 Z
   data_status: 2
   elapsed_seconds: 129780.0
@@ -1926,7 +1802,6 @@ hardrock_2015_chris_rempel_putnam_in_1:
 hardrock_2015_chris_rempel_putnam_out_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_putnam
-  id: 1511
   absolute_time: 2015-07-12 00:04:00.000000000 Z
   data_status: 2
   elapsed_seconds: 129840.0
@@ -1939,7 +1814,6 @@ hardrock_2015_chris_rempel_putnam_out_1:
 hardrock_2015_chris_rempel_finish_1:
   effort: hardrock_2015_chris_rempel
   split: hardrock_ccw_finish
-  id: 1512
   absolute_time: 2015-07-12 01:54:00.000000000 Z
   data_status: 2
   elapsed_seconds: 136440.0
@@ -1952,7 +1826,6 @@ hardrock_2015_chris_rempel_finish_1:
 hardrock_2015_robby_gerlach_start_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_start
-  id: 1513
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -1965,7 +1838,6 @@ hardrock_2015_robby_gerlach_start_1:
 hardrock_2015_robby_gerlach_cunningham_in_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_cunningham
-  id: 1514
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9600.0
@@ -1978,7 +1850,6 @@ hardrock_2015_robby_gerlach_cunningham_in_1:
 hardrock_2015_robby_gerlach_cunningham_out_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_cunningham
-  id: 1515
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9600.0
@@ -1991,7 +1862,6 @@ hardrock_2015_robby_gerlach_cunningham_out_1:
 hardrock_2015_robby_gerlach_sherman_in_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_sherman
-  id: 1520
   absolute_time: 2015-07-10 20:51:00.000000000 Z
   data_status: 2
   elapsed_seconds: 31860.0
@@ -2004,7 +1874,6 @@ hardrock_2015_robby_gerlach_sherman_in_1:
 hardrock_2015_robby_gerlach_sherman_out_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_sherman
-  id: 1521
   absolute_time: 2015-07-10 21:03:00.000000000 Z
   data_status: 2
   elapsed_seconds: 32580.0
@@ -2017,7 +1886,6 @@ hardrock_2015_robby_gerlach_sherman_out_1:
 hardrock_2015_robby_gerlach_grouse_in_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_grouse
-  id: 1524
   absolute_time: 2015-07-11 01:51:00.000000000 Z
   data_status: 2
   elapsed_seconds: 49860.0
@@ -2030,7 +1898,6 @@ hardrock_2015_robby_gerlach_grouse_in_1:
 hardrock_2015_robby_gerlach_grouse_out_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_grouse
-  id: 1525
   absolute_time: 2015-07-11 02:08:00.000000000 Z
   data_status: 2
   elapsed_seconds: 50880.0
@@ -2043,7 +1910,6 @@ hardrock_2015_robby_gerlach_grouse_out_1:
 hardrock_2015_robby_gerlach_ouray_in_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_ouray
-  id: 1528
   absolute_time: 2015-07-11 07:15:00.000000000 Z
   data_status: 2
   elapsed_seconds: 69300.0
@@ -2056,7 +1922,6 @@ hardrock_2015_robby_gerlach_ouray_in_1:
 hardrock_2015_robby_gerlach_ouray_out_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_ouray
-  id: 1529
   absolute_time: 2015-07-11 07:32:00.000000000 Z
   data_status: 2
   elapsed_seconds: 70320.0
@@ -2069,7 +1934,6 @@ hardrock_2015_robby_gerlach_ouray_out_1:
 hardrock_2015_robby_gerlach_telluride_in_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_telluride
-  id: 1534
   absolute_time: 2015-07-11 13:29:00.000000000 Z
   data_status: 2
   elapsed_seconds: 91740.0
@@ -2082,7 +1946,6 @@ hardrock_2015_robby_gerlach_telluride_in_1:
 hardrock_2015_robby_gerlach_telluride_out_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_telluride
-  id: 1535
   absolute_time: 2015-07-11 14:44:00.000000000 Z
   data_status: 2
   elapsed_seconds: 96240.0
@@ -2095,7 +1958,6 @@ hardrock_2015_robby_gerlach_telluride_out_1:
 hardrock_2015_robby_gerlach_putnam_in_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_putnam
-  id: 1540
   absolute_time: 2015-07-12 00:14:00.000000000 Z
   data_status: 2
   elapsed_seconds: 130440.0
@@ -2108,7 +1970,6 @@ hardrock_2015_robby_gerlach_putnam_in_1:
 hardrock_2015_robby_gerlach_putnam_out_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_putnam
-  id: 1541
   absolute_time: 2015-07-12 00:14:00.000000000 Z
   data_status: 2
   elapsed_seconds: 130440.0
@@ -2121,7 +1982,6 @@ hardrock_2015_robby_gerlach_putnam_out_1:
 hardrock_2015_robby_gerlach_finish_1:
   effort: hardrock_2015_robby_gerlach
   split: hardrock_ccw_finish
-  id: 1542
   absolute_time: 2015-07-12 01:56:00.000000000 Z
   data_status: 2
   elapsed_seconds: 136560.0
@@ -2134,7 +1994,6 @@ hardrock_2015_robby_gerlach_finish_1:
 hardrock_2015_rachelle_eichmann_start_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_start
-  id: 1573
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -2147,7 +2006,6 @@ hardrock_2015_rachelle_eichmann_start_1:
 hardrock_2015_rachelle_eichmann_cunningham_in_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_cunningham
-  id: 1574
   absolute_time: 2015-07-10 14:28:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8880.0
@@ -2160,7 +2018,6 @@ hardrock_2015_rachelle_eichmann_cunningham_in_1:
 hardrock_2015_rachelle_eichmann_cunningham_out_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_cunningham
-  id: 1575
   absolute_time: 2015-07-10 14:28:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8880.0
@@ -2173,7 +2030,6 @@ hardrock_2015_rachelle_eichmann_cunningham_out_1:
 hardrock_2015_rachelle_eichmann_sherman_in_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_sherman
-  id: 1580
   absolute_time: 2015-07-10 20:11:00.000000000 Z
   data_status: 2
   elapsed_seconds: 29460.0
@@ -2186,7 +2042,6 @@ hardrock_2015_rachelle_eichmann_sherman_in_1:
 hardrock_2015_rachelle_eichmann_sherman_out_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_sherman
-  id: 1581
   absolute_time: 2015-07-10 20:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30240.0
@@ -2199,7 +2054,6 @@ hardrock_2015_rachelle_eichmann_sherman_out_1:
 hardrock_2015_rachelle_eichmann_grouse_in_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_grouse
-  id: 1584
   absolute_time: 2015-07-11 00:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 46380.0
@@ -2212,7 +2066,6 @@ hardrock_2015_rachelle_eichmann_grouse_in_1:
 hardrock_2015_rachelle_eichmann_grouse_out_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_grouse
-  id: 1585
   absolute_time: 2015-07-11 01:10:00.000000000 Z
   data_status: 2
   elapsed_seconds: 47400.0
@@ -2225,7 +2078,6 @@ hardrock_2015_rachelle_eichmann_grouse_out_1:
 hardrock_2015_rachelle_eichmann_ouray_in_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_ouray
-  id: 1588
   absolute_time: 2015-07-11 06:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 66600.0
@@ -2238,7 +2090,6 @@ hardrock_2015_rachelle_eichmann_ouray_in_1:
 hardrock_2015_rachelle_eichmann_ouray_out_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_ouray
-  id: 1589
   absolute_time: 2015-07-11 06:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 67200.0
@@ -2251,7 +2102,6 @@ hardrock_2015_rachelle_eichmann_ouray_out_1:
 hardrock_2015_rachelle_eichmann_telluride_in_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_telluride
-  id: 1594
   absolute_time: 2015-07-11 13:45:00.000000000 Z
   data_status: 2
   elapsed_seconds: 92700.0
@@ -2264,7 +2114,6 @@ hardrock_2015_rachelle_eichmann_telluride_in_1:
 hardrock_2015_rachelle_eichmann_telluride_out_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_telluride
-  id: 1595
   absolute_time: 2015-07-11 14:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 93900.0
@@ -2277,7 +2126,6 @@ hardrock_2015_rachelle_eichmann_telluride_out_1:
 hardrock_2015_rachelle_eichmann_putnam_in_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_putnam
-  id: 1600
   absolute_time: 2015-07-12 01:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 133500.0
@@ -2290,7 +2138,6 @@ hardrock_2015_rachelle_eichmann_putnam_in_1:
 hardrock_2015_rachelle_eichmann_putnam_out_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_putnam
-  id: 1601
   absolute_time: 2015-07-12 01:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 133500.0
@@ -2303,7 +2150,6 @@ hardrock_2015_rachelle_eichmann_putnam_out_1:
 hardrock_2015_rachelle_eichmann_finish_1:
   effort: hardrock_2015_rachelle_eichmann
   split: hardrock_ccw_finish
-  id: 1602
   absolute_time: 2015-07-12 02:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 138960.0
@@ -2316,7 +2162,6 @@ hardrock_2015_rachelle_eichmann_finish_1:
 hardrock_2015_elden_morissette_start_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_start
-  id: 1633
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -2329,7 +2174,6 @@ hardrock_2015_elden_morissette_start_1:
 hardrock_2015_elden_morissette_cunningham_in_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_cunningham
-  id: 1634
   absolute_time: 2015-07-10 14:33:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9180.0
@@ -2342,7 +2186,6 @@ hardrock_2015_elden_morissette_cunningham_in_1:
 hardrock_2015_elden_morissette_cunningham_out_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_cunningham
-  id: 1635
   absolute_time: 2015-07-10 14:33:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9180.0
@@ -2355,7 +2198,6 @@ hardrock_2015_elden_morissette_cunningham_out_1:
 hardrock_2015_elden_morissette_sherman_in_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_sherman
-  id: 1640
   absolute_time: 2015-07-10 20:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30000.0
@@ -2368,7 +2210,6 @@ hardrock_2015_elden_morissette_sherman_in_1:
 hardrock_2015_elden_morissette_sherman_out_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_sherman
-  id: 1641
   absolute_time: 2015-07-10 20:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 31080.0
@@ -2381,7 +2222,6 @@ hardrock_2015_elden_morissette_sherman_out_1:
 hardrock_2015_elden_morissette_grouse_in_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_grouse
-  id: 1644
   absolute_time: 2015-07-11 01:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 48240.0
@@ -2394,7 +2234,6 @@ hardrock_2015_elden_morissette_grouse_in_1:
 hardrock_2015_elden_morissette_grouse_out_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_grouse
-  id: 1645
   absolute_time: 2015-07-11 01:50:00.000000000 Z
   data_status: 2
   elapsed_seconds: 49800.0
@@ -2407,7 +2246,6 @@ hardrock_2015_elden_morissette_grouse_out_1:
 hardrock_2015_elden_morissette_ouray_in_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_ouray
-  id: 1648
   absolute_time: 2015-07-11 06:15:00.000000000 Z
   data_status: 2
   elapsed_seconds: 65700.0
@@ -2420,7 +2258,6 @@ hardrock_2015_elden_morissette_ouray_in_1:
 hardrock_2015_elden_morissette_ouray_out_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_ouray
-  id: 1649
   absolute_time: 2015-07-11 06:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 68340.0
@@ -2433,7 +2270,6 @@ hardrock_2015_elden_morissette_ouray_out_1:
 hardrock_2015_elden_morissette_telluride_in_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_telluride
-  id: 1654
   absolute_time: 2015-07-11 13:08:00.000000000 Z
   data_status: 2
   elapsed_seconds: 90480.0
@@ -2446,7 +2282,6 @@ hardrock_2015_elden_morissette_telluride_in_1:
 hardrock_2015_elden_morissette_telluride_out_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_telluride
-  id: 1655
   absolute_time: 2015-07-11 13:33:00.000000000 Z
   data_status: 2
   elapsed_seconds: 91980.0
@@ -2459,7 +2294,6 @@ hardrock_2015_elden_morissette_telluride_out_1:
 hardrock_2015_elden_morissette_putnam_in_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_putnam
-  id: 1660
   absolute_time: 2015-07-12 00:48:00.000000000 Z
   data_status: 2
   elapsed_seconds: 132480.0
@@ -2472,7 +2306,6 @@ hardrock_2015_elden_morissette_putnam_in_1:
 hardrock_2015_elden_morissette_putnam_out_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_putnam
-  id: 1661
   absolute_time: 2015-07-12 00:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 132780.0
@@ -2485,7 +2318,6 @@ hardrock_2015_elden_morissette_putnam_out_1:
 hardrock_2015_elden_morissette_finish_1:
   effort: hardrock_2015_elden_morissette
   split: hardrock_ccw_finish
-  id: 1662
   absolute_time: 2015-07-12 02:41:00.000000000 Z
   data_status: 2
   elapsed_seconds: 139260.0
@@ -2498,7 +2330,6 @@ hardrock_2015_elden_morissette_finish_1:
 hardrock_2015_leroy_leffler_start_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_start
-  id: 1693
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -2511,7 +2342,6 @@ hardrock_2015_leroy_leffler_start_1:
 hardrock_2015_leroy_leffler_cunningham_in_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_cunningham
-  id: 1694
   absolute_time: 2015-07-10 14:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9480.0
@@ -2524,7 +2354,6 @@ hardrock_2015_leroy_leffler_cunningham_in_1:
 hardrock_2015_leroy_leffler_cunningham_out_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_cunningham
-  id: 1695
   absolute_time: 2015-07-10 14:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9480.0
@@ -2537,7 +2366,6 @@ hardrock_2015_leroy_leffler_cunningham_out_1:
 hardrock_2015_leroy_leffler_sherman_in_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_sherman
-  id: 1700
   absolute_time: 2015-07-10 20:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30120.0
@@ -2550,7 +2378,6 @@ hardrock_2015_leroy_leffler_sherman_in_1:
 hardrock_2015_leroy_leffler_sherman_out_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_sherman
-  id: 1701
   absolute_time: 2015-07-10 20:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 31080.0
@@ -2563,7 +2390,6 @@ hardrock_2015_leroy_leffler_sherman_out_1:
 hardrock_2015_leroy_leffler_grouse_in_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_grouse
-  id: 1704
   absolute_time: 2015-07-11 01:21:00.000000000 Z
   data_status: 2
   elapsed_seconds: 48060.0
@@ -2576,7 +2402,6 @@ hardrock_2015_leroy_leffler_grouse_in_1:
 hardrock_2015_leroy_leffler_grouse_out_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_grouse
-  id: 1705
   absolute_time: 2015-07-11 01:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 49080.0
@@ -2589,7 +2414,6 @@ hardrock_2015_leroy_leffler_grouse_out_1:
 hardrock_2015_leroy_leffler_ouray_in_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_ouray
-  id: 1708
   absolute_time: 2015-07-11 06:32:00.000000000 Z
   data_status: 2
   elapsed_seconds: 66720.0
@@ -2602,7 +2426,6 @@ hardrock_2015_leroy_leffler_ouray_in_1:
 hardrock_2015_leroy_leffler_ouray_out_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_ouray
-  id: 1709
   absolute_time: 2015-07-11 07:21:00.000000000 Z
   data_status: 2
   elapsed_seconds: 69660.0
@@ -2615,7 +2438,6 @@ hardrock_2015_leroy_leffler_ouray_out_1:
 hardrock_2015_leroy_leffler_telluride_in_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_telluride
-  id: 1714
   absolute_time: 2015-07-11 13:07:00.000000000 Z
   data_status: 2
   elapsed_seconds: 90420.0
@@ -2628,7 +2450,6 @@ hardrock_2015_leroy_leffler_telluride_in_1:
 hardrock_2015_leroy_leffler_telluride_out_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_telluride
-  id: 1715
   absolute_time: 2015-07-11 13:43:00.000000000 Z
   data_status: 2
   elapsed_seconds: 92580.0
@@ -2641,7 +2462,6 @@ hardrock_2015_leroy_leffler_telluride_out_1:
 hardrock_2015_leroy_leffler_putnam_in_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_putnam
-  id: 1720
   absolute_time: 2015-07-12 01:15:00.000000000 Z
   data_status: 2
   elapsed_seconds: 134100.0
@@ -2654,7 +2474,6 @@ hardrock_2015_leroy_leffler_putnam_in_1:
 hardrock_2015_leroy_leffler_putnam_out_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_putnam
-  id: 1721
   absolute_time: 2015-07-12 01:15:00.000000000 Z
   data_status: 2
   elapsed_seconds: 134100.0
@@ -2667,7 +2486,6 @@ hardrock_2015_leroy_leffler_putnam_out_1:
 hardrock_2015_leroy_leffler_finish_1:
   effort: hardrock_2015_leroy_leffler
   split: hardrock_ccw_finish
-  id: 1722
   absolute_time: 2015-07-12 03:11:00.000000000 Z
   data_status: 2
   elapsed_seconds: 141060.0
@@ -2680,7 +2498,6 @@ hardrock_2015_leroy_leffler_finish_1:
 hardrock_2015_samara_vandervort_start_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_start
-  id: 1993
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -2693,7 +2510,6 @@ hardrock_2015_samara_vandervort_start_1:
 hardrock_2015_samara_vandervort_cunningham_in_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_cunningham
-  id: 1994
   absolute_time: 2015-07-10 14:35:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9300.0
@@ -2706,7 +2522,6 @@ hardrock_2015_samara_vandervort_cunningham_in_1:
 hardrock_2015_samara_vandervort_cunningham_out_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_cunningham
-  id: 1995
   absolute_time: 2015-07-10 14:35:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9300.0
@@ -2719,7 +2534,6 @@ hardrock_2015_samara_vandervort_cunningham_out_1:
 hardrock_2015_samara_vandervort_sherman_in_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_sherman
-  id: 2000
   absolute_time: 2015-07-10 20:28:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30480.0
@@ -2732,7 +2546,6 @@ hardrock_2015_samara_vandervort_sherman_in_1:
 hardrock_2015_samara_vandervort_sherman_out_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_sherman
-  id: 2001
   absolute_time: 2015-07-10 20:42:00.000000000 Z
   data_status: 2
   elapsed_seconds: 31320.0
@@ -2745,7 +2558,6 @@ hardrock_2015_samara_vandervort_sherman_out_1:
 hardrock_2015_samara_vandervort_grouse_in_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_grouse
-  id: 2004
   absolute_time: 2015-07-11 01:50:00.000000000 Z
   data_status: 2
   elapsed_seconds: 49800.0
@@ -2758,7 +2570,6 @@ hardrock_2015_samara_vandervort_grouse_in_1:
 hardrock_2015_samara_vandervort_grouse_out_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_grouse
-  id: 2005
   absolute_time: 2015-07-11 02:03:00.000000000 Z
   data_status: 2
   elapsed_seconds: 50580.0
@@ -2771,7 +2582,6 @@ hardrock_2015_samara_vandervort_grouse_out_1:
 hardrock_2015_samara_vandervort_ouray_in_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_ouray
-  id: 2008
   absolute_time: 2015-07-11 07:06:00.000000000 Z
   data_status: 2
   elapsed_seconds: 68760.0
@@ -2784,7 +2594,6 @@ hardrock_2015_samara_vandervort_ouray_in_1:
 hardrock_2015_samara_vandervort_ouray_out_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_ouray
-  id: 2009
   absolute_time: 2015-07-11 07:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 69600.0
@@ -2797,7 +2606,6 @@ hardrock_2015_samara_vandervort_ouray_out_1:
 hardrock_2015_samara_vandervort_telluride_in_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_telluride
-  id: 2014
   absolute_time: 2015-07-11 14:11:00.000000000 Z
   data_status: 0
   elapsed_seconds: 94260.0
@@ -2810,7 +2618,6 @@ hardrock_2015_samara_vandervort_telluride_in_1:
 hardrock_2015_samara_vandervort_telluride_out_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_telluride
-  id: 2015
   absolute_time: 2015-07-11 14:29:00.000000000 Z
   data_status: 0
   elapsed_seconds: 95340.0
@@ -2823,7 +2630,6 @@ hardrock_2015_samara_vandervort_telluride_out_1:
 hardrock_2015_samara_vandervort_putnam_in_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_putnam
-  id: 2020
   absolute_time: 2015-07-12 01:58:00.000000000 Z
   data_status: 2
   elapsed_seconds: 136680.0
@@ -2836,7 +2642,6 @@ hardrock_2015_samara_vandervort_putnam_in_1:
 hardrock_2015_samara_vandervort_putnam_out_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_putnam
-  id: 2021
   absolute_time: 2015-07-12 02:04:00.000000000 Z
   data_status: 2
   elapsed_seconds: 137040.0
@@ -2849,7 +2654,6 @@ hardrock_2015_samara_vandervort_putnam_out_1:
 hardrock_2015_samara_vandervort_finish_1:
   effort: hardrock_2015_samara_vandervort
   split: hardrock_ccw_finish
-  id: 2022
   absolute_time: 2015-07-12 04:16:00.000000000 Z
   data_status: 2
   elapsed_seconds: 144960.0
@@ -2862,7 +2666,6 @@ hardrock_2015_samara_vandervort_finish_1:
 hardrock_2015_robt_wintheiser_start_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_start
-  id: 2623
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -2875,7 +2678,6 @@ hardrock_2015_robt_wintheiser_start_1:
 hardrock_2015_robt_wintheiser_cunningham_in_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_cunningham
-  id: 2624
   absolute_time: 2015-07-10 14:52:00.000000000 Z
   data_status: 2
   elapsed_seconds: 10320.0
@@ -2888,7 +2690,6 @@ hardrock_2015_robt_wintheiser_cunningham_in_1:
 hardrock_2015_robt_wintheiser_cunningham_out_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_cunningham
-  id: 2625
   absolute_time: 2015-07-10 14:52:00.000000000 Z
   data_status: 2
   elapsed_seconds: 10320.0
@@ -2901,7 +2702,6 @@ hardrock_2015_robt_wintheiser_cunningham_out_1:
 hardrock_2015_robt_wintheiser_sherman_in_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_sherman
-  id: 2630
   absolute_time: 2015-07-10 21:10:00.000000000 Z
   data_status: 2
   elapsed_seconds: 33000.0
@@ -2914,7 +2714,6 @@ hardrock_2015_robt_wintheiser_sherman_in_1:
 hardrock_2015_robt_wintheiser_sherman_out_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_sherman
-  id: 2631
   absolute_time: 2015-07-10 21:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 34020.0
@@ -2927,7 +2726,6 @@ hardrock_2015_robt_wintheiser_sherman_out_1:
 hardrock_2015_robt_wintheiser_grouse_in_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_grouse
-  id: 2634
   absolute_time: 2015-07-11 02:37:00.000000000 Z
   data_status: 2
   elapsed_seconds: 52620.0
@@ -2940,7 +2738,6 @@ hardrock_2015_robt_wintheiser_grouse_in_1:
 hardrock_2015_robt_wintheiser_grouse_out_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_grouse
-  id: 2635
   absolute_time: 2015-07-11 03:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 54000.0
@@ -2953,7 +2750,6 @@ hardrock_2015_robt_wintheiser_grouse_out_1:
 hardrock_2015_robt_wintheiser_ouray_in_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_ouray
-  id: 2638
   absolute_time: 2015-07-11 08:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 73440.0
@@ -2966,7 +2762,6 @@ hardrock_2015_robt_wintheiser_ouray_in_1:
 hardrock_2015_robt_wintheiser_ouray_out_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_ouray
-  id: 2639
   absolute_time: 2015-07-11 08:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 73620.0
@@ -2979,7 +2774,6 @@ hardrock_2015_robt_wintheiser_ouray_out_1:
 hardrock_2015_robt_wintheiser_telluride_in_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_telluride
-  id: 2644
   absolute_time: 2015-07-11 15:34:00.000000000 Z
   data_status: 2
   elapsed_seconds: 99240.0
@@ -2992,7 +2786,6 @@ hardrock_2015_robt_wintheiser_telluride_in_1:
 hardrock_2015_robt_wintheiser_telluride_out_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_telluride
-  id: 2645
   absolute_time: 2015-07-11 16:34:00.000000000 Z
   data_status: 2
   elapsed_seconds: 102840.0
@@ -3005,7 +2798,6 @@ hardrock_2015_robt_wintheiser_telluride_out_1:
 hardrock_2015_robt_wintheiser_putnam_in_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_putnam
-  id: 2650
   absolute_time: 2015-07-12 05:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 148920.0
@@ -3018,7 +2810,6 @@ hardrock_2015_robt_wintheiser_putnam_in_1:
 hardrock_2015_robt_wintheiser_putnam_out_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_putnam
-  id: 2651
   absolute_time: 2015-07-12 05:33:00.000000000 Z
   data_status: 2
   elapsed_seconds: 149580.0
@@ -3031,7 +2822,6 @@ hardrock_2015_robt_wintheiser_putnam_out_1:
 hardrock_2015_robt_wintheiser_finish_1:
   effort: hardrock_2015_robt_wintheiser
   split: hardrock_ccw_finish
-  id: 2652
   absolute_time: 2015-07-12 07:56:00.000000000 Z
   data_status: 2
   elapsed_seconds: 158160.0
@@ -3044,7 +2834,6 @@ hardrock_2015_robt_wintheiser_finish_1:
 hardrock_2015_demetrius_moen_start_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_start
-  id: 2683
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -3057,7 +2846,6 @@ hardrock_2015_demetrius_moen_start_1:
 hardrock_2015_demetrius_moen_cunningham_in_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_cunningham
-  id: 2684
   absolute_time: 2015-07-10 14:45:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9900.0
@@ -3070,7 +2858,6 @@ hardrock_2015_demetrius_moen_cunningham_in_1:
 hardrock_2015_demetrius_moen_cunningham_out_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_cunningham
-  id: 2685
   absolute_time: 2015-07-10 14:45:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9900.0
@@ -3083,7 +2870,6 @@ hardrock_2015_demetrius_moen_cunningham_out_1:
 hardrock_2015_demetrius_moen_sherman_in_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_sherman
-  id: 2690
   absolute_time: 2015-07-10 21:21:00.000000000 Z
   data_status: 2
   elapsed_seconds: 33660.0
@@ -3096,7 +2882,6 @@ hardrock_2015_demetrius_moen_sherman_in_1:
 hardrock_2015_demetrius_moen_sherman_out_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_sherman
-  id: 2691
   absolute_time: 2015-07-10 21:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 34560.0
@@ -3109,7 +2894,6 @@ hardrock_2015_demetrius_moen_sherman_out_1:
 hardrock_2015_demetrius_moen_grouse_in_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_grouse
-  id: 2694
   absolute_time: 2015-07-11 03:07:00.000000000 Z
   data_status: 2
   elapsed_seconds: 54420.0
@@ -3122,7 +2906,6 @@ hardrock_2015_demetrius_moen_grouse_in_1:
 hardrock_2015_demetrius_moen_grouse_out_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_grouse
-  id: 2695
   absolute_time: 2015-07-11 03:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 55620.0
@@ -3135,7 +2918,6 @@ hardrock_2015_demetrius_moen_grouse_out_1:
 hardrock_2015_demetrius_moen_ouray_in_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_ouray
-  id: 2698
   absolute_time: 2015-07-11 08:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 75180.0
@@ -3148,7 +2930,6 @@ hardrock_2015_demetrius_moen_ouray_in_1:
 hardrock_2015_demetrius_moen_ouray_out_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_ouray
-  id: 2699
   absolute_time: 2015-07-11 09:15:00.000000000 Z
   data_status: 2
   elapsed_seconds: 76500.0
@@ -3161,7 +2942,6 @@ hardrock_2015_demetrius_moen_ouray_out_1:
 hardrock_2015_demetrius_moen_telluride_in_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_telluride
-  id: 2704
   absolute_time: 2015-07-11 15:43:00.000000000 Z
   data_status: 2
   elapsed_seconds: 99780.0
@@ -3174,7 +2954,6 @@ hardrock_2015_demetrius_moen_telluride_in_1:
 hardrock_2015_demetrius_moen_telluride_out_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_telluride
-  id: 2705
   absolute_time: 2015-07-11 16:02:00.000000000 Z
   data_status: 2
   elapsed_seconds: 100920.0
@@ -3187,7 +2966,6 @@ hardrock_2015_demetrius_moen_telluride_out_1:
 hardrock_2015_demetrius_moen_putnam_in_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_putnam
-  id: 2710
   absolute_time: 2015-07-12 05:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 149220.0
@@ -3200,7 +2978,6 @@ hardrock_2015_demetrius_moen_putnam_in_1:
 hardrock_2015_demetrius_moen_putnam_out_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_putnam
-  id: 2711
   absolute_time: 2015-07-12 05:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 149760.0
@@ -3213,7 +2990,6 @@ hardrock_2015_demetrius_moen_putnam_out_1:
 hardrock_2015_demetrius_moen_finish_1:
   effort: hardrock_2015_demetrius_moen
   split: hardrock_ccw_finish
-  id: 2712
   absolute_time: 2015-07-12 08:01:00.000000000 Z
   data_status: 2
   elapsed_seconds: 158460.0
@@ -3226,7 +3002,6 @@ hardrock_2015_demetrius_moen_finish_1:
 hardrock_2015_vern_buckridge_start_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_start
-  id: 2953
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -3239,7 +3014,6 @@ hardrock_2015_vern_buckridge_start_1:
 hardrock_2015_vern_buckridge_cunningham_in_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_cunningham
-  id: 2954
   absolute_time: 2015-07-10 14:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9960.0
@@ -3252,7 +3026,6 @@ hardrock_2015_vern_buckridge_cunningham_in_1:
 hardrock_2015_vern_buckridge_cunningham_out_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_cunningham
-  id: 2955
   absolute_time: 2015-07-10 14:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9960.0
@@ -3265,7 +3038,6 @@ hardrock_2015_vern_buckridge_cunningham_out_1:
 hardrock_2015_vern_buckridge_sherman_in_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_sherman
-  id: 2960
   absolute_time: 2015-07-10 21:45:00.000000000 Z
   data_status: 2
   elapsed_seconds: 35100.0
@@ -3278,7 +3050,6 @@ hardrock_2015_vern_buckridge_sherman_in_1:
 hardrock_2015_vern_buckridge_sherman_out_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_sherman
-  id: 2961
   absolute_time: 2015-07-10 22:09:00.000000000 Z
   data_status: 2
   elapsed_seconds: 36540.0
@@ -3291,7 +3062,6 @@ hardrock_2015_vern_buckridge_sherman_out_1:
 hardrock_2015_vern_buckridge_grouse_in_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_grouse
-  id: 2964
   absolute_time: 2015-07-11 04:04:00.000000000 Z
   data_status: 2
   elapsed_seconds: 57840.0
@@ -3304,7 +3074,6 @@ hardrock_2015_vern_buckridge_grouse_in_1:
 hardrock_2015_vern_buckridge_grouse_out_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_grouse
-  id: 2965
   absolute_time: 2015-07-11 04:21:00.000000000 Z
   data_status: 2
   elapsed_seconds: 58860.0
@@ -3317,7 +3086,6 @@ hardrock_2015_vern_buckridge_grouse_out_1:
 hardrock_2015_vern_buckridge_ouray_in_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_ouray
-  id: 2968
   absolute_time: 2015-07-11 09:48:00.000000000 Z
   data_status: 2
   elapsed_seconds: 78480.0
@@ -3330,7 +3098,6 @@ hardrock_2015_vern_buckridge_ouray_in_1:
 hardrock_2015_vern_buckridge_ouray_out_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_ouray
-  id: 2969
   absolute_time: 2015-07-11 10:15:00.000000000 Z
   data_status: 2
   elapsed_seconds: 80100.0
@@ -3343,7 +3110,6 @@ hardrock_2015_vern_buckridge_ouray_out_1:
 hardrock_2015_vern_buckridge_telluride_in_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_telluride
-  id: 2974
   absolute_time: 2015-07-11 17:08:00.000000000 Z
   data_status: 2
   elapsed_seconds: 104880.0
@@ -3356,7 +3122,6 @@ hardrock_2015_vern_buckridge_telluride_in_1:
 hardrock_2015_vern_buckridge_telluride_out_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_telluride
-  id: 2975
   absolute_time: 2015-07-11 17:29:00.000000000 Z
   data_status: 2
   elapsed_seconds: 106140.0
@@ -3369,7 +3134,6 @@ hardrock_2015_vern_buckridge_telluride_out_1:
 hardrock_2015_vern_buckridge_putnam_in_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_putnam
-  id: 2980
   absolute_time: 2015-07-12 06:54:00.000000000 Z
   data_status: 2
   elapsed_seconds: 154440.0
@@ -3382,7 +3146,6 @@ hardrock_2015_vern_buckridge_putnam_in_1:
 hardrock_2015_vern_buckridge_putnam_out_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_putnam
-  id: 2981
   absolute_time: 2015-07-12 07:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 154800.0
@@ -3395,7 +3158,6 @@ hardrock_2015_vern_buckridge_putnam_out_1:
 hardrock_2015_vern_buckridge_finish_1:
   effort: hardrock_2015_vern_buckridge
   split: hardrock_ccw_finish
-  id: 2982
   absolute_time: 2015-07-12 09:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 163200.0
@@ -3408,7 +3170,6 @@ hardrock_2015_vern_buckridge_finish_1:
 hardrock_2015_donte_spencer_start_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_start
-  id: 3163
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -3421,7 +3182,6 @@ hardrock_2015_donte_spencer_start_1:
 hardrock_2015_donte_spencer_cunningham_in_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_cunningham
-  id: 3164
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9600.0
@@ -3434,7 +3194,6 @@ hardrock_2015_donte_spencer_cunningham_in_1:
 hardrock_2015_donte_spencer_cunningham_out_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_cunningham
-  id: 3165
   absolute_time: 2015-07-10 14:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9600.0
@@ -3447,7 +3206,6 @@ hardrock_2015_donte_spencer_cunningham_out_1:
 hardrock_2015_donte_spencer_sherman_in_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_sherman
-  id: 3170
   absolute_time: 2015-07-10 20:54:00.000000000 Z
   data_status: 2
   elapsed_seconds: 32040.0
@@ -3460,7 +3218,6 @@ hardrock_2015_donte_spencer_sherman_in_1:
 hardrock_2015_donte_spencer_sherman_out_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_sherman
-  id: 3171
   absolute_time: 2015-07-10 21:17:00.000000000 Z
   data_status: 2
   elapsed_seconds: 33420.0
@@ -3473,7 +3230,6 @@ hardrock_2015_donte_spencer_sherman_out_1:
 hardrock_2015_donte_spencer_grouse_in_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_grouse
-  id: 3174
   absolute_time: 2015-07-11 02:11:00.000000000 Z
   data_status: 2
   elapsed_seconds: 51060.0
@@ -3486,7 +3242,6 @@ hardrock_2015_donte_spencer_grouse_in_1:
 hardrock_2015_donte_spencer_grouse_out_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_grouse
-  id: 3175
   absolute_time: 2015-07-11 02:43:00.000000000 Z
   data_status: 2
   elapsed_seconds: 52980.0
@@ -3499,7 +3254,6 @@ hardrock_2015_donte_spencer_grouse_out_1:
 hardrock_2015_donte_spencer_ouray_in_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_ouray
-  id: 3178
   absolute_time: 2015-07-11 09:34:00.000000000 Z
   data_status: 2
   elapsed_seconds: 77640.0
@@ -3512,7 +3266,6 @@ hardrock_2015_donte_spencer_ouray_in_1:
 hardrock_2015_donte_spencer_ouray_out_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_ouray
-  id: 3179
   absolute_time: 2015-07-11 11:19:00.000000000 Z
   data_status: 2
   elapsed_seconds: 83940.0
@@ -3525,7 +3278,6 @@ hardrock_2015_donte_spencer_ouray_out_1:
 hardrock_2015_donte_spencer_telluride_in_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_telluride
-  id: 3184
   absolute_time: 2015-07-11 17:44:00.000000000 Z
   data_status: 2
   elapsed_seconds: 107040.0
@@ -3538,7 +3290,6 @@ hardrock_2015_donte_spencer_telluride_in_1:
 hardrock_2015_donte_spencer_telluride_out_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_telluride
-  id: 3185
   absolute_time: 2015-07-11 17:56:00.000000000 Z
   data_status: 2
   elapsed_seconds: 107760.0
@@ -3551,7 +3302,6 @@ hardrock_2015_donte_spencer_telluride_out_1:
 hardrock_2015_donte_spencer_putnam_in_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_putnam
-  id: 3190
   absolute_time: 2015-07-12 07:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 156240.0
@@ -3564,7 +3314,6 @@ hardrock_2015_donte_spencer_putnam_in_1:
 hardrock_2015_donte_spencer_putnam_out_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_putnam
-  id: 3191
   absolute_time: 2015-07-12 08:48:00.000000000 Z
   data_status: 2
   elapsed_seconds: 161280.0
@@ -3577,7 +3326,6 @@ hardrock_2015_donte_spencer_putnam_out_1:
 hardrock_2015_donte_spencer_finish_1:
   effort: hardrock_2015_donte_spencer
   split: hardrock_ccw_finish
-  id: 3192
   absolute_time: 2015-07-12 10:48:00.000000000 Z
   data_status: 2
   elapsed_seconds: 168480.0
@@ -3590,7 +3338,6 @@ hardrock_2015_donte_spencer_finish_1:
 hardrock_2015_bruno_fadel_start_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_start
-  id: 3283
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -3603,7 +3350,6 @@ hardrock_2015_bruno_fadel_start_1:
 hardrock_2015_bruno_fadel_cunningham_in_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_cunningham
-  id: 3284
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11100.0
@@ -3616,7 +3362,6 @@ hardrock_2015_bruno_fadel_cunningham_in_1:
 hardrock_2015_bruno_fadel_cunningham_out_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_cunningham
-  id: 3285
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11100.0
@@ -3629,7 +3374,6 @@ hardrock_2015_bruno_fadel_cunningham_out_1:
 hardrock_2015_bruno_fadel_sherman_in_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_sherman
-  id: 3290
   absolute_time: 2015-07-10 22:10:00.000000000 Z
   data_status: 2
   elapsed_seconds: 36600.0
@@ -3642,7 +3386,6 @@ hardrock_2015_bruno_fadel_sherman_in_1:
 hardrock_2015_bruno_fadel_sherman_out_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_sherman
-  id: 3291
   absolute_time: 2015-07-10 22:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 37200.0
@@ -3655,7 +3398,6 @@ hardrock_2015_bruno_fadel_sherman_out_1:
 hardrock_2015_bruno_fadel_grouse_in_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_grouse
-  id: 3294
   absolute_time: 2015-07-11 04:15:00.000000000 Z
   data_status: 2
   elapsed_seconds: 58500.0
@@ -3668,7 +3410,6 @@ hardrock_2015_bruno_fadel_grouse_in_1:
 hardrock_2015_bruno_fadel_grouse_out_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_grouse
-  id: 3295
   absolute_time: 2015-07-11 04:32:00.000000000 Z
   data_status: 2
   elapsed_seconds: 59520.0
@@ -3681,7 +3422,6 @@ hardrock_2015_bruno_fadel_grouse_out_1:
 hardrock_2015_bruno_fadel_ouray_in_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_ouray
-  id: 3298
   absolute_time: 2015-07-11 10:13:00.000000000 Z
   data_status: 2
   elapsed_seconds: 79980.0
@@ -3694,7 +3434,6 @@ hardrock_2015_bruno_fadel_ouray_in_1:
 hardrock_2015_bruno_fadel_ouray_out_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_ouray
-  id: 3299
   absolute_time: 2015-07-11 10:35:00.000000000 Z
   data_status: 2
   elapsed_seconds: 81300.0
@@ -3707,7 +3446,6 @@ hardrock_2015_bruno_fadel_ouray_out_1:
 hardrock_2015_bruno_fadel_telluride_in_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_telluride
-  id: 3304
   absolute_time: 2015-07-11 17:18:00.000000000 Z
   data_status: 2
   elapsed_seconds: 105480.0
@@ -3720,7 +3458,6 @@ hardrock_2015_bruno_fadel_telluride_in_1:
 hardrock_2015_bruno_fadel_telluride_out_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_telluride
-  id: 3305
   absolute_time: 2015-07-11 17:37:00.000000000 Z
   data_status: 2
   elapsed_seconds: 106620.0
@@ -3733,7 +3470,6 @@ hardrock_2015_bruno_fadel_telluride_out_1:
 hardrock_2015_bruno_fadel_putnam_in_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_putnam
-  id: 3310
   absolute_time: 2015-07-12 08:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 159720.0
@@ -3746,7 +3482,6 @@ hardrock_2015_bruno_fadel_putnam_in_1:
 hardrock_2015_bruno_fadel_putnam_out_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_putnam
-  id: 3311
   absolute_time: 2015-07-12 08:28:00.000000000 Z
   data_status: 2
   elapsed_seconds: 160080.0
@@ -3759,7 +3494,6 @@ hardrock_2015_bruno_fadel_putnam_out_1:
 hardrock_2015_bruno_fadel_finish_1:
   effort: hardrock_2015_bruno_fadel
   split: hardrock_ccw_finish
-  id: 3312
   absolute_time: 2015-07-12 11:17:00.000000000 Z
   data_status: 2
   elapsed_seconds: 170220.0
@@ -3772,7 +3506,6 @@ hardrock_2015_bruno_fadel_finish_1:
 hardrock_2015_gus_walker_start_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_start
-  id: 3313
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -3785,7 +3518,6 @@ hardrock_2015_gus_walker_start_1:
 hardrock_2015_gus_walker_cunningham_in_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_cunningham
-  id: 3314
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11100.0
@@ -3798,7 +3530,6 @@ hardrock_2015_gus_walker_cunningham_in_1:
 hardrock_2015_gus_walker_cunningham_out_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_cunningham
-  id: 3315
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11100.0
@@ -3811,7 +3542,6 @@ hardrock_2015_gus_walker_cunningham_out_1:
 hardrock_2015_gus_walker_sherman_in_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_sherman
-  id: 3320
   absolute_time: 2015-07-10 22:26:00.000000000 Z
   data_status: 2
   elapsed_seconds: 37560.0
@@ -3824,7 +3554,6 @@ hardrock_2015_gus_walker_sherman_in_1:
 hardrock_2015_gus_walker_sherman_out_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_sherman
-  id: 3321
   absolute_time: 2015-07-10 22:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 38760.0
@@ -3837,7 +3566,6 @@ hardrock_2015_gus_walker_sherman_out_1:
 hardrock_2015_gus_walker_grouse_in_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_grouse
-  id: 3324
   absolute_time: 2015-07-11 05:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 61500.0
@@ -3850,7 +3578,6 @@ hardrock_2015_gus_walker_grouse_in_1:
 hardrock_2015_gus_walker_grouse_out_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_grouse
-  id: 3325
   absolute_time: 2015-07-11 05:09:00.000000000 Z
   data_status: 2
   elapsed_seconds: 61740.0
@@ -3863,7 +3590,6 @@ hardrock_2015_gus_walker_grouse_out_1:
 hardrock_2015_gus_walker_ouray_in_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_ouray
-  id: 3328
   absolute_time: 2015-07-11 09:04:00.000000000 Z
   data_status: 2
   elapsed_seconds: 75840.0
@@ -3876,7 +3602,6 @@ hardrock_2015_gus_walker_ouray_in_1:
 hardrock_2015_gus_walker_ouray_out_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_ouray
-  id: 3329
   absolute_time: 2015-07-11 09:16:00.000000000 Z
   data_status: 2
   elapsed_seconds: 76560.0
@@ -3889,7 +3614,6 @@ hardrock_2015_gus_walker_ouray_out_1:
 hardrock_2015_gus_walker_telluride_in_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_telluride
-  id: 3334
   absolute_time: 2015-07-11 18:49:00.000000000 Z
   data_status: 1
   elapsed_seconds: 110940.0
@@ -3902,7 +3626,6 @@ hardrock_2015_gus_walker_telluride_in_1:
 hardrock_2015_gus_walker_telluride_out_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_telluride
-  id: 3335
   absolute_time: 2015-07-11 19:08:00.000000000 Z
   data_status: 1
   elapsed_seconds: 112080.0
@@ -3915,7 +3638,6 @@ hardrock_2015_gus_walker_telluride_out_1:
 hardrock_2015_gus_walker_putnam_in_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_putnam
-  id: 3340
   absolute_time: 2015-07-12 09:28:00.000000000 Z
   data_status: 2
   elapsed_seconds: 163680.0
@@ -3928,7 +3650,6 @@ hardrock_2015_gus_walker_putnam_in_1:
 hardrock_2015_gus_walker_putnam_out_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_putnam
-  id: 3341
   absolute_time: 2015-07-12 09:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 163800.0
@@ -3941,7 +3662,6 @@ hardrock_2015_gus_walker_putnam_out_1:
 hardrock_2015_gus_walker_finish_1:
   effort: hardrock_2015_gus_walker
   split: hardrock_ccw_finish
-  id: 3342
   absolute_time: 2015-07-12 11:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 170520.0
@@ -3954,7 +3674,6 @@ hardrock_2015_gus_walker_finish_1:
 hardrock_2015_susanna_abshire_start_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_start
-  id: 3433
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -3967,7 +3686,6 @@ hardrock_2015_susanna_abshire_start_1:
 hardrock_2015_susanna_abshire_cunningham_in_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_cunningham
-  id: 3434
   absolute_time: 2015-07-10 15:16:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11760.0
@@ -3980,7 +3698,6 @@ hardrock_2015_susanna_abshire_cunningham_in_1:
 hardrock_2015_susanna_abshire_cunningham_out_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_cunningham
-  id: 3435
   absolute_time: 2015-07-10 15:16:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11760.0
@@ -3993,7 +3710,6 @@ hardrock_2015_susanna_abshire_cunningham_out_1:
 hardrock_2015_susanna_abshire_sherman_in_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_sherman
-  id: 3440
   absolute_time: 2015-07-10 22:50:00.000000000 Z
   data_status: 2
   elapsed_seconds: 39000.0
@@ -4006,7 +3722,6 @@ hardrock_2015_susanna_abshire_sherman_in_1:
 hardrock_2015_susanna_abshire_sherman_out_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_sherman
-  id: 3441
   absolute_time: 2015-07-10 23:02:00.000000000 Z
   data_status: 2
   elapsed_seconds: 39720.0
@@ -4019,7 +3734,6 @@ hardrock_2015_susanna_abshire_sherman_out_1:
 hardrock_2015_susanna_abshire_grouse_in_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_grouse
-  id: 3444
   absolute_time: 2015-07-11 05:25:00.000000000 Z
   data_status: 2
   elapsed_seconds: 62700.0
@@ -4032,7 +3746,6 @@ hardrock_2015_susanna_abshire_grouse_in_1:
 hardrock_2015_susanna_abshire_grouse_out_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_grouse
-  id: 3445
   absolute_time: 2015-07-11 05:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 63480.0
@@ -4045,7 +3758,6 @@ hardrock_2015_susanna_abshire_grouse_out_1:
 hardrock_2015_susanna_abshire_telluride_in_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_telluride
-  id: 3454
   absolute_time: 2015-07-11 19:11:00.000000000 Z
   data_status: 2
   elapsed_seconds: 112260.0
@@ -4058,7 +3770,6 @@ hardrock_2015_susanna_abshire_telluride_in_1:
 hardrock_2015_susanna_abshire_telluride_out_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_telluride
-  id: 3455
   absolute_time: 2015-07-11 19:21:00.000000000 Z
   data_status: 2
   elapsed_seconds: 112860.0
@@ -4071,7 +3782,6 @@ hardrock_2015_susanna_abshire_telluride_out_1:
 hardrock_2015_susanna_abshire_putnam_in_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_putnam
-  id: 3460
   absolute_time: 2015-07-12 09:26:00.000000000 Z
   data_status: 2
   elapsed_seconds: 163560.0
@@ -4084,7 +3794,6 @@ hardrock_2015_susanna_abshire_putnam_in_1:
 hardrock_2015_susanna_abshire_putnam_out_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_putnam
-  id: 3461
   absolute_time: 2015-07-12 09:26:00.000000000 Z
   data_status: 2
   elapsed_seconds: 163560.0
@@ -4097,7 +3806,6 @@ hardrock_2015_susanna_abshire_putnam_out_1:
 hardrock_2015_susanna_abshire_finish_1:
   effort: hardrock_2015_susanna_abshire
   split: hardrock_ccw_finish
-  id: 3462
   absolute_time: 2015-07-12 11:31:00.000000000 Z
   data_status: 2
   elapsed_seconds: 171060.0
@@ -4110,7 +3818,6 @@ hardrock_2015_susanna_abshire_finish_1:
 hardrock_2015_leandro_cole_start_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_start
-  id: 3553
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -4123,7 +3830,6 @@ hardrock_2015_leandro_cole_start_1:
 hardrock_2015_leandro_cole_cunningham_in_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_cunningham
-  id: 3554
   absolute_time: 2015-07-10 15:14:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11640.0
@@ -4136,7 +3842,6 @@ hardrock_2015_leandro_cole_cunningham_in_1:
 hardrock_2015_leandro_cole_cunningham_out_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_cunningham
-  id: 3555
   absolute_time: 2015-07-10 15:14:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11640.0
@@ -4149,7 +3854,6 @@ hardrock_2015_leandro_cole_cunningham_out_1:
 hardrock_2015_leandro_cole_sherman_in_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_sherman
-  id: 3560
   absolute_time: 2015-07-10 22:15:00.000000000 Z
   data_status: 2
   elapsed_seconds: 36900.0
@@ -4162,7 +3866,6 @@ hardrock_2015_leandro_cole_sherman_in_1:
 hardrock_2015_leandro_cole_sherman_out_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_sherman
-  id: 3561
   absolute_time: 2015-07-10 22:35:00.000000000 Z
   data_status: 2
   elapsed_seconds: 38100.0
@@ -4175,7 +3878,6 @@ hardrock_2015_leandro_cole_sherman_out_1:
 hardrock_2015_leandro_cole_grouse_in_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_grouse
-  id: 3564
   absolute_time: 2015-07-11 04:18:00.000000000 Z
   data_status: 2
   elapsed_seconds: 58680.0
@@ -4188,7 +3890,6 @@ hardrock_2015_leandro_cole_grouse_in_1:
 hardrock_2015_leandro_cole_grouse_out_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_grouse
-  id: 3565
   absolute_time: 2015-07-11 04:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 60780.0
@@ -4201,7 +3902,6 @@ hardrock_2015_leandro_cole_grouse_out_1:
 hardrock_2015_leandro_cole_ouray_in_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_ouray
-  id: 3568
   absolute_time: 2015-07-11 07:39:00.000000000 Z
   data_status: 1
   elapsed_seconds: 70740.0
@@ -4214,7 +3914,6 @@ hardrock_2015_leandro_cole_ouray_in_1:
 hardrock_2015_leandro_cole_ouray_out_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_ouray
-  id: 3569
   absolute_time: 2015-07-11 07:47:00.000000000 Z
   data_status: 1
   elapsed_seconds: 71220.0
@@ -4227,7 +3926,6 @@ hardrock_2015_leandro_cole_ouray_out_1:
 hardrock_2015_leandro_cole_telluride_in_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_telluride
-  id: 3574
   absolute_time: 2015-07-11 18:49:00.000000000 Z
   data_status: 2
   elapsed_seconds: 110940.0
@@ -4240,7 +3938,6 @@ hardrock_2015_leandro_cole_telluride_in_1:
 hardrock_2015_leandro_cole_telluride_out_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_telluride
-  id: 3575
   absolute_time: 2015-07-11 19:14:00.000000000 Z
   data_status: 2
   elapsed_seconds: 112440.0
@@ -4253,7 +3950,6 @@ hardrock_2015_leandro_cole_telluride_out_1:
 hardrock_2015_leandro_cole_putnam_in_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_putnam
-  id: 3580
   absolute_time: 2015-07-12 09:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 163800.0
@@ -4266,7 +3962,6 @@ hardrock_2015_leandro_cole_putnam_in_1:
 hardrock_2015_leandro_cole_putnam_out_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_putnam
-  id: 3581
   absolute_time: 2015-07-12 09:32:00.000000000 Z
   data_status: 2
   elapsed_seconds: 163920.0
@@ -4279,7 +3974,6 @@ hardrock_2015_leandro_cole_putnam_out_1:
 hardrock_2015_leandro_cole_finish_1:
   effort: hardrock_2015_leandro_cole
   split: hardrock_ccw_finish
-  id: 3582
   absolute_time: 2015-07-12 11:37:00.000000000 Z
   data_status: 2
   elapsed_seconds: 171420.0
@@ -4292,7 +3986,6 @@ hardrock_2015_leandro_cole_finish_1:
 hardrock_2015_benedict_davis_start_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_start
-  id: 3673
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -4305,7 +3998,6 @@ hardrock_2015_benedict_davis_start_1:
 hardrock_2015_benedict_davis_cunningham_in_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_cunningham
-  id: 3674
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11100.0
@@ -4318,7 +4010,6 @@ hardrock_2015_benedict_davis_cunningham_in_1:
 hardrock_2015_benedict_davis_cunningham_out_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_cunningham
-  id: 3675
   absolute_time: 2015-07-10 15:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11100.0
@@ -4331,7 +4022,6 @@ hardrock_2015_benedict_davis_cunningham_out_1:
 hardrock_2015_benedict_davis_sherman_in_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_sherman
-  id: 3680
   absolute_time: 2015-07-10 22:29:00.000000000 Z
   data_status: 2
   elapsed_seconds: 37740.0
@@ -4344,7 +4034,6 @@ hardrock_2015_benedict_davis_sherman_in_1:
 hardrock_2015_benedict_davis_sherman_out_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_sherman
-  id: 3681
   absolute_time: 2015-07-10 22:58:00.000000000 Z
   data_status: 2
   elapsed_seconds: 39480.0
@@ -4357,7 +4046,6 @@ hardrock_2015_benedict_davis_sherman_out_1:
 hardrock_2015_benedict_davis_grouse_in_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_grouse
-  id: 3684
   absolute_time: 2015-07-11 04:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 61140.0
@@ -4370,7 +4058,6 @@ hardrock_2015_benedict_davis_grouse_in_1:
 hardrock_2015_benedict_davis_grouse_out_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_grouse
-  id: 3685
   absolute_time: 2015-07-11 05:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 63360.0
@@ -4383,7 +4070,6 @@ hardrock_2015_benedict_davis_grouse_out_1:
 hardrock_2015_benedict_davis_ouray_in_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_ouray
-  id: 3688
   absolute_time: 2015-07-11 08:24:00.000000000 Z
   data_status: 1
   elapsed_seconds: 73440.0
@@ -4396,7 +4082,6 @@ hardrock_2015_benedict_davis_ouray_in_1:
 hardrock_2015_benedict_davis_ouray_out_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_ouray
-  id: 3689
   absolute_time: 2015-07-11 08:30:00.000000000 Z
   data_status: 1
   elapsed_seconds: 73800.0
@@ -4409,7 +4094,6 @@ hardrock_2015_benedict_davis_ouray_out_1:
 hardrock_2015_benedict_davis_telluride_in_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_telluride
-  id: 3694
   absolute_time: 2015-07-11 17:55:00.000000000 Z
   data_status: 2
   elapsed_seconds: 107700.0
@@ -4422,7 +4106,6 @@ hardrock_2015_benedict_davis_telluride_in_1:
 hardrock_2015_benedict_davis_telluride_out_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_telluride
-  id: 3695
   absolute_time: 2015-07-11 18:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 109620.0
@@ -4435,7 +4118,6 @@ hardrock_2015_benedict_davis_telluride_out_1:
 hardrock_2015_benedict_davis_putnam_in_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_putnam
-  id: 3700
   absolute_time: 2015-07-12 09:58:00.000000000 Z
   data_status: 2
   elapsed_seconds: 165480.0
@@ -4448,7 +4130,6 @@ hardrock_2015_benedict_davis_putnam_in_1:
 hardrock_2015_benedict_davis_putnam_out_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_putnam
-  id: 3701
   absolute_time: 2015-07-12 10:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 165600.0
@@ -4461,7 +4142,6 @@ hardrock_2015_benedict_davis_putnam_out_1:
 hardrock_2015_benedict_davis_finish_1:
   effort: hardrock_2015_benedict_davis
   split: hardrock_ccw_finish
-  id: 3702
   absolute_time: 2015-07-12 11:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 172740.0
@@ -4474,7 +4154,6 @@ hardrock_2015_benedict_davis_finish_1:
 hardrock_2015_raphael_swift_start_1:
   effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_start
-  id: 3869
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -4487,7 +4166,6 @@ hardrock_2015_raphael_swift_start_1:
 hardrock_2015_raphael_swift_cunningham_in_1:
   effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_cunningham
-  id: 3870
   absolute_time: 2015-07-10 15:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 12240.0
@@ -4500,7 +4178,6 @@ hardrock_2015_raphael_swift_cunningham_in_1:
 hardrock_2015_raphael_swift_cunningham_out_1:
   effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_cunningham
-  id: 3871
   absolute_time: 2015-07-10 15:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 12240.0
@@ -4513,7 +4190,6 @@ hardrock_2015_raphael_swift_cunningham_out_1:
 hardrock_2015_raphael_swift_sherman_in_1:
   effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_sherman
-  id: 3876
   absolute_time: 2015-07-10 22:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 39180.0
@@ -4526,7 +4202,6 @@ hardrock_2015_raphael_swift_sherman_in_1:
 hardrock_2015_raphael_swift_sherman_out_1:
   effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_sherman
-  id: 3877
   absolute_time: 2015-07-10 23:02:00.000000000 Z
   data_status: 2
   elapsed_seconds: 39720.0
@@ -4539,7 +4214,6 @@ hardrock_2015_raphael_swift_sherman_out_1:
 hardrock_2015_raphael_swift_grouse_in_1:
   effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_grouse
-  id: 3880
   absolute_time: 2015-07-11 05:04:00.000000000 Z
   data_status: 2
   elapsed_seconds: 61440.0
@@ -4552,7 +4226,6 @@ hardrock_2015_raphael_swift_grouse_in_1:
 hardrock_2015_raphael_swift_grouse_out_1:
   effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_grouse
-  id: 3881
   absolute_time: 2015-07-11 05:13:00.000000000 Z
   data_status: 2
   elapsed_seconds: 61980.0
@@ -4565,7 +4238,6 @@ hardrock_2015_raphael_swift_grouse_out_1:
 hardrock_2015_raphael_swift_ouray_in_1:
   effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_ouray
-  id: 3884
   absolute_time: 2015-07-11 07:59:00.000000000 Z
   data_status: 1
   elapsed_seconds: 71940.0
@@ -4578,7 +4250,6 @@ hardrock_2015_raphael_swift_ouray_in_1:
 hardrock_2015_raphael_swift_ouray_out_1:
   effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_ouray
-  id: 3885
   absolute_time: 2015-07-11 08:06:00.000000000 Z
   data_status: 1
   elapsed_seconds: 72360.0
@@ -4591,7 +4262,6 @@ hardrock_2015_raphael_swift_ouray_out_1:
 hardrock_2015_raphael_swift_telluride_in_1:
   effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_telluride
-  id: 3890
   absolute_time: 2015-07-11 18:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 109320.0
@@ -4604,7 +4274,6 @@ hardrock_2015_raphael_swift_telluride_in_1:
 hardrock_2015_raphael_swift_telluride_out_1:
   effort: hardrock_2015_raphael_swift
   split: hardrock_ccw_telluride
-  id: 3891
   absolute_time: 2015-07-11 18:44:00.000000000 Z
   data_status: 2
   elapsed_seconds: 110640.0
@@ -4617,7 +4286,6 @@ hardrock_2015_raphael_swift_telluride_out_1:
 hardrock_2015_bad_status_start_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_start
-  id: 3919
   absolute_time: 2015-07-10 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -4630,7 +4298,6 @@ hardrock_2015_bad_status_start_1:
 hardrock_2015_bad_status_cunningham_in_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_cunningham
-  id: 3920
   absolute_time: 2015-07-10 15:13:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11580.0
@@ -4643,7 +4310,6 @@ hardrock_2015_bad_status_cunningham_in_1:
 hardrock_2015_bad_status_cunningham_out_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_cunningham
-  id: 3921
   absolute_time: 2015-07-10 15:13:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11580.0
@@ -4656,7 +4322,6 @@ hardrock_2015_bad_status_cunningham_out_1:
 hardrock_2015_bad_status_sherman_in_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_sherman
-  id: 3926
   absolute_time: 2015-07-10 23:11:00.000000000 Z
   data_status: 2
   elapsed_seconds: 40260.0
@@ -4669,7 +4334,6 @@ hardrock_2015_bad_status_sherman_in_1:
 hardrock_2015_bad_status_sherman_out_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_sherman
-  id: 3927
   absolute_time: 2015-07-10 23:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 40920.0
@@ -4682,7 +4346,6 @@ hardrock_2015_bad_status_sherman_out_1:
 hardrock_2015_bad_status_grouse_in_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_grouse
-  id: 3930
   absolute_time: 2015-07-11 06:37:00.000000000 Z
   data_status: 2
   elapsed_seconds: 67020.0
@@ -4695,7 +4358,6 @@ hardrock_2015_bad_status_grouse_in_1:
 hardrock_2015_bad_status_grouse_out_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_grouse
-  id: 3931
   absolute_time: 2015-07-11 06:51:00.000000000 Z
   data_status: 2
   elapsed_seconds: 67860.0
@@ -4708,7 +4370,6 @@ hardrock_2015_bad_status_grouse_out_1:
 hardrock_2015_bad_status_ouray_in_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_ouray
-  id: 3934
   absolute_time: 2015-07-11 13:19:00.000000000 Z
   data_status: 2
   elapsed_seconds: 91140.0
@@ -4721,7 +4382,6 @@ hardrock_2015_bad_status_ouray_in_1:
 hardrock_2015_bad_status_ouray_out_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_ouray
-  id: 3935
   absolute_time: 2015-07-11 14:09:00.000000000 Z
   data_status: 2
   elapsed_seconds: 94140.0
@@ -4731,2805 +4391,9 @@ hardrock_2015_bad_status_ouray_out_1:
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
-hardrock_2015_irvin_harber_start_1:
-  effort: hardrock_2015_irvin_harber
-  split: hardrock_ccw_start
-  id: 3980
-  absolute_time: 2015-07-10 12:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2015_irvin_harber_cunningham_in_1:
-  effort: hardrock_2015_irvin_harber
-  split: hardrock_ccw_cunningham
-  id: 3981
-  absolute_time: 2015-07-10 14:24:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 8640.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2015_irvin_harber_cunningham_out_1:
-  effort: hardrock_2015_irvin_harber
-  split: hardrock_ccw_cunningham
-  id: 3982
-  absolute_time: 2015-07-10 14:24:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 8640.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2015_irvin_harber_sherman_in_1:
-  effort: hardrock_2015_irvin_harber
-  split: hardrock_ccw_sherman
-  id: 3987
-  absolute_time: 2015-07-10 19:39:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 27540.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2015_irvin_harber_sherman_out_1:
-  effort: hardrock_2015_irvin_harber
-  split: hardrock_ccw_sherman
-  id: 3988
-  absolute_time: 2015-07-10 19:45:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 27900.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2015_irvin_harber_grouse_in_1:
-  effort: hardrock_2015_irvin_harber
-  split: hardrock_ccw_grouse
-  id: 3991
-  absolute_time: 2015-07-11 00:44:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 45840.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2015_irvin_harber_grouse_out_1:
-  effort: hardrock_2015_irvin_harber
-  split: hardrock_ccw_grouse
-  id: 3992
-  absolute_time: 2015-07-11 01:10:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 47400.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2015_irvin_harber_ouray_in_1:
-  effort: hardrock_2015_irvin_harber
-  split: hardrock_ccw_ouray
-  id: 3995
-  absolute_time: 2015-07-11 05:46:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 63960.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2015_irvin_harber_ouray_out_1:
-  effort: hardrock_2015_irvin_harber
-  split: hardrock_ccw_ouray
-  id: 3996
-  absolute_time: 2015-07-11 05:46:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 63960.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2015_cassondra_nienow_start_1:
-  effort: hardrock_2015_cassondra_nienow
-  split: hardrock_ccw_start
-  id: 4190
-  absolute_time: 2015-07-10 12:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2015_cassondra_nienow_cunningham_in_1:
-  effort: hardrock_2015_cassondra_nienow
-  split: hardrock_ccw_cunningham
-  id: 4191
-  absolute_time: 2015-07-10 15:31:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 12660.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2015_cassondra_nienow_cunningham_out_1:
-  effort: hardrock_2015_cassondra_nienow
-  split: hardrock_ccw_cunningham
-  id: 4192
-  absolute_time: 2015-07-10 15:31:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 12660.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2015_cassondra_nienow_sherman_in_1:
-  effort: hardrock_2015_cassondra_nienow
-  split: hardrock_ccw_sherman
-  id: 4197
-  absolute_time: 2015-07-11 00:03:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 43380.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2015_cassondra_nienow_sherman_out_1:
-  effort: hardrock_2015_cassondra_nienow
-  split: hardrock_ccw_sherman
-  id: 4198
-  absolute_time: 2015-07-11 00:03:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 43380.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2015_donn_mckenzie_start_1:
-  effort: hardrock_2015_donn_mckenzie
-  split: hardrock_ccw_start
-  id: 4217
-  absolute_time: 2015-07-10 12:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2015_donn_mckenzie_cunningham_in_1:
-  effort: hardrock_2015_donn_mckenzie
-  split: hardrock_ccw_cunningham
-  id: 4218
-  absolute_time: 2015-07-10 14:30:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 9000.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2015_donn_mckenzie_cunningham_out_1:
-  effort: hardrock_2015_donn_mckenzie
-  split: hardrock_ccw_cunningham
-  id: 4219
-  absolute_time: 2015-07-10 14:30:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 9000.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-ramble_finished_first_start_1:
-  effort: ramble_finished_first
-  split: ramble_even_course_start
-  id: 15144
-  absolute_time: 2006-09-16 14:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ramble_finished_first_finish_1:
-  effort: ramble_finished_first
-  split: ramble_even_course_finish
-  id: 15145
-  absolute_time: 2006-09-16 14:34:22.000000000 Z
-  data_status: 2
-  elapsed_seconds: 2062.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-ramble_finished_second_start_1:
-  effort: ramble_finished_second
-  split: ramble_even_course_start
-  id: 15160
-  absolute_time: 2006-09-16 14:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ramble_finished_second_finish_1:
-  effort: ramble_finished_second
-  split: ramble_even_course_finish
-  id: 15161
-  absolute_time: 2006-09-16 14:37:31.000000000 Z
-  data_status: 2
-  elapsed_seconds: 2251.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-ramble_start_only_start_1:
-  effort: ramble_start_only
-  split: ramble_even_course_start
-  id: 15166
-  absolute_time: 2006-09-16 14:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_first_start_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_start
-  id: 91259
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_first_telluride_in_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_telluride
-  id: 91264
-  absolute_time: 2014-07-11 18:24:00.000000000 Z
-  data_status:
-  elapsed_seconds: 23040.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_first_telluride_out_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_telluride
-  id: 91265
-  absolute_time: 2014-07-11 18:26:00.000000000 Z
-  data_status:
-  elapsed_seconds: 23160.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_first_ouray_in_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_ouray
-  id: 91270
-  absolute_time: 2014-07-11 21:50:00.000000000 Z
-  data_status:
-  elapsed_seconds: 35400.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_first_ouray_out_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_ouray
-  id: 91271
-  absolute_time: 2014-07-11 21:52:00.000000000 Z
-  data_status:
-  elapsed_seconds: 35520.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_first_grouse_in_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_grouse
-  id: 91274
-  absolute_time: 2014-07-12 01:38:00.000000000 Z
-  data_status:
-  elapsed_seconds: 49080.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_first_grouse_out_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_grouse
-  id: 91275
-  absolute_time: 2014-07-12 01:43:00.000000000 Z
-  data_status:
-  elapsed_seconds: 49380.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_first_sherman_in_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_sherman
-  id: 91278
-  absolute_time: 2014-07-12 06:08:00.000000000 Z
-  data_status:
-  elapsed_seconds: 65280.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_first_sherman_out_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_sherman
-  id: 91279
-  absolute_time: 2014-07-12 06:17:00.000000000 Z
-  data_status:
-  elapsed_seconds: 65820.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_first_cunningham_in_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_cunningham
-  id: 91284
-  absolute_time: 2014-07-12 13:21:00.000000000 Z
-  data_status:
-  elapsed_seconds: 91260.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_first_cunningham_out_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_cunningham
-  id: 91285
-  absolute_time: 2014-07-12 13:27:00.000000000 Z
-  data_status:
-  elapsed_seconds: 91620.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_first_finish_1:
-  effort: hardrock_2014_finished_first
-  split: hardrock_cw_finish
-  id: 91286
-  absolute_time: 2014-07-12 16:07:38.000000000 Z
-  data_status:
-  elapsed_seconds: 101258.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_with_stop_start_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_start
-  id: 91287
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_with_stop_telluride_in_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_telluride
-  id: 91292
-  absolute_time: 2014-07-11 18:59:00.000000000 Z
-  data_status:
-  elapsed_seconds: 25140.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_with_stop_telluride_out_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_telluride
-  id: 91293
-  absolute_time: 2014-07-11 19:03:00.000000000 Z
-  data_status:
-  elapsed_seconds: 25380.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_with_stop_ouray_in_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_ouray
-  id: 91298
-  absolute_time: 2014-07-11 22:43:00.000000000 Z
-  data_status:
-  elapsed_seconds: 38580.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_with_stop_ouray_out_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_ouray
-  id: 91299
-  absolute_time: 2014-07-11 22:46:00.000000000 Z
-  data_status:
-  elapsed_seconds: 38760.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_with_stop_grouse_in_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_grouse
-  id: 91302
-  absolute_time: 2014-07-12 02:56:00.000000000 Z
-  data_status:
-  elapsed_seconds: 53760.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_with_stop_grouse_out_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_grouse
-  id: 91303
-  absolute_time: 2014-07-12 03:06:00.000000000 Z
-  data_status:
-  elapsed_seconds: 54360.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_with_stop_sherman_in_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_sherman
-  id: 91306
-  absolute_time: 2014-07-12 07:05:00.000000000 Z
-  data_status:
-  elapsed_seconds: 68700.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_with_stop_sherman_out_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_sherman
-  id: 91307
-  absolute_time: 2014-07-12 07:15:00.000000000 Z
-  data_status:
-  elapsed_seconds: 69300.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_with_stop_cunningham_in_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_cunningham
-  id: 91312
-  absolute_time: 2014-07-12 13:43:00.000000000 Z
-  data_status:
-  elapsed_seconds: 92580.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_with_stop_cunningham_out_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_cunningham
-  id: 91313
-  absolute_time: 2014-07-12 13:46:00.000000000 Z
-  data_status:
-  elapsed_seconds: 92760.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_with_stop_finish_1:
-  effort: hardrock_2014_finished_with_stop
-  split: hardrock_cw_finish
-  id: 91314
-  absolute_time: 2014-07-12 16:23:42.000000000 Z
-  data_status:
-  elapsed_seconds: 102222.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_without_stop_start_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_start
-  id: 91315
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_without_stop_telluride_in_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_telluride
-  id: 91320
-  absolute_time: 2014-07-11 18:53:00.000000000 Z
-  data_status:
-  elapsed_seconds: 24780.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_without_stop_telluride_out_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_telluride
-  id: 91321
-  absolute_time: 2014-07-11 18:56:00.000000000 Z
-  data_status:
-  elapsed_seconds: 24960.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_without_stop_ouray_in_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_ouray
-  id: 91326
-  absolute_time: 2014-07-11 22:43:00.000000000 Z
-  data_status:
-  elapsed_seconds: 38580.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_without_stop_ouray_out_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_ouray
-  id: 91327
-  absolute_time: 2014-07-11 22:50:00.000000000 Z
-  data_status:
-  elapsed_seconds: 39000.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_without_stop_grouse_in_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_grouse
-  id: 91330
-  absolute_time: 2014-07-12 03:10:00.000000000 Z
-  data_status:
-  elapsed_seconds: 54600.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_without_stop_grouse_out_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_grouse
-  id: 91331
-  absolute_time: 2014-07-12 03:15:00.000000000 Z
-  data_status:
-  elapsed_seconds: 54900.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_without_stop_sherman_in_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_sherman
-  id: 91334
-  absolute_time: 2014-07-12 07:15:00.000000000 Z
-  data_status:
-  elapsed_seconds: 69300.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_without_stop_sherman_out_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_sherman
-  id: 91335
-  absolute_time: 2014-07-12 07:23:59.000000000 Z
-  data_status:
-  elapsed_seconds: 69839.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_without_stop_cunningham_in_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_cunningham
-  id: 91340
-  absolute_time: 2014-07-12 14:04:00.000000000 Z
-  data_status:
-  elapsed_seconds: 93840.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_finished_without_stop_cunningham_out_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_cunningham
-  id: 91341
-  absolute_time: 2014-07-12 14:04:00.000000000 Z
-  data_status:
-  elapsed_seconds: 93840.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_finished_without_stop_finish_1:
-  effort: hardrock_2014_finished_without_stop
-  split: hardrock_cw_finish
-  id: 91342
-  absolute_time: 2014-07-12 16:28:54.000000000 Z
-  data_status:
-  elapsed_seconds: 102534.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_claudio_wunsch_start_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_start
-  id: 91819
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_claudio_wunsch_telluride_in_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_telluride
-  id: 91824
-  absolute_time: 2014-07-11 19:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 25200.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_claudio_wunsch_telluride_out_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_telluride
-  id: 91825
-  absolute_time: 2014-07-11 19:07:00.000000000 Z
-  data_status:
-  elapsed_seconds: 25620.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_claudio_wunsch_ouray_in_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_ouray
-  id: 91830
-  absolute_time: 2014-07-11 23:04:00.000000000 Z
-  data_status:
-  elapsed_seconds: 39840.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_claudio_wunsch_ouray_out_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_ouray
-  id: 91831
-  absolute_time: 2014-07-11 23:24:00.000000000 Z
-  data_status:
-  elapsed_seconds: 41040.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_claudio_wunsch_grouse_in_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_grouse
-  id: 91834
-  absolute_time: 2014-07-12 03:55:00.000000000 Z
-  data_status:
-  elapsed_seconds: 57300.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_claudio_wunsch_grouse_out_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_grouse
-  id: 91835
-  absolute_time: 2014-07-12 04:37:00.000000000 Z
-  data_status:
-  elapsed_seconds: 59820.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_claudio_wunsch_sherman_in_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_sherman
-  id: 91838
-  absolute_time: 2014-07-12 10:17:00.000000000 Z
-  data_status:
-  elapsed_seconds: 80220.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_claudio_wunsch_sherman_out_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_sherman
-  id: 91839
-  absolute_time: 2014-07-12 10:33:00.000000000 Z
-  data_status:
-  elapsed_seconds: 81180.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_claudio_wunsch_cunningham_in_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_cunningham
-  id: 91844
-  absolute_time: 2014-07-12 19:19:00.000000000 Z
-  data_status:
-  elapsed_seconds: 112740.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_claudio_wunsch_cunningham_out_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_cunningham
-  id: 91845
-  absolute_time: 2014-07-12 19:34:00.000000000 Z
-  data_status:
-  elapsed_seconds: 113640.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_claudio_wunsch_finish_1:
-  effort: hardrock_2014_claudio_wunsch
-  split: hardrock_cw_finish
-  id: 91846
-  absolute_time: 2014-07-12 23:58:21.000000000 Z
-  data_status:
-  elapsed_seconds: 129501.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_rachelle_eichmann_start_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_start
-  id: 92015
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_rachelle_eichmann_telluride_in_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_telluride
-  id: 92020
-  absolute_time: 2014-07-11 20:26:59.000000000 Z
-  data_status:
-  elapsed_seconds: 30419.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_rachelle_eichmann_telluride_out_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_telluride
-  id: 92021
-  absolute_time: 2014-07-11 20:39:00.000000000 Z
-  data_status:
-  elapsed_seconds: 31140.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_rachelle_eichmann_ouray_in_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_ouray
-  id: 92026
-  absolute_time: 2014-07-12 01:23:00.000000000 Z
-  data_status:
-  elapsed_seconds: 48180.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_rachelle_eichmann_ouray_out_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_ouray
-  id: 92027
-  absolute_time: 2014-07-12 01:33:00.000000000 Z
-  data_status:
-  elapsed_seconds: 48780.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_rachelle_eichmann_grouse_in_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_grouse
-  id: 92030
-  absolute_time: 2014-07-12 07:25:00.000000000 Z
-  data_status:
-  elapsed_seconds: 69900.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_rachelle_eichmann_grouse_out_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_grouse
-  id: 92031
-  absolute_time: 2014-07-12 07:49:00.000000000 Z
-  data_status:
-  elapsed_seconds: 71340.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_rachelle_eichmann_sherman_in_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_sherman
-  id: 92034
-  absolute_time: 2014-07-12 13:30:00.000000000 Z
-  data_status:
-  elapsed_seconds: 91800.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_rachelle_eichmann_sherman_out_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_sherman
-  id: 92035
-  absolute_time: 2014-07-12 13:49:00.000000000 Z
-  data_status:
-  elapsed_seconds: 92940.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_rachelle_eichmann_cunningham_in_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_cunningham
-  id: 92040
-  absolute_time: 2014-07-12 21:53:00.000000000 Z
-  data_status:
-  elapsed_seconds: 121980.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_rachelle_eichmann_cunningham_out_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_cunningham
-  id: 92041
-  absolute_time: 2014-07-12 21:58:00.000000000 Z
-  data_status:
-  elapsed_seconds: 122280.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_rachelle_eichmann_finish_1:
-  effort: hardrock_2014_rachelle_eichmann
-  split: hardrock_cw_finish
-  id: 92042
-  absolute_time: 2014-07-13 01:39:17.000000000 Z
-  data_status:
-  elapsed_seconds: 135557.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_keith_metz_start_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_start
-  id: 92211
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_keith_metz_telluride_in_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_telluride
-  id: 92216
-  absolute_time: 2014-07-11 20:30:00.000000000 Z
-  data_status:
-  elapsed_seconds: 30600.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_keith_metz_telluride_out_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_telluride
-  id: 92217
-  absolute_time: 2014-07-11 20:42:00.000000000 Z
-  data_status:
-  elapsed_seconds: 31320.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_keith_metz_ouray_in_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_ouray
-  id: 92222
-  absolute_time: 2014-07-12 01:27:00.000000000 Z
-  data_status:
-  elapsed_seconds: 48420.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_keith_metz_ouray_out_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_ouray
-  id: 92223
-  absolute_time: 2014-07-12 01:43:00.000000000 Z
-  data_status:
-  elapsed_seconds: 49380.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_keith_metz_grouse_in_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_grouse
-  id: 92226
-  absolute_time: 2014-07-12 07:30:00.000000000 Z
-  data_status:
-  elapsed_seconds: 70200.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_keith_metz_grouse_out_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_grouse
-  id: 92227
-  absolute_time: 2014-07-12 07:56:00.000000000 Z
-  data_status:
-  elapsed_seconds: 71760.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_keith_metz_sherman_in_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_sherman
-  id: 92230
-  absolute_time: 2014-07-12 14:03:00.000000000 Z
-  data_status:
-  elapsed_seconds: 93780.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_keith_metz_sherman_out_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_sherman
-  id: 92231
-  absolute_time: 2014-07-12 14:22:00.000000000 Z
-  data_status:
-  elapsed_seconds: 94920.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_keith_metz_cunningham_in_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_cunningham
-  id: 92236
-  absolute_time: 2014-07-12 23:19:00.000000000 Z
-  data_status:
-  elapsed_seconds: 127140.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_keith_metz_cunningham_out_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_cunningham
-  id: 92237
-  absolute_time: 2014-07-12 23:30:00.000000000 Z
-  data_status:
-  elapsed_seconds: 127800.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_keith_metz_finish_1:
-  effort: hardrock_2014_keith_metz
-  split: hardrock_cw_finish
-  id: 92238
-  absolute_time: 2014-07-13 02:59:02.000000000 Z
-  data_status:
-  elapsed_seconds: 140342.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_major_green_start_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_start
-  id: 92239
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_major_green_telluride_in_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_telluride
-  id: 92244
-  absolute_time: 2014-07-11 20:52:00.000000000 Z
-  data_status:
-  elapsed_seconds: 31920.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_major_green_telluride_out_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_telluride
-  id: 92245
-  absolute_time: 2014-07-11 20:58:00.000000000 Z
-  data_status:
-  elapsed_seconds: 32280.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_major_green_ouray_in_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_ouray
-  id: 92250
-  absolute_time: 2014-07-12 02:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 50400.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_major_green_ouray_out_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_ouray
-  id: 92251
-  absolute_time: 2014-07-12 02:12:00.000000000 Z
-  data_status:
-  elapsed_seconds: 51120.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_major_green_grouse_in_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_grouse
-  id: 92254
-  absolute_time: 2014-07-12 08:07:00.000000000 Z
-  data_status:
-  elapsed_seconds: 72420.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_major_green_grouse_out_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_grouse
-  id: 92255
-  absolute_time: 2014-07-12 08:18:00.000000000 Z
-  data_status:
-  elapsed_seconds: 73080.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_major_green_sherman_in_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_sherman
-  id: 92258
-  absolute_time: 2014-07-12 14:25:00.000000000 Z
-  data_status:
-  elapsed_seconds: 95100.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_major_green_sherman_out_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_sherman
-  id: 92259
-  absolute_time: 2014-07-12 14:40:00.000000000 Z
-  data_status:
-  elapsed_seconds: 96000.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_major_green_cunningham_in_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_cunningham
-  id: 92264
-  absolute_time: 2014-07-12 23:13:00.000000000 Z
-  data_status:
-  elapsed_seconds: 126780.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_major_green_cunningham_out_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_cunningham
-  id: 92265
-  absolute_time: 2014-07-12 23:23:00.000000000 Z
-  data_status:
-  elapsed_seconds: 127380.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_major_green_finish_1:
-  effort: hardrock_2014_major_green
-  split: hardrock_cw_finish
-  id: 92266
-  absolute_time: 2014-07-13 03:03:41.000000000 Z
-  data_status:
-  elapsed_seconds: 140621.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_humberto_adams_start_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_start
-  id: 92631
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_humberto_adams_telluride_in_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_telluride
-  id: 92636
-  absolute_time: 2014-07-11 20:54:59.000000000 Z
-  data_status:
-  elapsed_seconds: 32099.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_humberto_adams_telluride_out_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_telluride
-  id: 92637
-  absolute_time: 2014-07-11 21:58:00.000000000 Z
-  data_status:
-  elapsed_seconds: 35880.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_humberto_adams_ouray_in_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_ouray
-  id: 92642
-  absolute_time: 2014-07-12 01:56:59.000000000 Z
-  data_status:
-  elapsed_seconds: 50219.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_humberto_adams_ouray_out_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_ouray
-  id: 92643
-  absolute_time: 2014-07-12 02:20:00.000000000 Z
-  data_status:
-  elapsed_seconds: 51600.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_humberto_adams_grouse_in_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_grouse
-  id: 92646
-  absolute_time: 2014-07-12 09:36:00.000000000 Z
-  data_status:
-  elapsed_seconds: 77760.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_humberto_adams_grouse_out_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_grouse
-  id: 92647
-  absolute_time: 2014-07-12 10:22:00.000000000 Z
-  data_status:
-  elapsed_seconds: 80520.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_humberto_adams_sherman_in_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_sherman
-  id: 92650
-  absolute_time: 2014-07-12 16:25:00.000000000 Z
-  data_status:
-  elapsed_seconds: 102300.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_humberto_adams_sherman_out_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_sherman
-  id: 92651
-  absolute_time: 2014-07-12 16:45:00.000000000 Z
-  data_status:
-  elapsed_seconds: 103500.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_humberto_adams_cunningham_in_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_cunningham
-  id: 92656
-  absolute_time: 2014-07-13 01:18:00.000000000 Z
-  data_status:
-  elapsed_seconds: 134280.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_humberto_adams_cunningham_out_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_cunningham
-  id: 92657
-  absolute_time: 2014-07-13 01:30:00.000000000 Z
-  data_status:
-  elapsed_seconds: 135000.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_humberto_adams_finish_1:
-  effort: hardrock_2014_humberto_adams
-  split: hardrock_cw_finish
-  id: 92658
-  absolute_time: 2014-07-13 05:40:21.000000000 Z
-  data_status:
-  elapsed_seconds: 150021.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_omer_yundt_start_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_start
-  id: 93331
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_omer_yundt_telluride_in_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_telluride
-  id: 93336
-  absolute_time: 2014-07-11 21:34:00.000000000 Z
-  data_status:
-  elapsed_seconds: 34440.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_omer_yundt_telluride_out_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_telluride
-  id: 93337
-  absolute_time: 2014-07-11 22:06:00.000000000 Z
-  data_status:
-  elapsed_seconds: 36360.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_omer_yundt_ouray_in_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_ouray
-  id: 93342
-  absolute_time: 2014-07-12 03:38:00.000000000 Z
-  data_status:
-  elapsed_seconds: 56280.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_omer_yundt_ouray_out_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_ouray
-  id: 93343
-  absolute_time: 2014-07-12 04:26:00.000000000 Z
-  data_status:
-  elapsed_seconds: 59160.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_omer_yundt_grouse_in_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_grouse
-  id: 93346
-  absolute_time: 2014-07-12 10:33:00.000000000 Z
-  data_status:
-  elapsed_seconds: 81180.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_omer_yundt_grouse_out_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_grouse
-  id: 93347
-  absolute_time: 2014-07-12 11:34:00.000000000 Z
-  data_status:
-  elapsed_seconds: 84840.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_omer_yundt_sherman_in_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_sherman
-  id: 93350
-  absolute_time: 2014-07-12 17:22:00.000000000 Z
-  data_status:
-  elapsed_seconds: 105720.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_omer_yundt_sherman_out_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_sherman
-  id: 93351
-  absolute_time: 2014-07-12 18:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 108000.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_omer_yundt_cunningham_in_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_cunningham
-  id: 93356
-  absolute_time: 2014-07-13 02:14:00.000000000 Z
-  data_status:
-  elapsed_seconds: 137640.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_omer_yundt_cunningham_out_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_cunningham
-  id: 93357
-  absolute_time: 2014-07-13 02:33:00.000000000 Z
-  data_status:
-  elapsed_seconds: 138780.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_omer_yundt_finish_1:
-  effort: hardrock_2014_omer_yundt
-  split: hardrock_cw_finish
-  id: 93358
-  absolute_time: 2014-07-13 08:48:15.000000000 Z
-  data_status:
-  elapsed_seconds: 161295.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_pat_schaden_start_1:
-  effort: hardrock_2014_pat_schaden
-  split: hardrock_cw_start
-  id: 93359
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_pat_schaden_telluride_in_1:
-  effort: hardrock_2014_pat_schaden
-  split: hardrock_cw_telluride
-  id: 93364
-  absolute_time: 2014-07-11 22:35:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 38100.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_pat_schaden_telluride_out_1:
-  effort: hardrock_2014_pat_schaden
-  split: hardrock_cw_telluride
-  id: 93365
-  absolute_time: 2014-07-11 22:47:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 38820.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_pat_schaden_ouray_in_1:
-  effort: hardrock_2014_pat_schaden
-  split: hardrock_cw_ouray
-  id: 93370
-  absolute_time: 2014-07-12 04:44:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 60240.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_pat_schaden_ouray_out_1:
-  effort: hardrock_2014_pat_schaden
-  split: hardrock_cw_ouray
-  id: 93371
-  absolute_time: 2014-07-12 05:16:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 62160.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_pat_schaden_grouse_in_1:
-  effort: hardrock_2014_pat_schaden
-  split: hardrock_cw_grouse
-  id: 93374
-  absolute_time: 2014-07-12 12:27:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 88020.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_pat_schaden_grouse_out_1:
-  effort: hardrock_2014_pat_schaden
-  split: hardrock_cw_grouse
-  id: 93375
-  absolute_time: 2014-07-12 12:48:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 89280.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_pat_schaden_sherman_in_1:
-  effort: hardrock_2014_pat_schaden
-  split: hardrock_cw_sherman
-  id: 93378
-  absolute_time: 2014-07-12 18:29:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 109740.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_pat_schaden_sherman_out_1:
-  effort: hardrock_2014_pat_schaden
-  split: hardrock_cw_sherman
-  id: 93379
-  absolute_time: 2014-07-12 18:52:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 111120.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_pat_schaden_cunningham_in_1:
-  effort: hardrock_2014_pat_schaden
-  split: hardrock_cw_cunningham
-  id: 93384
-  absolute_time: 2014-07-13 04:14:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 144840.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_clarence_goyette_start_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_start
-  id: 93415
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_clarence_goyette_telluride_in_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_telluride
-  id: 93420
-  absolute_time: 2014-07-11 22:05:00.000000000 Z
-  data_status:
-  elapsed_seconds: 36300.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_clarence_goyette_telluride_out_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_telluride
-  id: 93421
-  absolute_time: 2014-07-11 22:14:00.000000000 Z
-  data_status:
-  elapsed_seconds: 36840.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_clarence_goyette_ouray_in_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_ouray
-  id: 93426
-  absolute_time: 2014-07-12 04:32:00.000000000 Z
-  data_status:
-  elapsed_seconds: 59520.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_clarence_goyette_ouray_out_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_ouray
-  id: 93427
-  absolute_time: 2014-07-12 05:02:00.000000000 Z
-  data_status:
-  elapsed_seconds: 61320.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_clarence_goyette_grouse_in_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_grouse
-  id: 93430
-  absolute_time: 2014-07-12 11:19:00.000000000 Z
-  data_status:
-  elapsed_seconds: 83940.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_clarence_goyette_grouse_out_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_grouse
-  id: 93431
-  absolute_time: 2014-07-12 11:59:00.000000000 Z
-  data_status:
-  elapsed_seconds: 86340.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_clarence_goyette_sherman_in_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_sherman
-  id: 93434
-  absolute_time: 2014-07-12 18:06:00.000000000 Z
-  data_status:
-  elapsed_seconds: 108360.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_clarence_goyette_sherman_out_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_sherman
-  id: 93435
-  absolute_time: 2014-07-12 18:32:00.000000000 Z
-  data_status:
-  elapsed_seconds: 109920.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_clarence_goyette_cunningham_in_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_cunningham
-  id: 93440
-  absolute_time: 2014-07-13 04:02:00.000000000 Z
-  data_status:
-  elapsed_seconds: 144120.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_clarence_goyette_cunningham_out_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_cunningham
-  id: 93441
-  absolute_time: 2014-07-13 04:32:00.000000000 Z
-  data_status:
-  elapsed_seconds: 145920.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_clarence_goyette_finish_1:
-  effort: hardrock_2014_clarence_goyette
-  split: hardrock_cw_finish
-  id: 93442
-  absolute_time: 2014-07-13 09:21:28.000000000 Z
-  data_status:
-  elapsed_seconds: 163288.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_irvin_corkery_start_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_start
-  id: 93471
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_irvin_corkery_telluride_in_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_telluride
-  id: 93476
-  absolute_time: 2014-07-11 20:21:00.000000000 Z
-  data_status:
-  elapsed_seconds: 30060.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_irvin_corkery_telluride_out_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_telluride
-  id: 93477
-  absolute_time: 2014-07-11 20:32:00.000000000 Z
-  data_status:
-  elapsed_seconds: 30720.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_irvin_corkery_ouray_in_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_ouray
-  id: 93482
-  absolute_time: 2014-07-12 01:25:00.000000000 Z
-  data_status:
-  elapsed_seconds: 48300.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_irvin_corkery_ouray_out_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_ouray
-  id: 93483
-  absolute_time: 2014-07-12 01:45:00.000000000 Z
-  data_status:
-  elapsed_seconds: 49500.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_irvin_corkery_grouse_in_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_grouse
-  id: 93486
-  absolute_time: 2014-07-12 07:39:00.000000000 Z
-  data_status:
-  elapsed_seconds: 70740.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_irvin_corkery_grouse_out_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_grouse
-  id: 93487
-  absolute_time: 2014-07-12 08:12:59.000000000 Z
-  data_status:
-  elapsed_seconds: 72779.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_irvin_corkery_sherman_in_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_sherman
-  id: 93490
-  absolute_time: 2014-07-12 15:59:00.000000000 Z
-  data_status:
-  elapsed_seconds: 100740.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_irvin_corkery_sherman_out_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_sherman
-  id: 93491
-  absolute_time: 2014-07-12 16:35:00.000000000 Z
-  data_status:
-  elapsed_seconds: 102900.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_irvin_corkery_cunningham_in_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_cunningham
-  id: 93496
-  absolute_time: 2014-07-13 03:38:00.000000000 Z
-  data_status:
-  elapsed_seconds: 142680.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_irvin_corkery_cunningham_out_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_cunningham
-  id: 93497
-  absolute_time: 2014-07-13 03:54:00.000000000 Z
-  data_status:
-  elapsed_seconds: 143640.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_irvin_corkery_finish_1:
-  effort: hardrock_2014_irvin_corkery
-  split: hardrock_cw_finish
-  id: 93498
-  absolute_time: 2014-07-13 09:25:16.000000000 Z
-  data_status:
-  elapsed_seconds: 163516.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_willis_murray_start_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_start
-  id: 93527
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_willis_murray_telluride_in_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_telluride
-  id: 93532
-  absolute_time: 2014-07-11 22:05:00.000000000 Z
-  data_status:
-  elapsed_seconds: 36300.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_willis_murray_telluride_out_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_telluride
-  id: 93533
-  absolute_time: 2014-07-11 22:20:00.000000000 Z
-  data_status:
-  elapsed_seconds: 37200.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_willis_murray_ouray_in_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_ouray
-  id: 93538
-  absolute_time: 2014-07-12 03:53:00.000000000 Z
-  data_status:
-  elapsed_seconds: 57180.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_willis_murray_ouray_out_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_ouray
-  id: 93539
-  absolute_time: 2014-07-12 04:31:00.000000000 Z
-  data_status:
-  elapsed_seconds: 59460.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_willis_murray_grouse_in_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_grouse
-  id: 93542
-  absolute_time: 2014-07-12 11:49:00.000000000 Z
-  data_status:
-  elapsed_seconds: 85740.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_willis_murray_grouse_out_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_grouse
-  id: 93543
-  absolute_time: 2014-07-12 12:18:00.000000000 Z
-  data_status:
-  elapsed_seconds: 87480.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_willis_murray_sherman_in_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_sherman
-  id: 93546
-  absolute_time: 2014-07-12 18:11:00.000000000 Z
-  data_status:
-  elapsed_seconds: 108660.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_willis_murray_sherman_out_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_sherman
-  id: 93547
-  absolute_time: 2014-07-12 18:46:00.000000000 Z
-  data_status:
-  elapsed_seconds: 110760.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_willis_murray_cunningham_in_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_cunningham
-  id: 93552
-  absolute_time: 2014-07-13 04:11:00.000000000 Z
-  data_status:
-  elapsed_seconds: 144660.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_willis_murray_cunningham_out_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_cunningham
-  id: 93553
-  absolute_time: 2014-07-13 04:38:00.000000000 Z
-  data_status:
-  elapsed_seconds: 146280.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_willis_murray_finish_1:
-  effort: hardrock_2014_willis_murray
-  split: hardrock_cw_finish
-  id: 93554
-  absolute_time: 2014-07-13 09:40:40.000000000 Z
-  data_status:
-  elapsed_seconds: 164440.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_ken_bradtke_start_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_start
-  id: 93611
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_ken_bradtke_telluride_in_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_telluride
-  id: 93616
-  absolute_time: 2014-07-11 21:58:00.000000000 Z
-  data_status:
-  elapsed_seconds: 35880.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_ken_bradtke_telluride_out_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_telluride
-  id: 93617
-  absolute_time: 2014-07-11 22:11:00.000000000 Z
-  data_status:
-  elapsed_seconds: 36660.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_ken_bradtke_ouray_in_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_ouray
-  id: 93622
-  absolute_time: 2014-07-12 04:48:00.000000000 Z
-  data_status:
-  elapsed_seconds: 60480.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_ken_bradtke_ouray_out_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_ouray
-  id: 93623
-  absolute_time: 2014-07-12 05:31:00.000000000 Z
-  data_status:
-  elapsed_seconds: 63060.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_ken_bradtke_grouse_in_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_grouse
-  id: 93626
-  absolute_time: 2014-07-12 12:07:00.000000000 Z
-  data_status:
-  elapsed_seconds: 86820.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_ken_bradtke_grouse_out_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_grouse
-  id: 93627
-  absolute_time: 2014-07-12 12:24:00.000000000 Z
-  data_status:
-  elapsed_seconds: 87840.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_ken_bradtke_sherman_in_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_sherman
-  id: 93630
-  absolute_time: 2014-07-12 18:02:00.000000000 Z
-  data_status:
-  elapsed_seconds: 108120.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_ken_bradtke_sherman_out_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_sherman
-  id: 93631
-  absolute_time: 2014-07-12 18:37:00.000000000 Z
-  data_status:
-  elapsed_seconds: 110220.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_ken_bradtke_cunningham_in_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_cunningham
-  id: 93636
-  absolute_time: 2014-07-13 04:54:00.000000000 Z
-  data_status:
-  elapsed_seconds: 147240.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_ken_bradtke_cunningham_out_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_cunningham
-  id: 93637
-  absolute_time: 2014-07-13 05:08:00.000000000 Z
-  data_status:
-  elapsed_seconds: 148080.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_ken_bradtke_finish_1:
-  effort: hardrock_2014_ken_bradtke
-  split: hardrock_cw_finish
-  id: 93638
-  absolute_time: 2014-07-13 10:23:44.000000000 Z
-  data_status:
-  elapsed_seconds: 167024.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_progress_sherman_start_1:
-  effort: hardrock_2014_progress_sherman
-  split: hardrock_cw_start
-  id: 94155
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_progress_sherman_telluride_in_1:
-  effort: hardrock_2014_progress_sherman
-  split: hardrock_cw_telluride
-  id: 94160
-  absolute_time: 2014-07-11 23:07:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 40020.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_progress_sherman_telluride_out_1:
-  effort: hardrock_2014_progress_sherman
-  split: hardrock_cw_telluride
-  id: 94161
-  absolute_time: 2014-07-11 23:16:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 40560.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_progress_sherman_ouray_in_1:
-  effort: hardrock_2014_progress_sherman
-  split: hardrock_cw_ouray
-  id: 94166
-  absolute_time: 2014-07-12 05:57:59.000000000 Z
-  data_status: 2
-  elapsed_seconds: 64679.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_progress_sherman_ouray_out_1:
-  effort: hardrock_2014_progress_sherman
-  split: hardrock_cw_ouray
-  id: 94167
-  absolute_time: 2014-07-12 06:16:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 65760.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_progress_sherman_grouse_in_1:
-  effort: hardrock_2014_progress_sherman
-  split: hardrock_cw_grouse
-  id: 94170
-  absolute_time: 2014-07-12 13:40:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 92400.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_progress_sherman_grouse_out_1:
-  effort: hardrock_2014_progress_sherman
-  split: hardrock_cw_grouse
-  id: 94171
-  absolute_time: 2014-07-12 14:06:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 93960.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_progress_sherman_sherman_in_1:
-  effort: hardrock_2014_progress_sherman
-  split: hardrock_cw_sherman
-  id: 94174
-  absolute_time: 2014-07-12 21:13:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 119580.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_progress_sherman_sherman_out_1:
-  effort: hardrock_2014_progress_sherman
-  split: hardrock_cw_sherman
-  id: 94175
-  absolute_time: 2014-07-12 21:28:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 120480.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_multiple_stops_start_1:
-  effort: hardrock_2014_multiple_stops
-  split: hardrock_cw_start
-  id: 94437
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_multiple_stops_telluride_in_1:
-  effort: hardrock_2014_multiple_stops
-  split: hardrock_cw_telluride
-  id: 94442
-  absolute_time: 2014-07-11 22:36:00.000000000 Z
-  data_status:
-  elapsed_seconds: 38160.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_multiple_stops_telluride_out_1:
-  effort: hardrock_2014_multiple_stops
-  split: hardrock_cw_telluride
-  id: 94443
-  absolute_time: 2014-07-11 22:52:00.000000000 Z
-  data_status:
-  elapsed_seconds: 39120.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_multiple_stops_ouray_in_1:
-  effort: hardrock_2014_multiple_stops
-  split: hardrock_cw_ouray
-  id: 94448
-  absolute_time: 2014-07-12 05:20:00.000000000 Z
-  data_status:
-  elapsed_seconds: 62400.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_multiple_stops_ouray_out_1:
-  effort: hardrock_2014_multiple_stops
-  split: hardrock_cw_ouray
-  id: 94449
-  absolute_time: 2014-07-12 05:48:00.000000000 Z
-  data_status:
-  elapsed_seconds: 64080.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_multiple_stops_grouse_in_1:
-  effort: hardrock_2014_multiple_stops
-  split: hardrock_cw_grouse
-  id: 94452
-  absolute_time: 2014-07-12 13:10:00.000000000 Z
-  data_status:
-  elapsed_seconds: 90600.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_multiple_stops_grouse_out_1:
-  effort: hardrock_2014_multiple_stops
-  split: hardrock_cw_grouse
-  id: 94453
-  absolute_time: 2014-07-12 13:10:00.000000000 Z
-  data_status:
-  elapsed_seconds: 90600.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_without_start_telluride_in_1:
-  effort: hardrock_2014_without_start
-  split: hardrock_cw_telluride
-  id: 94459
-  absolute_time: 2014-07-11 23:17:00.000000000 Z
-  data_status: 2
-  elapsed_seconds:
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_without_start_telluride_out_1:
-  effort: hardrock_2014_without_start
-  split: hardrock_cw_telluride
-  id: 94460
-  absolute_time: 2014-07-11 23:27:00.000000000 Z
-  data_status: 2
-  elapsed_seconds:
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_without_start_ouray_in_1:
-  effort: hardrock_2014_without_start
-  split: hardrock_cw_ouray
-  id: 94465
-  absolute_time: 2014-07-12 06:06:00.000000000 Z
-  data_status: 2
-  elapsed_seconds:
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_without_start_ouray_out_1:
-  effort: hardrock_2014_without_start
-  split: hardrock_cw_ouray
-  id: 94466
-  absolute_time: 2014-07-12 06:29:00.000000000 Z
-  data_status: 2
-  elapsed_seconds:
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_without_start_grouse_in_1:
-  effort: hardrock_2014_without_start
-  split: hardrock_cw_grouse
-  id: 94469
-  absolute_time: 2014-07-12 13:56:00.000000000 Z
-  data_status: 2
-  elapsed_seconds:
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_without_start_grouse_out_1:
-  effort: hardrock_2014_without_start
-  split: hardrock_cw_grouse
-  id: 94470
-  absolute_time: 2014-07-12 13:56:00.000000000 Z
-  data_status: 2
-  elapsed_seconds:
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_drop_ouray_start_1:
-  effort: hardrock_2014_drop_ouray
-  split: hardrock_cw_start
-  id: 94471
-  absolute_time: 2014-07-11 12:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_drop_ouray_telluride_in_1:
-  effort: hardrock_2014_drop_ouray
-  split: hardrock_cw_telluride
-  id: 94476
-  absolute_time: 2014-07-11 23:42:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 42120.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_drop_ouray_telluride_out_1:
-  effort: hardrock_2014_drop_ouray
-  split: hardrock_cw_telluride
-  id: 94477
-  absolute_time: 2014-07-11 23:54:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 42840.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 64
-  status_reason:
-hardrock_2014_drop_ouray_ouray_in_1:
-  effort: hardrock_2014_drop_ouray
-  split: hardrock_cw_ouray
-  id: 94482
-  absolute_time: 2014-07-12 06:24:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 66240.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2014_drop_ouray_ouray_out_1:
-  effort: hardrock_2014_drop_ouray
-  split: hardrock_cw_ouray
-  id: 94483
-  absolute_time: 2014-07-12 06:28:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 66480.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 64
-  status_reason:
 hardrock_2015_bad_status_telluride_in_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_telluride
-  id: 101536
   absolute_time: 2015-07-11 21:05:00.000000000 Z
   data_status: 1
   elapsed_seconds: 119100.0
@@ -7542,7 +4406,6 @@ hardrock_2015_bad_status_telluride_in_1:
 hardrock_2015_bad_status_telluride_out_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_telluride
-  id: 101537
   absolute_time: 2015-07-11 21:30:00.000000000 Z
   data_status: 1
   elapsed_seconds: 120600.0
@@ -7552,36 +4415,9 @@ hardrock_2015_bad_status_telluride_out_1:
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
-hardrock_2015_irvin_harber_telluride_in_1:
-  effort: hardrock_2015_irvin_harber
-  split: hardrock_ccw_telluride
-  id: 101540
-  absolute_time: 2015-07-11 11:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 82800.0
-  lap: 1
-  pacer: true
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-hardrock_2015_irvin_harber_telluride_out_1:
-  effort: hardrock_2015_irvin_harber
-  split: hardrock_ccw_telluride
-  id: 101541
-  absolute_time: 2015-07-11 12:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 86400.0
-  lap: 1
-  pacer: true
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 64
-  status_reason:
 hardrock_2015_bad_status_putnam_in_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_putnam
-  id: 101555
   absolute_time: 2015-07-12 01:00:00.000000000 Z
   data_status: 0
   elapsed_seconds: 133200.0
@@ -7594,7 +4430,6 @@ hardrock_2015_bad_status_putnam_in_1:
 hardrock_2015_bad_status_putnam_out_1:
   effort: hardrock_2015_bad_status
   split: hardrock_ccw_putnam
-  id: 101556
   absolute_time: 2015-07-12 01:05:00.000000000 Z
   data_status: 0
   elapsed_seconds: 133500.0
@@ -7604,10 +4439,2613 @@ hardrock_2015_bad_status_putnam_out_1:
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
+hardrock_2015_irvin_harber_start_1:
+  effort: hardrock_2015_irvin_harber
+  split: hardrock_ccw_start
+  absolute_time: 2015-07-10 12:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2015_irvin_harber_cunningham_in_1:
+  effort: hardrock_2015_irvin_harber
+  split: hardrock_ccw_cunningham
+  absolute_time: 2015-07-10 14:24:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 8640.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2015_irvin_harber_cunningham_out_1:
+  effort: hardrock_2015_irvin_harber
+  split: hardrock_ccw_cunningham
+  absolute_time: 2015-07-10 14:24:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 8640.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2015_irvin_harber_sherman_in_1:
+  effort: hardrock_2015_irvin_harber
+  split: hardrock_ccw_sherman
+  absolute_time: 2015-07-10 19:39:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 27540.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2015_irvin_harber_sherman_out_1:
+  effort: hardrock_2015_irvin_harber
+  split: hardrock_ccw_sherman
+  absolute_time: 2015-07-10 19:45:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 27900.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2015_irvin_harber_grouse_in_1:
+  effort: hardrock_2015_irvin_harber
+  split: hardrock_ccw_grouse
+  absolute_time: 2015-07-11 00:44:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 45840.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2015_irvin_harber_grouse_out_1:
+  effort: hardrock_2015_irvin_harber
+  split: hardrock_ccw_grouse
+  absolute_time: 2015-07-11 01:10:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 47400.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2015_irvin_harber_ouray_in_1:
+  effort: hardrock_2015_irvin_harber
+  split: hardrock_ccw_ouray
+  absolute_time: 2015-07-11 05:46:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 63960.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2015_irvin_harber_ouray_out_1:
+  effort: hardrock_2015_irvin_harber
+  split: hardrock_ccw_ouray
+  absolute_time: 2015-07-11 05:46:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 63960.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2015_irvin_harber_telluride_in_1:
+  effort: hardrock_2015_irvin_harber
+  split: hardrock_ccw_telluride
+  absolute_time: 2015-07-11 11:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 82800.0
+  lap: 1
+  pacer: true
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2015_irvin_harber_telluride_out_1:
+  effort: hardrock_2015_irvin_harber
+  split: hardrock_ccw_telluride
+  absolute_time: 2015-07-11 12:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 86400.0
+  lap: 1
+  pacer: true
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2015_cassondra_nienow_start_1:
+  effort: hardrock_2015_cassondra_nienow
+  split: hardrock_ccw_start
+  absolute_time: 2015-07-10 12:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2015_cassondra_nienow_cunningham_in_1:
+  effort: hardrock_2015_cassondra_nienow
+  split: hardrock_ccw_cunningham
+  absolute_time: 2015-07-10 15:31:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 12660.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2015_cassondra_nienow_cunningham_out_1:
+  effort: hardrock_2015_cassondra_nienow
+  split: hardrock_ccw_cunningham
+  absolute_time: 2015-07-10 15:31:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 12660.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2015_cassondra_nienow_sherman_in_1:
+  effort: hardrock_2015_cassondra_nienow
+  split: hardrock_ccw_sherman
+  absolute_time: 2015-07-11 00:03:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 43380.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2015_cassondra_nienow_sherman_out_1:
+  effort: hardrock_2015_cassondra_nienow
+  split: hardrock_ccw_sherman
+  absolute_time: 2015-07-11 00:03:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 43380.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2015_donn_mckenzie_start_1:
+  effort: hardrock_2015_donn_mckenzie
+  split: hardrock_ccw_start
+  absolute_time: 2015-07-10 12:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2015_donn_mckenzie_cunningham_in_1:
+  effort: hardrock_2015_donn_mckenzie
+  split: hardrock_ccw_cunningham
+  absolute_time: 2015-07-10 14:30:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 9000.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2015_donn_mckenzie_cunningham_out_1:
+  effort: hardrock_2015_donn_mckenzie
+  split: hardrock_ccw_cunningham
+  absolute_time: 2015-07-10 14:30:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 9000.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+ramble_finished_first_start_1:
+  effort: ramble_finished_first
+  split: ramble_even_course_start
+  absolute_time: 2006-09-16 14:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ramble_finished_first_finish_1:
+  effort: ramble_finished_first
+  split: ramble_even_course_finish
+  absolute_time: 2006-09-16 14:34:22.000000000 Z
+  data_status: 2
+  elapsed_seconds: 2062.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+ramble_finished_second_start_1:
+  effort: ramble_finished_second
+  split: ramble_even_course_start
+  absolute_time: 2006-09-16 14:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ramble_finished_second_finish_1:
+  effort: ramble_finished_second
+  split: ramble_even_course_finish
+  absolute_time: 2006-09-16 14:37:31.000000000 Z
+  data_status: 2
+  elapsed_seconds: 2251.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+ramble_start_only_start_1:
+  effort: ramble_start_only
+  split: ramble_even_course_start
+  absolute_time: 2006-09-16 14:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_first_start_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_first_finish_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-12 16:07:38.000000000 Z
+  data_status:
+  elapsed_seconds: 101258.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_first_telluride_in_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 18:24:00.000000000 Z
+  data_status:
+  elapsed_seconds: 23040.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_first_telluride_out_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 18:26:00.000000000 Z
+  data_status:
+  elapsed_seconds: 23160.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_first_ouray_in_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-11 21:50:00.000000000 Z
+  data_status:
+  elapsed_seconds: 35400.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_first_ouray_out_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-11 21:52:00.000000000 Z
+  data_status:
+  elapsed_seconds: 35520.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_first_grouse_in_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 01:38:00.000000000 Z
+  data_status:
+  elapsed_seconds: 49080.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_first_grouse_out_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 01:43:00.000000000 Z
+  data_status:
+  elapsed_seconds: 49380.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_first_sherman_in_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 06:08:00.000000000 Z
+  data_status:
+  elapsed_seconds: 65280.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_first_sherman_out_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 06:17:00.000000000 Z
+  data_status:
+  elapsed_seconds: 65820.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_first_cunningham_in_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 13:21:00.000000000 Z
+  data_status:
+  elapsed_seconds: 91260.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_first_cunningham_out_1:
+  effort: hardrock_2014_finished_first
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 13:27:00.000000000 Z
+  data_status:
+  elapsed_seconds: 91620.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_with_stop_start_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_with_stop_finish_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-12 16:23:42.000000000 Z
+  data_status:
+  elapsed_seconds: 102222.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_with_stop_telluride_in_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 18:59:00.000000000 Z
+  data_status:
+  elapsed_seconds: 25140.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_with_stop_telluride_out_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 19:03:00.000000000 Z
+  data_status:
+  elapsed_seconds: 25380.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_with_stop_ouray_in_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-11 22:43:00.000000000 Z
+  data_status:
+  elapsed_seconds: 38580.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_with_stop_ouray_out_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-11 22:46:00.000000000 Z
+  data_status:
+  elapsed_seconds: 38760.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_with_stop_grouse_in_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 02:56:00.000000000 Z
+  data_status:
+  elapsed_seconds: 53760.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_with_stop_grouse_out_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 03:06:00.000000000 Z
+  data_status:
+  elapsed_seconds: 54360.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_with_stop_sherman_in_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 07:05:00.000000000 Z
+  data_status:
+  elapsed_seconds: 68700.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_with_stop_sherman_out_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 07:15:00.000000000 Z
+  data_status:
+  elapsed_seconds: 69300.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_with_stop_cunningham_in_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 13:43:00.000000000 Z
+  data_status:
+  elapsed_seconds: 92580.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_with_stop_cunningham_out_1:
+  effort: hardrock_2014_finished_with_stop
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 13:46:00.000000000 Z
+  data_status:
+  elapsed_seconds: 92760.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_without_stop_start_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_without_stop_finish_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-12 16:28:54.000000000 Z
+  data_status:
+  elapsed_seconds: 102534.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_without_stop_telluride_in_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 18:53:00.000000000 Z
+  data_status:
+  elapsed_seconds: 24780.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_without_stop_telluride_out_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 18:56:00.000000000 Z
+  data_status:
+  elapsed_seconds: 24960.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_without_stop_ouray_in_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-11 22:43:00.000000000 Z
+  data_status:
+  elapsed_seconds: 38580.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_without_stop_ouray_out_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-11 22:50:00.000000000 Z
+  data_status:
+  elapsed_seconds: 39000.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_without_stop_grouse_in_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 03:10:00.000000000 Z
+  data_status:
+  elapsed_seconds: 54600.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_without_stop_grouse_out_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 03:15:00.000000000 Z
+  data_status:
+  elapsed_seconds: 54900.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_without_stop_sherman_in_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 07:15:00.000000000 Z
+  data_status:
+  elapsed_seconds: 69300.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_without_stop_sherman_out_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 07:23:59.000000000 Z
+  data_status:
+  elapsed_seconds: 69839.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_finished_without_stop_cunningham_in_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 14:04:00.000000000 Z
+  data_status:
+  elapsed_seconds: 93840.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_finished_without_stop_cunningham_out_1:
+  effort: hardrock_2014_finished_without_stop
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 14:04:00.000000000 Z
+  data_status:
+  elapsed_seconds: 93840.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_claudio_wunsch_start_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_claudio_wunsch_finish_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-12 23:58:21.000000000 Z
+  data_status:
+  elapsed_seconds: 129501.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_claudio_wunsch_telluride_in_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 19:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 25200.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_claudio_wunsch_telluride_out_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 19:07:00.000000000 Z
+  data_status:
+  elapsed_seconds: 25620.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_claudio_wunsch_ouray_in_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-11 23:04:00.000000000 Z
+  data_status:
+  elapsed_seconds: 39840.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_claudio_wunsch_ouray_out_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-11 23:24:00.000000000 Z
+  data_status:
+  elapsed_seconds: 41040.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_claudio_wunsch_grouse_in_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 03:55:00.000000000 Z
+  data_status:
+  elapsed_seconds: 57300.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_claudio_wunsch_grouse_out_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 04:37:00.000000000 Z
+  data_status:
+  elapsed_seconds: 59820.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_claudio_wunsch_sherman_in_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 10:17:00.000000000 Z
+  data_status:
+  elapsed_seconds: 80220.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_claudio_wunsch_sherman_out_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 10:33:00.000000000 Z
+  data_status:
+  elapsed_seconds: 81180.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_claudio_wunsch_cunningham_in_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 19:19:00.000000000 Z
+  data_status:
+  elapsed_seconds: 112740.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_claudio_wunsch_cunningham_out_1:
+  effort: hardrock_2014_claudio_wunsch
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 19:34:00.000000000 Z
+  data_status:
+  elapsed_seconds: 113640.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_rachelle_eichmann_start_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_rachelle_eichmann_finish_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-13 01:39:17.000000000 Z
+  data_status:
+  elapsed_seconds: 135557.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_rachelle_eichmann_telluride_in_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 20:26:59.000000000 Z
+  data_status:
+  elapsed_seconds: 30419.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_rachelle_eichmann_telluride_out_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 20:39:00.000000000 Z
+  data_status:
+  elapsed_seconds: 31140.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_rachelle_eichmann_ouray_in_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 01:23:00.000000000 Z
+  data_status:
+  elapsed_seconds: 48180.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_rachelle_eichmann_ouray_out_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 01:33:00.000000000 Z
+  data_status:
+  elapsed_seconds: 48780.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_rachelle_eichmann_grouse_in_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 07:25:00.000000000 Z
+  data_status:
+  elapsed_seconds: 69900.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_rachelle_eichmann_grouse_out_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 07:49:00.000000000 Z
+  data_status:
+  elapsed_seconds: 71340.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_rachelle_eichmann_sherman_in_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 13:30:00.000000000 Z
+  data_status:
+  elapsed_seconds: 91800.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_rachelle_eichmann_sherman_out_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 13:49:00.000000000 Z
+  data_status:
+  elapsed_seconds: 92940.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_rachelle_eichmann_cunningham_in_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 21:53:00.000000000 Z
+  data_status:
+  elapsed_seconds: 121980.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_rachelle_eichmann_cunningham_out_1:
+  effort: hardrock_2014_rachelle_eichmann
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 21:58:00.000000000 Z
+  data_status:
+  elapsed_seconds: 122280.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_keith_metz_start_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_keith_metz_finish_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-13 02:59:02.000000000 Z
+  data_status:
+  elapsed_seconds: 140342.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_keith_metz_telluride_in_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 20:30:00.000000000 Z
+  data_status:
+  elapsed_seconds: 30600.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_keith_metz_telluride_out_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 20:42:00.000000000 Z
+  data_status:
+  elapsed_seconds: 31320.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_keith_metz_ouray_in_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 01:27:00.000000000 Z
+  data_status:
+  elapsed_seconds: 48420.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_keith_metz_ouray_out_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 01:43:00.000000000 Z
+  data_status:
+  elapsed_seconds: 49380.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_keith_metz_grouse_in_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 07:30:00.000000000 Z
+  data_status:
+  elapsed_seconds: 70200.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_keith_metz_grouse_out_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 07:56:00.000000000 Z
+  data_status:
+  elapsed_seconds: 71760.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_keith_metz_sherman_in_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 14:03:00.000000000 Z
+  data_status:
+  elapsed_seconds: 93780.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_keith_metz_sherman_out_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 14:22:00.000000000 Z
+  data_status:
+  elapsed_seconds: 94920.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_keith_metz_cunningham_in_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 23:19:00.000000000 Z
+  data_status:
+  elapsed_seconds: 127140.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_keith_metz_cunningham_out_1:
+  effort: hardrock_2014_keith_metz
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 23:30:00.000000000 Z
+  data_status:
+  elapsed_seconds: 127800.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_major_green_start_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_major_green_finish_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-13 03:03:41.000000000 Z
+  data_status:
+  elapsed_seconds: 140621.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_major_green_telluride_in_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 20:52:00.000000000 Z
+  data_status:
+  elapsed_seconds: 31920.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_major_green_telluride_out_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 20:58:00.000000000 Z
+  data_status:
+  elapsed_seconds: 32280.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_major_green_ouray_in_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 02:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 50400.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_major_green_ouray_out_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 02:12:00.000000000 Z
+  data_status:
+  elapsed_seconds: 51120.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_major_green_grouse_in_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 08:07:00.000000000 Z
+  data_status:
+  elapsed_seconds: 72420.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_major_green_grouse_out_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 08:18:00.000000000 Z
+  data_status:
+  elapsed_seconds: 73080.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_major_green_sherman_in_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 14:25:00.000000000 Z
+  data_status:
+  elapsed_seconds: 95100.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_major_green_sherman_out_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 14:40:00.000000000 Z
+  data_status:
+  elapsed_seconds: 96000.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_major_green_cunningham_in_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 23:13:00.000000000 Z
+  data_status:
+  elapsed_seconds: 126780.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_major_green_cunningham_out_1:
+  effort: hardrock_2014_major_green
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-12 23:23:00.000000000 Z
+  data_status:
+  elapsed_seconds: 127380.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_humberto_adams_start_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_humberto_adams_finish_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-13 05:40:21.000000000 Z
+  data_status:
+  elapsed_seconds: 150021.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_humberto_adams_telluride_in_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 20:54:59.000000000 Z
+  data_status:
+  elapsed_seconds: 32099.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_humberto_adams_telluride_out_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 21:58:00.000000000 Z
+  data_status:
+  elapsed_seconds: 35880.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_humberto_adams_ouray_in_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 01:56:59.000000000 Z
+  data_status:
+  elapsed_seconds: 50219.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_humberto_adams_ouray_out_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 02:20:00.000000000 Z
+  data_status:
+  elapsed_seconds: 51600.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_humberto_adams_grouse_in_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 09:36:00.000000000 Z
+  data_status:
+  elapsed_seconds: 77760.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_humberto_adams_grouse_out_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 10:22:00.000000000 Z
+  data_status:
+  elapsed_seconds: 80520.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_humberto_adams_sherman_in_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 16:25:00.000000000 Z
+  data_status:
+  elapsed_seconds: 102300.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_humberto_adams_sherman_out_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 16:45:00.000000000 Z
+  data_status:
+  elapsed_seconds: 103500.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_humberto_adams_cunningham_in_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 01:18:00.000000000 Z
+  data_status:
+  elapsed_seconds: 134280.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_humberto_adams_cunningham_out_1:
+  effort: hardrock_2014_humberto_adams
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 01:30:00.000000000 Z
+  data_status:
+  elapsed_seconds: 135000.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_omer_yundt_start_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_omer_yundt_finish_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-13 08:48:15.000000000 Z
+  data_status:
+  elapsed_seconds: 161295.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_omer_yundt_telluride_in_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 21:34:00.000000000 Z
+  data_status:
+  elapsed_seconds: 34440.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_omer_yundt_telluride_out_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 22:06:00.000000000 Z
+  data_status:
+  elapsed_seconds: 36360.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_omer_yundt_ouray_in_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 03:38:00.000000000 Z
+  data_status:
+  elapsed_seconds: 56280.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_omer_yundt_ouray_out_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 04:26:00.000000000 Z
+  data_status:
+  elapsed_seconds: 59160.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_omer_yundt_grouse_in_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 10:33:00.000000000 Z
+  data_status:
+  elapsed_seconds: 81180.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_omer_yundt_grouse_out_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 11:34:00.000000000 Z
+  data_status:
+  elapsed_seconds: 84840.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_omer_yundt_sherman_in_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 17:22:00.000000000 Z
+  data_status:
+  elapsed_seconds: 105720.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_omer_yundt_sherman_out_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 18:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 108000.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_omer_yundt_cunningham_in_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 02:14:00.000000000 Z
+  data_status:
+  elapsed_seconds: 137640.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_omer_yundt_cunningham_out_1:
+  effort: hardrock_2014_omer_yundt
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 02:33:00.000000000 Z
+  data_status:
+  elapsed_seconds: 138780.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_pat_schaden_start_1:
+  effort: hardrock_2014_pat_schaden
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_pat_schaden_telluride_in_1:
+  effort: hardrock_2014_pat_schaden
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 22:35:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 38100.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_pat_schaden_telluride_out_1:
+  effort: hardrock_2014_pat_schaden
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 22:47:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 38820.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_pat_schaden_ouray_in_1:
+  effort: hardrock_2014_pat_schaden
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 04:44:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 60240.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_pat_schaden_ouray_out_1:
+  effort: hardrock_2014_pat_schaden
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 05:16:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 62160.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_pat_schaden_grouse_in_1:
+  effort: hardrock_2014_pat_schaden
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 12:27:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 88020.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_pat_schaden_grouse_out_1:
+  effort: hardrock_2014_pat_schaden
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 12:48:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 89280.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_pat_schaden_sherman_in_1:
+  effort: hardrock_2014_pat_schaden
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 18:29:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 109740.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_pat_schaden_sherman_out_1:
+  effort: hardrock_2014_pat_schaden
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 18:52:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 111120.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_pat_schaden_cunningham_in_1:
+  effort: hardrock_2014_pat_schaden
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 04:14:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 144840.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_clarence_goyette_start_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_clarence_goyette_finish_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-13 09:21:28.000000000 Z
+  data_status:
+  elapsed_seconds: 163288.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_clarence_goyette_telluride_in_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 22:05:00.000000000 Z
+  data_status:
+  elapsed_seconds: 36300.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_clarence_goyette_telluride_out_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 22:14:00.000000000 Z
+  data_status:
+  elapsed_seconds: 36840.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_clarence_goyette_ouray_in_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 04:32:00.000000000 Z
+  data_status:
+  elapsed_seconds: 59520.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_clarence_goyette_ouray_out_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 05:02:00.000000000 Z
+  data_status:
+  elapsed_seconds: 61320.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_clarence_goyette_grouse_in_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 11:19:00.000000000 Z
+  data_status:
+  elapsed_seconds: 83940.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_clarence_goyette_grouse_out_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 11:59:00.000000000 Z
+  data_status:
+  elapsed_seconds: 86340.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_clarence_goyette_sherman_in_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 18:06:00.000000000 Z
+  data_status:
+  elapsed_seconds: 108360.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_clarence_goyette_sherman_out_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 18:32:00.000000000 Z
+  data_status:
+  elapsed_seconds: 109920.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_clarence_goyette_cunningham_in_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 04:02:00.000000000 Z
+  data_status:
+  elapsed_seconds: 144120.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_clarence_goyette_cunningham_out_1:
+  effort: hardrock_2014_clarence_goyette
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 04:32:00.000000000 Z
+  data_status:
+  elapsed_seconds: 145920.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_irvin_corkery_start_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_irvin_corkery_finish_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-13 09:25:16.000000000 Z
+  data_status:
+  elapsed_seconds: 163516.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_irvin_corkery_telluride_in_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 20:21:00.000000000 Z
+  data_status:
+  elapsed_seconds: 30060.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_irvin_corkery_telluride_out_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 20:32:00.000000000 Z
+  data_status:
+  elapsed_seconds: 30720.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_irvin_corkery_ouray_in_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 01:25:00.000000000 Z
+  data_status:
+  elapsed_seconds: 48300.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_irvin_corkery_ouray_out_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 01:45:00.000000000 Z
+  data_status:
+  elapsed_seconds: 49500.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_irvin_corkery_grouse_in_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 07:39:00.000000000 Z
+  data_status:
+  elapsed_seconds: 70740.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_irvin_corkery_grouse_out_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 08:12:59.000000000 Z
+  data_status:
+  elapsed_seconds: 72779.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_irvin_corkery_sherman_in_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 15:59:00.000000000 Z
+  data_status:
+  elapsed_seconds: 100740.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_irvin_corkery_sherman_out_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 16:35:00.000000000 Z
+  data_status:
+  elapsed_seconds: 102900.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_irvin_corkery_cunningham_in_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 03:38:00.000000000 Z
+  data_status:
+  elapsed_seconds: 142680.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_irvin_corkery_cunningham_out_1:
+  effort: hardrock_2014_irvin_corkery
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 03:54:00.000000000 Z
+  data_status:
+  elapsed_seconds: 143640.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_willis_murray_start_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_willis_murray_finish_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-13 09:40:40.000000000 Z
+  data_status:
+  elapsed_seconds: 164440.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_willis_murray_telluride_in_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 22:05:00.000000000 Z
+  data_status:
+  elapsed_seconds: 36300.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_willis_murray_telluride_out_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 22:20:00.000000000 Z
+  data_status:
+  elapsed_seconds: 37200.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_willis_murray_ouray_in_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 03:53:00.000000000 Z
+  data_status:
+  elapsed_seconds: 57180.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_willis_murray_ouray_out_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 04:31:00.000000000 Z
+  data_status:
+  elapsed_seconds: 59460.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_willis_murray_grouse_in_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 11:49:00.000000000 Z
+  data_status:
+  elapsed_seconds: 85740.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_willis_murray_grouse_out_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 12:18:00.000000000 Z
+  data_status:
+  elapsed_seconds: 87480.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_willis_murray_sherman_in_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 18:11:00.000000000 Z
+  data_status:
+  elapsed_seconds: 108660.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_willis_murray_sherman_out_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 18:46:00.000000000 Z
+  data_status:
+  elapsed_seconds: 110760.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_willis_murray_cunningham_in_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 04:11:00.000000000 Z
+  data_status:
+  elapsed_seconds: 144660.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_willis_murray_cunningham_out_1:
+  effort: hardrock_2014_willis_murray
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 04:38:00.000000000 Z
+  data_status:
+  elapsed_seconds: 146280.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_ken_bradtke_start_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_ken_bradtke_finish_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_finish
+  absolute_time: 2014-07-13 10:23:44.000000000 Z
+  data_status:
+  elapsed_seconds: 167024.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_ken_bradtke_telluride_in_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 21:58:00.000000000 Z
+  data_status:
+  elapsed_seconds: 35880.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_ken_bradtke_telluride_out_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 22:11:00.000000000 Z
+  data_status:
+  elapsed_seconds: 36660.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_ken_bradtke_ouray_in_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 04:48:00.000000000 Z
+  data_status:
+  elapsed_seconds: 60480.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_ken_bradtke_ouray_out_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 05:31:00.000000000 Z
+  data_status:
+  elapsed_seconds: 63060.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_ken_bradtke_grouse_in_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 12:07:00.000000000 Z
+  data_status:
+  elapsed_seconds: 86820.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_ken_bradtke_grouse_out_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 12:24:00.000000000 Z
+  data_status:
+  elapsed_seconds: 87840.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_ken_bradtke_sherman_in_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 18:02:00.000000000 Z
+  data_status:
+  elapsed_seconds: 108120.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_ken_bradtke_sherman_out_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 18:37:00.000000000 Z
+  data_status:
+  elapsed_seconds: 110220.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_ken_bradtke_cunningham_in_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 04:54:00.000000000 Z
+  data_status:
+  elapsed_seconds: 147240.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_ken_bradtke_cunningham_out_1:
+  effort: hardrock_2014_ken_bradtke
+  split: hardrock_cw_cunningham
+  absolute_time: 2014-07-13 05:08:00.000000000 Z
+  data_status:
+  elapsed_seconds: 148080.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_progress_sherman_start_1:
+  effort: hardrock_2014_progress_sherman
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_progress_sherman_telluride_in_1:
+  effort: hardrock_2014_progress_sherman
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 23:07:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 40020.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_progress_sherman_telluride_out_1:
+  effort: hardrock_2014_progress_sherman
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 23:16:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 40560.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_progress_sherman_ouray_in_1:
+  effort: hardrock_2014_progress_sherman
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 05:57:59.000000000 Z
+  data_status: 2
+  elapsed_seconds: 64679.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_progress_sherman_ouray_out_1:
+  effort: hardrock_2014_progress_sherman
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 06:16:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 65760.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_progress_sherman_grouse_in_1:
+  effort: hardrock_2014_progress_sherman
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 13:40:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 92400.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_progress_sherman_grouse_out_1:
+  effort: hardrock_2014_progress_sherman
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 14:06:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 93960.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_progress_sherman_sherman_in_1:
+  effort: hardrock_2014_progress_sherman
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 21:13:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 119580.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_progress_sherman_sherman_out_1:
+  effort: hardrock_2014_progress_sherman
+  split: hardrock_cw_sherman
+  absolute_time: 2014-07-12 21:28:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 120480.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_multiple_stops_start_1:
+  effort: hardrock_2014_multiple_stops
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_multiple_stops_telluride_in_1:
+  effort: hardrock_2014_multiple_stops
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 22:36:00.000000000 Z
+  data_status:
+  elapsed_seconds: 38160.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_multiple_stops_telluride_out_1:
+  effort: hardrock_2014_multiple_stops
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 22:52:00.000000000 Z
+  data_status:
+  elapsed_seconds: 39120.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_multiple_stops_ouray_in_1:
+  effort: hardrock_2014_multiple_stops
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 05:20:00.000000000 Z
+  data_status:
+  elapsed_seconds: 62400.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_multiple_stops_ouray_out_1:
+  effort: hardrock_2014_multiple_stops
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 05:48:00.000000000 Z
+  data_status:
+  elapsed_seconds: 64080.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_multiple_stops_grouse_in_1:
+  effort: hardrock_2014_multiple_stops
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 13:10:00.000000000 Z
+  data_status:
+  elapsed_seconds: 90600.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_multiple_stops_grouse_out_1:
+  effort: hardrock_2014_multiple_stops
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 13:10:00.000000000 Z
+  data_status:
+  elapsed_seconds: 90600.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_without_start_telluride_in_1:
+  effort: hardrock_2014_without_start
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 23:17:00.000000000 Z
+  data_status: 2
+  elapsed_seconds:
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_without_start_telluride_out_1:
+  effort: hardrock_2014_without_start
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 23:27:00.000000000 Z
+  data_status: 2
+  elapsed_seconds:
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_without_start_ouray_in_1:
+  effort: hardrock_2014_without_start
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 06:06:00.000000000 Z
+  data_status: 2
+  elapsed_seconds:
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_without_start_ouray_out_1:
+  effort: hardrock_2014_without_start
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 06:29:00.000000000 Z
+  data_status: 2
+  elapsed_seconds:
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_without_start_grouse_in_1:
+  effort: hardrock_2014_without_start
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 13:56:00.000000000 Z
+  data_status: 2
+  elapsed_seconds:
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_without_start_grouse_out_1:
+  effort: hardrock_2014_without_start
+  split: hardrock_cw_grouse
+  absolute_time: 2014-07-12 13:56:00.000000000 Z
+  data_status: 2
+  elapsed_seconds:
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_drop_ouray_start_1:
+  effort: hardrock_2014_drop_ouray
+  split: hardrock_cw_start
+  absolute_time: 2014-07-11 12:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_drop_ouray_telluride_in_1:
+  effort: hardrock_2014_drop_ouray
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 23:42:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 42120.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_drop_ouray_telluride_out_1:
+  effort: hardrock_2014_drop_ouray
+  split: hardrock_cw_telluride
+  absolute_time: 2014-07-11 23:54:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 42840.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
+hardrock_2014_drop_ouray_ouray_in_1:
+  effort: hardrock_2014_drop_ouray
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 06:24:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 66240.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+hardrock_2014_drop_ouray_ouray_out_1:
+  effort: hardrock_2014_drop_ouray
+  split: hardrock_cw_ouray
+  absolute_time: 2014-07-12 06:28:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 66480.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 64
+  status_reason:
 rufa_2016_finished_first_start_1:
   effort: rufa_2016_finished_first
   split: rufa_course_start
-  id: 132044
   absolute_time: 2016-02-13 13:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -7620,7 +7058,6 @@ rufa_2016_finished_first_start_1:
 rufa_2016_finished_first_grandeur_peak_1:
   effort: rufa_2016_finished_first
   split: rufa_course_grandeur_peak
-  id: 132045
   absolute_time: 2016-02-13 13:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 3540.0
@@ -7630,23 +7067,9 @@ rufa_2016_finished_first_grandeur_peak_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2016_finished_first_grandeur_peak_2:
-  effort: rufa_2016_finished_first
-  split: rufa_course_grandeur_peak
-  id: 132046
-  absolute_time: 2016-02-13 15:39:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 9540.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2016_finished_first_finish_2:
   effort: rufa_2016_finished_first
   split: rufa_course_finish
-  id: 132047
   absolute_time: 2016-02-13 16:12:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11520.0
@@ -7656,10 +7079,21 @@ rufa_2016_finished_first_finish_2:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2016_finished_first_grandeur_peak_2:
+  effort: rufa_2016_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2016-02-13 15:39:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 9540.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2016_finished_first_grandeur_peak_3:
   effort: rufa_2016_finished_first
   split: rufa_course_grandeur_peak
-  id: 132048
   absolute_time: 2016-02-13 17:29:00.000000000 Z
   data_status: 2
   elapsed_seconds: 16140.0
@@ -7669,23 +7103,9 @@ rufa_2016_finished_first_grandeur_peak_3:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2016_finished_first_grandeur_peak_4:
-  effort: rufa_2016_finished_first
-  split: rufa_course_grandeur_peak
-  id: 132049
-  absolute_time: 2016-02-13 19:30:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 23400.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2016_finished_first_finish_4:
   effort: rufa_2016_finished_first
   split: rufa_course_finish
-  id: 132050
   absolute_time: 2016-02-13 20:04:00.000000000 Z
   data_status: 2
   elapsed_seconds: 25440.0
@@ -7695,10 +7115,21 @@ rufa_2016_finished_first_finish_4:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2016_finished_first_grandeur_peak_4:
+  effort: rufa_2016_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2016-02-13 19:30:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 23400.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2016_finished_first_start_5:
   effort: rufa_2016_finished_first
   split: rufa_course_start
-  id: 132051
   absolute_time: 2016-02-13 20:09:00.000000000 Z
   data_status: 2
   elapsed_seconds: 25740.0
@@ -7708,23 +7139,9 @@ rufa_2016_finished_first_start_5:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2016_finished_first_grandeur_peak_5:
-  effort: rufa_2016_finished_first
-  split: rufa_course_grandeur_peak
-  id: 132052
-  absolute_time: 2016-02-13 21:22:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 30120.0
-  lap: 5
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2016_finished_first_finish_5:
   effort: rufa_2016_finished_first
   split: rufa_course_finish
-  id: 132053
   absolute_time: 2016-02-13 21:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 32340.0
@@ -7734,10 +7151,21 @@ rufa_2016_finished_first_finish_5:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2016_finished_first_grandeur_peak_5:
+  effort: rufa_2016_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2016-02-13 21:22:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 30120.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2016_finished_first_start_6:
   effort: rufa_2016_finished_first
   split: rufa_course_start
-  id: 132054
   absolute_time: 2016-02-13 22:07:00.000000000 Z
   data_status: 2
   elapsed_seconds: 32820.0
@@ -7747,23 +7175,9 @@ rufa_2016_finished_first_start_6:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2016_finished_first_grandeur_peak_6:
-  effort: rufa_2016_finished_first
-  split: rufa_course_grandeur_peak
-  id: 132055
-  absolute_time: 2016-02-13 23:26:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 37560.0
-  lap: 6
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2016_finished_first_finish_6:
   effort: rufa_2016_finished_first
   split: rufa_course_finish
-  id: 132056
   absolute_time: 2016-02-14 00:07:00.000000000 Z
   data_status: 2
   elapsed_seconds: 40020.0
@@ -7773,10 +7187,21 @@ rufa_2016_finished_first_finish_6:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2016_finished_first_grandeur_peak_6:
+  effort: rufa_2016_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2016-02-13 23:26:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 37560.0
+  lap: 6
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2016_finished_first_start_7:
   effort: rufa_2016_finished_first
   split: rufa_course_start
-  id: 132057
   absolute_time: 2016-02-14 00:55:00.000000000 Z
   data_status: 2
   elapsed_seconds: 42900.0
@@ -7786,23 +7211,9 @@ rufa_2016_finished_first_start_7:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2016_finished_first_grandeur_peak_7:
-  effort: rufa_2016_finished_first
-  split: rufa_course_grandeur_peak
-  id: 132058
-  absolute_time: 2016-02-14 02:17:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 47820.0
-  lap: 7
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2016_finished_first_finish_7:
   effort: rufa_2016_finished_first
   split: rufa_course_finish
-  id: 132059
   absolute_time: 2016-02-14 03:01:00.000000000 Z
   data_status: 2
   elapsed_seconds: 50460.0
@@ -7812,10 +7223,21 @@ rufa_2016_finished_first_finish_7:
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
+rufa_2016_finished_first_grandeur_peak_7:
+  effort: rufa_2016_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2016-02-14 02:17:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 47820.0
+  lap: 7
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2016_finished_second_start_1:
   effort: rufa_2016_finished_second
   split: rufa_course_start
-  id: 132075
   absolute_time: 2016-02-13 13:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -7825,23 +7247,9 @@ rufa_2016_finished_second_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2016_finished_second_grandeur_peak_1:
-  effort: rufa_2016_finished_second
-  split: rufa_course_grandeur_peak
-  id: 132076
-  absolute_time: 2016-02-13 13:47:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 2820.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2016_finished_second_finish_1:
   effort: rufa_2016_finished_second
   split: rufa_course_finish
-  id: 132077
   absolute_time: 2016-02-13 14:13:00.000000000 Z
   data_status: 2
   elapsed_seconds: 4380.0
@@ -7851,10 +7259,21 @@ rufa_2016_finished_second_finish_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2016_finished_second_grandeur_peak_1:
+  effort: rufa_2016_finished_second
+  split: rufa_course_grandeur_peak
+  absolute_time: 2016-02-13 13:47:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 2820.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2016_finished_second_start_2:
   effort: rufa_2016_finished_second
   split: rufa_course_start
-  id: 132078
   absolute_time: 2016-02-13 14:16:00.000000000 Z
   data_status: 2
   elapsed_seconds: 4560.0
@@ -7864,23 +7283,9 @@ rufa_2016_finished_second_start_2:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2016_finished_second_grandeur_peak_2:
-  effort: rufa_2016_finished_second
-  split: rufa_course_grandeur_peak
-  id: 132079
-  absolute_time: 2016-02-13 15:03:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 7380.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2016_finished_second_finish_2:
   effort: rufa_2016_finished_second
   split: rufa_course_finish
-  id: 132080
   absolute_time: 2016-02-13 15:29:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8940.0
@@ -7890,14 +7295,13 @@ rufa_2016_finished_second_finish_2:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2016_finished_second_grandeur_peak_3:
+rufa_2016_finished_second_grandeur_peak_2:
   effort: rufa_2016_finished_second
   split: rufa_course_grandeur_peak
-  id: 132081
-  absolute_time: 2016-02-13 16:22:00.000000000 Z
+  absolute_time: 2016-02-13 15:03:00.000000000 Z
   data_status: 2
-  elapsed_seconds: 12120.0
-  lap: 3
+  elapsed_seconds: 7380.0
+  lap: 2
   pacer:
   remarks:
   stopped_here: false
@@ -7906,7 +7310,6 @@ rufa_2016_finished_second_grandeur_peak_3:
 rufa_2016_finished_second_finish_3:
   effort: rufa_2016_finished_second
   split: rufa_course_finish
-  id: 132082
   absolute_time: 2016-02-13 16:47:00.000000000 Z
   data_status: 2
   elapsed_seconds: 13620.0
@@ -7916,10 +7319,21 @@ rufa_2016_finished_second_finish_3:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2016_finished_second_grandeur_peak_3:
+  effort: rufa_2016_finished_second
+  split: rufa_course_grandeur_peak
+  absolute_time: 2016-02-13 16:22:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 12120.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2016_finished_second_start_4:
   effort: rufa_2016_finished_second
   split: rufa_course_start
-  id: 132083
   absolute_time: 2016-02-13 16:51:00.000000000 Z
   data_status: 2
   elapsed_seconds: 13860.0
@@ -7929,23 +7343,9 @@ rufa_2016_finished_second_start_4:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2016_finished_second_grandeur_peak_4:
-  effort: rufa_2016_finished_second
-  split: rufa_course_grandeur_peak
-  id: 132084
-  absolute_time: 2016-02-13 17:45:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 17100.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2016_finished_second_finish_4:
   effort: rufa_2016_finished_second
   split: rufa_course_finish
-  id: 132085
   absolute_time: 2016-02-13 18:12:00.000000000 Z
   data_status: 2
   elapsed_seconds: 18720.0
@@ -7955,14 +7355,13 @@ rufa_2016_finished_second_finish_4:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2016_finished_second_grandeur_peak_5:
+rufa_2016_finished_second_grandeur_peak_4:
   effort: rufa_2016_finished_second
   split: rufa_course_grandeur_peak
-  id: 132086
-  absolute_time: 2016-02-13 19:18:00.000000000 Z
+  absolute_time: 2016-02-13 17:45:00.000000000 Z
   data_status: 2
-  elapsed_seconds: 22680.0
-  lap: 5
+  elapsed_seconds: 17100.0
+  lap: 4
   pacer:
   remarks:
   stopped_here: false
@@ -7971,7 +7370,6 @@ rufa_2016_finished_second_grandeur_peak_5:
 rufa_2016_finished_second_finish_5:
   effort: rufa_2016_finished_second
   split: rufa_course_finish
-  id: 132087
   absolute_time: 2016-02-13 19:49:00.000000000 Z
   data_status: 2
   elapsed_seconds: 24540.0
@@ -7981,10 +7379,21 @@ rufa_2016_finished_second_finish_5:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2016_finished_second_grandeur_peak_5:
+  effort: rufa_2016_finished_second
+  split: rufa_course_grandeur_peak
+  absolute_time: 2016-02-13 19:18:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 22680.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2016_finished_second_start_6:
   effort: rufa_2016_finished_second
   split: rufa_course_start
-  id: 132088
   absolute_time: 2016-02-13 19:56:00.000000000 Z
   data_status: 2
   elapsed_seconds: 24960.0
@@ -7994,23 +7403,9 @@ rufa_2016_finished_second_start_6:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2016_finished_second_grandeur_peak_6:
-  effort: rufa_2016_finished_second
-  split: rufa_course_grandeur_peak
-  id: 132089
-  absolute_time: 2016-02-13 20:58:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 28680.0
-  lap: 6
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2016_finished_second_finish_6:
   effort: rufa_2016_finished_second
   split: rufa_course_finish
-  id: 132090
   absolute_time: 2016-02-13 21:28:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30480.0
@@ -8020,10 +7415,21 @@ rufa_2016_finished_second_finish_6:
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
+rufa_2016_finished_second_grandeur_peak_6:
+  effort: rufa_2016_finished_second
+  split: rufa_course_grandeur_peak
+  absolute_time: 2016-02-13 20:58:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 28680.0
+  lap: 6
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2016_progress_lap1_start_1:
   effort: rufa_2016_progress_lap1
   split: rufa_course_start
-  id: 132438
   absolute_time: 2016-02-13 13:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -8036,7 +7442,6 @@ rufa_2016_progress_lap1_start_1:
 rufa_2016_progress_lap1_grandeur_peak_1:
   effort: rufa_2016_progress_lap1
   split: rufa_course_grandeur_peak
-  id: 132439
   absolute_time: 2016-02-13 14:25:00.000000000 Z
   data_status: 2
   elapsed_seconds: 5100.0
@@ -8049,7 +7454,6 @@ rufa_2016_progress_lap1_grandeur_peak_1:
 rufa_2017_24h_finished_first_start_1:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_start
-  id: 133963
   absolute_time: 2017-02-11 13:10:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -8059,10 +7463,21 @@ rufa_2017_24h_finished_first_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_finished_first_finish_1:
+  effort: rufa_2017_24h_finished_first
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 15:05:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 6900.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_finished_first_grandeur_peak_1:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_grandeur_peak
-  id: 133964
   absolute_time: 2017-02-11 14:23:00.000000000 Z
   data_status: 2
   elapsed_seconds: 4380.0
@@ -8072,39 +7487,12 @@ rufa_2017_24h_finished_first_grandeur_peak_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_finished_first_finish_1:
-  effort: rufa_2017_24h_finished_first
-  split: rufa_course_finish
-  id: 133965
-  absolute_time: 2017-02-11 15:05:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 6900.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_finished_first_start_2:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_start
-  id: 133966
   absolute_time: 2017-02-11 15:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 6900.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_24h_finished_first_grandeur_peak_2:
-  effort: rufa_2017_24h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 133967
-  absolute_time: 2017-02-11 16:36:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 12360.0
   lap: 2
   pacer:
   remarks:
@@ -8114,7 +7502,6 @@ rufa_2017_24h_finished_first_grandeur_peak_2:
 rufa_2017_24h_finished_first_finish_2:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
-  id: 133968
   absolute_time: 2017-02-11 17:12:00.000000000 Z
   data_status: 2
   elapsed_seconds: 14520.0
@@ -8124,10 +7511,21 @@ rufa_2017_24h_finished_first_finish_2:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_finished_first_grandeur_peak_2:
+  effort: rufa_2017_24h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 16:36:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 12360.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_finished_first_start_3:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_start
-  id: 133969
   absolute_time: 2017-02-11 17:19:00.000000000 Z
   data_status: 2
   elapsed_seconds: 14940.0
@@ -8137,23 +7535,9 @@ rufa_2017_24h_finished_first_start_3:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_finished_first_grandeur_peak_3:
-  effort: rufa_2017_24h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 133970
-  absolute_time: 2017-02-11 18:47:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 20220.0
-  lap: 3
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_finished_first_finish_3:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
-  id: 133971
   absolute_time: 2017-02-11 19:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 22440.0
@@ -8163,10 +7547,21 @@ rufa_2017_24h_finished_first_finish_3:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_finished_first_grandeur_peak_3:
+  effort: rufa_2017_24h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 18:47:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 20220.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_finished_first_start_4:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_start
-  id: 133972
   absolute_time: 2017-02-11 19:31:00.000000000 Z
   data_status: 2
   elapsed_seconds: 22860.0
@@ -8176,23 +7571,9 @@ rufa_2017_24h_finished_first_start_4:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_finished_first_grandeur_peak_4:
-  effort: rufa_2017_24h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 133973
-  absolute_time: 2017-02-11 21:05:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 28500.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_finished_first_finish_4:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
-  id: 133974
   absolute_time: 2017-02-11 21:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30960.0
@@ -8202,10 +7583,21 @@ rufa_2017_24h_finished_first_finish_4:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_finished_first_grandeur_peak_4:
+  effort: rufa_2017_24h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 21:05:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 28500.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_finished_first_start_5:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_start
-  id: 133975
   absolute_time: 2017-02-11 22:06:00.000000000 Z
   data_status: 2
   elapsed_seconds: 32160.0
@@ -8215,23 +7607,9 @@ rufa_2017_24h_finished_first_start_5:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_finished_first_grandeur_peak_5:
-  effort: rufa_2017_24h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 133976
-  absolute_time: 2017-02-11 23:40:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 37800.0
-  lap: 5
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_finished_first_finish_5:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
-  id: 133977
   absolute_time: 2017-02-12 00:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 40200.0
@@ -8241,10 +7619,21 @@ rufa_2017_24h_finished_first_finish_5:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_finished_first_grandeur_peak_5:
+  effort: rufa_2017_24h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 23:40:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 37800.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_finished_first_start_6:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_start
-  id: 133978
   absolute_time: 2017-02-12 00:50:00.000000000 Z
   data_status: 2
   elapsed_seconds: 42000.0
@@ -8254,23 +7643,9 @@ rufa_2017_24h_finished_first_start_6:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_finished_first_grandeur_peak_6:
-  effort: rufa_2017_24h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 133979
-  absolute_time: 2017-02-12 02:25:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 47700.0
-  lap: 6
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_finished_first_finish_6:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
-  id: 133980
   absolute_time: 2017-02-12 03:15:00.000000000 Z
   data_status: 2
   elapsed_seconds: 50700.0
@@ -8280,10 +7655,21 @@ rufa_2017_24h_finished_first_finish_6:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_finished_first_grandeur_peak_6:
+  effort: rufa_2017_24h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-12 02:25:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 47700.0
+  lap: 6
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_finished_first_start_7:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_start
-  id: 133981
   absolute_time: 2017-02-12 03:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 52080.0
@@ -8293,23 +7679,9 @@ rufa_2017_24h_finished_first_start_7:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_finished_first_grandeur_peak_7:
-  effort: rufa_2017_24h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 133982
-  absolute_time: 2017-02-12 05:19:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 58140.0
-  lap: 7
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_finished_first_finish_7:
   effort: rufa_2017_24h_finished_first
   split: rufa_course_finish
-  id: 133983
   absolute_time: 2017-02-12 06:08:00.000000000 Z
   data_status: 2
   elapsed_seconds: 61080.0
@@ -8319,26 +7691,24 @@ rufa_2017_24h_finished_first_finish_7:
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_progress_lap6_start_1:
-  effort: rufa_2017_24h_progress_lap6
-  split: rufa_course_start
-  id: 134001
-  absolute_time: 2017-02-11 15:00:00.000000000 Z
+rufa_2017_24h_finished_first_grandeur_peak_7:
+  effort: rufa_2017_24h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-12 05:19:00.000000000 Z
   data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
+  elapsed_seconds: 58140.0
+  lap: 7
   pacer:
   remarks:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_progress_lap6_grandeur_peak_1:
+rufa_2017_24h_progress_lap6_start_1:
   effort: rufa_2017_24h_progress_lap6
-  split: rufa_course_grandeur_peak
-  id: 134002
-  absolute_time: 2017-02-11 15:57:00.000000000 Z
+  split: rufa_course_start
+  absolute_time: 2017-02-11 15:00:00.000000000 Z
   data_status: 2
-  elapsed_seconds: 3420.0
+  elapsed_seconds: 0.0
   lap: 1
   pacer:
   remarks:
@@ -8348,10 +7718,21 @@ rufa_2017_24h_progress_lap6_grandeur_peak_1:
 rufa_2017_24h_progress_lap6_finish_1:
   effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
-  id: 134003
   absolute_time: 2017-02-11 16:28:00.000000000 Z
   data_status: 2
   elapsed_seconds: 5280.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_24h_progress_lap6_grandeur_peak_1:
+  effort: rufa_2017_24h_progress_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 15:57:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 3420.0
   lap: 1
   pacer:
   remarks:
@@ -8361,7 +7742,6 @@ rufa_2017_24h_progress_lap6_finish_1:
 rufa_2017_24h_progress_lap6_start_2:
   effort: rufa_2017_24h_progress_lap6
   split: rufa_course_start
-  id: 134004
   absolute_time: 2017-02-11 16:28:00.000000000 Z
   data_status: 2
   elapsed_seconds: 5280.0
@@ -8371,23 +7751,9 @@ rufa_2017_24h_progress_lap6_start_2:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_progress_lap6_grandeur_peak_2:
-  effort: rufa_2017_24h_progress_lap6
-  split: rufa_course_grandeur_peak
-  id: 134005
-  absolute_time: 2017-02-11 17:29:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 8940.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_progress_lap6_finish_2:
   effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
-  id: 134006
   absolute_time: 2017-02-11 18:01:00.000000000 Z
   data_status: 2
   elapsed_seconds: 10860.0
@@ -8397,10 +7763,21 @@ rufa_2017_24h_progress_lap6_finish_2:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_progress_lap6_grandeur_peak_2:
+  effort: rufa_2017_24h_progress_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 17:29:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 8940.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_progress_lap6_start_3:
   effort: rufa_2017_24h_progress_lap6
   split: rufa_course_start
-  id: 134007
   absolute_time: 2017-02-11 18:02:00.000000000 Z
   data_status: 2
   elapsed_seconds: 10920.0
@@ -8410,23 +7787,9 @@ rufa_2017_24h_progress_lap6_start_3:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_progress_lap6_grandeur_peak_3:
-  effort: rufa_2017_24h_progress_lap6
-  split: rufa_course_grandeur_peak
-  id: 134008
-  absolute_time: 2017-02-11 19:13:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 15180.0
-  lap: 3
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_progress_lap6_finish_3:
   effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
-  id: 134009
   absolute_time: 2017-02-11 19:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 17160.0
@@ -8436,10 +7799,21 @@ rufa_2017_24h_progress_lap6_finish_3:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_progress_lap6_grandeur_peak_3:
+  effort: rufa_2017_24h_progress_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 19:13:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 15180.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_progress_lap6_start_4:
   effort: rufa_2017_24h_progress_lap6
   split: rufa_course_start
-  id: 134010
   absolute_time: 2017-02-11 19:48:00.000000000 Z
   data_status: 2
   elapsed_seconds: 17280.0
@@ -8449,23 +7823,9 @@ rufa_2017_24h_progress_lap6_start_4:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_progress_lap6_grandeur_peak_4:
-  effort: rufa_2017_24h_progress_lap6
-  split: rufa_course_grandeur_peak
-  id: 134011
-  absolute_time: 2017-02-11 21:01:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 21660.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_progress_lap6_finish_4:
   effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
-  id: 134012
   absolute_time: 2017-02-11 21:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 23760.0
@@ -8475,10 +7835,21 @@ rufa_2017_24h_progress_lap6_finish_4:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_progress_lap6_grandeur_peak_4:
+  effort: rufa_2017_24h_progress_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 21:01:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 21660.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_progress_lap6_start_5:
   effort: rufa_2017_24h_progress_lap6
   split: rufa_course_start
-  id: 134013
   absolute_time: 2017-02-11 21:39:00.000000000 Z
   data_status: 2
   elapsed_seconds: 23940.0
@@ -8488,23 +7859,9 @@ rufa_2017_24h_progress_lap6_start_5:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_progress_lap6_grandeur_peak_5:
-  effort: rufa_2017_24h_progress_lap6
-  split: rufa_course_grandeur_peak
-  id: 134014
-  absolute_time: 2017-02-11 22:53:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 28380.0
-  lap: 5
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_progress_lap6_finish_5:
   effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
-  id: 134015
   absolute_time: 2017-02-11 23:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30420.0
@@ -8514,10 +7871,21 @@ rufa_2017_24h_progress_lap6_finish_5:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_progress_lap6_grandeur_peak_5:
+  effort: rufa_2017_24h_progress_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 22:53:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 28380.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_progress_lap6_start_6:
   effort: rufa_2017_24h_progress_lap6
   split: rufa_course_start
-  id: 134016
   absolute_time: 2017-02-11 23:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30600.0
@@ -8527,23 +7895,9 @@ rufa_2017_24h_progress_lap6_start_6:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_progress_lap6_grandeur_peak_6:
-  effort: rufa_2017_24h_progress_lap6
-  split: rufa_course_grandeur_peak
-  id: 134017
-  absolute_time: 2017-02-12 00:49:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 35340.0
-  lap: 6
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_progress_lap6_finish_6:
   effort: rufa_2017_24h_progress_lap6
   split: rufa_course_finish
-  id: 134018
   absolute_time: 2017-02-12 01:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 37200.0
@@ -8553,26 +7907,24 @@ rufa_2017_24h_progress_lap6_finish_6:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_multiple_stops_start_1:
-  effort: rufa_2017_24h_multiple_stops
-  split: rufa_course_start
-  id: 134805
-  absolute_time: 2017-02-11 15:00:00.000000000 Z
+rufa_2017_24h_progress_lap6_grandeur_peak_6:
+  effort: rufa_2017_24h_progress_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-12 00:49:00.000000000 Z
   data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
+  elapsed_seconds: 35340.0
+  lap: 6
   pacer:
   remarks:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_multiple_stops_grandeur_peak_1:
+rufa_2017_24h_multiple_stops_start_1:
   effort: rufa_2017_24h_multiple_stops
-  split: rufa_course_grandeur_peak
-  id: 134806
-  absolute_time: 2017-02-11 16:05:00.000000000 Z
+  split: rufa_course_start
+  absolute_time: 2017-02-11 15:00:00.000000000 Z
   data_status: 2
-  elapsed_seconds: 3900.0
+  elapsed_seconds: 0.0
   lap: 1
   pacer:
   remarks:
@@ -8582,10 +7934,21 @@ rufa_2017_24h_multiple_stops_grandeur_peak_1:
 rufa_2017_24h_multiple_stops_finish_1:
   effort: rufa_2017_24h_multiple_stops
   split: rufa_course_finish
-  id: 134807
   absolute_time: 2017-02-11 16:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 6000.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_24h_multiple_stops_grandeur_peak_1:
+  effort: rufa_2017_24h_multiple_stops
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 16:05:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 3900.0
   lap: 1
   pacer:
   remarks:
@@ -8595,7 +7958,6 @@ rufa_2017_24h_multiple_stops_finish_1:
 rufa_2017_24h_multiple_stops_start_2:
   effort: rufa_2017_24h_multiple_stops
   split: rufa_course_start
-  id: 134808
   absolute_time: 2017-02-11 16:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 6000.0
@@ -8605,23 +7967,9 @@ rufa_2017_24h_multiple_stops_start_2:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_multiple_stops_grandeur_peak_2:
-  effort: rufa_2017_24h_multiple_stops
-  split: rufa_course_grandeur_peak
-  id: 134809
-  absolute_time: 2017-02-11 17:52:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 10320.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_multiple_stops_finish_2:
   effort: rufa_2017_24h_multiple_stops
   split: rufa_course_finish
-  id: 134810
   absolute_time: 2017-02-11 18:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 12240.0
@@ -8631,14 +7979,13 @@ rufa_2017_24h_multiple_stops_finish_2:
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_multiple_stops_grandeur_peak_3:
+rufa_2017_24h_multiple_stops_grandeur_peak_2:
   effort: rufa_2017_24h_multiple_stops
   split: rufa_course_grandeur_peak
-  id: 134811
-  absolute_time: 2017-02-11 19:55:00.000000000 Z
+  absolute_time: 2017-02-11 17:52:00.000000000 Z
   data_status: 2
-  elapsed_seconds: 17700.0
-  lap: 3
+  elapsed_seconds: 10320.0
+  lap: 2
   pacer:
   remarks:
   stopped_here: false
@@ -8647,7 +7994,6 @@ rufa_2017_24h_multiple_stops_grandeur_peak_3:
 rufa_2017_24h_multiple_stops_finish_3:
   effort: rufa_2017_24h_multiple_stops
   split: rufa_course_finish
-  id: 134812
   absolute_time: 2017-02-11 20:42:00.000000000 Z
   data_status: 2
   elapsed_seconds: 20520.0
@@ -8657,10 +8003,21 @@ rufa_2017_24h_multiple_stops_finish_3:
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_multiple_stops_grandeur_peak_3:
+  effort: rufa_2017_24h_multiple_stops
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 19:55:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 17700.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_finished_last_start_1:
   effort: rufa_2017_24h_finished_last
   split: rufa_course_start
-  id: 135007
   absolute_time: 2017-02-11 15:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -8670,23 +8027,9 @@ rufa_2017_24h_finished_last_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_finished_last_grandeur_peak_1:
-  effort: rufa_2017_24h_finished_last
-  split: rufa_course_grandeur_peak
-  id: 135008
-  absolute_time: 2017-02-11 16:17:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 4620.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_finished_last_finish_1:
   effort: rufa_2017_24h_finished_last
   split: rufa_course_finish
-  id: 135009
   absolute_time: 2017-02-11 16:54:00.000000000 Z
   data_status: 2
   elapsed_seconds: 6840.0
@@ -8696,10 +8039,21 @@ rufa_2017_24h_finished_last_finish_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_finished_last_grandeur_peak_1:
+  effort: rufa_2017_24h_finished_last
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 16:17:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 4620.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_finished_last_start_2:
   effort: rufa_2017_24h_finished_last
   split: rufa_course_start
-  id: 135010
   absolute_time: 2017-02-11 16:58:00.000000000 Z
   data_status: 2
   elapsed_seconds: 7080.0
@@ -8709,23 +8063,9 @@ rufa_2017_24h_finished_last_start_2:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_finished_last_grandeur_peak_2:
-  effort: rufa_2017_24h_finished_last
-  split: rufa_course_grandeur_peak
-  id: 135011
-  absolute_time: 2017-02-11 18:21:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 12060.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_finished_last_finish_2:
   effort: rufa_2017_24h_finished_last
   split: rufa_course_finish
-  id: 135012
   absolute_time: 2017-02-11 18:57:00.000000000 Z
   data_status: 2
   elapsed_seconds: 14220.0
@@ -8735,10 +8075,21 @@ rufa_2017_24h_finished_last_finish_2:
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_finished_last_grandeur_peak_2:
+  effort: rufa_2017_24h_finished_last
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 18:21:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 12060.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 rufa_2017_24h_progress_lap1_start_1:
   effort: rufa_2017_24h_progress_lap1
   split: rufa_course_start
-  id: 135132
   absolute_time: 2017-02-11 16:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -8748,23 +8099,9 @@ rufa_2017_24h_progress_lap1_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-rufa_2017_24h_progress_lap1_grandeur_peak_1:
-  effort: rufa_2017_24h_progress_lap1
-  split: rufa_course_grandeur_peak
-  id: 135133
-  absolute_time: 2017-02-11 17:27:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 5220.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 rufa_2017_24h_progress_lap1_finish_1:
   effort: rufa_2017_24h_progress_lap1
   split: rufa_course_finish
-  id: 135134
   absolute_time: 2017-02-11 18:53:00.000000000 Z
   data_status: 1
   elapsed_seconds: 10380.0
@@ -8774,10 +8111,21 @@ rufa_2017_24h_progress_lap1_finish_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+rufa_2017_24h_progress_lap1_grandeur_peak_1:
+  effort: rufa_2017_24h_progress_lap1
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 17:27:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 5220.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 hardrock_2016_lavon_paucek_start_1:
   effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_start
-  id: 146923
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -8787,10 +8135,21 @@ hardrock_2016_lavon_paucek_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+hardrock_2016_lavon_paucek_finish_1:
+  effort: hardrock_2016_lavon_paucek
+  split: hardrock_cw_finish
+  absolute_time: 2016-07-16 17:02:09.000000000 Z
+  data_status: 2
+  elapsed_seconds: 104529.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
 hardrock_2016_lavon_paucek_telluride_in_1:
   effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_telluride
-  id: 146928
   absolute_time: 2016-07-15 18:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 23760.0
@@ -8803,7 +8162,6 @@ hardrock_2016_lavon_paucek_telluride_in_1:
 hardrock_2016_lavon_paucek_telluride_out_1:
   effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_telluride
-  id: 146929
   absolute_time: 2016-07-15 18:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 23880.0
@@ -8816,7 +8174,6 @@ hardrock_2016_lavon_paucek_telluride_out_1:
 hardrock_2016_lavon_paucek_ouray_in_1:
   effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_ouray
-  id: 146934
   absolute_time: 2016-07-15 22:11:00.000000000 Z
   data_status: 2
   elapsed_seconds: 36660.0
@@ -8829,7 +8186,6 @@ hardrock_2016_lavon_paucek_ouray_in_1:
 hardrock_2016_lavon_paucek_ouray_out_1:
   effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_ouray
-  id: 146935
   absolute_time: 2016-07-15 22:16:00.000000000 Z
   data_status: 2
   elapsed_seconds: 36960.0
@@ -8842,7 +8198,6 @@ hardrock_2016_lavon_paucek_ouray_out_1:
 hardrock_2016_lavon_paucek_grouse_in_1:
   effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_grouse
-  id: 146938
   absolute_time: 2016-07-16 02:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 52560.0
@@ -8855,7 +8210,6 @@ hardrock_2016_lavon_paucek_grouse_in_1:
 hardrock_2016_lavon_paucek_grouse_out_1:
   effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_grouse
-  id: 146939
   absolute_time: 2016-07-16 02:36:00.000000000 Z
   data_status: 2
   elapsed_seconds: 52560.0
@@ -8868,7 +8222,6 @@ hardrock_2016_lavon_paucek_grouse_out_1:
 hardrock_2016_lavon_paucek_sherman_in_1:
   effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_sherman
-  id: 146942
   absolute_time: 2016-07-16 07:02:00.000000000 Z
   data_status: 2
   elapsed_seconds: 68520.0
@@ -8881,7 +8234,6 @@ hardrock_2016_lavon_paucek_sherman_in_1:
 hardrock_2016_lavon_paucek_sherman_out_1:
   effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_sherman
-  id: 146943
   absolute_time: 2016-07-16 07:09:00.000000000 Z
   data_status: 2
   elapsed_seconds: 68940.0
@@ -8894,7 +8246,6 @@ hardrock_2016_lavon_paucek_sherman_out_1:
 hardrock_2016_lavon_paucek_cunningham_in_1:
   effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_cunningham
-  id: 146948
   absolute_time: 2016-07-16 14:11:00.000000000 Z
   data_status: 2
   elapsed_seconds: 94260.0
@@ -8907,7 +8258,6 @@ hardrock_2016_lavon_paucek_cunningham_in_1:
 hardrock_2016_lavon_paucek_cunningham_out_1:
   effort: hardrock_2016_lavon_paucek
   split: hardrock_cw_cunningham
-  id: 146949
   absolute_time: 2016-07-16 14:13:00.000000000 Z
   data_status: 2
   elapsed_seconds: 94380.0
@@ -8917,23 +8267,9 @@ hardrock_2016_lavon_paucek_cunningham_out_1:
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
-hardrock_2016_lavon_paucek_finish_1:
-  effort: hardrock_2016_lavon_paucek
-  split: hardrock_cw_finish
-  id: 146950
-  absolute_time: 2016-07-16 17:02:09.000000000 Z
-  data_status: 2
-  elapsed_seconds: 104529.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
 hardrock_2016_vesta_borer_start_1:
   effort: hardrock_2016_vesta_borer
   split: hardrock_cw_start
-  id: 147315
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -8946,7 +8282,6 @@ hardrock_2016_vesta_borer_start_1:
 hardrock_2016_vesta_borer_telluride_in_1:
   effort: hardrock_2016_vesta_borer
   split: hardrock_cw_telluride
-  id: 147320
   absolute_time: 2016-07-15 20:17:00.000000000 Z
   data_status: 2
   elapsed_seconds: 29820.0
@@ -8959,7 +8294,6 @@ hardrock_2016_vesta_borer_telluride_in_1:
 hardrock_2016_vesta_borer_telluride_out_1:
   effort: hardrock_2016_vesta_borer
   split: hardrock_cw_telluride
-  id: 147321
   absolute_time: 2016-07-15 20:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30120.0
@@ -8972,7 +8306,6 @@ hardrock_2016_vesta_borer_telluride_out_1:
 hardrock_2016_vesta_borer_ouray_in_1:
   effort: hardrock_2016_vesta_borer
   split: hardrock_cw_ouray
-  id: 147326
   absolute_time: 2016-07-16 00:49:00.000000000 Z
   data_status: 2
   elapsed_seconds: 46140.0
@@ -8985,7 +8318,6 @@ hardrock_2016_vesta_borer_ouray_in_1:
 hardrock_2016_vesta_borer_ouray_out_1:
   effort: hardrock_2016_vesta_borer
   split: hardrock_cw_ouray
-  id: 147327
   absolute_time: 2016-07-16 00:58:00.000000000 Z
   data_status: 2
   elapsed_seconds: 46680.0
@@ -8998,7 +8330,6 @@ hardrock_2016_vesta_borer_ouray_out_1:
 hardrock_2016_vesta_borer_grouse_in_1:
   effort: hardrock_2016_vesta_borer
   split: hardrock_cw_grouse
-  id: 147330
   absolute_time: 2016-07-16 06:14:00.000000000 Z
   data_status: 2
   elapsed_seconds: 65640.0
@@ -9011,7 +8342,6 @@ hardrock_2016_vesta_borer_grouse_in_1:
 hardrock_2016_vesta_borer_grouse_out_1:
   effort: hardrock_2016_vesta_borer
   split: hardrock_cw_grouse
-  id: 147331
   absolute_time: 2016-07-16 06:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 66240.0
@@ -9024,7 +8354,6 @@ hardrock_2016_vesta_borer_grouse_out_1:
 hardrock_2016_vesta_borer_sherman_in_1:
   effort: hardrock_2016_vesta_borer
   split: hardrock_cw_sherman
-  id: 147334
   absolute_time: 2016-07-16 11:23:00.000000000 Z
   data_status: 2
   elapsed_seconds: 84180.0
@@ -9037,7 +8366,6 @@ hardrock_2016_vesta_borer_sherman_in_1:
 hardrock_2016_vesta_borer_sherman_out_1:
   effort: hardrock_2016_vesta_borer
   split: hardrock_cw_sherman
-  id: 147335
   absolute_time: 2016-07-16 11:41:00.000000000 Z
   data_status: 2
   elapsed_seconds: 85260.0
@@ -9050,7 +8378,6 @@ hardrock_2016_vesta_borer_sherman_out_1:
 hardrock_2016_vesta_borer_cunningham_in_1:
   effort: hardrock_2016_vesta_borer
   split: hardrock_cw_cunningham
-  id: 147340
   absolute_time: 2016-07-16 19:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 111600.0
@@ -9063,7 +8390,6 @@ hardrock_2016_vesta_borer_cunningham_in_1:
 hardrock_2016_vesta_borer_cunningham_out_1:
   effort: hardrock_2016_vesta_borer
   split: hardrock_cw_cunningham
-  id: 147341
   absolute_time: 2016-07-16 19:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 111900.0
@@ -9076,7 +8402,6 @@ hardrock_2016_vesta_borer_cunningham_out_1:
 hardrock_2016_kory_kulas_start_1:
   effort: hardrock_2016_kory_kulas
   split: hardrock_cw_start
-  id: 147455
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -9089,7 +8414,6 @@ hardrock_2016_kory_kulas_start_1:
 hardrock_2016_kory_kulas_telluride_in_1:
   effort: hardrock_2016_kory_kulas
   split: hardrock_cw_telluride
-  id: 147460
   absolute_time: 2016-07-15 20:16:00.000000000 Z
   data_status: 2
   elapsed_seconds: 29760.0
@@ -9102,7 +8426,6 @@ hardrock_2016_kory_kulas_telluride_in_1:
 hardrock_2016_kory_kulas_telluride_out_1:
   effort: hardrock_2016_kory_kulas
   split: hardrock_cw_telluride
-  id: 147461
   absolute_time: 2016-07-15 20:25:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30300.0
@@ -9115,7 +8438,6 @@ hardrock_2016_kory_kulas_telluride_out_1:
 hardrock_2016_kory_kulas_ouray_in_1:
   effort: hardrock_2016_kory_kulas
   split: hardrock_cw_ouray
-  id: 147466
   absolute_time: 2016-07-16 01:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 47100.0
@@ -9128,7 +8450,6 @@ hardrock_2016_kory_kulas_ouray_in_1:
 hardrock_2016_kory_kulas_ouray_out_1:
   effort: hardrock_2016_kory_kulas
   split: hardrock_cw_ouray
-  id: 147467
   absolute_time: 2016-07-16 01:16:00.000000000 Z
   data_status: 2
   elapsed_seconds: 47760.0
@@ -9141,7 +8462,6 @@ hardrock_2016_kory_kulas_ouray_out_1:
 hardrock_2016_kory_kulas_grouse_in_1:
   effort: hardrock_2016_kory_kulas
   split: hardrock_cw_grouse
-  id: 147470
   absolute_time: 2016-07-16 07:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 70200.0
@@ -9154,7 +8474,6 @@ hardrock_2016_kory_kulas_grouse_in_1:
 hardrock_2016_kory_kulas_grouse_out_1:
   effort: hardrock_2016_kory_kulas
   split: hardrock_cw_grouse
-  id: 147471
   absolute_time: 2016-07-16 07:55:00.000000000 Z
   data_status: 2
   elapsed_seconds: 71700.0
@@ -9167,7 +8486,6 @@ hardrock_2016_kory_kulas_grouse_out_1:
 hardrock_2016_kory_kulas_sherman_in_1:
   effort: hardrock_2016_kory_kulas
   split: hardrock_cw_sherman
-  id: 147474
   absolute_time: 2016-07-16 13:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 90000.0
@@ -9180,7 +8498,6 @@ hardrock_2016_kory_kulas_sherman_in_1:
 hardrock_2016_kory_kulas_sherman_out_1:
   effort: hardrock_2016_kory_kulas
   split: hardrock_cw_sherman
-  id: 147475
   absolute_time: 2016-07-16 13:08:00.000000000 Z
   data_status: 2
   elapsed_seconds: 90480.0
@@ -9193,7 +8510,6 @@ hardrock_2016_kory_kulas_sherman_out_1:
 hardrock_2016_kory_kulas_cunningham_in_1:
   effort: hardrock_2016_kory_kulas
   split: hardrock_cw_cunningham
-  id: 147480
   absolute_time: 2016-07-16 20:51:00.000000000 Z
   data_status: 2
   elapsed_seconds: 118260.0
@@ -9206,7 +8522,6 @@ hardrock_2016_kory_kulas_cunningham_in_1:
 hardrock_2016_kory_kulas_cunningham_out_1:
   effort: hardrock_2016_kory_kulas
   split: hardrock_cw_cunningham
-  id: 147481
   absolute_time: 2016-07-16 20:58:00.000000000 Z
   data_status: 2
   elapsed_seconds: 118680.0
@@ -9219,7 +8534,6 @@ hardrock_2016_kory_kulas_cunningham_out_1:
 hardrock_2016_shad_hirthe_start_1:
   effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_start
-  id: 147679
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -9232,7 +8546,6 @@ hardrock_2016_shad_hirthe_start_1:
 hardrock_2016_shad_hirthe_telluride_in_1:
   effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_telluride
-  id: 147684
   absolute_time: 2016-07-15 19:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 28740.0
@@ -9245,7 +8558,6 @@ hardrock_2016_shad_hirthe_telluride_in_1:
 hardrock_2016_shad_hirthe_telluride_out_1:
   effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_telluride
-  id: 147685
   absolute_time: 2016-07-15 20:07:00.000000000 Z
   data_status: 2
   elapsed_seconds: 29220.0
@@ -9258,7 +8570,6 @@ hardrock_2016_shad_hirthe_telluride_out_1:
 hardrock_2016_shad_hirthe_ouray_in_1:
   effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_ouray
-  id: 147690
   absolute_time: 2016-07-16 00:35:00.000000000 Z
   data_status: 2
   elapsed_seconds: 45300.0
@@ -9271,7 +8582,6 @@ hardrock_2016_shad_hirthe_ouray_in_1:
 hardrock_2016_shad_hirthe_ouray_out_1:
   effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_ouray
-  id: 147691
   absolute_time: 2016-07-16 00:47:00.000000000 Z
   data_status: 2
   elapsed_seconds: 46020.0
@@ -9284,7 +8594,6 @@ hardrock_2016_shad_hirthe_ouray_out_1:
 hardrock_2016_shad_hirthe_grouse_in_1:
   effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_grouse
-  id: 147694
   absolute_time: 2016-07-16 06:28:00.000000000 Z
   data_status: 2
   elapsed_seconds: 66480.0
@@ -9297,7 +8606,6 @@ hardrock_2016_shad_hirthe_grouse_in_1:
 hardrock_2016_shad_hirthe_grouse_out_1:
   effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_grouse
-  id: 147695
   absolute_time: 2016-07-16 06:47:00.000000000 Z
   data_status: 2
   elapsed_seconds: 67620.0
@@ -9310,7 +8618,6 @@ hardrock_2016_shad_hirthe_grouse_out_1:
 hardrock_2016_shad_hirthe_sherman_in_1:
   effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_sherman
-  id: 147698
   absolute_time: 2016-07-16 12:35:00.000000000 Z
   data_status: 2
   elapsed_seconds: 88500.0
@@ -9323,7 +8630,6 @@ hardrock_2016_shad_hirthe_sherman_in_1:
 hardrock_2016_shad_hirthe_sherman_out_1:
   effort: hardrock_2016_shad_hirthe
   split: hardrock_cw_sherman
-  id: 147699
   absolute_time: 2016-07-16 12:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 89940.0
@@ -9336,7 +8642,6 @@ hardrock_2016_shad_hirthe_sherman_out_1:
 hardrock_2016_douglas_vandervort_start_1:
   effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_start
-  id: 147819
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -9349,7 +8654,6 @@ hardrock_2016_douglas_vandervort_start_1:
 hardrock_2016_douglas_vandervort_telluride_in_1:
   effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_telluride
-  id: 147824
   absolute_time: 2016-07-15 20:16:00.000000000 Z
   data_status: 2
   elapsed_seconds: 29760.0
@@ -9362,7 +8666,6 @@ hardrock_2016_douglas_vandervort_telluride_in_1:
 hardrock_2016_douglas_vandervort_telluride_out_1:
   effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_telluride
-  id: 147825
   absolute_time: 2016-07-15 20:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30420.0
@@ -9375,7 +8678,6 @@ hardrock_2016_douglas_vandervort_telluride_out_1:
 hardrock_2016_douglas_vandervort_ouray_in_1:
   effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_ouray
-  id: 147830
   absolute_time: 2016-07-16 01:19:00.000000000 Z
   data_status: 2
   elapsed_seconds: 47940.0
@@ -9388,7 +8690,6 @@ hardrock_2016_douglas_vandervort_ouray_in_1:
 hardrock_2016_douglas_vandervort_ouray_out_1:
   effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_ouray
-  id: 147831
   absolute_time: 2016-07-16 01:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 49560.0
@@ -9401,7 +8702,6 @@ hardrock_2016_douglas_vandervort_ouray_out_1:
 hardrock_2016_douglas_vandervort_grouse_in_1:
   effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_grouse
-  id: 147834
   absolute_time: 2016-07-16 08:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 72000.0
@@ -9414,7 +8714,6 @@ hardrock_2016_douglas_vandervort_grouse_in_1:
 hardrock_2016_douglas_vandervort_grouse_out_1:
   effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_grouse
-  id: 147835
   absolute_time: 2016-07-16 08:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 73620.0
@@ -9427,7 +8726,6 @@ hardrock_2016_douglas_vandervort_grouse_out_1:
 hardrock_2016_douglas_vandervort_sherman_in_1:
   effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_sherman
-  id: 147838
   absolute_time: 2016-07-16 13:49:00.000000000 Z
   data_status: 2
   elapsed_seconds: 92940.0
@@ -9440,7 +8738,6 @@ hardrock_2016_douglas_vandervort_sherman_in_1:
 hardrock_2016_douglas_vandervort_sherman_out_1:
   effort: hardrock_2016_douglas_vandervort
   split: hardrock_cw_sherman
-  id: 147839
   absolute_time: 2016-07-16 14:19:00.000000000 Z
   data_status: 2
   elapsed_seconds: 94740.0
@@ -9453,7 +8750,6 @@ hardrock_2016_douglas_vandervort_sherman_out_1:
 hardrock_2016_missing_telluride_out_start_1:
   effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_start
-  id: 147987
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -9466,7 +8762,6 @@ hardrock_2016_missing_telluride_out_start_1:
 hardrock_2016_missing_telluride_out_telluride_in_1:
   effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_telluride
-  id: 147992
   absolute_time: 2016-07-15 21:41:00.000000000 Z
   data_status: 2
   elapsed_seconds: 34860.0
@@ -9479,7 +8774,6 @@ hardrock_2016_missing_telluride_out_telluride_in_1:
 hardrock_2016_missing_telluride_out_ouray_in_1:
   effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_ouray
-  id: 147998
   absolute_time: 2016-07-16 02:54:00.000000000 Z
   data_status: 2
   elapsed_seconds: 53640.0
@@ -9492,7 +8786,6 @@ hardrock_2016_missing_telluride_out_ouray_in_1:
 hardrock_2016_missing_telluride_out_ouray_out_1:
   effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_ouray
-  id: 147999
   absolute_time: 2016-07-16 03:10:00.000000000 Z
   data_status: 2
   elapsed_seconds: 54600.0
@@ -9505,7 +8798,6 @@ hardrock_2016_missing_telluride_out_ouray_out_1:
 hardrock_2016_missing_telluride_out_grouse_in_1:
   effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_grouse
-  id: 148002
   absolute_time: 2016-07-16 09:04:00.000000000 Z
   data_status: 2
   elapsed_seconds: 75840.0
@@ -9518,7 +8810,6 @@ hardrock_2016_missing_telluride_out_grouse_in_1:
 hardrock_2016_missing_telluride_out_grouse_out_1:
   effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_grouse
-  id: 148003
   absolute_time: 2016-07-16 09:16:00.000000000 Z
   data_status: 2
   elapsed_seconds: 76560.0
@@ -9531,7 +8822,6 @@ hardrock_2016_missing_telluride_out_grouse_out_1:
 hardrock_2016_missing_telluride_out_sherman_in_1:
   effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_sherman
-  id: 148006
   absolute_time: 2016-07-16 14:51:00.000000000 Z
   data_status: 2
   elapsed_seconds: 96660.0
@@ -9544,7 +8834,6 @@ hardrock_2016_missing_telluride_out_sherman_in_1:
 hardrock_2016_missing_telluride_out_sherman_out_1:
   effort: hardrock_2016_missing_telluride_out
   split: hardrock_cw_sherman
-  id: 148007
   absolute_time: 2016-07-16 15:13:00.000000000 Z
   data_status: 2
   elapsed_seconds: 97980.0
@@ -9557,7 +8846,6 @@ hardrock_2016_missing_telluride_out_sherman_out_1:
 hardrock_2016_junior_lesch_start_1:
   effort: hardrock_2016_junior_lesch
   split: hardrock_cw_start
-  id: 148071
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -9570,7 +8858,6 @@ hardrock_2016_junior_lesch_start_1:
 hardrock_2016_junior_lesch_telluride_in_1:
   effort: hardrock_2016_junior_lesch
   split: hardrock_cw_telluride
-  id: 148076
   absolute_time: 2016-07-15 20:10:00.000000000 Z
   data_status: 2
   elapsed_seconds: 29400.0
@@ -9583,7 +8870,6 @@ hardrock_2016_junior_lesch_telluride_in_1:
 hardrock_2016_junior_lesch_telluride_out_1:
   effort: hardrock_2016_junior_lesch
   split: hardrock_cw_telluride
-  id: 148077
   absolute_time: 2016-07-15 20:17:00.000000000 Z
   data_status: 2
   elapsed_seconds: 29820.0
@@ -9596,7 +8882,6 @@ hardrock_2016_junior_lesch_telluride_out_1:
 hardrock_2016_junior_lesch_ouray_in_1:
   effort: hardrock_2016_junior_lesch
   split: hardrock_cw_ouray
-  id: 148082
   absolute_time: 2016-07-16 00:57:00.000000000 Z
   data_status: 2
   elapsed_seconds: 46620.0
@@ -9609,7 +8894,6 @@ hardrock_2016_junior_lesch_ouray_in_1:
 hardrock_2016_junior_lesch_ouray_out_1:
   effort: hardrock_2016_junior_lesch
   split: hardrock_cw_ouray
-  id: 148083
   absolute_time: 2016-07-16 01:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 48000.0
@@ -9622,7 +8906,6 @@ hardrock_2016_junior_lesch_ouray_out_1:
 hardrock_2016_junior_lesch_grouse_in_1:
   effort: hardrock_2016_junior_lesch
   split: hardrock_cw_grouse
-  id: 148086
   absolute_time: 2016-07-16 07:31:00.000000000 Z
   data_status: 2
   elapsed_seconds: 70260.0
@@ -9635,7 +8918,6 @@ hardrock_2016_junior_lesch_grouse_in_1:
 hardrock_2016_junior_lesch_grouse_out_1:
   effort: hardrock_2016_junior_lesch
   split: hardrock_cw_grouse
-  id: 148087
   absolute_time: 2016-07-16 08:42:00.000000000 Z
   data_status: 2
   elapsed_seconds: 74520.0
@@ -9648,7 +8930,6 @@ hardrock_2016_junior_lesch_grouse_out_1:
 hardrock_2016_junior_lesch_sherman_in_1:
   effort: hardrock_2016_junior_lesch
   split: hardrock_cw_sherman
-  id: 148090
   absolute_time: 2016-07-16 15:10:00.000000000 Z
   data_status: 2
   elapsed_seconds: 97800.0
@@ -9661,7 +8942,6 @@ hardrock_2016_junior_lesch_sherman_in_1:
 hardrock_2016_junior_lesch_sherman_out_1:
   effort: hardrock_2016_junior_lesch
   split: hardrock_cw_sherman
-  id: 148091
   absolute_time: 2016-07-16 15:44:00.000000000 Z
   data_status: 2
   elapsed_seconds: 99840.0
@@ -9674,7 +8954,6 @@ hardrock_2016_junior_lesch_sherman_out_1:
 hardrock_2016_eddy_goldner_start_1:
   effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_start
-  id: 148183
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -9687,7 +8966,6 @@ hardrock_2016_eddy_goldner_start_1:
 hardrock_2016_eddy_goldner_telluride_in_1:
   effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_telluride
-  id: 148188
   absolute_time: 2016-07-15 19:41:00.000000000 Z
   data_status: 2
   elapsed_seconds: 27660.0
@@ -9700,7 +8978,6 @@ hardrock_2016_eddy_goldner_telluride_in_1:
 hardrock_2016_eddy_goldner_telluride_out_1:
   effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_telluride
-  id: 148189
   absolute_time: 2016-07-15 19:54:00.000000000 Z
   data_status: 2
   elapsed_seconds: 28440.0
@@ -9713,7 +8990,6 @@ hardrock_2016_eddy_goldner_telluride_out_1:
 hardrock_2016_eddy_goldner_ouray_in_1:
   effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_ouray
-  id: 148194
   absolute_time: 2016-07-16 00:48:00.000000000 Z
   data_status: 2
   elapsed_seconds: 46080.0
@@ -9726,7 +9002,6 @@ hardrock_2016_eddy_goldner_ouray_in_1:
 hardrock_2016_eddy_goldner_ouray_out_1:
   effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_ouray
-  id: 148195
   absolute_time: 2016-07-16 01:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 47100.0
@@ -9739,7 +9014,6 @@ hardrock_2016_eddy_goldner_ouray_out_1:
 hardrock_2016_eddy_goldner_grouse_in_1:
   effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_grouse
-  id: 148198
   absolute_time: 2016-07-16 07:42:00.000000000 Z
   data_status: 2
   elapsed_seconds: 70920.0
@@ -9752,7 +9026,6 @@ hardrock_2016_eddy_goldner_grouse_in_1:
 hardrock_2016_eddy_goldner_grouse_out_1:
   effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_grouse
-  id: 148199
   absolute_time: 2016-07-16 08:25:00.000000000 Z
   data_status: 2
   elapsed_seconds: 73500.0
@@ -9765,7 +9038,6 @@ hardrock_2016_eddy_goldner_grouse_out_1:
 hardrock_2016_eddy_goldner_sherman_in_1:
   effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_sherman
-  id: 148202
   absolute_time: 2016-07-16 14:24:00.000000000 Z
   data_status: 2
   elapsed_seconds: 95040.0
@@ -9778,7 +9050,6 @@ hardrock_2016_eddy_goldner_sherman_in_1:
 hardrock_2016_eddy_goldner_sherman_out_1:
   effort: hardrock_2016_eddy_goldner
   split: hardrock_cw_sherman
-  id: 148203
   absolute_time: 2016-07-16 15:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 97200.0
@@ -9791,7 +9062,6 @@ hardrock_2016_eddy_goldner_sherman_out_1:
 hardrock_2016_progress_sherman_start_1:
   effort: hardrock_2016_progress_sherman
   split: hardrock_cw_start
-  id: 148547
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -9804,7 +9074,6 @@ hardrock_2016_progress_sherman_start_1:
 hardrock_2016_progress_sherman_telluride_in_1:
   effort: hardrock_2016_progress_sherman
   split: hardrock_cw_telluride
-  id: 148552
   absolute_time: 2016-07-15 19:44:00.000000000 Z
   data_status: 2
   elapsed_seconds: 27840.0
@@ -9817,7 +9086,6 @@ hardrock_2016_progress_sherman_telluride_in_1:
 hardrock_2016_progress_sherman_telluride_out_1:
   effort: hardrock_2016_progress_sherman
   split: hardrock_cw_telluride
-  id: 148553
   absolute_time: 2016-07-15 19:47:00.000000000 Z
   data_status: 2
   elapsed_seconds: 28020.0
@@ -9830,7 +9098,6 @@ hardrock_2016_progress_sherman_telluride_out_1:
 hardrock_2016_progress_sherman_ouray_in_1:
   effort: hardrock_2016_progress_sherman
   split: hardrock_cw_ouray
-  id: 148558
   absolute_time: 2016-07-16 00:03:00.000000000 Z
   data_status: 2
   elapsed_seconds: 43380.0
@@ -9843,7 +9110,6 @@ hardrock_2016_progress_sherman_ouray_in_1:
 hardrock_2016_progress_sherman_ouray_out_1:
   effort: hardrock_2016_progress_sherman
   split: hardrock_cw_ouray
-  id: 148559
   absolute_time: 2016-07-16 00:09:00.000000000 Z
   data_status: 2
   elapsed_seconds: 43740.0
@@ -9856,7 +9122,6 @@ hardrock_2016_progress_sherman_ouray_out_1:
 hardrock_2016_progress_sherman_grouse_in_1:
   effort: hardrock_2016_progress_sherman
   split: hardrock_cw_grouse
-  id: 148562
   absolute_time: 2016-07-16 05:08:00.000000000 Z
   data_status: 2
   elapsed_seconds: 61680.0
@@ -9869,7 +9134,6 @@ hardrock_2016_progress_sherman_grouse_in_1:
 hardrock_2016_progress_sherman_grouse_out_1:
   effort: hardrock_2016_progress_sherman
   split: hardrock_cw_grouse
-  id: 148563
   absolute_time: 2016-07-16 05:32:00.000000000 Z
   data_status: 2
   elapsed_seconds: 63120.0
@@ -9882,7 +9146,6 @@ hardrock_2016_progress_sherman_grouse_out_1:
 hardrock_2016_progress_sherman_sherman_in_1:
   effort: hardrock_2016_progress_sherman
   split: hardrock_cw_sherman
-  id: 148566
   absolute_time: 2016-07-16 11:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 84420.0
@@ -9895,7 +9158,6 @@ hardrock_2016_progress_sherman_sherman_in_1:
 hardrock_2016_progress_sherman_sherman_out_1:
   effort: hardrock_2016_progress_sherman
   split: hardrock_cw_sherman
-  id: 148567
   absolute_time: 2016-07-16 11:52:00.000000000 Z
   data_status: 2
   elapsed_seconds: 85920.0
@@ -9908,7 +9170,6 @@ hardrock_2016_progress_sherman_sherman_out_1:
 hardrock_2016_benito_moen_start_1:
   effort: hardrock_2016_benito_moen
   split: hardrock_cw_start
-  id: 148799
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -9921,7 +9182,6 @@ hardrock_2016_benito_moen_start_1:
 hardrock_2016_benito_moen_telluride_in_1:
   effort: hardrock_2016_benito_moen
   split: hardrock_cw_telluride
-  id: 148804
   absolute_time: 2016-07-15 20:42:00.000000000 Z
   data_status: 2
   elapsed_seconds: 31320.0
@@ -9934,7 +9194,6 @@ hardrock_2016_benito_moen_telluride_in_1:
 hardrock_2016_benito_moen_telluride_out_1:
   effort: hardrock_2016_benito_moen
   split: hardrock_cw_telluride
-  id: 148805
   absolute_time: 2016-07-15 20:54:00.000000000 Z
   data_status: 2
   elapsed_seconds: 32040.0
@@ -9947,7 +9206,6 @@ hardrock_2016_benito_moen_telluride_out_1:
 hardrock_2016_benito_moen_ouray_in_1:
   effort: hardrock_2016_benito_moen
   split: hardrock_cw_ouray
-  id: 148810
   absolute_time: 2016-07-16 02:32:00.000000000 Z
   data_status: 2
   elapsed_seconds: 52320.0
@@ -9960,7 +9218,6 @@ hardrock_2016_benito_moen_ouray_in_1:
 hardrock_2016_benito_moen_ouray_out_1:
   effort: hardrock_2016_benito_moen
   split: hardrock_cw_ouray
-  id: 148811
   absolute_time: 2016-07-16 03:32:00.000000000 Z
   data_status: 2
   elapsed_seconds: 55920.0
@@ -9973,7 +9230,6 @@ hardrock_2016_benito_moen_ouray_out_1:
 hardrock_2016_benito_moen_grouse_in_1:
   effort: hardrock_2016_benito_moen
   split: hardrock_cw_grouse
-  id: 148814
   absolute_time: 2016-07-16 10:02:00.000000000 Z
   data_status: 2
   elapsed_seconds: 79320.0
@@ -9986,7 +9242,6 @@ hardrock_2016_benito_moen_grouse_in_1:
 hardrock_2016_benito_moen_grouse_out_1:
   effort: hardrock_2016_benito_moen
   split: hardrock_cw_grouse
-  id: 148815
   absolute_time: 2016-07-16 11:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 83100.0
@@ -9999,7 +9254,6 @@ hardrock_2016_benito_moen_grouse_out_1:
 hardrock_2016_benito_moen_sherman_in_1:
   effort: hardrock_2016_benito_moen
   split: hardrock_cw_sherman
-  id: 148818
   absolute_time: 2016-07-16 16:45:00.000000000 Z
   data_status: 2
   elapsed_seconds: 103500.0
@@ -10012,7 +9266,6 @@ hardrock_2016_benito_moen_sherman_in_1:
 hardrock_2016_benito_moen_sherman_out_1:
   effort: hardrock_2016_benito_moen
   split: hardrock_cw_sherman
-  id: 148819
   absolute_time: 2016-07-16 17:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 106020.0
@@ -10025,7 +9278,6 @@ hardrock_2016_benito_moen_sherman_out_1:
 hardrock_2016_kendall_koch_start_1:
   effort: hardrock_2016_kendall_koch
   split: hardrock_cw_start
-  id: 148883
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -10038,7 +9290,6 @@ hardrock_2016_kendall_koch_start_1:
 hardrock_2016_kendall_koch_telluride_in_1:
   effort: hardrock_2016_kendall_koch
   split: hardrock_cw_telluride
-  id: 148888
   absolute_time: 2016-07-15 21:44:00.000000000 Z
   data_status: 2
   elapsed_seconds: 35040.0
@@ -10051,7 +9302,6 @@ hardrock_2016_kendall_koch_telluride_in_1:
 hardrock_2016_kendall_koch_telluride_out_1:
   effort: hardrock_2016_kendall_koch
   split: hardrock_cw_telluride
-  id: 148889
   absolute_time: 2016-07-15 21:54:00.000000000 Z
   data_status: 2
   elapsed_seconds: 35640.0
@@ -10064,7 +9314,6 @@ hardrock_2016_kendall_koch_telluride_out_1:
 hardrock_2016_kendall_koch_ouray_in_1:
   effort: hardrock_2016_kendall_koch
   split: hardrock_cw_ouray
-  id: 148894
   absolute_time: 2016-07-16 03:43:00.000000000 Z
   data_status: 2
   elapsed_seconds: 56580.0
@@ -10077,7 +9326,6 @@ hardrock_2016_kendall_koch_ouray_in_1:
 hardrock_2016_kendall_koch_ouray_out_1:
   effort: hardrock_2016_kendall_koch
   split: hardrock_cw_ouray
-  id: 148895
   absolute_time: 2016-07-16 03:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 56760.0
@@ -10090,7 +9338,6 @@ hardrock_2016_kendall_koch_ouray_out_1:
 hardrock_2016_kendall_koch_grouse_in_1:
   effort: hardrock_2016_kendall_koch
   split: hardrock_cw_grouse
-  id: 148898
   absolute_time: 2016-07-16 10:18:00.000000000 Z
   data_status: 2
   elapsed_seconds: 80280.0
@@ -10103,7 +9350,6 @@ hardrock_2016_kendall_koch_grouse_in_1:
 hardrock_2016_kendall_koch_grouse_out_1:
   effort: hardrock_2016_kendall_koch
   split: hardrock_cw_grouse
-  id: 148899
   absolute_time: 2016-07-16 10:22:00.000000000 Z
   data_status: 2
   elapsed_seconds: 80520.0
@@ -10116,7 +9362,6 @@ hardrock_2016_kendall_koch_grouse_out_1:
 hardrock_2016_kendall_koch_sherman_in_1:
   effort: hardrock_2016_kendall_koch
   split: hardrock_cw_sherman
-  id: 148902
   absolute_time: 2016-07-16 17:08:00.000000000 Z
   data_status: 2
   elapsed_seconds: 104880.0
@@ -10129,7 +9374,6 @@ hardrock_2016_kendall_koch_sherman_in_1:
 hardrock_2016_kendall_koch_sherman_out_1:
   effort: hardrock_2016_kendall_koch
   split: hardrock_cw_sherman
-  id: 148903
   absolute_time: 2016-07-16 17:32:00.000000000 Z
   data_status: 2
   elapsed_seconds: 106320.0
@@ -10142,7 +9386,6 @@ hardrock_2016_kendall_koch_sherman_out_1:
 hardrock_2016_charlie_mueller_start_1:
   effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_start
-  id: 148967
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -10155,7 +9398,6 @@ hardrock_2016_charlie_mueller_start_1:
 hardrock_2016_charlie_mueller_telluride_in_1:
   effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_telluride
-  id: 148972
   absolute_time: 2016-07-15 21:45:00.000000000 Z
   data_status: 2
   elapsed_seconds: 35100.0
@@ -10168,7 +9410,6 @@ hardrock_2016_charlie_mueller_telluride_in_1:
 hardrock_2016_charlie_mueller_telluride_out_1:
   effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_telluride
-  id: 148973
   absolute_time: 2016-07-15 22:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 36000.0
@@ -10181,7 +9422,6 @@ hardrock_2016_charlie_mueller_telluride_out_1:
 hardrock_2016_charlie_mueller_ouray_in_1:
   effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_ouray
-  id: 148978
   absolute_time: 2016-07-16 03:38:00.000000000 Z
   data_status: 2
   elapsed_seconds: 56280.0
@@ -10194,7 +9434,6 @@ hardrock_2016_charlie_mueller_ouray_in_1:
 hardrock_2016_charlie_mueller_ouray_out_1:
   effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_ouray
-  id: 148979
   absolute_time: 2016-07-16 04:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 57600.0
@@ -10207,7 +9446,6 @@ hardrock_2016_charlie_mueller_ouray_out_1:
 hardrock_2016_charlie_mueller_grouse_in_1:
   effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_grouse
-  id: 148982
   absolute_time: 2016-07-16 10:15:00.000000000 Z
   data_status: 2
   elapsed_seconds: 80100.0
@@ -10220,7 +9458,6 @@ hardrock_2016_charlie_mueller_grouse_in_1:
 hardrock_2016_charlie_mueller_grouse_out_1:
   effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_grouse
-  id: 148983
   absolute_time: 2016-07-16 10:27:00.000000000 Z
   data_status: 2
   elapsed_seconds: 80820.0
@@ -10233,7 +9470,6 @@ hardrock_2016_charlie_mueller_grouse_out_1:
 hardrock_2016_charlie_mueller_sherman_in_1:
   effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_sherman
-  id: 148986
   absolute_time: 2016-07-16 16:45:00.000000000 Z
   data_status: 2
   elapsed_seconds: 103500.0
@@ -10246,7 +9482,6 @@ hardrock_2016_charlie_mueller_sherman_in_1:
 hardrock_2016_charlie_mueller_sherman_out_1:
   effort: hardrock_2016_charlie_mueller
   split: hardrock_cw_sherman
-  id: 148987
   absolute_time: 2016-07-16 17:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 104700.0
@@ -10259,7 +9494,6 @@ hardrock_2016_charlie_mueller_sherman_out_1:
 hardrock_2016_brinda_fisher_start_1:
   effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_start
-  id: 149891
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -10272,7 +9506,6 @@ hardrock_2016_brinda_fisher_start_1:
 hardrock_2016_brinda_fisher_telluride_in_1:
   effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_telluride
-  id: 149896
   absolute_time: 2016-07-15 22:57:00.000000000 Z
   data_status: 2
   elapsed_seconds: 39420.0
@@ -10285,7 +9518,6 @@ hardrock_2016_brinda_fisher_telluride_in_1:
 hardrock_2016_brinda_fisher_telluride_out_1:
   effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_telluride
-  id: 149897
   absolute_time: 2016-07-15 23:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 39600.0
@@ -10298,7 +9530,6 @@ hardrock_2016_brinda_fisher_telluride_out_1:
 hardrock_2016_brinda_fisher_ouray_in_1:
   effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_ouray
-  id: 149902
   absolute_time: 2016-07-16 05:56:00.000000000 Z
   data_status: 2
   elapsed_seconds: 64560.0
@@ -10311,7 +9542,6 @@ hardrock_2016_brinda_fisher_ouray_in_1:
 hardrock_2016_brinda_fisher_ouray_out_1:
   effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_ouray
-  id: 149903
   absolute_time: 2016-07-16 06:25:00.000000000 Z
   data_status: 2
   elapsed_seconds: 66300.0
@@ -10324,7 +9554,6 @@ hardrock_2016_brinda_fisher_ouray_out_1:
 hardrock_2016_brinda_fisher_grouse_in_1:
   effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_grouse
-  id: 149906
   absolute_time: 2016-07-16 14:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 93900.0
@@ -10337,7 +9566,6 @@ hardrock_2016_brinda_fisher_grouse_in_1:
 hardrock_2016_brinda_fisher_grouse_out_1:
   effort: hardrock_2016_brinda_fisher
   split: hardrock_cw_grouse
-  id: 149907
   absolute_time: 2016-07-16 14:19:00.000000000 Z
   data_status: 2
   elapsed_seconds: 94740.0
@@ -10350,7 +9578,6 @@ hardrock_2016_brinda_fisher_grouse_out_1:
 hardrock_2016_rene_mclaughlin_start_1:
   effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_start
-  id: 149997
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -10363,7 +9590,6 @@ hardrock_2016_rene_mclaughlin_start_1:
 hardrock_2016_rene_mclaughlin_telluride_in_1:
   effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_telluride
-  id: 150002
   absolute_time: 2016-07-15 22:06:00.000000000 Z
   data_status: 2
   elapsed_seconds: 36360.0
@@ -10376,7 +9602,6 @@ hardrock_2016_rene_mclaughlin_telluride_in_1:
 hardrock_2016_rene_mclaughlin_telluride_out_1:
   effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_telluride
-  id: 150003
   absolute_time: 2016-07-15 22:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 37200.0
@@ -10389,7 +9614,6 @@ hardrock_2016_rene_mclaughlin_telluride_out_1:
 hardrock_2016_rene_mclaughlin_ouray_in_1:
   effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_ouray
-  id: 150008
   absolute_time: 2016-07-16 04:34:00.000000000 Z
   data_status: 2
   elapsed_seconds: 59640.0
@@ -10402,7 +9626,6 @@ hardrock_2016_rene_mclaughlin_ouray_in_1:
 hardrock_2016_rene_mclaughlin_ouray_out_1:
   effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_ouray
-  id: 150009
   absolute_time: 2016-07-16 04:55:00.000000000 Z
   data_status: 2
   elapsed_seconds: 60900.0
@@ -10415,7 +9638,6 @@ hardrock_2016_rene_mclaughlin_ouray_out_1:
 hardrock_2016_rene_mclaughlin_grouse_in_1:
   effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_grouse
-  id: 150012
   absolute_time: 2016-07-16 12:07:00.000000000 Z
   data_status: 2
   elapsed_seconds: 86820.0
@@ -10428,7 +9650,6 @@ hardrock_2016_rene_mclaughlin_grouse_in_1:
 hardrock_2016_rene_mclaughlin_grouse_out_1:
   effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_grouse
-  id: 150013
   absolute_time: 2016-07-16 13:37:00.000000000 Z
   data_status: 2
   elapsed_seconds: 92220.0
@@ -10441,7 +9662,6 @@ hardrock_2016_rene_mclaughlin_grouse_out_1:
 hardrock_2016_rene_mclaughlin_sherman_in_1:
   effort: hardrock_2016_rene_mclaughlin
   split: hardrock_cw_sherman
-  id: 150016
   absolute_time: 2016-07-16 20:41:00.000000000 Z
   data_status: 2
   elapsed_seconds: 117660.0
@@ -10454,7 +9674,6 @@ hardrock_2016_rene_mclaughlin_sherman_in_1:
 hardrock_2016_dropped_grouse_start_1:
   effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_start
-  id: 150319
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -10467,7 +9686,6 @@ hardrock_2016_dropped_grouse_start_1:
 hardrock_2016_dropped_grouse_telluride_in_1:
   effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_telluride
-  id: 150324
   absolute_time: 2016-07-15 18:35:00.000000000 Z
   data_status: 2
   elapsed_seconds: 23700.0
@@ -10480,7 +9698,6 @@ hardrock_2016_dropped_grouse_telluride_in_1:
 hardrock_2016_dropped_grouse_telluride_out_1:
   effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_telluride
-  id: 150325
   absolute_time: 2016-07-15 18:39:00.000000000 Z
   data_status: 2
   elapsed_seconds: 23940.0
@@ -10493,7 +9710,6 @@ hardrock_2016_dropped_grouse_telluride_out_1:
 hardrock_2016_dropped_grouse_ouray_in_1:
   effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_ouray
-  id: 150330
   absolute_time: 2016-07-15 22:06:00.000000000 Z
   data_status: 2
   elapsed_seconds: 36360.0
@@ -10506,7 +9722,6 @@ hardrock_2016_dropped_grouse_ouray_in_1:
 hardrock_2016_dropped_grouse_ouray_out_1:
   effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_ouray
-  id: 150331
   absolute_time: 2016-07-15 22:12:00.000000000 Z
   data_status: 2
   elapsed_seconds: 36720.0
@@ -10519,7 +9734,6 @@ hardrock_2016_dropped_grouse_ouray_out_1:
 hardrock_2016_dropped_grouse_grouse_in_1:
   effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_grouse
-  id: 150334
   absolute_time: 2016-07-16 02:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 52800.0
@@ -10532,7 +9746,6 @@ hardrock_2016_dropped_grouse_grouse_in_1:
 hardrock_2016_dropped_grouse_grouse_out_1:
   effort: hardrock_2016_dropped_grouse
   split: hardrock_cw_grouse
-  id: 150335
   absolute_time: 2016-07-16 02:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 52800.0
@@ -10545,7 +9758,6 @@ hardrock_2016_dropped_grouse_grouse_out_1:
 hardrock_2016_mervin_smitham_start_1:
   effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_start
-  id: 150387
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -10558,7 +9770,6 @@ hardrock_2016_mervin_smitham_start_1:
 hardrock_2016_mervin_smitham_telluride_in_1:
   effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_telluride
-  id: 150392
   absolute_time: 2016-07-15 21:07:00.000000000 Z
   data_status: 2
   elapsed_seconds: 32820.0
@@ -10571,7 +9782,6 @@ hardrock_2016_mervin_smitham_telluride_in_1:
 hardrock_2016_mervin_smitham_telluride_out_1:
   effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_telluride
-  id: 150393
   absolute_time: 2016-07-15 21:25:00.000000000 Z
   data_status: 2
   elapsed_seconds: 33900.0
@@ -10584,7 +9794,6 @@ hardrock_2016_mervin_smitham_telluride_out_1:
 hardrock_2016_mervin_smitham_ouray_in_1:
   effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_ouray
-  id: 150398
   absolute_time: 2016-07-16 03:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 54000.0
@@ -10597,7 +9806,6 @@ hardrock_2016_mervin_smitham_ouray_in_1:
 hardrock_2016_mervin_smitham_ouray_out_1:
   effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_ouray
-  id: 150399
   absolute_time: 2016-07-16 03:59:00.000000000 Z
   data_status: 2
   elapsed_seconds: 57540.0
@@ -10610,7 +9818,6 @@ hardrock_2016_mervin_smitham_ouray_out_1:
 hardrock_2016_mervin_smitham_grouse_in_1:
   effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_grouse
-  id: 150402
   absolute_time: 2016-07-16 11:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 85980.0
@@ -10623,7 +9830,6 @@ hardrock_2016_mervin_smitham_grouse_in_1:
 hardrock_2016_mervin_smitham_grouse_out_1:
   effort: hardrock_2016_mervin_smitham
   split: hardrock_cw_grouse
-  id: 150403
   absolute_time: 2016-07-16 11:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 85980.0
@@ -10636,7 +9842,6 @@ hardrock_2016_mervin_smitham_grouse_out_1:
 hardrock_2016_rhett_auer_start_1:
   effort: hardrock_2016_rhett_auer
   split: hardrock_cw_start
-  id: 150455
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -10649,7 +9854,6 @@ hardrock_2016_rhett_auer_start_1:
 hardrock_2016_rhett_auer_telluride_in_1:
   effort: hardrock_2016_rhett_auer
   split: hardrock_cw_telluride
-  id: 150460
   absolute_time: 2016-07-15 18:04:00.000000000 Z
   data_status: 2
   elapsed_seconds: 21840.0
@@ -10662,7 +9866,6 @@ hardrock_2016_rhett_auer_telluride_in_1:
 hardrock_2016_rhett_auer_telluride_out_1:
   effort: hardrock_2016_rhett_auer
   split: hardrock_cw_telluride
-  id: 150461
   absolute_time: 2016-07-15 18:06:00.000000000 Z
   data_status: 2
   elapsed_seconds: 21960.0
@@ -10675,7 +9878,6 @@ hardrock_2016_rhett_auer_telluride_out_1:
 hardrock_2016_rhett_auer_ouray_in_1:
   effort: hardrock_2016_rhett_auer
   split: hardrock_cw_ouray
-  id: 150466
   absolute_time: 2016-07-15 21:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 34800.0
@@ -10688,7 +9890,6 @@ hardrock_2016_rhett_auer_ouray_in_1:
 hardrock_2016_rhett_auer_ouray_out_1:
   effort: hardrock_2016_rhett_auer
   split: hardrock_cw_ouray
-  id: 150467
   absolute_time: 2016-07-15 21:53:00.000000000 Z
   data_status: 2
   elapsed_seconds: 35580.0
@@ -10701,7 +9902,6 @@ hardrock_2016_rhett_auer_ouray_out_1:
 hardrock_2016_hoyt_macejkovic_start_1:
   effort: hardrock_2016_hoyt_macejkovic
   split: hardrock_cw_start
-  id: 150494
   absolute_time: 2016-07-15 12:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -10714,7 +9914,6 @@ hardrock_2016_hoyt_macejkovic_start_1:
 hardrock_2016_hoyt_macejkovic_telluride_in_1:
   effort: hardrock_2016_hoyt_macejkovic
   split: hardrock_cw_telluride
-  id: 150499
   absolute_time: 2016-07-15 21:56:00.000000000 Z
   data_status: 2
   elapsed_seconds: 35760.0
@@ -10727,7 +9926,6 @@ hardrock_2016_hoyt_macejkovic_telluride_in_1:
 hardrock_2016_hoyt_macejkovic_telluride_out_1:
   effort: hardrock_2016_hoyt_macejkovic
   split: hardrock_cw_telluride
-  id: 150500
   absolute_time: 2016-07-15 22:11:00.000000000 Z
   data_status: 2
   elapsed_seconds: 36660.0
@@ -10740,7 +9938,6 @@ hardrock_2016_hoyt_macejkovic_telluride_out_1:
 hardrock_2016_hoyt_macejkovic_ouray_in_1:
   effort: hardrock_2016_hoyt_macejkovic
   split: hardrock_cw_ouray
-  id: 150505
   absolute_time: 2016-07-16 04:44:00.000000000 Z
   data_status: 2
   elapsed_seconds: 60240.0
@@ -10753,7 +9950,6 @@ hardrock_2016_hoyt_macejkovic_ouray_in_1:
 hardrock_2016_hoyt_macejkovic_ouray_out_1:
   effort: hardrock_2016_hoyt_macejkovic
   split: hardrock_cw_ouray
-  id: 150506
   absolute_time: 2016-07-16 05:46:00.000000000 Z
   data_status: 2
   elapsed_seconds: 63960.0
@@ -10763,13 +9959,48 @@ hardrock_2016_hoyt_macejkovic_ouray_out_1:
   stopped_here: true
   sub_split_bitkey: 64
   status_reason:
+hardrock_2016_start_only_start_1:
+  effort: hardrock_2016_start_only
+  split: hardrock_cw_start
+  absolute_time: 2016-07-15 12:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 ggd30_50k_finished_first_start_1:
   effort: ggd30_50k_finished_first
   split: d30_50k_course_start
-  id: 184081
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status:
   elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ggd30_50k_finished_first_finish_1:
+  effort: ggd30_50k_finished_first
+  split: d30_50k_course_finish
+  absolute_time: 2017-06-03 18:29:47.410000000 Z
+  data_status:
+  elapsed_seconds: 19787.41
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ggd30_50k_finished_first_aid_5_1:
+  effort: ggd30_50k_finished_first
+  split: d30_50k_course_aid_5
+  absolute_time: 2017-06-03 18:09:59.140000000 Z
+  data_status:
+  elapsed_seconds: 18599.14
   lap: 1
   pacer:
   remarks:
@@ -10779,7 +10010,6 @@ ggd30_50k_finished_first_start_1:
 ggd30_50k_finished_first_aid_1_1:
   effort: ggd30_50k_finished_first
   split: d30_50k_course_aid_1
-  id: 184082
   absolute_time: 2017-06-03 13:46:48.170000000 Z
   data_status:
   elapsed_seconds: 2808.17
@@ -10789,13 +10019,12 @@ ggd30_50k_finished_first_aid_1_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-ggd30_50k_finished_first_aid_2_1:
+ggd30_50k_finished_first_aid_4_1:
   effort: ggd30_50k_finished_first
-  split: d30_50k_course_aid_2
-  id: 184083
-  absolute_time: 2017-06-03 14:54:09.710000000 Z
+  split: d30_50k_course_aid_4
+  absolute_time: 2017-06-03 17:11:12.540000000 Z
   data_status:
-  elapsed_seconds: 6849.71
+  elapsed_seconds: 15072.54
   lap: 1
   pacer:
   remarks:
@@ -10805,7 +10034,6 @@ ggd30_50k_finished_first_aid_2_1:
 ggd30_50k_finished_first_aid_3_1:
   effort: ggd30_50k_finished_first
   split: d30_50k_course_aid_3
-  id: 184084
   absolute_time: 2017-06-03 15:53:16.010000000 Z
   data_status:
   elapsed_seconds: 10396.01
@@ -10815,10 +10043,21 @@ ggd30_50k_finished_first_aid_3_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+ggd30_50k_finished_first_aid_2_1:
+  effort: ggd30_50k_finished_first
+  split: d30_50k_course_aid_2
+  absolute_time: 2017-06-03 14:54:09.710000000 Z
+  data_status:
+  elapsed_seconds: 6849.71
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 ggd30_50k_bad_finish_start_1:
   effort: ggd30_50k_bad_finish
   split: d30_50k_course_start
-  id: 184337
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -10828,10 +10067,33 @@ ggd30_50k_bad_finish_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+ggd30_50k_bad_finish_finish_1:
+  effort: ggd30_50k_bad_finish
+  split: d30_50k_course_finish
+  absolute_time: 2017-06-03 19:24:16.590000000 Z
+  data_status: 0
+  elapsed_seconds: 23056.59
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ggd30_50k_bad_finish_aid_5_1:
+  effort: ggd30_50k_bad_finish
+  split: d30_50k_course_aid_5
+  absolute_time: 2017-06-03 19:40:01.980000000 Z
+  data_status: 2
+  elapsed_seconds: 24001.98
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 ggd30_50k_bad_finish_aid_1_1:
   effort: ggd30_50k_bad_finish
   split: d30_50k_course_aid_1
-  id: 184338
   absolute_time: 2017-06-03 13:49:00.820000000 Z
   data_status: 2
   elapsed_seconds: 2940.82
@@ -10841,13 +10103,12 @@ ggd30_50k_bad_finish_aid_1_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-ggd30_50k_bad_finish_aid_2_1:
+ggd30_50k_bad_finish_aid_4_1:
   effort: ggd30_50k_bad_finish
-  split: d30_50k_course_aid_2
-  id: 184339
-  absolute_time: 2017-06-03 15:05:22.760000000 Z
+  split: d30_50k_course_aid_4
+  absolute_time: 2017-06-03 17:49:35.620000000 Z
   data_status: 2
-  elapsed_seconds: 7522.76
+  elapsed_seconds: 17375.62
   lap: 1
   pacer:
   remarks:
@@ -10857,7 +10118,6 @@ ggd30_50k_bad_finish_aid_2_1:
 ggd30_50k_bad_finish_aid_3_1:
   effort: ggd30_50k_bad_finish
   split: d30_50k_course_aid_3
-  id: 184340
   absolute_time: 2017-06-03 16:15:30.090000000 Z
   data_status: 2
   elapsed_seconds: 11730.09
@@ -10867,10 +10127,21 @@ ggd30_50k_bad_finish_aid_3_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+ggd30_50k_bad_finish_aid_2_1:
+  effort: ggd30_50k_bad_finish
+  split: d30_50k_course_aid_2
+  absolute_time: 2017-06-03 15:05:22.760000000 Z
+  data_status: 2
+  elapsed_seconds: 7522.76
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 ggd30_50k_progress_aid4_start_1:
   effort: ggd30_50k_progress_aid4
   split: d30_50k_course_start
-  id: 185898
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status:
   elapsed_seconds: 0.0
@@ -10883,7 +10154,6 @@ ggd30_50k_progress_aid4_start_1:
 ggd30_50k_progress_aid4_aid_1_1:
   effort: ggd30_50k_progress_aid4
   split: d30_50k_course_aid_1
-  id: 185899
   absolute_time: 2017-06-03 14:13:10.900000000 Z
   data_status:
   elapsed_seconds: 4390.9
@@ -10893,10 +10163,33 @@ ggd30_50k_progress_aid4_aid_1_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+ggd30_50k_progress_aid4_aid_4_1:
+  effort: ggd30_50k_progress_aid4
+  split: d30_50k_course_aid_4
+  absolute_time: 2017-06-03 19:46:07.330000000 Z
+  data_status:
+  elapsed_seconds: 24367.33
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ggd30_50k_progress_aid4_aid_3_1:
+  effort: ggd30_50k_progress_aid4
+  split: d30_50k_course_aid_3
+  absolute_time: 2017-06-03 17:38:48.070000000 Z
+  data_status:
+  elapsed_seconds: 16728.07
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 ggd30_50k_progress_aid4_aid_2_1:
   effort: ggd30_50k_progress_aid4
   split: d30_50k_course_aid_2
-  id: 185900
   absolute_time: 2017-06-03 15:59:30.110000000 Z
   data_status:
   elapsed_seconds: 10770.11
@@ -10909,7 +10202,6 @@ ggd30_50k_progress_aid4_aid_2_1:
 ggd30_50k_progress_aid3_start_1:
   effort: ggd30_50k_progress_aid3
   split: d30_50k_course_start
-  id: 185965
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -10922,7 +10214,6 @@ ggd30_50k_progress_aid3_start_1:
 ggd30_50k_progress_aid3_aid_1_1:
   effort: ggd30_50k_progress_aid3
   split: d30_50k_course_aid_1
-  id: 185966
   absolute_time: 2017-06-03 14:11:47.000000000 Z
   data_status: 2
   elapsed_seconds: 4307.0
@@ -10932,10 +10223,21 @@ ggd30_50k_progress_aid3_aid_1_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+ggd30_50k_progress_aid3_aid_3_1:
+  effort: ggd30_50k_progress_aid3
+  split: d30_50k_course_aid_3
+  absolute_time: 2017-06-03 17:39:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 16740.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 ggd30_50k_progress_aid3_aid_2_1:
   effort: ggd30_50k_progress_aid3
   split: d30_50k_course_aid_2
-  id: 185967
   absolute_time: 2017-06-03 15:56:58.000000000 Z
   data_status: 2
   elapsed_seconds: 10618.0
@@ -10948,7 +10250,6 @@ ggd30_50k_progress_aid3_aid_2_1:
 ggd30_50k_drop_aid4_start_1:
   effort: ggd30_50k_drop_aid4
   split: d30_50k_course_start
-  id: 186151
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -10961,7 +10262,6 @@ ggd30_50k_drop_aid4_start_1:
 ggd30_50k_drop_aid4_aid_1_1:
   effort: ggd30_50k_drop_aid4
   split: d30_50k_course_aid_1
-  id: 186152
   absolute_time: 2017-06-03 14:01:33.780000000 Z
   data_status: 2
   elapsed_seconds: 3693.78
@@ -10971,153 +10271,9 @@ ggd30_50k_drop_aid4_aid_1_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-ggd30_50k_drop_aid4_aid_2_1:
-  effort: ggd30_50k_drop_aid4
-  split: d30_50k_course_aid_2
-  id: 186153
-  absolute_time: 2017-06-03 15:35:56.730000000 Z
-  data_status: 2
-  elapsed_seconds: 9356.73
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_finished_first_aid_4_1:
-  effort: ggd30_50k_finished_first
-  split: d30_50k_course_aid_4
-  id: 188949
-  absolute_time: 2017-06-03 17:11:12.540000000 Z
-  data_status:
-  elapsed_seconds: 15072.54
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_finished_first_aid_5_1:
-  effort: ggd30_50k_finished_first
-  split: d30_50k_course_aid_5
-  id: 188950
-  absolute_time: 2017-06-03 18:09:59.140000000 Z
-  data_status:
-  elapsed_seconds: 18599.14
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_finished_first_finish_1:
-  effort: ggd30_50k_finished_first
-  split: d30_50k_course_finish
-  id: 188951
-  absolute_time: 2017-06-03 18:29:47.410000000 Z
-  data_status:
-  elapsed_seconds: 19787.41
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_bad_finish_aid_4_1:
-  effort: ggd30_50k_bad_finish
-  split: d30_50k_course_aid_4
-  id: 189053
-  absolute_time: 2017-06-03 17:49:35.620000000 Z
-  data_status: 2
-  elapsed_seconds: 17375.62
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_bad_finish_aid_5_1:
-  effort: ggd30_50k_bad_finish
-  split: d30_50k_course_aid_5
-  id: 189054
-  absolute_time: 2017-06-03 19:40:01.980000000 Z
-  data_status: 2
-  elapsed_seconds: 24001.98
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_bad_finish_finish_1:
-  effort: ggd30_50k_bad_finish
-  split: d30_50k_course_finish
-  id: 189055
-  absolute_time: 2017-06-03 19:24:16.590000000 Z
-  data_status: 0
-  elapsed_seconds: 23056.59
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_progress_aid4_aid_3_1:
-  effort: ggd30_50k_progress_aid4
-  split: d30_50k_course_aid_3
-  id: 189813
-  absolute_time: 2017-06-03 17:38:48.070000000 Z
-  data_status:
-  elapsed_seconds: 16728.07
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_progress_aid4_aid_4_1:
-  effort: ggd30_50k_progress_aid4
-  split: d30_50k_course_aid_4
-  id: 189814
-  absolute_time: 2017-06-03 19:46:07.330000000 Z
-  data_status:
-  elapsed_seconds: 24367.33
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_progress_aid3_aid_3_1:
-  effort: ggd30_50k_progress_aid3
-  split: d30_50k_course_aid_3
-  id: 189850
-  absolute_time: 2017-06-03 17:39:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 16740.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_drop_aid4_aid_3_1:
-  effort: ggd30_50k_drop_aid4
-  split: d30_50k_course_aid_3
-  id: 189951
-  absolute_time: 2017-06-03 17:11:07.470000000 Z
-  data_status: 2
-  elapsed_seconds: 15067.47
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 ggd30_50k_drop_aid4_aid_4_1:
   effort: ggd30_50k_drop_aid4
   split: d30_50k_course_aid_4
-  id: 189952
   absolute_time: 2017-06-03 19:47:10.550000000 Z
   data_status: 2
   elapsed_seconds: 24430.55
@@ -11127,10 +10283,45 @@ ggd30_50k_drop_aid4_aid_4_1:
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
-ggd30_12m_finished_first_start_1:
-  effort: ggd30_12m_finished_first
+ggd30_50k_drop_aid4_aid_3_1:
+  effort: ggd30_50k_drop_aid4
+  split: d30_50k_course_aid_3
+  absolute_time: 2017-06-03 17:11:07.470000000 Z
+  data_status: 2
+  elapsed_seconds: 15067.47
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ggd30_50k_drop_aid4_aid_2_1:
+  effort: ggd30_50k_drop_aid4
+  split: d30_50k_course_aid_2
+  absolute_time: 2017-06-03 15:35:56.730000000 Z
+  data_status: 2
+  elapsed_seconds: 9356.73
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ggd30_50k_start_only_start_1:
+  effort: ggd30_50k_start_only
+  split: d30_50k_course_start
+  absolute_time: 2017-06-03 13:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ggd30_12m_start_only_start_1:
+  effort: ggd30_12m_start_only
   split: d30_12m_course_start
-  id: 190116
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status:
   elapsed_seconds: 0.0
@@ -11140,23 +10331,9 @@ ggd30_12m_finished_first_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-ggd30_12m_finished_first_finish_1:
-  effort: ggd30_12m_finished_first
-  split: d30_12m_course_finish
-  id: 190117
-  absolute_time: 2017-06-03 17:48:09.280000000 Z
-  data_status:
-  elapsed_seconds: 6489.28
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 ggd30_12m_finished_second_start_1:
   effort: ggd30_12m_finished_second
   split: d30_12m_course_start
-  id: 190272
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status:
   elapsed_seconds: 0.0
@@ -11169,7 +10346,6 @@ ggd30_12m_finished_second_start_1:
 ggd30_12m_finished_second_finish_1:
   effort: ggd30_12m_finished_second
   split: d30_12m_course_finish
-  id: 190273
   absolute_time: 2017-06-03 18:54:56.690000000 Z
   data_status:
   elapsed_seconds: 10496.69
@@ -11179,12 +10355,11 @@ ggd30_12m_finished_second_finish_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-hardrock_2015_cedric_windler_start_1:
-  effort: hardrock_2015_cedric_windler
-  split: hardrock_ccw_start
-  id: 190477
-  absolute_time: 2015-07-10 12:00:00.000000000 Z
-  data_status: 2
+ggd30_12m_finished_first_start_1:
+  effort: ggd30_12m_finished_first
+  split: d30_12m_course_start
+  absolute_time: 2017-06-03 16:00:00.000000000 Z
+  data_status:
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -11192,13 +10367,12 @@ hardrock_2015_cedric_windler_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-hardrock_2015_tuan_jacobs_start_1:
-  effort: hardrock_2015_tuan_jacobs
-  split: hardrock_ccw_start
-  id: 190478
-  absolute_time: 2015-07-10 12:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
+ggd30_12m_finished_first_finish_1:
+  effort: ggd30_12m_finished_first
+  split: d30_12m_course_finish
+  absolute_time: 2017-06-03 17:48:09.280000000 Z
+  data_status:
+  elapsed_seconds: 6489.28
   lap: 1
   pacer:
   remarks:
@@ -11208,7 +10382,6 @@ hardrock_2015_tuan_jacobs_start_1:
 sum_55k_finished_first_start_1:
   effort: sum_55k_finished_first
   split: sum_55k_course_start
-  id: 190499
   absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -11218,10 +10391,21 @@ sum_55k_finished_first_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+sum_55k_finished_first_finish_1:
+  effort: sum_55k_finished_first
+  split: sum_55k_course_finish
+  absolute_time: 2017-10-07 23:58:06.000000000 Z
+  data_status: 2
+  elapsed_seconds: 32286.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
 sum_55k_finished_first_molas_pass_aid1_in_1:
   effort: sum_55k_finished_first
   split: sum_55k_course_molas_pass_aid1
-  id: 190500
   absolute_time: 2017-10-07 18:20:36.000000000 Z
   data_status: 2
   elapsed_seconds: 12036.0
@@ -11234,7 +10418,6 @@ sum_55k_finished_first_molas_pass_aid1_in_1:
 sum_55k_finished_first_molas_pass_aid1_out_1:
   effort: sum_55k_finished_first
   split: sum_55k_course_molas_pass_aid1
-  id: 190501
   absolute_time: 2017-10-07 18:22:10.000000000 Z
   data_status: 2
   elapsed_seconds: 12130.0
@@ -11247,7 +10430,6 @@ sum_55k_finished_first_molas_pass_aid1_out_1:
 sum_55k_finished_first_rolling_pass_aid2_in_1:
   effort: sum_55k_finished_first
   split: sum_55k_course_rolling_pass_aid2
-  id: 190502
   absolute_time: 2017-10-07 20:48:20.000000000 Z
   data_status: 2
   elapsed_seconds: 20900.0
@@ -11260,7 +10442,6 @@ sum_55k_finished_first_rolling_pass_aid2_in_1:
 sum_55k_finished_first_rolling_pass_aid2_out_1:
   effort: sum_55k_finished_first
   split: sum_55k_course_rolling_pass_aid2
-  id: 190503
   absolute_time: 2017-10-07 20:50:20.000000000 Z
   data_status: 2
   elapsed_seconds: 21020.0
@@ -11273,7 +10454,6 @@ sum_55k_finished_first_rolling_pass_aid2_out_1:
 sum_55k_finished_first_bandera_mine_aid5_in_1:
   effort: sum_55k_finished_first
   split: sum_55k_course_bandera_mine_aid5
-  id: 190504
   absolute_time: 2017-10-07 21:28:20.000000000 Z
   data_status: 2
   elapsed_seconds: 23300.0
@@ -11286,7 +10466,6 @@ sum_55k_finished_first_bandera_mine_aid5_in_1:
 sum_55k_finished_first_bandera_mine_aid5_out_1:
   effort: sum_55k_finished_first
   split: sum_55k_course_bandera_mine_aid5
-  id: 190505
   absolute_time: 2017-10-07 21:28:20.000000000 Z
   data_status: 2
   elapsed_seconds: 23300.0
@@ -11299,7 +10478,6 @@ sum_55k_finished_first_bandera_mine_aid5_out_1:
 sum_55k_finished_first_anvil_cg_aid6_in_1:
   effort: sum_55k_finished_first
   split: sum_55k_course_anvil_cg_aid6
-  id: 190506
   absolute_time: 2017-10-07 22:43:35.000000000 Z
   data_status: 2
   elapsed_seconds: 27815.0
@@ -11312,7 +10490,6 @@ sum_55k_finished_first_anvil_cg_aid6_in_1:
 sum_55k_finished_first_anvil_cg_aid6_out_1:
   effort: sum_55k_finished_first
   split: sum_55k_course_anvil_cg_aid6
-  id: 190507
   absolute_time: 2017-10-07 22:51:27.000000000 Z
   data_status: 2
   elapsed_seconds: 28287.0
@@ -11322,23 +10499,9 @@ sum_55k_finished_first_anvil_cg_aid6_out_1:
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
-sum_55k_finished_first_finish_1:
-  effort: sum_55k_finished_first
-  split: sum_55k_course_finish
-  id: 190508
-  absolute_time: 2017-10-07 23:58:06.000000000 Z
-  data_status: 2
-  elapsed_seconds: 32286.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
 sum_55k_finished_second_start_1:
   effort: sum_55k_finished_second
   split: sum_55k_course_start
-  id: 190519
   absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -11348,10 +10511,21 @@ sum_55k_finished_second_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+sum_55k_finished_second_finish_1:
+  effort: sum_55k_finished_second
+  split: sum_55k_course_finish
+  absolute_time: 2017-10-08 00:07:38.000000000 Z
+  data_status: 2
+  elapsed_seconds: 32858.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
 sum_55k_finished_second_molas_pass_aid1_in_1:
   effort: sum_55k_finished_second
   split: sum_55k_course_molas_pass_aid1
-  id: 190520
   absolute_time: 2017-10-07 18:30:31.000000000 Z
   data_status: 2
   elapsed_seconds: 12631.0
@@ -11364,7 +10538,6 @@ sum_55k_finished_second_molas_pass_aid1_in_1:
 sum_55k_finished_second_molas_pass_aid1_out_1:
   effort: sum_55k_finished_second
   split: sum_55k_course_molas_pass_aid1
-  id: 190521
   absolute_time: 2017-10-07 18:31:46.000000000 Z
   data_status: 2
   elapsed_seconds: 12706.0
@@ -11377,7 +10550,6 @@ sum_55k_finished_second_molas_pass_aid1_out_1:
 sum_55k_finished_second_rolling_pass_aid2_in_1:
   effort: sum_55k_finished_second
   split: sum_55k_course_rolling_pass_aid2
-  id: 190522
   absolute_time: 2017-10-07 21:13:00.000000000 Z
   data_status: 2
   elapsed_seconds: 22380.0
@@ -11390,7 +10562,6 @@ sum_55k_finished_second_rolling_pass_aid2_in_1:
 sum_55k_finished_second_rolling_pass_aid2_out_1:
   effort: sum_55k_finished_second
   split: sum_55k_course_rolling_pass_aid2
-  id: 190523
   absolute_time: 2017-10-07 21:18:00.000000000 Z
   data_status: 2
   elapsed_seconds: 22680.0
@@ -11403,7 +10574,6 @@ sum_55k_finished_second_rolling_pass_aid2_out_1:
 sum_55k_finished_second_bandera_mine_aid5_in_1:
   effort: sum_55k_finished_second
   split: sum_55k_course_bandera_mine_aid5
-  id: 190524
   absolute_time: 2017-10-07 22:04:20.000000000 Z
   data_status: 2
   elapsed_seconds: 25460.0
@@ -11416,7 +10586,6 @@ sum_55k_finished_second_bandera_mine_aid5_in_1:
 sum_55k_finished_second_bandera_mine_aid5_out_1:
   effort: sum_55k_finished_second
   split: sum_55k_course_bandera_mine_aid5
-  id: 190525
   absolute_time: 2017-10-07 22:05:20.000000000 Z
   data_status: 2
   elapsed_seconds: 25520.0
@@ -11429,7 +10598,6 @@ sum_55k_finished_second_bandera_mine_aid5_out_1:
 sum_55k_finished_second_anvil_cg_aid6_in_1:
   effort: sum_55k_finished_second
   split: sum_55k_course_anvil_cg_aid6
-  id: 190526
   absolute_time: 2017-10-07 23:13:46.000000000 Z
   data_status: 2
   elapsed_seconds: 29626.0
@@ -11442,7 +10610,6 @@ sum_55k_finished_second_anvil_cg_aid6_in_1:
 sum_55k_finished_second_anvil_cg_aid6_out_1:
   effort: sum_55k_finished_second
   split: sum_55k_course_anvil_cg_aid6
-  id: 190527
   absolute_time: 2017-10-07 23:13:50.000000000 Z
   data_status: 2
   elapsed_seconds: 29630.0
@@ -11452,23 +10619,9 @@ sum_55k_finished_second_anvil_cg_aid6_out_1:
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
-sum_55k_finished_second_finish_1:
-  effort: sum_55k_finished_second
-  split: sum_55k_course_finish
-  id: 190528
-  absolute_time: 2017-10-08 00:07:38.000000000 Z
-  data_status: 2
-  elapsed_seconds: 32858.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
 sum_55k_progress_rolling_start_1:
   effort: sum_55k_progress_rolling
   split: sum_55k_course_start
-  id: 190668
   absolute_time: 2017-10-07 13:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -11481,7 +10634,6 @@ sum_55k_progress_rolling_start_1:
 sum_55k_progress_rolling_molas_pass_aid1_in_1:
   effort: sum_55k_progress_rolling
   split: sum_55k_course_molas_pass_aid1
-  id: 190669
   absolute_time: 2017-10-07 15:12:00.000000000 Z
   data_status: 2
   elapsed_seconds: 7920.0
@@ -11494,7 +10646,6 @@ sum_55k_progress_rolling_molas_pass_aid1_in_1:
 sum_55k_progress_rolling_molas_pass_aid1_out_1:
   effort: sum_55k_progress_rolling
   split: sum_55k_course_molas_pass_aid1
-  id: 190670
   absolute_time: 2017-10-07 15:19:00.000000000 Z
   data_status: 2
   elapsed_seconds: 8340.0
@@ -11507,7 +10658,6 @@ sum_55k_progress_rolling_molas_pass_aid1_out_1:
 sum_55k_progress_rolling_rolling_pass_aid2_in_1:
   effort: sum_55k_progress_rolling
   split: sum_55k_course_rolling_pass_aid2
-  id: 190671
   absolute_time: 2017-10-07 17:05:00.000000000 Z
   data_status: 2
   elapsed_seconds: 14700.0
@@ -11520,7 +10670,6 @@ sum_55k_progress_rolling_rolling_pass_aid2_in_1:
 sum_55k_progress_rolling_rolling_pass_aid2_out_1:
   effort: sum_55k_progress_rolling
   split: sum_55k_course_rolling_pass_aid2
-  id: 190672
   absolute_time: 2017-10-07 17:15:00.000000000 Z
   data_status: 2
   elapsed_seconds: 15300.0
@@ -11533,7 +10682,6 @@ sum_55k_progress_rolling_rolling_pass_aid2_out_1:
 sum_55k_drop_bandera_start_1:
   effort: sum_55k_drop_bandera
   split: sum_55k_course_start
-  id: 190678
   absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -11546,7 +10694,6 @@ sum_55k_drop_bandera_start_1:
 sum_55k_drop_bandera_molas_pass_aid1_in_1:
   effort: sum_55k_drop_bandera
   split: sum_55k_course_molas_pass_aid1
-  id: 190679
   absolute_time: 2017-10-07 19:12:27.000000000 Z
   data_status: 2
   elapsed_seconds: 15147.0
@@ -11559,7 +10706,6 @@ sum_55k_drop_bandera_molas_pass_aid1_in_1:
 sum_55k_drop_bandera_molas_pass_aid1_out_1:
   effort: sum_55k_drop_bandera
   split: sum_55k_course_molas_pass_aid1
-  id: 190680
   absolute_time: 2017-10-07 19:19:02.000000000 Z
   data_status: 2
   elapsed_seconds: 15542.0
@@ -11572,7 +10718,6 @@ sum_55k_drop_bandera_molas_pass_aid1_out_1:
 sum_55k_drop_bandera_rolling_pass_aid2_in_1:
   effort: sum_55k_drop_bandera
   split: sum_55k_course_rolling_pass_aid2
-  id: 190681
   absolute_time: 2017-10-07 22:27:20.000000000 Z
   data_status: 2
   elapsed_seconds: 26840.0
@@ -11585,7 +10730,6 @@ sum_55k_drop_bandera_rolling_pass_aid2_in_1:
 sum_55k_drop_bandera_rolling_pass_aid2_out_1:
   effort: sum_55k_drop_bandera
   split: sum_55k_course_rolling_pass_aid2
-  id: 190682
   absolute_time: 2017-10-07 22:54:20.000000000 Z
   data_status:
   elapsed_seconds: 28460.0
@@ -11598,7 +10742,6 @@ sum_55k_drop_bandera_rolling_pass_aid2_out_1:
 sum_55k_drop_bandera_bandera_mine_aid5_in_1:
   effort: sum_55k_drop_bandera
   split: sum_55k_course_bandera_mine_aid5
-  id: 190683
   absolute_time: 2017-10-08 00:21:20.000000000 Z
   data_status: 2
   elapsed_seconds: 33680.0
@@ -11608,62 +10751,21 @@ sum_55k_drop_bandera_bandera_mine_aid5_in_1:
   stopped_here: true
   sub_split_bitkey: 1
   status_reason:
-sum_100k_drop_anvil_anvil_cg_aid6_in_1:
-  effort: sum_100k_drop_anvil
-  split: sum_100k_course_anvil_cg_aid6
-  id: 190694
-  absolute_time: 2017-09-24 03:11:00.000000000 Z
+sum_55k_start_only_start_1:
+  effort: sum_55k_start_only
+  split: sum_55k_course_start
+  absolute_time: 2017-10-07 15:00:00.000000000 Z
   data_status:
-  elapsed_seconds: 51060.0
-  lap: 1
-  pacer: false
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-sum_100k_drop_anvil_anvil_cg_aid6_out_1:
-  effort: sum_100k_drop_anvil
-  split: sum_100k_course_anvil_cg_aid6
-  id: 190695
-  absolute_time: 2017-09-24 03:21:00.000000000 Z
-  data_status:
-  elapsed_seconds: 51660.0
-  lap: 1
-  pacer: false
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 64
-  status_reason:
-sum_100k_drop_anvil_rolling_pass_aid2_in_1:
-  effort: sum_100k_drop_anvil
-  split: sum_100k_course_rolling_pass_aid2
-  id: 190696
-  absolute_time: 2017-09-23 15:09:00.000000000 Z
-  data_status:
-  elapsed_seconds: 7740.0
-  lap: 1
-  pacer: false
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-sum_100k_drop_anvil_rolling_pass_aid2_out_1:
-  effort: sum_100k_drop_anvil
-  split: sum_100k_course_rolling_pass_aid2
-  id: 190697
-  absolute_time: 2017-09-24 07:03:05.000000000 Z
-  data_status:
-  elapsed_seconds: 64985.0
+  elapsed_seconds: 0.0
   lap: 1
   pacer:
   remarks:
   stopped_here: false
-  sub_split_bitkey: 64
+  sub_split_bitkey: 1
   status_reason:
 sum_100k_drop_anvil_start_1:
   effort: sum_100k_drop_anvil
   split: sum_100k_course_start
-  id: 190698
   absolute_time: 2017-09-23 13:00:00.000000000 Z
   data_status:
   elapsed_seconds: 0.0
@@ -11676,7 +10778,6 @@ sum_100k_drop_anvil_start_1:
 sum_100k_drop_anvil_molas_pass_aid1_in_1:
   effort: sum_100k_drop_anvil
   split: sum_100k_course_molas_pass_aid1
-  id: 190699
   absolute_time: 2017-09-23 14:30:00.000000000 Z
   data_status:
   elapsed_seconds: 5400.0
@@ -11689,7 +10790,6 @@ sum_100k_drop_anvil_molas_pass_aid1_in_1:
 sum_100k_drop_anvil_molas_pass_aid1_out_1:
   effort: sum_100k_drop_anvil
   split: sum_100k_course_molas_pass_aid1
-  id: 190700
   absolute_time: 2017-09-23 14:32:00.000000000 Z
   data_status:
   elapsed_seconds: 5520.0
@@ -11699,10 +10799,33 @@ sum_100k_drop_anvil_molas_pass_aid1_out_1:
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
+sum_100k_drop_anvil_rolling_pass_aid2_in_1:
+  effort: sum_100k_drop_anvil
+  split: sum_100k_course_rolling_pass_aid2
+  absolute_time: 2017-09-23 15:09:00.000000000 Z
+  data_status:
+  elapsed_seconds: 7740.0
+  lap: 1
+  pacer: false
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+sum_100k_drop_anvil_rolling_pass_aid2_out_1:
+  effort: sum_100k_drop_anvil
+  split: sum_100k_course_rolling_pass_aid2
+  absolute_time: 2017-09-24 07:03:05.000000000 Z
+  data_status:
+  elapsed_seconds: 64985.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 64
+  status_reason:
 sum_100k_drop_anvil_cascade_creek_rd_aid3_in_1:
   effort: sum_100k_drop_anvil
   split: sum_100k_course_cascade_creek_rd_aid3
-  id: 190701
   absolute_time: 2017-09-24 07:24:00.000000000 Z
   data_status:
   elapsed_seconds: 66240.0
@@ -11715,7 +10838,6 @@ sum_100k_drop_anvil_cascade_creek_rd_aid3_in_1:
 sum_100k_drop_anvil_cascade_creek_rd_aid3_out_1:
   effort: sum_100k_drop_anvil
   split: sum_100k_course_cascade_creek_rd_aid3
-  id: 190702
   absolute_time: 2017-09-24 07:28:00.000000000 Z
   data_status:
   elapsed_seconds: 66480.0
@@ -11728,7 +10850,6 @@ sum_100k_drop_anvil_cascade_creek_rd_aid3_out_1:
 sum_100k_drop_anvil_engineer_mtn_th_aid4_in_1:
   effort: sum_100k_drop_anvil
   split: sum_100k_course_engineer_mtn_th_aid4
-  id: 190703
   absolute_time: 2017-09-24 15:09:00.000000000 Z
   data_status:
   elapsed_seconds: 94140.0
@@ -11741,7 +10862,6 @@ sum_100k_drop_anvil_engineer_mtn_th_aid4_in_1:
 sum_100k_drop_anvil_engineer_mtn_th_aid4_out_1:
   effort: sum_100k_drop_anvil
   split: sum_100k_course_engineer_mtn_th_aid4
-  id: 190704
   absolute_time: 2017-09-24 15:09:09.000000000 Z
   data_status:
   elapsed_seconds: 94149.0
@@ -11751,816 +10871,33 @@ sum_100k_drop_anvil_engineer_mtn_th_aid4_out_1:
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
-ggd30_12m_start_only_start_1:
-  effort: ggd30_12m_start_only
-  split: d30_12m_course_start
-  id: 190731
-  absolute_time: 2017-06-03 16:00:00.000000000 Z
+sum_100k_drop_anvil_anvil_cg_aid6_in_1:
+  effort: sum_100k_drop_anvil
+  split: sum_100k_course_anvil_cg_aid6
+  absolute_time: 2017-09-24 03:11:00.000000000 Z
   data_status:
-  elapsed_seconds: 0.0
+  elapsed_seconds: 51060.0
   lap: 1
-  pacer:
+  pacer: false
   remarks:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-ggd30_50k_start_only_start_1:
-  effort: ggd30_50k_start_only
-  split: d30_50k_course_start
-  id: 190761
-  absolute_time: 2017-06-03 13:00:00.000000000 Z
+sum_100k_drop_anvil_anvil_cg_aid6_out_1:
+  effort: sum_100k_drop_anvil
+  split: sum_100k_course_anvil_cg_aid6
+  absolute_time: 2017-09-24 03:21:00.000000000 Z
   data_status:
-  elapsed_seconds: 0.0
+  elapsed_seconds: 51660.0
   lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-sum_55k_start_only_start_1:
-  effort: sum_55k_start_only
-  split: sum_55k_course_start
-  id: 190816
-  absolute_time: 2017-10-07 15:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_start_1:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_start
-  id: 192182
-  absolute_time: 2017-02-11 14:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_finish_1:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_finish
-  id: 192183
-  absolute_time: 2017-02-11 15:33:52.000000000 Z
-  data_status:
-  elapsed_seconds: 5632.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_start_2:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_start
-  id: 192184
-  absolute_time: 2017-02-11 15:40:32.000000000 Z
-  data_status:
-  elapsed_seconds: 6032.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_grandeur_peak_2:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 192185
-  absolute_time: 2017-02-11 16:43:26.000000000 Z
-  data_status:
-  elapsed_seconds: 9806.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_finish_2:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_finish
-  id: 192186
-  absolute_time: 2017-02-11 17:10:10.000000000 Z
-  data_status:
-  elapsed_seconds: 11410.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_start_3:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_start
-  id: 192187
-  absolute_time: 2017-02-11 17:18:26.000000000 Z
-  data_status:
-  elapsed_seconds: 11906.0
-  lap: 3
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_grandeur_peak_3:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 192188
-  absolute_time: 2017-02-11 18:15:00.000000000 Z
-  data_status:
-  elapsed_seconds: 15300.0
-  lap: 3
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_finish_3:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_finish
-  id: 192189
-  absolute_time: 2017-02-11 18:41:05.000000000 Z
-  data_status:
-  elapsed_seconds: 16865.0
-  lap: 3
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_start_4:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_start
-  id: 192190
-  absolute_time: 2017-02-11 18:44:57.000000000 Z
-  data_status:
-  elapsed_seconds: 17097.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_grandeur_peak_4:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 192191
-  absolute_time: 2017-02-11 19:43:15.000000000 Z
-  data_status:
-  elapsed_seconds: 20595.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_finish_4:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_finish
-  id: 192192
-  absolute_time: 2017-02-11 20:10:39.000000000 Z
-  data_status:
-  elapsed_seconds: 22239.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_start_5:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_start
-  id: 192193
-  absolute_time: 2017-02-11 20:16:40.000000000 Z
-  data_status:
-  elapsed_seconds: 22600.0
-  lap: 5
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_grandeur_peak_5:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 192194
-  absolute_time: 2017-02-11 21:19:28.000000000 Z
-  data_status:
-  elapsed_seconds: 26368.0
-  lap: 5
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_finish_5:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_finish
-  id: 192195
-  absolute_time: 2017-02-11 21:50:23.000000000 Z
-  data_status:
-  elapsed_seconds: 28223.0
-  lap: 5
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_start_6:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_start
-  id: 192196
-  absolute_time: 2017-02-11 21:59:13.000000000 Z
-  data_status:
-  elapsed_seconds: 28753.0
-  lap: 6
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_grandeur_peak_6:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 192197
-  absolute_time: 2017-02-11 23:07:18.000000000 Z
-  data_status:
-  elapsed_seconds: 32838.0
-  lap: 6
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_finish_6:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_finish
-  id: 192198
-  absolute_time: 2017-02-11 23:38:34.000000000 Z
-  data_status:
-  elapsed_seconds: 34714.0
-  lap: 6
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_start_7:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_start
-  id: 192199
-  absolute_time: 2017-02-11 23:52:03.000000000 Z
-  data_status:
-  elapsed_seconds: 35523.0
-  lap: 7
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_grandeur_peak_7:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_grandeur_peak
-  id: 192200
-  absolute_time: 2017-02-12 01:01:00.000000000 Z
-  data_status:
-  elapsed_seconds: 39660.0
-  lap: 7
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_first_finish_7:
-  effort: rufa_2017_12h_finished_first
-  split: rufa_course_finish
-  id: 192201
-  absolute_time: 2017-02-12 01:35:12.000000000 Z
-  data_status:
-  elapsed_seconds: 41712.0
-  lap: 7
-  pacer:
+  pacer: false
   remarks:
   stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_start_1:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_start
-  id: 192278
-  absolute_time: 2017-02-11 14:00:00.000000000 Z
-  data_status:
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_grandeur_peak_1:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_grandeur_peak
-  id: 192279
-  absolute_time: 2017-02-11 14:58:53.000000000 Z
-  data_status:
-  elapsed_seconds: 3533.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_finish_1:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_finish
-  id: 192280
-  absolute_time: 2017-02-11 15:30:50.000000000 Z
-  data_status:
-  elapsed_seconds: 5450.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_start_2:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_start
-  id: 192281
-  absolute_time: 2017-02-11 15:33:13.000000000 Z
-  data_status:
-  elapsed_seconds: 5593.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_grandeur_peak_2:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_grandeur_peak
-  id: 192282
-  absolute_time: 2017-02-11 16:38:35.000000000 Z
-  data_status:
-  elapsed_seconds: 9515.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_finish_2:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_finish
-  id: 192283
-  absolute_time: 2017-02-11 17:10:32.000000000 Z
-  data_status:
-  elapsed_seconds: 11432.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_start_3:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_start
-  id: 192284
-  absolute_time: 2017-02-11 17:21:18.000000000 Z
-  data_status:
-  elapsed_seconds: 12078.0
-  lap: 3
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_grandeur_peak_3:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_grandeur_peak
-  id: 192285
-  absolute_time: 2017-02-11 18:31:00.000000000 Z
-  data_status:
-  elapsed_seconds: 16260.0
-  lap: 3
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_finish_3:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_finish
-  id: 192286
-  absolute_time: 2017-02-11 19:04:24.000000000 Z
-  data_status:
-  elapsed_seconds: 18264.0
-  lap: 3
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_start_4:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_start
-  id: 192287
-  absolute_time: 2017-02-11 19:12:11.000000000 Z
-  data_status:
-  elapsed_seconds: 18731.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_grandeur_peak_4:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_grandeur_peak
-  id: 192288
-  absolute_time: 2017-02-11 20:23:51.000000000 Z
-  data_status:
-  elapsed_seconds: 23031.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_finish_4:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_finish
-  id: 192289
-  absolute_time: 2017-02-11 21:02:55.000000000 Z
-  data_status:
-  elapsed_seconds: 25375.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_start_5:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_start
-  id: 192290
-  absolute_time: 2017-02-11 21:25:05.000000000 Z
-  data_status:
-  elapsed_seconds: 26705.0
-  lap: 5
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_grandeur_peak_5:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_grandeur_peak
-  id: 192291
-  absolute_time: 2017-02-11 22:42:57.000000000 Z
-  data_status:
-  elapsed_seconds: 31377.0
-  lap: 5
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_finish_5:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_finish
-  id: 192292
-  absolute_time: 2017-02-11 23:20:36.000000000 Z
-  data_status:
-  elapsed_seconds: 33636.0
-  lap: 5
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_start_6:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_start
-  id: 192293
-  absolute_time: 2017-02-11 23:35:51.000000000 Z
-  data_status:
-  elapsed_seconds: 34551.0
-  lap: 6
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_grandeur_peak_6:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_grandeur_peak
-  id: 192294
-  absolute_time: 2017-02-12 00:51:18.000000000 Z
-  data_status:
-  elapsed_seconds: 39078.0
-  lap: 6
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_finished_lap6_finish_6:
-  effort: rufa_2017_12h_finished_lap6
-  split: rufa_course_finish
-  id: 192295
-  absolute_time: 2017-02-12 01:27:38.000000000 Z
-  data_status:
-  elapsed_seconds: 41258.0
-  lap: 6
-  pacer:
-  remarks:
-  stopped_here: true
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_start_1:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_start
-  id: 192420
-  absolute_time: 2017-02-11 14:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_grandeur_peak_1:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_grandeur_peak
-  id: 192421
-  absolute_time: 2017-02-11 15:08:31.000000000 Z
-  data_status: 2
-  elapsed_seconds: 4111.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_finish_1:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_finish
-  id: 192422
-  absolute_time: 2017-02-11 15:44:16.000000000 Z
-  data_status: 2
-  elapsed_seconds: 6256.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_start_2:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_start
-  id: 192423
-  absolute_time: 2017-02-11 15:47:17.000000000 Z
-  data_status: 2
-  elapsed_seconds: 6437.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_grandeur_peak_2:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_grandeur_peak
-  id: 192424
-  absolute_time: 2017-02-11 17:07:41.000000000 Z
-  data_status: 2
-  elapsed_seconds: 11261.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_finish_2:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_finish
-  id: 192425
-  absolute_time: 2017-02-11 17:45:17.000000000 Z
-  data_status: 2
-  elapsed_seconds: 13517.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_start_3:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_start
-  id: 192426
-  absolute_time: 2017-02-11 17:51:49.000000000 Z
-  data_status: 2
-  elapsed_seconds: 13909.0
-  lap: 3
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_grandeur_peak_3:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_grandeur_peak
-  id: 192427
-  absolute_time: 2017-02-11 19:16:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 18960.0
-  lap: 3
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_finish_3:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_finish
-  id: 192428
-  absolute_time: 2017-02-11 19:57:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 21420.0
-  lap: 3
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_start_4:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_start
-  id: 192429
-  absolute_time: 2017-02-11 20:06:16.000000000 Z
-  data_status: 2
-  elapsed_seconds: 21976.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_grandeur_peak_4:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_grandeur_peak
-  id: 192430
-  absolute_time: 2017-02-11 21:36:13.000000000 Z
-  data_status: 2
-  elapsed_seconds: 27373.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_finish_4:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_finish
-  id: 192431
-  absolute_time: 2017-02-11 22:26:23.000000000 Z
-  data_status: 2
-  elapsed_seconds: 30383.0
-  lap: 4
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_start_5:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_start
-  id: 192432
-  absolute_time: 2017-02-11 22:47:18.000000000 Z
-  data_status: 2
-  elapsed_seconds: 31638.0
-  lap: 5
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap5_partial_grandeur_peak_5:
-  effort: rufa_2017_12h_progress_lap5_partial
-  split: rufa_course_grandeur_peak
-  id: 192433
-  absolute_time: 2017-02-12 00:29:17.000000000 Z
-  data_status: 2
-  elapsed_seconds: 37757.0
-  lap: 5
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap2_start_1:
-  effort: rufa_2017_12h_progress_lap2
-  split: rufa_course_start
-  id: 192497
-  absolute_time: 2017-02-11 14:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap2_grandeur_peak_1:
-  effort: rufa_2017_12h_progress_lap2
-  split: rufa_course_grandeur_peak
-  id: 192498
-  absolute_time: 2017-02-11 15:13:16.000000000 Z
-  data_status: 2
-  elapsed_seconds: 4396.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap2_finish_1:
-  effort: rufa_2017_12h_progress_lap2
-  split: rufa_course_finish
-  id: 192499
-  absolute_time: 2017-02-11 16:03:44.000000000 Z
-  data_status: 2
-  elapsed_seconds: 7424.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap2_start_2:
-  effort: rufa_2017_12h_progress_lap2
-  split: rufa_course_start
-  id: 192500
-  absolute_time: 2017-02-11 16:05:43.000000000 Z
-  data_status: 2
-  elapsed_seconds: 7543.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap2_grandeur_peak_2:
-  effort: rufa_2017_12h_progress_lap2
-  split: rufa_course_grandeur_peak
-  id: 192501
-  absolute_time: 2017-02-11 17:25:36.000000000 Z
-  data_status: 2
-  elapsed_seconds: 12336.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_progress_lap2_finish_2:
-  effort: rufa_2017_12h_progress_lap2
-  split: rufa_course_finish
-  id: 192502
-  absolute_time: 2017-02-11 18:13:54.000000000 Z
-  data_status: 2
-  elapsed_seconds: 15234.0
-  lap: 2
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-rufa_2017_12h_start_only_start_1:
-  effort: rufa_2017_12h_start_only
-  split: rufa_course_start
-  id: 192542
-  absolute_time: 2017-02-11 14:00:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 0.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
+  sub_split_bitkey: 64
   status_reason:
 sum_100k_progress_cascade_start_1:
   effort: sum_100k_progress_cascade
   split: sum_100k_course_start
-  id: 192697
   absolute_time: 2017-09-23 13:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -12573,7 +10910,6 @@ sum_100k_progress_cascade_start_1:
 sum_100k_progress_cascade_molas_pass_aid1_in_1:
   effort: sum_100k_progress_cascade
   split: sum_100k_course_molas_pass_aid1
-  id: 192698
   absolute_time: 2017-09-23 15:20:00.000000000 Z
   data_status:
   elapsed_seconds: 8400.0
@@ -12586,7 +10922,6 @@ sum_100k_progress_cascade_molas_pass_aid1_in_1:
 sum_100k_progress_cascade_molas_pass_aid1_out_1:
   effort: sum_100k_progress_cascade
   split: sum_100k_course_molas_pass_aid1
-  id: 192699
   absolute_time: 2017-09-23 15:25:00.000000000 Z
   data_status:
   elapsed_seconds: 8700.0
@@ -12599,7 +10934,6 @@ sum_100k_progress_cascade_molas_pass_aid1_out_1:
 sum_100k_progress_cascade_rolling_pass_aid2_in_1:
   effort: sum_100k_progress_cascade
   split: sum_100k_course_rolling_pass_aid2
-  id: 192700
   absolute_time: 2017-09-23 17:11:00.000000000 Z
   data_status:
   elapsed_seconds: 15060.0
@@ -12612,7 +10946,6 @@ sum_100k_progress_cascade_rolling_pass_aid2_in_1:
 sum_100k_progress_cascade_rolling_pass_aid2_out_1:
   effort: sum_100k_progress_cascade
   split: sum_100k_course_rolling_pass_aid2
-  id: 192701
   absolute_time: 2017-09-23 17:22:00.000000000 Z
   data_status:
   elapsed_seconds: 15720.0
@@ -12625,7 +10958,6 @@ sum_100k_progress_cascade_rolling_pass_aid2_out_1:
 sum_100k_progress_cascade_cascade_creek_rd_aid3_in_1:
   effort: sum_100k_progress_cascade
   split: sum_100k_course_cascade_creek_rd_aid3
-  id: 192703
   absolute_time: 2017-09-23 19:50:00.000000000 Z
   data_status:
   elapsed_seconds: 24600.0
@@ -12638,7 +10970,6 @@ sum_100k_progress_cascade_cascade_creek_rd_aid3_in_1:
 sum_100k_progress_cascade_cascade_creek_rd_aid3_out_1:
   effort: sum_100k_progress_cascade
   split: sum_100k_course_cascade_creek_rd_aid3
-  id: 192704
   absolute_time: 2017-09-23 20:14:00.000000000 Z
   data_status:
   elapsed_seconds: 26040.0
@@ -12648,12 +10979,707 @@ sum_100k_progress_cascade_cascade_creek_rd_aid3_out_1:
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
-hardrock_2016_start_only_start_1:
-  effort: hardrock_2016_start_only
-  split: hardrock_cw_start
-  id: 192705
-  absolute_time: 2016-07-15 12:00:00.000000000 Z
+rufa_2017_12h_finished_first_start_1:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_start
+  absolute_time: 2017-02-11 14:00:00.000000000 Z
   data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_finish_1:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 15:33:52.000000000 Z
+  data_status:
+  elapsed_seconds: 5632.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_start_2:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_start
+  absolute_time: 2017-02-11 15:40:32.000000000 Z
+  data_status:
+  elapsed_seconds: 6032.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_finish_2:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 17:10:10.000000000 Z
+  data_status:
+  elapsed_seconds: 11410.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_grandeur_peak_2:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 16:43:26.000000000 Z
+  data_status:
+  elapsed_seconds: 9806.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_start_3:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_start
+  absolute_time: 2017-02-11 17:18:26.000000000 Z
+  data_status:
+  elapsed_seconds: 11906.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_finish_3:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 18:41:05.000000000 Z
+  data_status:
+  elapsed_seconds: 16865.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_grandeur_peak_3:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 18:15:00.000000000 Z
+  data_status:
+  elapsed_seconds: 15300.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_start_4:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_start
+  absolute_time: 2017-02-11 18:44:57.000000000 Z
+  data_status:
+  elapsed_seconds: 17097.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_finish_4:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 20:10:39.000000000 Z
+  data_status:
+  elapsed_seconds: 22239.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_grandeur_peak_4:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 19:43:15.000000000 Z
+  data_status:
+  elapsed_seconds: 20595.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_start_5:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_start
+  absolute_time: 2017-02-11 20:16:40.000000000 Z
+  data_status:
+  elapsed_seconds: 22600.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_finish_5:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 21:50:23.000000000 Z
+  data_status:
+  elapsed_seconds: 28223.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_grandeur_peak_5:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 21:19:28.000000000 Z
+  data_status:
+  elapsed_seconds: 26368.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_start_6:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_start
+  absolute_time: 2017-02-11 21:59:13.000000000 Z
+  data_status:
+  elapsed_seconds: 28753.0
+  lap: 6
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_finish_6:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 23:38:34.000000000 Z
+  data_status:
+  elapsed_seconds: 34714.0
+  lap: 6
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_grandeur_peak_6:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 23:07:18.000000000 Z
+  data_status:
+  elapsed_seconds: 32838.0
+  lap: 6
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_start_7:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_start
+  absolute_time: 2017-02-11 23:52:03.000000000 Z
+  data_status:
+  elapsed_seconds: 35523.0
+  lap: 7
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_finish_7:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_finish
+  absolute_time: 2017-02-12 01:35:12.000000000 Z
+  data_status:
+  elapsed_seconds: 41712.0
+  lap: 7
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_first_grandeur_peak_7:
+  effort: rufa_2017_12h_finished_first
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-12 01:01:00.000000000 Z
+  data_status:
+  elapsed_seconds: 39660.0
+  lap: 7
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_start_1:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_start
+  absolute_time: 2017-02-11 14:00:00.000000000 Z
+  data_status:
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_finish_1:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 15:30:50.000000000 Z
+  data_status:
+  elapsed_seconds: 5450.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_grandeur_peak_1:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 14:58:53.000000000 Z
+  data_status:
+  elapsed_seconds: 3533.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_start_2:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_start
+  absolute_time: 2017-02-11 15:33:13.000000000 Z
+  data_status:
+  elapsed_seconds: 5593.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_finish_2:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 17:10:32.000000000 Z
+  data_status:
+  elapsed_seconds: 11432.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_grandeur_peak_2:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 16:38:35.000000000 Z
+  data_status:
+  elapsed_seconds: 9515.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_start_3:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_start
+  absolute_time: 2017-02-11 17:21:18.000000000 Z
+  data_status:
+  elapsed_seconds: 12078.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_finish_3:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 19:04:24.000000000 Z
+  data_status:
+  elapsed_seconds: 18264.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_grandeur_peak_3:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 18:31:00.000000000 Z
+  data_status:
+  elapsed_seconds: 16260.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_start_4:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_start
+  absolute_time: 2017-02-11 19:12:11.000000000 Z
+  data_status:
+  elapsed_seconds: 18731.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_finish_4:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 21:02:55.000000000 Z
+  data_status:
+  elapsed_seconds: 25375.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_grandeur_peak_4:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 20:23:51.000000000 Z
+  data_status:
+  elapsed_seconds: 23031.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_start_5:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_start
+  absolute_time: 2017-02-11 21:25:05.000000000 Z
+  data_status:
+  elapsed_seconds: 26705.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_finish_5:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 23:20:36.000000000 Z
+  data_status:
+  elapsed_seconds: 33636.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_grandeur_peak_5:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 22:42:57.000000000 Z
+  data_status:
+  elapsed_seconds: 31377.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_start_6:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_start
+  absolute_time: 2017-02-11 23:35:51.000000000 Z
+  data_status:
+  elapsed_seconds: 34551.0
+  lap: 6
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_finish_6:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_finish
+  absolute_time: 2017-02-12 01:27:38.000000000 Z
+  data_status:
+  elapsed_seconds: 41258.0
+  lap: 6
+  pacer:
+  remarks:
+  stopped_here: true
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_finished_lap6_grandeur_peak_6:
+  effort: rufa_2017_12h_finished_lap6
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-12 00:51:18.000000000 Z
+  data_status:
+  elapsed_seconds: 39078.0
+  lap: 6
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_start_1:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_start
+  absolute_time: 2017-02-11 14:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_finish_1:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 15:44:16.000000000 Z
+  data_status: 2
+  elapsed_seconds: 6256.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_grandeur_peak_1:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 15:08:31.000000000 Z
+  data_status: 2
+  elapsed_seconds: 4111.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_start_2:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_start
+  absolute_time: 2017-02-11 15:47:17.000000000 Z
+  data_status: 2
+  elapsed_seconds: 6437.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_finish_2:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 17:45:17.000000000 Z
+  data_status: 2
+  elapsed_seconds: 13517.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_grandeur_peak_2:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 17:07:41.000000000 Z
+  data_status: 2
+  elapsed_seconds: 11261.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_start_3:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_start
+  absolute_time: 2017-02-11 17:51:49.000000000 Z
+  data_status: 2
+  elapsed_seconds: 13909.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_finish_3:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 19:57:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 21420.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_grandeur_peak_3:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 19:16:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 18960.0
+  lap: 3
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_start_4:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_start
+  absolute_time: 2017-02-11 20:06:16.000000000 Z
+  data_status: 2
+  elapsed_seconds: 21976.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_finish_4:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 22:26:23.000000000 Z
+  data_status: 2
+  elapsed_seconds: 30383.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_grandeur_peak_4:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 21:36:13.000000000 Z
+  data_status: 2
+  elapsed_seconds: 27373.0
+  lap: 4
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_start_5:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_start
+  absolute_time: 2017-02-11 22:47:18.000000000 Z
+  data_status: 2
+  elapsed_seconds: 31638.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap5_partial_grandeur_peak_5:
+  effort: rufa_2017_12h_progress_lap5_partial
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-12 00:29:17.000000000 Z
+  data_status: 2
+  elapsed_seconds: 37757.0
+  lap: 5
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap2_start_1:
+  effort: rufa_2017_12h_progress_lap2
+  split: rufa_course_start
+  absolute_time: 2017-02-11 14:00:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 0.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap2_finish_1:
+  effort: rufa_2017_12h_progress_lap2
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 16:03:44.000000000 Z
+  data_status: 2
+  elapsed_seconds: 7424.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap2_grandeur_peak_1:
+  effort: rufa_2017_12h_progress_lap2
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 15:13:16.000000000 Z
+  data_status: 2
+  elapsed_seconds: 4396.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap2_start_2:
+  effort: rufa_2017_12h_progress_lap2
+  split: rufa_course_start
+  absolute_time: 2017-02-11 16:05:43.000000000 Z
+  data_status: 2
+  elapsed_seconds: 7543.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap2_finish_2:
+  effort: rufa_2017_12h_progress_lap2
+  split: rufa_course_finish
+  absolute_time: 2017-02-11 18:13:54.000000000 Z
+  data_status: 2
+  elapsed_seconds: 15234.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_progress_lap2_grandeur_peak_2:
+  effort: rufa_2017_12h_progress_lap2
+  split: rufa_course_grandeur_peak
+  absolute_time: 2017-02-11 17:25:36.000000000 Z
+  data_status: 2
+  elapsed_seconds: 12336.0
+  lap: 2
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+rufa_2017_12h_start_only_start_1:
+  effort: rufa_2017_12h_start_only
+  split: rufa_course_start
+  absolute_time: 2017-02-11 14:00:00.000000000 Z
+  data_status: 2
   elapsed_seconds: 0.0
   lap: 1
   pacer:
@@ -12664,7 +11690,6 @@ hardrock_2016_start_only_start_1:
 sum_100k_on_dst_change_start_1:
   effort: sum_100k_on_dst_change
   split: sum_100k_course_start
-  id: 192708
   absolute_time: 2017-11-05 14:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -12674,10 +11699,21 @@ sum_100k_on_dst_change_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+sum_100k_on_dst_change_molas_pass_aid1_in_1:
+  effort: sum_100k_on_dst_change
+  split: sum_100k_course_molas_pass_aid1
+  absolute_time: 2017-11-05 16:25:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 8700.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 sum_100k_across_dst_change_start_1:
   effort: sum_100k_across_dst_change
   split: sum_100k_course_start
-  id: 192709
   absolute_time: 2017-11-05 06:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -12690,7 +11726,6 @@ sum_100k_across_dst_change_start_1:
 sum_100k_across_dst_change_molas_pass_aid1_in_1:
   effort: sum_100k_across_dst_change
   split: sum_100k_course_molas_pass_aid1
-  id: 192710
   absolute_time: 2017-11-05 09:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 10800.0
@@ -12700,23 +11735,9 @@ sum_100k_across_dst_change_molas_pass_aid1_in_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-sum_100k_on_dst_change_molas_pass_aid1_in_1:
-  effort: sum_100k_on_dst_change
-  split: sum_100k_course_molas_pass_aid1
-  id: 192715
-  absolute_time: 2017-11-05 16:25:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 8700.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 ggd30_50k_finished_second_start_1:
   effort: ggd30_50k_finished_second
   split: d30_50k_course_start
-  id: 192716
   absolute_time: 2017-06-03 13:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -12726,75 +11747,9 @@ ggd30_50k_finished_second_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
-ggd30_50k_finished_second_aid_1_1:
-  effort: ggd30_50k_finished_second
-  split: d30_50k_course_aid_1
-  id: 192717
-  absolute_time: 2017-06-03 13:52:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 3120.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_finished_second_aid_2_1:
-  effort: ggd30_50k_finished_second
-  split: d30_50k_course_aid_2
-  id: 192718
-  absolute_time: 2017-06-03 15:01:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 7260.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_finished_second_aid_3_1:
-  effort: ggd30_50k_finished_second
-  split: d30_50k_course_aid_3
-  id: 192719
-  absolute_time: 2017-06-03 16:15:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 11700.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_finished_second_aid_4_1:
-  effort: ggd30_50k_finished_second
-  split: d30_50k_course_aid_4
-  id: 192720
-  absolute_time: 2017-06-03 17:48:00.000000000 Z
-  data_status: 2
-  elapsed_seconds: 17280.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
-ggd30_50k_finished_second_aid_5_1:
-  effort: ggd30_50k_finished_second
-  split: d30_50k_course_aid_5
-  id: 192721
-  absolute_time: 2017-06-03 18:50:00.000000000 Z
-  data_status:
-  elapsed_seconds: 21000.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 ggd30_50k_finished_second_finish_1:
   effort: ggd30_50k_finished_second
   split: d30_50k_course_finish
-  id: 192722
   absolute_time: 2017-06-03 19:12:00.000000000 Z
   data_status:
   elapsed_seconds: 22320.0
@@ -12804,10 +11759,69 @@ ggd30_50k_finished_second_finish_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+ggd30_50k_finished_second_aid_5_1:
+  effort: ggd30_50k_finished_second
+  split: d30_50k_course_aid_5
+  absolute_time: 2017-06-03 18:50:00.000000000 Z
+  data_status:
+  elapsed_seconds: 21000.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ggd30_50k_finished_second_aid_1_1:
+  effort: ggd30_50k_finished_second
+  split: d30_50k_course_aid_1
+  absolute_time: 2017-06-03 13:52:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 3120.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ggd30_50k_finished_second_aid_4_1:
+  effort: ggd30_50k_finished_second
+  split: d30_50k_course_aid_4
+  absolute_time: 2017-06-03 17:48:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 17280.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ggd30_50k_finished_second_aid_3_1:
+  effort: ggd30_50k_finished_second
+  split: d30_50k_course_aid_3
+  absolute_time: 2017-06-03 16:15:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 11700.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
+ggd30_50k_finished_second_aid_2_1:
+  effort: ggd30_50k_finished_second
+  split: d30_50k_course_aid_2
+  absolute_time: 2017-06-03 15:01:00.000000000 Z
+  data_status: 2
+  elapsed_seconds: 7260.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 ggd30_12m_series_finisher_start_1:
   effort: ggd30_12m_series_finisher
   split: d30_12m_course_start
-  id: 192723
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -12820,7 +11834,6 @@ ggd30_12m_series_finisher_start_1:
 ggd30_12m_series_finisher_finish_1:
   effort: ggd30_12m_series_finisher
   split: d30_12m_course_finish
-  id: 192724
   absolute_time: 2017-06-03 18:55:00.000000000 Z
   data_status:
   elapsed_seconds: 10500.0
@@ -12833,7 +11846,6 @@ ggd30_12m_series_finisher_finish_1:
 sum_55k_series_finisher_start_1:
   effort: sum_55k_series_finisher
   split: sum_55k_course_start
-  id: 192725
   absolute_time: 2017-09-23 15:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -12843,10 +11855,21 @@ sum_55k_series_finisher_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+sum_55k_series_finisher_finish_1:
+  effort: sum_55k_series_finisher
+  split: sum_55k_course_finish
+  absolute_time: 2017-09-24 01:20:00.000000000 Z
+  data_status:
+  elapsed_seconds: 37200.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 sum_55k_series_finisher_molas_pass_aid1_in_1:
   effort: sum_55k_series_finisher
   split: sum_55k_course_molas_pass_aid1
-  id: 192726
   absolute_time: 2017-09-23 17:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9000.0
@@ -12859,7 +11882,6 @@ sum_55k_series_finisher_molas_pass_aid1_in_1:
 sum_55k_series_finisher_molas_pass_aid1_out_1:
   effort: sum_55k_series_finisher
   split: sum_55k_course_molas_pass_aid1
-  id: 192727
   absolute_time: 2017-09-23 17:35:00.000000000 Z
   data_status: 2
   elapsed_seconds: 9300.0
@@ -12872,7 +11894,6 @@ sum_55k_series_finisher_molas_pass_aid1_out_1:
 sum_55k_series_finisher_rolling_pass_aid2_in_1:
   effort: sum_55k_series_finisher
   split: sum_55k_course_rolling_pass_aid2
-  id: 192728
   absolute_time: 2017-09-23 20:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 19200.0
@@ -12885,7 +11906,6 @@ sum_55k_series_finisher_rolling_pass_aid2_in_1:
 sum_55k_series_finisher_rolling_pass_aid2_out_1:
   effort: sum_55k_series_finisher
   split: sum_55k_course_rolling_pass_aid2
-  id: 192729
   absolute_time: 2017-09-23 20:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 19800.0
@@ -12898,7 +11918,6 @@ sum_55k_series_finisher_rolling_pass_aid2_out_1:
 sum_55k_series_finisher_bandera_mine_aid5_in_1:
   effort: sum_55k_series_finisher
   split: sum_55k_course_bandera_mine_aid5
-  id: 192730
   absolute_time: 2017-09-23 22:30:00.000000000 Z
   data_status: 2
   elapsed_seconds: 27000.0
@@ -12911,7 +11930,6 @@ sum_55k_series_finisher_bandera_mine_aid5_in_1:
 sum_55k_series_finisher_bandera_mine_aid5_out_1:
   effort: sum_55k_series_finisher
   split: sum_55k_course_bandera_mine_aid5
-  id: 192731
   absolute_time: 2017-09-23 22:44:00.000000000 Z
   data_status:
   elapsed_seconds: 27840.0
@@ -12924,7 +11942,6 @@ sum_55k_series_finisher_bandera_mine_aid5_out_1:
 sum_55k_series_finisher_anvil_cg_aid6_in_1:
   effort: sum_55k_series_finisher
   split: sum_55k_course_anvil_cg_aid6
-  id: 192732
   absolute_time: 2017-09-24 00:15:00.000000000 Z
   data_status:
   elapsed_seconds: 33300.0
@@ -12937,7 +11954,6 @@ sum_55k_series_finisher_anvil_cg_aid6_in_1:
 sum_55k_series_finisher_anvil_cg_aid6_out_1:
   effort: sum_55k_series_finisher
   split: sum_55k_course_anvil_cg_aid6
-  id: 192733
   absolute_time: 2017-09-24 00:25:00.000000000 Z
   data_status:
   elapsed_seconds: 33900.0
@@ -12947,23 +11963,9 @@ sum_55k_series_finisher_anvil_cg_aid6_out_1:
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
-sum_55k_series_finisher_finish_1:
-  effort: sum_55k_series_finisher
-  split: sum_55k_course_finish
-  id: 192734
-  absolute_time: 2017-09-24 01:20:00.000000000 Z
-  data_status:
-  elapsed_seconds: 37200.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 sum_55k_slow_finisher_start_1:
   effort: sum_55k_slow_finisher
   split: sum_55k_course_start
-  id: 192735
   absolute_time: 2017-09-23 15:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -12973,10 +11975,21 @@ sum_55k_slow_finisher_start_1:
   stopped_here: false
   sub_split_bitkey: 1
   status_reason:
+sum_55k_slow_finisher_finish_1:
+  effort: sum_55k_slow_finisher
+  split: sum_55k_course_finish
+  absolute_time: 2017-09-24 03:21:21.000000000 Z
+  data_status: 2
+  elapsed_seconds: 44481.0
+  lap: 1
+  pacer:
+  remarks:
+  stopped_here: false
+  sub_split_bitkey: 1
+  status_reason:
 sum_55k_slow_finisher_molas_pass_aid1_in_1:
   effort: sum_55k_slow_finisher
   split: sum_55k_course_molas_pass_aid1
-  id: 192736
   absolute_time: 2017-09-23 18:10:00.000000000 Z
   data_status: 2
   elapsed_seconds: 11400.0
@@ -12989,7 +12002,6 @@ sum_55k_slow_finisher_molas_pass_aid1_in_1:
 sum_55k_slow_finisher_molas_pass_aid1_out_1:
   effort: sum_55k_slow_finisher
   split: sum_55k_course_molas_pass_aid1
-  id: 192737
   absolute_time: 2017-09-23 18:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 12000.0
@@ -13002,7 +12014,6 @@ sum_55k_slow_finisher_molas_pass_aid1_out_1:
 sum_55k_slow_finisher_rolling_pass_aid2_in_1:
   effort: sum_55k_slow_finisher
   split: sum_55k_course_rolling_pass_aid2
-  id: 192738
   absolute_time: 2017-09-23 21:35:00.000000000 Z
   data_status: 2
   elapsed_seconds: 23700.0
@@ -13015,7 +12026,6 @@ sum_55k_slow_finisher_rolling_pass_aid2_in_1:
 sum_55k_slow_finisher_rolling_pass_aid2_out_1:
   effort: sum_55k_slow_finisher
   split: sum_55k_course_rolling_pass_aid2
-  id: 192739
   absolute_time: 2017-09-23 21:45:00.000000000 Z
   data_status: 2
   elapsed_seconds: 24300.0
@@ -13028,7 +12038,6 @@ sum_55k_slow_finisher_rolling_pass_aid2_out_1:
 sum_55k_slow_finisher_bandera_mine_aid5_in_1:
   effort: sum_55k_slow_finisher
   split: sum_55k_course_bandera_mine_aid5
-  id: 192740
   absolute_time: 2017-09-23 23:20:00.000000000 Z
   data_status: 2
   elapsed_seconds: 30000.0
@@ -13041,7 +12050,6 @@ sum_55k_slow_finisher_bandera_mine_aid5_in_1:
 sum_55k_slow_finisher_bandera_mine_aid5_out_1:
   effort: sum_55k_slow_finisher
   split: sum_55k_course_bandera_mine_aid5
-  id: 192741
   absolute_time: 2017-09-23 23:40:00.000000000 Z
   data_status: 2
   elapsed_seconds: 31200.0
@@ -13054,7 +12062,6 @@ sum_55k_slow_finisher_bandera_mine_aid5_out_1:
 sum_55k_slow_finisher_anvil_cg_aid6_in_1:
   effort: sum_55k_slow_finisher
   split: sum_55k_course_anvil_cg_aid6
-  id: 192742
   absolute_time: 2017-09-24 01:33:00.000000000 Z
   data_status: 2
   elapsed_seconds: 37980.0
@@ -13067,7 +12074,6 @@ sum_55k_slow_finisher_anvil_cg_aid6_in_1:
 sum_55k_slow_finisher_anvil_cg_aid6_out_1:
   effort: sum_55k_slow_finisher
   split: sum_55k_course_anvil_cg_aid6
-  id: 192743
   absolute_time: 2017-09-24 01:55:00.000000000 Z
   data_status: 2
   elapsed_seconds: 39300.0
@@ -13077,23 +12083,9 @@ sum_55k_slow_finisher_anvil_cg_aid6_out_1:
   stopped_here: false
   sub_split_bitkey: 64
   status_reason:
-sum_55k_slow_finisher_finish_1:
-  effort: sum_55k_slow_finisher
-  split: sum_55k_course_finish
-  id: 192744
-  absolute_time: 2017-09-24 03:21:21.000000000 Z
-  data_status: 2
-  elapsed_seconds: 44481.0
-  lap: 1
-  pacer:
-  remarks:
-  stopped_here: false
-  sub_split_bitkey: 1
-  status_reason:
 ggd30_12m_slow_finisher_start_1:
   effort: ggd30_12m_slow_finisher
   split: d30_12m_course_start
-  id: 192745
   absolute_time: 2017-06-03 16:00:00.000000000 Z
   data_status: 2
   elapsed_seconds: 0.0
@@ -13106,7 +12098,6 @@ ggd30_12m_slow_finisher_start_1:
 ggd30_12m_slow_finisher_finish_1:
   effort: ggd30_12m_slow_finisher
   split: d30_12m_course_finish
-  id: 192746
   absolute_time: 2017-06-03 20:32:10.000000000 Z
   data_status:
   elapsed_seconds: 16330.0

--- a/spec/services/time_predictor_spec.rb
+++ b/spec/services/time_predictor_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TimePredictor do
   let(:vert_gain_factor) { SegmentTimeCalculator::UP_VERT_GAIN_FACTOR }
   let(:event) { events(:sum_55k) }
   let(:effort) { efforts(:sum_55k_progress_rolling) }
-  let(:subject_split_times) { effort.split_times }
+  let(:subject_split_times) { effort.split_times.ordered }
   let(:ordered_splits) { event.ordered_splits }
   let(:start) { ordered_splits.first }
   let(:aid_1) { ordered_splits.second }


### PR DESCRIPTION
## Summary

Final fixture in the portability series. Makes `split_times` portable (1009 rows). Builds on #2105 (`Effort` belongs_to associations for `final_split_time`/`stopped_split_time`).

### Changes
- **`SplitTime#slug`**: new method returning the content-based identifier (`<effort_slug_underscored>_<split_name_parameterized>_<lap>`). Needed because the `db:to_fixtures` dumper calls `parent.slug.tr("-", "_")` when rewriting FK refs from other tables — `SplitTime` has no slug column, so without this method the dumper would crash (the same way it does on `LotteryDivision`). The string matches what the rake task's existing `split_times` title special-case computes for the fixture key itself, so labels stay consistent across both code paths.
- **`fixture_helper.rb`**: add `:split_times` to `PORTABLE_FIXTURE_TABLES` and `split_times: "effort_id, lap, split_id, sub_split_bitkey"` to `ORDER_BY_MAP` (matches the unique index `index_split_times_on_effort_id_and_time_point`). Without an explicit ORDER_BY, default would be `"id"` — which gives hash-id-random row ordering on re-dumps. The semantic ordering groups rows by effort, which makes YAML diffs readable.
- **`split_times.yml`**: regenerated. Drops 1009 `id:` fields. Rows reorder by the new ORDER_BY (so the YAML diff is large), but labels are content-based (`hardrock_2015_tuan_jacobs_start_1` etc.) and stay assigned to the same underlying rows — all `split_times(:label)` accessors in specs continue to resolve correctly.
- **`raw_times.yml`**: regenerated. The `split_time_id: <int>` references become `split_time: <label>` (since `RawTime belongs_to :split_time` and `split_times` is now portable).
- **`efforts.yml`**: regenerated. The two FK columns become labels: `final_split_time_id: <int>` → `final_split_time: <label>`, same for `stopped_split_time`. Cached values (`overall_performance`, `finished`, `completed_laps`, etc.) stay in YAML — per discussion, Option A (store-in-fixtures) was chosen over post-load computation to keep this PR focused.

### Verified
- 371 examples pass across `Effort`, `SplitTime`, `RawTime` model specs, `Results::*` services, `Api::V1::EventGroupsController`, and `Interactors::BulkDeleteEventGroupTimes` / `ResetEffortPerformanceData`.
- `rubocop` clean on touched Ruby files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2065
