### PR TITLE
Drop PORTABLE_FIXTURE_TABLES constant

### DIFF
--- a/lib/tasks/db/fixture_helper.rb
+++ b/lib/tasks/db/fixture_helper.rb
@@ -35,47 +35,9 @@ module FixtureHelper
     :users,
   ].freeze
 
-  # Portable fixture tables are assigned an :id by Rails and are referenced by title
-  # rather than id in other fixture tables.
-  PORTABLE_FIXTURE_TABLES = [
-    :aid_stations,
-    :connections,
-    :course_group_courses,
-    :course_groups,
-    :courses,
-    :credentials,
-    :efforts,
-    :event_groups,
-    :event_series,
-    :event_series_events,
-    :events,
-    :historical_facts,
-    :lotteries,
-    :lottery_divisions,
-    :lottery_draws,
-    :lottery_entrants,
-    :lottery_simulation_runs,
-    :lottery_tickets,
-    :monetary_donations,
-    :notifications,
-    :organizations,
-    :partners,
-    :people,
-    :projection_assessment_runs,
-    :raw_times,
-    :results_categories,
-    :results_templates,
-    :results_template_categories,
-    :split_times,
-    :splits,
-    :stewardships,
-    :subscriptions,
-    :users,
-  ].freeze
-
-  # ORDER BY clause used when dumping fixtures. Required for any non-slug portable table
-  # so labels are stable across regenerations and across schema changes (otherwise a new
-  # column could become an unexpected sort key, scrambling every label and FK reference).
+  # ORDER BY clause used when dumping fixtures. Required for any non-slug table so labels
+  # are stable across regenerations and across schema changes (otherwise a new column
+  # could become an unexpected sort key, scrambling every label and FK reference).
   # Pick columns that uniquely identify a row by its real-world identity.
   ORDER_BY_MAP = {
     aid_stations: "event_id, split_id",

--- a/lib/tasks/db/fixtures.rake
+++ b/lib/tasks/db/fixtures.rake
@@ -13,7 +13,6 @@ namespace :db do
 
       model = table_name.classify.constantize
       model_slugged = model.columns.map(&:name).include?("slug")
-      table_portable = table_name.to_sym.in? FixtureHelper::PORTABLE_FIXTURE_TABLES
       belongs_to_associations = model.reflect_on_all_associations(:belongs_to)
 
       json_column_names = model.columns.select { |c| c.sql_type_metadata.type.in?([:json, :jsonb]) }.map(&:name)
@@ -22,7 +21,7 @@ namespace :db do
       file_path = Rails.root.join("spec/fixtures/#{table_name}.yml").to_s
       File.open(file_path, "w") do |file|
         order_clause = FixtureHelper::ORDER_BY_MAP[table_name.to_sym] ||
-                       order_clause_for(table_name, table_portable, model_slugged)
+                       order_clause_for(table_name, model_slugged)
 
         rows = ActiveRecord::Base.connection.select_all("SELECT * FROM #{table_name} ORDER BY #{order_clause}")
         data = rows.each_with_object({}) do |record, hash|
@@ -45,7 +44,7 @@ namespace :db do
                   end
           attributes_to_preserve = FixtureHelper::ATTRIBUTES_TO_PRESERVE_BY_TABLE.fetch(table_name.to_sym, [])
           attributes_to_ignore = FixtureHelper::ATTRIBUTES_TO_IGNORE - attributes_to_preserve
-          attributes_to_ignore << :id if table_name.to_sym.in? FixtureHelper::PORTABLE_FIXTURE_TABLES
+          attributes_to_ignore << :id
           record.except!(*attributes_to_ignore.map(&:to_s))
 
           association_hash = {}
@@ -55,17 +54,12 @@ namespace :db do
               record_parent_type = record[foreign_type]
               next if record_parent_type.nil?
 
-              record_parent_table = record_parent_type.constantize.table_name
-              next unless record_parent_table.to_sym.in? FixtureHelper::PORTABLE_FIXTURE_TABLES
-
               parent_class = record.delete(foreign_type).constantize
               parent_id = record.delete(association.foreign_key)
               parent = parent_class.find(parent_id)
               parent_title = parent.slug.tr("-", "_")
               association_hash[association.name.to_s] = "#{parent_title} (#{parent_class.name})"
             else
-              next unless association.table_name.to_sym.in? FixtureHelper::PORTABLE_FIXTURE_TABLES
-
               parent_class = association.class_name.constantize
               parent_id = record.delete(association.foreign_key)
               if parent_id.nil?
@@ -88,15 +82,13 @@ namespace :db do
   end
 
   # Determines the SQL ORDER BY clause used when dumping a table's rows.
-  # Non-slug portable tables (other than split_times, which generates content-based titles
-  # of its own) MUST have an explicit FixtureHelper::ORDER_BY_MAP entry — there is no safe
-  # default, since their `<table>_NNNN` labels depend on row order, and ad-hoc sorts can
-  # silently scramble every label and every FK reference whenever a column is added.
-  def order_clause_for(table_name, table_portable, model_slugged)
-    return "slug" if table_portable && model_slugged
-    return "id" unless table_portable && table_name != "split_times"
+  # Non-slug tables MUST have an explicit FixtureHelper::ORDER_BY_MAP entry — there is no
+  # safe default, since their `<table>_NNNN` labels depend on row order, and ad-hoc sorts
+  # can silently scramble every label and every FK reference whenever a column is added.
+  def order_clause_for(table_name, model_slugged)
+    return "slug" if model_slugged
 
-    raise "Non-slug portable table '#{table_name}' needs an explicit FixtureHelper::ORDER_BY_MAP entry"
+    raise "Non-slug table '#{table_name}' needs an explicit FixtureHelper::ORDER_BY_MAP entry"
   end
 
   desc "Convert Rails test fixtures to development database"


### PR DESCRIPTION
## Summary

After #2106, every entry in `FIXTURE_TABLES` is also in `PORTABLE_FIXTURE_TABLES` — every `table.in? PORTABLE_FIXTURE_TABLES` check is trivially true. Cleanup PR drops the constant and the dead conditionals.

### Changes
- **`fixture_helper.rb`**: remove the `PORTABLE_FIXTURE_TABLES` array. Update the `ORDER_BY_MAP` comment ("any non-slug portable table" → "any non-slug table").
- **`fixtures.rake`**:
  - Drop the `table_portable = ...` local.
  - `attributes_to_ignore << :id` always fires (was gated).
  - The `next unless ... PORTABLE_FIXTURE_TABLES` skips in both the polymorphic and normal `belongs_to` branches are gone — label-rewrite always happens.
  - `order_clause_for` simplifies to `return "slug" if model_slugged; raise unless ORDER_BY_MAP entry`. No more split_times special-case (it already has an ORDER_BY_MAP entry).
  - Update the comment to match.

The contract becomes: "every entry in `FIXTURE_TABLES` is portable; if it has no slug column, it needs an `ORDER_BY_MAP` entry." If a future non-portable table is genuinely needed, re-introduce the gate — but flag it as an exception rather than carry a constant that's now indistinguishable from `FIXTURE_TABLES`.

### Verified
- Re-dumping `course_group_courses.yml` (focused dump via temporary `FIXTURE_TABLES = [:course_group_courses]`) produced byte-identical output (`git diff` was empty).
- 239 examples pass (Effort, RawTime, SplitTime model specs — confirming fixture loading still works end-to-end).
- `rubocop lib/tasks/db/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #2065
