### PR TITLE
Load Google Maps API asynchronously via bootstrap loader

### DIFF
--- a/app/javascript/controllers/course_setup/split_location_controller.js
+++ b/app/javascript/controllers/course_setup/split_location_controller.js
@@ -10,7 +10,12 @@ export default class extends Controller {
     "map",
   ]
 
-  connect() {
+  async connect() {
+    await Promise.all([
+      google.maps.importLibrary("elevation"), // ElevationService
+      google.maps.importLibrary("core"),      // LatLng
+    ])
+
     this._elevator = new google.maps.ElevationService();
   }
 

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -12,7 +12,13 @@ export default class extends Controller {
     editable: Boolean,
   }
 
-  connect() {
+  async connect() {
+    await Promise.all([
+      google.maps.importLibrary("maps"),    // Map, Polyline, InfoWindow
+      google.maps.importLibrary("marker"),  // Marker
+      google.maps.importLibrary("core"),    // LatLng, LatLngBounds, Point, event, Animation
+    ])
+
     const controller = this
     const courseId = this.courseIdValue;
     const eventId = this.eventIdValue;

--- a/app/views/layouts/_google_maps_api_js.html.erb
+++ b/app/views/layouts/_google_maps_api_js.html.erb
@@ -1,7 +1,13 @@
 <% unless Rails.env.test? %>
-<%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?libraries=places" \
-                           "&callback=Function.prototype" \
-                           "&key=#{::OstConfig.google_maps_api_key}" %>
+  <%# Google's official inline bootstrap loader. Loads the API with loading=async %>
+  <%# (no console warning) and exposes google.maps.importLibrary() for on-demand %>
+  <%# library loading. Consuming Stimulus controllers await importLibrary in connect(). %>
+  <script>
+    (g => { var h, a, k, p = "The Google Maps JavaScript API", c = "google", l = "importLibrary", q = "__ib__", m = document, b = window; b = b[c] || (b[c] = {}); var d = b.maps || (b.maps = {}), r = new Set, e = new URLSearchParams, u = () => h || (h = new Promise(async (f, n) => { await (a = m.createElement("script")); e.set("libraries", [...r] + ""); for (k in g) e.set(k.replace(/[A-Z]/g, t => "_" + t[0].toLowerCase()), g[k]); e.set("callback", c + ".maps." + q); a.src = `https://maps.${c}apis.com/maps/api/js?` + e; d[q] = f; a.onerror = () => h = n(Error(p + " could not load.")); a.nonce = m.querySelector("script[nonce]")?.nonce || ""; m.head.append(a) })); d[l] ? console.warn(p + " only loads once. Ignoring:", g) : d[l] = (f, ...n) => r.add(f) && u().then(() => d[l](f, ...n)) })({
+      key: "<%= ::OstConfig.google_maps_api_key %>",
+      v: "weekly",
+    });
+  </script>
 <% else %>
   <!-- Test env: provide a minimal stub so any code that references google.maps.places won't crash -->
   <script>
@@ -28,6 +34,7 @@
       maps.LatLngBounds = function () {};
       maps.LatLngBounds.prototype.extend = function () {};
       maps.LatLngBounds.prototype.getCenter = function () { return new maps.LatLng(0, 0); };
+      maps.LatLngBounds.prototype.isEmpty = function () { return true; };
 
       // Map
       maps.Map = function (el, opts) {
@@ -35,8 +42,10 @@
       };
       maps.Map.prototype.setCenter = function () {};
       maps.Map.prototype.setZoom = function () {};
+      maps.Map.prototype.getZoom = function () { return 4; };
       maps.Map.prototype.fitBounds = function () {};
       maps.Map.prototype.getBounds = function () { return new maps.LatLngBounds(); };
+      maps.Map.prototype.addListener = function () { return { remove: function () {} }; };
 
       // Marker
       maps.Marker = function (opts) {
@@ -74,6 +83,19 @@
         this.addListener = function () { return { remove: function () {} }; };
         this.getPlace = function () { return {}; };
       };
+
+      // Marker animations
+      maps.Animation = { BOUNCE: 1, DROP: 2 };
+
+      // Elevation service
+      maps.ElevationService = function () {
+        this.getElevationForLocations = function () {
+          return Promise.resolve({ results: [] });
+        };
+      };
+
+      // Async loader shim: controllers await google.maps.importLibrary() in connect().
+      maps.importLibrary = function () { return Promise.resolve(maps); };
 
       maps.__stubbed = true;
     }());


### PR DESCRIPTION
## Summary

Fixes the console warning:

> Google Maps JavaScript API has been loaded directly without loading=async. This can result in suboptimal performance.

The API was loaded synchronously via a render-blocking `javascript_include_tag`. This switches to Google's official inline bootstrap loader (`loading=async`), which exposes `google.maps.importLibrary()` and emits no warning.

## Changes

- **`_google_maps_api_js.html.erb`** — replace the `javascript_include_tag` with Google's async bootstrap loader. Drops the eager `libraries=places` param (no Autocomplete usage exists; libraries now load on demand).
- **`maps_controller.js` / `course_setup/split_location_controller.js`** — async loading no longer guarantees `google.maps` is populated before controllers connect, so each `connect()` now `await`s the libraries it needs (`maps`/`marker`/`core`, and `elevation`/`core`) before using them. The rest of each controller body is unchanged.
- **Test stub** (else branch of the partial) — add an `importLibrary` shim plus `Animation`, `ElevationService`, `Map#addListener`, `Map#getZoom`, and `LatLngBounds#isEmpty`. Previously the synchronous `connect()` threw at `_gmap.addListener` and Stimulus swallowed it, so the map silently never initialized in tests. The async version surfaces the full init path, which the fuller stub now supports.

## Verification

- `spec/system/event_group_construction/setup_course_edit_splits_spec.rb` — passes (loads both controllers, `js: true`).
- `spec/system/courses/visit_course_splits_spec.rb` + `visit_course_events_spec.rb` — pass (course show page with map).

Resolves #2109

🤖 Generated with [Claude Code](https://claude.com/claude-code)