### PR TITLE
Avoid 500 on access-denied redirect to external referrer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -120,7 +120,19 @@ class ApplicationController < ActionController::Base
 
   def user_not_authorized
     flash[:alert] = "Access denied."
-    redirect_to(request.referrer || root_path)
+    redirect_to(safe_referrer || root_path)
+  end
+
+  # Returns request.referrer only when it points at our own host, otherwise nil.
+  # Prevents ActionController::Redirecting::OpenRedirectError (a 500) when a user
+  # arrives from an external origin such as accounts.google.com after OAuth sign-in.
+  def safe_referrer
+    referrer = request.referrer
+    return if referrer.blank?
+
+    URI(referrer).host == request.host ? referrer : nil
+  rescue URI::InvalidURIError
+    nil
   end
 
   def set_current_url_options

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "UsersController" do
+  include Warden::Test::Helpers
+
+  let(:non_admin_user) { users(:third_user) }
+
+  after { Warden.test_reset! }
+
+  describe "GET /users" do
+    context "when signed in as a non-admin" do
+      before { login_as non_admin_user, scope: :user }
+
+      it "redirects to root with an access-denied alert" do
+        get users_path
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq("Access denied.")
+      end
+
+      it "redirects back to a same-host referrer" do
+        get users_path, headers: { "HTTP_REFERER" => "http://www.example.com/organizations" }
+
+        expect(response).to redirect_to("http://www.example.com/organizations")
+        expect(flash[:alert]).to eq("Access denied.")
+      end
+
+      it "falls back to root rather than raising on an external referrer" do
+        get users_path, headers: { "HTTP_REFERER" => "https://accounts.google.com/" }
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq("Access denied.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Scout flagged an unresolved `ActionController::Redirecting::OpenRedirectError` (a 500) on `users#index`. Root cause: `ApplicationController#user_not_authorized` redirects back to `request.referrer`, and Rails 7+ refuses to `redirect_to` an external host without `allow_other_host: true`. When a signed-in user arrived from an external origin (here, `accounts.google.com` after a Google OAuth sign-in) and then hit an admin-only page, the access-denied bounce-back raised instead of redirecting.

## Fix

Add a `safe_referrer` helper that returns `request.referrer` only when it points at our own host, otherwise `nil` (also guarding malformed URIs). `user_not_authorized` now uses `safe_referrer || root_path`.

This preserves the legitimate same-host bounce-back, eliminates the 500, and does **not** use `allow_other_host: true` — which would convert the 500 into a genuine open-redirect, since `request.referrer` is client-controlled.

## Scope

`request.referrer`-based redirects exist in several other controllers with the same latent risk, but only `user_not_authorized` has surfaced in Scout (it's reachable by any unauthorized request). This PR is intentionally scoped to the observed error; a broader sweep can follow if desired.

## Tests

New `spec/requests/users_controller_spec.rb` covers:
- no referrer -> root
- same-host referrer -> preserved
- external referrer -> falls back to root rather than raising (verified to fail without the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)