### PR TITLE
Only load Cloudflare beacon in real production (not staging)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
   <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
   <%= render "layouts/google_maps_api_js" %>
   <%= csrf_meta_tags %>
-  <%= render "layouts/cloudflare_analytics" if Rails.env.production? %>
+  <%= render "layouts/cloudflare_analytics" if OstConfig.cloudflare_analytics_enabled? %>
   <%= render "layouts/favicon" %>
 </head>
 

--- a/config/initializers/01_ost_config.rb
+++ b/config/initializers/01_ost_config.rb
@@ -65,6 +65,14 @@ module OstConfig
     Rails.application.credentials.dig(:cloudflare, :analytics, :token)
   end
 
+  # The Web Analytics token is registered for the production hostname, so the
+  # beacon only works there. Staging runs as Rails.env.production? but with
+  # CREDENTIALS_ENV=staging; loading the beacon there just 404s against the RUM
+  # endpoint and spams the console.
+  def self.cloudflare_analytics_enabled?
+    Rails.env.production? && credentials_env != "staging" && cloudflare_analytics_token.present?
+  end
+
   def self.cloudflare_turnstile_secret_key
     Rails.application.credentials.dig(:cloudflare, :turnstile, :secret_key)
   end

--- a/spec/config/ost_config_spec.rb
+++ b/spec/config/ost_config_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe OstConfig do
+  describe ".cloudflare_analytics_enabled?" do
+    subject { described_class.cloudflare_analytics_enabled? }
+
+    before do
+      allow(Rails.env).to receive(:production?).and_return(production)
+      allow(described_class).to receive_messages(credentials_env: credentials_env, cloudflare_analytics_token: token)
+    end
+
+    context "when in production with a token and no staging override" do
+      let(:production) { true }
+      let(:credentials_env) { nil }
+      let(:token) { "abc123" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when on staging (production env with CREDENTIALS_ENV=staging)" do
+      let(:production) { true }
+      let(:credentials_env) { "staging" }
+      let(:token) { "abc123" }
+
+      it { is_expected.to be false }
+    end
+
+    context "when in production without a token" do
+      let(:production) { true }
+      let(:credentials_env) { nil }
+      let(:token) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when outside production" do
+      let(:production) { false }
+      let(:credentials_env) { nil }
+      let(:token) { "abc123" }
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The Cloudflare Web Analytics beacon was loading on **staging**, where it 404s against the RUM endpoint and spams the browser console:

```
[Error] ... Status code: 404
[Error] XMLHttpRequest cannot load https://cloudflareinsights.com/cdn-cgi/rum due to access control checks.
```

The beacon's render was gated on `Rails.env.production?` (`application.html.erb:11`). Staging runs as `RAILS_ENV=production` (distinguished only by `CREDENTIALS_ENV=staging`, via `OstConfig.credentials_env`), so the gate was `true` on staging too. The analytics token is registered in Cloudflare for the production hostname, so the beacon can only work there.

## Fix

Add `OstConfig.cloudflare_analytics_enabled?` (real production, not staging, token present) and gate the render on it:

```ruby
def self.cloudflare_analytics_enabled?
  Rails.env.production? && credentials_env != "staging" && cloudflare_analytics_token.present?
end
```

Keeps analytics working in production, stops the failing beacon (and likely the related `window.styleMedia` warning) on staging, and the `token.present?` guard avoids ever rendering an empty-token beacon.

## Scope

This addresses the **staging** 404. The same `cdn-cgi/rum` message also shows up in production, but that one has a different, client-side cause (Safari ITP / tracker blockers blocking the cross-origin beacon) and has no server-side fix — see the analysis in #2114.

## Tests

New `spec/config/ost_config_spec.rb` covers `cloudflare_analytics_enabled?`: production-with-token (true), staging (false), production-without-token (falsey), and non-production (false). 4 passing. RuboCop and erb_lint clean.

Resolves #2114

🤖 Generated with [Claude Code](https://claude.com/claude-code)