### PR TITLE
Bound Projection event lookback when ignore_times_beyond is given

### DIFF
--- a/app/models/projection.rb
+++ b/app/models/projection.rb
@@ -27,7 +27,7 @@ class Projection < ::ApplicationQuery
     starting_lap, starting_split_id, starting_bitkey = starting_time_point.values
     ignore_timestamp = ApplicationRecord.connection.quote(ignore_times_beyond.presence)
 
-    return NULL_QUERY if completed_seconds == 0 || subject_time_points.empty?
+    return NULL_QUERY if completed_seconds.zero? || subject_time_points.empty?
 
     projected_where_array = subject_time_points.map do |tp|
       "(lap = #{tp.lap} and split_id = #{tp.split_id} and sub_split_bitkey = #{tp.bitkey})"
@@ -35,7 +35,7 @@ class Projection < ::ApplicationQuery
     projected_where_clause = projected_where_array.join(" or ").presence || "true"
 
     <<~SQL.squish
-      with 
+      with
         relevant_event_ids as (
           select events.id as event_id
           from events
@@ -44,18 +44,19 @@ class Projection < ::ApplicationQuery
             join splits on splits.course_id = courses.id
           where splits.id = #{starting_split_id}
             and (event_groups.concealed is false or event_groups.concealed is null)
+            and (#{ignore_timestamp} is null or events.scheduled_start_time <= #{ignore_timestamp})
           order by scheduled_start_time desc
           limit #{EVENT_LOOKBACK_COUNT}
         ),
 
         completed_split_times as (
-          select cst.effort_id, 
+          select cst.effort_id,
                  cst.absolute_time,
                  extract(epoch from(cst.absolute_time - sst.absolute_time)) as completed_segment_seconds,
                  abs(extract(epoch from(cst.absolute_time - sst.absolute_time)) - #{completed_seconds}) as difference
           from split_times cst
-            inner join split_times sst 
-                    on sst.effort_id = cst.effort_id 
+            inner join split_times sst
+                    on sst.effort_id = cst.effort_id
                    and sst.lap = #{starting_lap}
                    and sst.split_id = #{starting_split_id}
                    and sst.sub_split_bitkey = #{starting_bitkey}
@@ -76,7 +77,7 @@ class Projection < ::ApplicationQuery
         ),
 
         main_subquery as (
-          select pst.effort_id, 
+          select pst.effort_id,
               lap,
               split_id,
               sub_split_bitkey,
@@ -92,29 +93,29 @@ class Projection < ::ApplicationQuery
 
         ratio_subquery as (
           select *,
-              case when completed_segment_seconds = 0 
-                   then null 
+              case when completed_segment_seconds = 0
+                   then null
                    else round((projected_segment_seconds / completed_segment_seconds)::numeric, 6) end as ratio
           from main_subquery
         ),
-          
+
         order_count_subquery as (
           select *,
               row_number() over (partition by lap, split_id, sub_split_bitkey order by ratio) as row_number,
               sum(1) over (partition by lap, split_id, sub_split_bitkey) as total
           from ratio_subquery
         ),
-          
+
         quartiles as (
-          select lap, 
-                 effort_id, 
-                 split_id, 
+          select lap,
+                 effort_id,
+                 split_id,
                  sub_split_bitkey,
                  effort_year,
                  ratio,
                  avg(case when row_number >= (floor(total/2.0)/2.0)
                            and row_number <= (floor(total/2.0)/2.0) + 1
-                     then ratio else null end) 
+                     then ratio else null end)
                  over (partition by lap, split_id, sub_split_bitkey) as q1,
                  avg(case when row_number >= (total/2.0)
                            and row_number <= (total/2.0) + 1
@@ -126,7 +127,7 @@ class Projection < ::ApplicationQuery
                  over (partition by lap, split_id, sub_split_bitkey) as q3
           from order_count_subquery
         ),
-              
+
         bounds as (
           select *,
               q3 - q1 as iqr,
@@ -139,15 +140,15 @@ class Projection < ::ApplicationQuery
           select *
           from bounds
           where effort_id not in (
-            select distinct effort_id 
-            from bounds 
+            select distinct effort_id
+            from bounds
             where ratio not between lower_bound and upper_bound
           )
         ),
 
         stats_subquery as (
-          select lap, 
-                 split_id, 
+          select lap,
+                 split_id,
                  sub_split_bitkey,
                  array_to_string(array_agg(distinct effort_year), ',') as effort_years,
                  count(ratio) as effort_count,
@@ -156,22 +157,22 @@ class Projection < ::ApplicationQuery
           from valid_ratios
           group by lap, split_id, sub_split_bitkey
         ),
-      
+
         final_subquery as (
-          select lap, 
-                 split_id, 
+          select lap,
+                 split_id,
                  sub_split_bitkey,
                  effort_count,
                  effort_years,
                  case when average >= 0 and (average - std2) is not null
-                      then greatest(0, average - std2) 
+                      then greatest(0, average - std2)
                       else average - std2 end as low_ratio,
                  average as average_ratio,
                  average + std2 as high_ratio
           from stats_subquery
         )
-          
-      select final_subquery.*, 
+
+      select final_subquery.*,
           round(low_ratio * #{completed_seconds})::int as low_seconds,
           round(average_ratio * #{completed_seconds})::int as average_seconds,
           round(high_ratio * #{completed_seconds})::int as high_seconds

--- a/spec/models/projection_spec.rb
+++ b/spec/models/projection_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ::Projection, type: :model do
         ignore_times_beyond: ignore_times_beyond,
       )
     end
+
     let(:split_time) { effort.ordered_split_times.last }
     let(:effort) { efforts(:hardrock_2016_rene_mclaughlin) }
     let(:time_points) { effort.event.required_time_points }
@@ -54,6 +55,34 @@ RSpec.describe ::Projection, type: :model do
           expect(projection.high_seconds).to be_within(100).of(44_700)
         end
       end
+
+      context "when ignore_times_beyond predates newer events on the same course" do
+        let(:effort) { efforts(:hardrock_2014_finished_without_stop) }
+        let(:split_time) { effort.ordered_split_times[5] }
+        let(:subject_time_points) { [time_points[6]] }
+        let(:ignore_times_beyond) { split_time.absolute_time }
+
+        before do
+          4.times do |i|
+            create(
+              :event,
+              :with_short_name,
+              course: courses(:hardrock_cw),
+              event_group: event_groups(:hardrock_2016),
+              scheduled_start_time: Time.zone.parse("#{2017 + i}-07-14 12:00:00"),
+            )
+          end
+        end
+
+        it "draws its sample only from events available at that time" do
+          expect(subject).to be_present
+
+          projection = subject.first
+          expect(projection.time_point).to eq(subject_time_points.first)
+          expect(projection.effort_years).to eq([2014])
+          expect(projection.effort_count).to be_positive
+        end
+      end
     end
 
     context "when given a starting split time" do
@@ -73,6 +102,7 @@ RSpec.describe ::Projection, type: :model do
 
   describe "#time_point" do
     subject { described_class.new(lap: lap, split_id: split_id, sub_split_bitkey: bitkey) }
+
     let(:lap) { 1 }
     let(:split_id) { 2 }
     let(:bitkey) { out_bitkey }


### PR DESCRIPTION
## Summary

`Projection`'s `relevant_event_ids` CTE picks the five most recent events on the course **as of query time**, with no reference to the prediction moment. For live use that's fine. But when backtesting with `ignore_times_beyond` (as `ProjectionAssessments::Runner` does), the lookback selects events that postdate the anchor — whose split times the ignore filter then excludes entirely — crowding genuinely usable older events out of the five slots. Backtests for events more than a few years old return starved or empty samples instead of reproducing what the live system would have predicted.

This adds one condition to the CTE:

```sql
and (#{ignore_timestamp} is null or events.scheduled_start_time <= #{ignore_timestamp})
```

- **Backtests** now sample the five most recent events *as of the anchor timestamp* — including the subject event itself, whose pre-anchor times are legitimate (front-runner data), with `ignore_times_beyond` still policing that boundary as before.
- **Live behavior is unchanged**: without `ignore_times_beyond` the clause is a no-op, and a live anchor postdates every existing event, so the same five events are selected either way.

The new spec reproduces the failure: a 2014 subject effort with four newer events on the same course returns an empty result without the fix, and a 2014-only sample with it.

Also per house style: stripped the accidental trailing whitespace from the SQL heredoc (it gets `.squish`ed anyway) rather than letting rubocop preserve it, and fixed minor style offenses in the touched files.

Context: needed for backtesting prediction accuracy on High Lonesome 2018+ (buffer calibration for the Aid Station Gating feature, #2118).

🤖 Generated with [Claude Code](https://claude.com/claude-code)