### PR TITLE
Add projection_assessments:export rake task

### DIFF
--- a/lib/projection_assessments/runner.rb
+++ b/lib/projection_assessments/runner.rb
@@ -5,13 +5,15 @@ module ProjectionAssessments
     UPDATE_INTERVAL = 5
 
     # @param [::ProjectionAssessmentRun] assessment_run
+    # @yield optional block called after each effort is assessed
     # @return [Integer]
-    def self.perform!(assessment_run)
-      new(assessment_run).perform!
+    def self.perform!(assessment_run, &)
+      new(assessment_run, &).perform!
     end
 
-    def initialize(assessment_run)
+    def initialize(assessment_run, &block)
       @assessment_run = assessment_run
+      @progress_callback = block
       @current_effort = nil
       @errors = []
     end
@@ -26,7 +28,7 @@ module ProjectionAssessments
 
     private
 
-    attr_reader :assessment_run, :errors
+    attr_reader :assessment_run, :errors, :progress_callback
     attr_accessor :current_assessment, :current_effort
 
     delegate :completed_lap, :completed_split_id, :completed_bitkey,
@@ -45,6 +47,7 @@ module ProjectionAssessments
         self.current_effort = effort
         assess_effort
         save_assessment!
+        progress_callback&.call
       end
 
       assessment_run.finished! if errors.empty?

--- a/lib/tasks/projection_assessments.rake
+++ b/lib/tasks/projection_assessments.rake
@@ -22,51 +22,55 @@ namespace :projection_assessments do
     output_path = ENV["OUTPUT"].presence ||
                   Rails.root.join("tmp", "projection_assessments_#{Time.current.strftime('%Y%m%d%H%M%S')}.csv").to_s
 
-    runs = event_slugs.map do |slug|
-      event = ::Event.friendly.find(slug)
-      completed_split = event.splits.find_by(parameterized_base_name: completed_split_name.parameterize) ||
-                        abort("Event #{slug} has no split named #{completed_split_name}")
-      projected_split = event.splits.find_by(parameterized_base_name: projected_split_name.parameterize) ||
-                        abort("Event #{slug} has no split named #{projected_split_name}")
+    ActiveRecord::Base.logger.silence do
+      runs = event_slugs.map do |slug|
+        event = ::Event.friendly.find(slug)
+        completed_split = event.splits.find_by(parameterized_base_name: completed_split_name.parameterize) ||
+                          abort("Event #{slug} has no split named #{completed_split_name}")
+        projected_split = event.splits.find_by(parameterized_base_name: projected_split_name.parameterize) ||
+                          abort("Event #{slug} has no split named #{projected_split_name}")
 
-      run = event.projection_assessment_runs.create!(
-        completed_lap: lap,
-        completed_split: completed_split,
-        completed_bitkey: completed_bitkey,
-        projected_lap: lap,
-        projected_split: projected_split,
-        projected_bitkey: projected_bitkey,
-      )
+        run = event.projection_assessment_runs.create!(
+          completed_lap: lap,
+          completed_split: completed_split,
+          completed_bitkey: completed_bitkey,
+          projected_lap: lap,
+          projected_split: projected_split,
+          projected_bitkey: projected_bitkey,
+        )
 
-      puts "Assessing #{slug}: #{completed_split.base_name} #{SubSplit.kind(completed_bitkey)} -> " \
-           "#{projected_split.base_name} #{SubSplit.kind(projected_bitkey)} (#{event.efforts.count} efforts)"
-      ::ProjectionAssessments::Runner.perform!(run)
-      puts "  #{run.status}: #{run.success_count.to_i} succeeded, #{run.failure_count.to_i} failed " \
-           "in #{run.elapsed_time.to_i} seconds"
-      warn "  errors: #{run.parsed_errors.join('; ')}" if run.failed?
-      run
-    end
-
-    rows = runs.flat_map do |run|
-      event = run.event
-      time_zone = event.home_time_zone
-      year = event.scheduled_start_time.in_time_zone(time_zone).year
-
-      run.assessments.includes(:effort).reject { |assessment| assessment.projected_early.blank? }.map do |assessment|
-        [
-          assessment.effort.full_name,
-          year,
-          assessment.projected_early.in_time_zone(time_zone).strftime("%Y-%m-%d %H:%M:%S"),
-          assessment.actual&.in_time_zone(time_zone)&.strftime("%Y-%m-%d %H:%M:%S"),
-        ]
+        efforts_count = event.efforts.count
+        puts "Assessing #{slug}: #{completed_split.base_name} #{SubSplit.kind(completed_bitkey)} -> " \
+             "#{projected_split.base_name} #{SubSplit.kind(projected_bitkey)} (#{efforts_count} efforts)"
+        progress_bar = ::ProgressBar.new(efforts_count)
+        ::ProjectionAssessments::Runner.perform!(run) { progress_bar.increment! }
+        puts "  #{run.status}: #{run.success_count.to_i} succeeded, #{run.failure_count.to_i} failed " \
+             "in #{run.elapsed_time.to_i} seconds"
+        warn "  errors: #{run.parsed_errors.join('; ')}" if run.failed?
+        run
       end
-    end
 
-    CSV.open(output_path, "w") do |csv|
-      csv << ["Runner name", "Race year", "Earliest predicted arrival", "Actual arrival"]
-      rows.sort_by { |row| [row[1], row[0]] }.each { |row| csv << row }
-    end
+      rows = runs.flat_map do |run|
+        event = run.event
+        time_zone = event.home_time_zone
+        year = event.scheduled_start_time.in_time_zone(time_zone).year
 
-    puts "Wrote #{rows.size} rows to #{output_path}"
+        run.assessments.includes(:effort).reject { |assessment| assessment.projected_early.blank? }.map do |assessment|
+          [
+            assessment.effort.full_name,
+            year,
+            assessment.projected_early.in_time_zone(time_zone).strftime("%Y-%m-%d %H:%M:%S"),
+            assessment.actual&.in_time_zone(time_zone)&.strftime("%Y-%m-%d %H:%M:%S"),
+          ]
+        end
+      end
+
+      CSV.open(output_path, "w") do |csv|
+        csv << ["Runner name", "Race year", "Earliest predicted arrival", "Actual arrival"]
+        rows.sort_by { |row| [row[1], row[0]] }.each { |row| csv << row }
+      end
+
+      puts "Wrote #{rows.size} rows to #{output_path}"
+    end
   end
 end

--- a/lib/tasks/projection_assessments.rake
+++ b/lib/tasks/projection_assessments.rake
@@ -1,0 +1,72 @@
+require "csv"
+
+namespace :projection_assessments do
+  desc "Backtest projections for EVENTS and export results to CSV"
+  task export: :environment do
+    event_slugs = ENV["EVENTS"].to_s.split(",").map(&:strip).reject(&:empty?)
+    completed_split_name = ENV.fetch("COMPLETED_SPLIT", nil)
+    projected_split_name = ENV.fetch("PROJECTED_SPLIT", nil)
+
+    if event_slugs.empty? || completed_split_name.blank? || projected_split_name.blank?
+      abort(<<~USAGE)
+        Usage:
+          EVENTS=<slug>[,<slug>...] COMPLETED_SPLIT=<base name> PROJECTED_SPLIT=<base name> \\
+          [COMPLETED_SUB_SPLIT=out] [PROJECTED_SUB_SPLIT=in] [LAP=1] [OUTPUT=<path>] \\
+          bin/rails projection_assessments:export
+      USAGE
+    end
+
+    completed_bitkey = SubSplit.bitkey(ENV.fetch("COMPLETED_SUB_SPLIT", "out")) || abort("Invalid COMPLETED_SUB_SPLIT")
+    projected_bitkey = SubSplit.bitkey(ENV.fetch("PROJECTED_SUB_SPLIT", "in")) || abort("Invalid PROJECTED_SUB_SPLIT")
+    lap = ENV.fetch("LAP", "1").to_i
+    output_path = ENV["OUTPUT"].presence ||
+                  Rails.root.join("tmp", "projection_assessments_#{Time.current.strftime('%Y%m%d%H%M%S')}.csv").to_s
+
+    runs = event_slugs.map do |slug|
+      event = ::Event.friendly.find(slug)
+      completed_split = event.splits.find_by(parameterized_base_name: completed_split_name.parameterize) ||
+                        abort("Event #{slug} has no split named #{completed_split_name}")
+      projected_split = event.splits.find_by(parameterized_base_name: projected_split_name.parameterize) ||
+                        abort("Event #{slug} has no split named #{projected_split_name}")
+
+      run = event.projection_assessment_runs.create!(
+        completed_lap: lap,
+        completed_split: completed_split,
+        completed_bitkey: completed_bitkey,
+        projected_lap: lap,
+        projected_split: projected_split,
+        projected_bitkey: projected_bitkey,
+      )
+
+      puts "Assessing #{slug}: #{completed_split.base_name} #{SubSplit.kind(completed_bitkey)} -> " \
+           "#{projected_split.base_name} #{SubSplit.kind(projected_bitkey)} (#{event.efforts.count} efforts)"
+      ::ProjectionAssessments::Runner.perform!(run)
+      puts "  #{run.status}: #{run.success_count.to_i} succeeded, #{run.failure_count.to_i} failed " \
+           "in #{run.elapsed_time.to_i} seconds"
+      warn "  errors: #{run.parsed_errors.join('; ')}" if run.failed?
+      run
+    end
+
+    rows = runs.flat_map do |run|
+      event = run.event
+      time_zone = event.home_time_zone
+      year = event.scheduled_start_time.in_time_zone(time_zone).year
+
+      run.assessments.includes(:effort).reject { |assessment| assessment.projected_early.blank? }.map do |assessment|
+        [
+          assessment.effort.full_name,
+          year,
+          assessment.projected_early.in_time_zone(time_zone).strftime("%Y-%m-%d %H:%M:%S"),
+          assessment.actual&.in_time_zone(time_zone)&.strftime("%Y-%m-%d %H:%M:%S"),
+        ]
+      end
+    end
+
+    CSV.open(output_path, "w") do |csv|
+      csv << ["Runner name", "Race year", "Earliest predicted arrival", "Actual arrival"]
+      rows.sort_by { |row| [row[1], row[0]] }.each { |row| csv << row }
+    end
+
+    puts "Wrote #{rows.size} rows to #{output_path}"
+  end
+end

--- a/spec/lib/projection_assessments/runner_spec.rb
+++ b/spec/lib/projection_assessments/runner_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe ProjectionAssessments::Runner do
       expect(assessment_run.assessments.count).to eq(event.efforts.count)
     end
 
+    context "when given a progress block" do
+      subject { described_class.new(assessment_run) { progress_calls << 1 } }
+
+      let(:progress_calls) { [] }
+
+      it "calls the block once per effort" do
+        expect(progress_calls.size).to eq(event.efforts.count)
+      end
+    end
+
     context "when the effort has completed and projected split_times" do
       let(:effort) { efforts(:hardrock_2016_lavon_paucek) }
 

--- a/spec/lib/tasks/projection_assessments/export_spec.rb
+++ b/spec/lib/tasks/projection_assessments/export_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+require "rake"
+require "tempfile"
+
+RSpec.describe "projection_assessments:export", type: :task do
+  let(:task_name) { "projection_assessments:export" }
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.none? { |t| t.name == task_name }
+    Rake::Task[task_name].reenable
+  end
+
+  # The task interface is ENV-driven, so the spec must write ENV to exercise it.
+  # rubocop:disable Rails/EnvironmentVariableAccess
+  def with_env(values)
+    values.each { |key, value| ENV[key] = value }
+    yield
+  ensure
+    values.each_key { |key| ENV.delete(key) }
+  end
+  # rubocop:enable Rails/EnvironmentVariableAccess
+
+  def silent_invoke
+    suppress_output { Rake::Task[task_name].invoke }
+  end
+
+  def suppress_output
+    original_stdout = $stdout
+    original_stderr = $stderr
+    $stdout = StringIO.new
+    $stderr = StringIO.new
+    yield
+  ensure
+    $stdout = original_stdout
+    $stderr = original_stderr
+  end
+
+  context "with valid arguments" do
+    it "runs an assessment and writes a CSV of predictions and actuals" do
+      Tempfile.open(["assessments", ".csv"]) do |file|
+        env = {
+          "EVENTS" => events(:hardrock_2016).slug,
+          "COMPLETED_SPLIT" => "Telluride",
+          "PROJECTED_SPLIT" => "Grouse",
+          "OUTPUT" => file.path,
+        }
+
+        with_env(env) do
+          expect { silent_invoke }.to change(ProjectionAssessmentRun, :count).by(1)
+        end
+
+        run = ProjectionAssessmentRun.last
+        expect(run.event).to eq(events(:hardrock_2016))
+        expect(run.completed_split).to eq(splits(:hardrock_cw_telluride))
+        expect(run.completed_bitkey).to eq(SubSplit::OUT_BITKEY)
+        expect(run.projected_split).to eq(splits(:hardrock_cw_grouse))
+        expect(run.projected_bitkey).to eq(SubSplit::IN_BITKEY)
+        expect(run).to be_finished
+
+        table = CSV.read(file.path, headers: true)
+        expect(table.headers).to eq(["Runner name", "Race year", "Earliest predicted arrival", "Actual arrival"])
+
+        # Expected values match the assessments verified in projection_assessments/runner_spec.rb
+        completed_and_projected = table.find { |row| row["Runner name"] == efforts(:hardrock_2016_lavon_paucek).full_name }
+        expect(completed_and_projected["Race year"]).to eq("2016")
+        expect(completed_and_projected["Earliest predicted arrival"]).to eq("2016-07-15 19:29:48")
+        expect(completed_and_projected["Actual arrival"]).to eq("2016-07-15 20:36:00")
+
+        completed_only = table.find { |row| row["Runner name"] == efforts(:hardrock_2016_rhett_auer).full_name }
+        expect(completed_only["Earliest predicted arrival"]).to be_present
+        expect(completed_only["Actual arrival"]).to be_nil
+
+        no_prediction = table.find { |row| row["Runner name"] == efforts(:hardrock_2016_start_only).full_name }
+        expect(no_prediction).to be_nil
+      end
+    end
+  end
+
+  context "with missing arguments" do
+    it "aborts with usage instructions" do
+      expect { silent_invoke }.to raise_error(SystemExit)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A CLI front end for the dormant `ProjectionAssessments::Runner` backend (built in #1198, never given UI): creates and runs an assessment for each given event, then exports one CSV of per-runner **earliest predicted** vs **actual** arrival times. Immediate purpose: backtesting prediction accuracy on High Lonesome 2018+ so a race director can calibrate the crew-release buffer for the Aid Station Gating feature (#2118). Depends on the event-lookback fix (#2124, merged) for honest old-year backtests.

### Usage

```
EVENTS=2018-high-lonesome-100,2019-high-lonesome-100,... \
COMPLETED_SPLIT="Tin Cup" PROJECTED_SPLIT="Hancock" \
OUTPUT=tmp/hilo_assessments.csv \
bin/rails projection_assessments:export
```

- `COMPLETED_SUB_SPLIT` (default `out`) and `PROJECTED_SUB_SPLIT` (default `in`) — defaults match gate semantics (anchored when the runner leaves the gating station, predicting arrival at the target)
- `LAP` (default 1); `OUTPUT` defaults to a timestamped file in `tmp/`
- Splits are looked up per event by parameterized base name, so one invocation covers years with differing split ids
- CSV columns: Runner name, Race year, Earliest predicted arrival, Actual arrival (blank for runners who never reached the target); times in the event's home time zone; rows without a prediction (runner never reached the anchor) are omitted

### Verification

- Task spec (`type: :task`, following the `maintenance:import_monetary_donations` pattern) asserts run attributes and exact CSV values cross-checked against `projection_assessments/runner_spec.rb`
- Smoke-tested end to end against the dev database (hardrock-2016, Telluride Out → Grouse In): 19 efforts assessed, 17 rows written, times localized

Relates to #2118

🤖 Generated with [Claude Code](https://claude.com/claude-code)