### PR TITLE
Handle empty projection results in ProjectionAssessments::Runner

### DIFF
--- a/lib/projection_assessments/runner.rb
+++ b/lib/projection_assessments/runner.rb
@@ -81,11 +81,13 @@ module ProjectionAssessments
         ignore_times_beyond: completed_absolute_time,
       ).first
 
+      current_assessment.assign_attributes(actual: projected_absolute_time)
+      return unless projection
+
       current_assessment.assign_attributes(
         projected_early: completed_absolute_time + projection.low_seconds,
         projected_best: completed_absolute_time + projection.average_seconds,
         projected_late: completed_absolute_time + projection.high_seconds,
-        actual: projected_absolute_time,
       )
     end
 

--- a/spec/lib/projection_assessments/runner_spec.rb
+++ b/spec/lib/projection_assessments/runner_spec.rb
@@ -68,4 +68,21 @@ RSpec.describe ProjectionAssessments::Runner do
       end
     end
   end
+
+  describe "#perform! when the projection query returns no results" do
+    let(:effort) { efforts(:hardrock_2016_lavon_paucek) }
+
+    before { allow(Projection).to receive(:execute_query).and_return([]) }
+
+    it "records the actual time without projections and finishes the run" do
+      subject.perform!
+
+      assessment = assessment_run.assessments.find_by(effort_id: effort.id)
+      expect(assessment.projected_early).to be_nil
+      expect(assessment.projected_best).to be_nil
+      expect(assessment.projected_late).to be_nil
+      expect(assessment.actual).to eq("2016-07-15 20:36:00 -0600")
+      expect(assessment_run.reload).to be_finished
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Running the High Lonesome backtest in production crashed partway through the 2019 event:

```
NoMethodError: undefined method 'low_seconds' for nil
lib/projection_assessments/runner.rb:85:in 'assess_effort'
```

`Projection.execute_query(...).first` is nil whenever the query finds no usable historical sample — entirely possible for thin-history backtests or when the ±30% similarity filter excludes everyone. The 2019 High Lonesome is the extreme case: neither 2017 nor 2018 had a Tin Cup aid station, so 2019 predictions can draw only on same-race front-runners, and the first runners through Tin Cup have no sample at all. This is a latent bug from the original 2024 runner; it never surfaced because the one historical run (2023, Antero → Cottonwood) always found samples.

The runner now records the assessment with `actual` populated and all three projections nil — consistent with the existing no-completed-split-time behavior — and the run finishes instead of aborting. The export task already omits rows without predictions, so no change needed there.

New spec stubs an empty projection result and asserts the nil-projection assessment plus a finished run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)