### PR TITLE
Include prediction-less rows with actual times in assessment export

### DIFF
--- a/lib/tasks/projection_assessments.rake
+++ b/lib/tasks/projection_assessments.rake
@@ -55,11 +55,11 @@ namespace :projection_assessments do
         time_zone = event.home_time_zone
         year = event.scheduled_start_time.in_time_zone(time_zone).year
 
-        run.assessments.includes(:effort).reject { |assessment| assessment.projected_early.blank? }.map do |assessment|
+        run.assessments.includes(:effort).reject { |a| a.projected_early.blank? && a.actual.blank? }.map do |assessment|
           [
             assessment.effort.full_name,
             year,
-            assessment.projected_early.in_time_zone(time_zone).strftime("%Y-%m-%d %H:%M:%S"),
+            assessment.projected_early&.in_time_zone(time_zone)&.strftime("%Y-%m-%d %H:%M:%S"),
             assessment.actual&.in_time_zone(time_zone)&.strftime("%Y-%m-%d %H:%M:%S"),
           ]
         end

--- a/spec/lib/tasks/projection_assessments/export_spec.rb
+++ b/spec/lib/tasks/projection_assessments/export_spec.rb
@@ -76,6 +76,31 @@ RSpec.describe "projection_assessments:export", type: :task do
     end
   end
 
+  context "when no projections are available" do
+    it "includes rows with actual times and blank predictions" do
+      Tempfile.open(["assessments", ".csv"]) do |file|
+        env = {
+          "EVENTS" => events(:hardrock_2016).slug,
+          "COMPLETED_SPLIT" => "Telluride",
+          "PROJECTED_SPLIT" => "Grouse",
+          "OUTPUT" => file.path,
+        }
+
+        allow(Projection).to receive(:execute_query).and_return([])
+        with_env(env) { silent_invoke }
+
+        table = CSV.read(file.path, headers: true)
+
+        no_prediction = table.find { |row| row["Runner name"] == efforts(:hardrock_2016_lavon_paucek).full_name }
+        expect(no_prediction["Earliest predicted arrival"]).to be_nil
+        expect(no_prediction["Actual arrival"]).to eq("2016-07-15 20:36:00")
+
+        no_anchor = table.find { |row| row["Runner name"] == efforts(:hardrock_2016_start_only).full_name }
+        expect(no_anchor).to be_nil
+      end
+    end
+  end
+
   context "with missing arguments" do
     it "aborts with usage instructions" do
       expect { silent_invoke }.to raise_error(SystemExit)


### PR DESCRIPTION
## Summary

The High Lonesome backtest CSV silently omitted every runner who completed Tin Cup → Hancock but had no prediction available.

Rows now appear whenever the runner has an actual arrival **or** a prediction, with blanks where no prediction existed:

- More auditable: the file is a complete roster of everyone who ran the segment
- Prediction coverage becomes visible — an operationally relevant fact for gate officials, since the live gating view will face the same no-prediction runners

Rows with neither value remain excluded. Known residual gap (noted, acceptable for now): a runner who reached the anchor, got no prediction, and dropped before the target produces an all-blank assessment indistinguishable from never reaching the anchor, so they're still omitted; closing that would require storing the anchor time on the assessment.

The "one-line change" turned out to be two — the new spec (stubbed empty projections) caught that the row builder also assumed `projected_early` was always present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)