### PR TITLE
Fix Live Raw Times page intermittently showing UTC instead of localized time

### DIFF
--- a/app/models/concerns/time_recordable.rb
+++ b/app/models/concerns/time_recordable.rb
@@ -44,7 +44,7 @@ module TimeRecordable
     if absolute_time && zone
       TimeConversion.absolute_to_hms(absolute_time.in_time_zone(zone))
     else
-      TimeConversion.user_entered_to_military(entered_time)
+      TimeConversion.user_entered_to_military(entered_time, zone)
     end
   end
 end

--- a/lib/time_conversion.rb
+++ b/lib/time_conversion.rb
@@ -52,9 +52,11 @@ class TimeConversion
   # Converts attempted military times like "12:45:ss" to real military times i.e. "12:45:00".
   # Pads with `0` where needed, i.e. "5:33" => 05:33:00.
   # Also converts timestamps like "2022-07-15 15:45:00-0600" to military times i.e. "15:45:00".
+  # When a zone is given, timestamps are localized to that zone before formatting, so a UTC
+  # timestamp such as "2014-07-11T10:45:00Z" renders as local military time rather than UTC.
   #
   # Returns nil when the argument does not match any valid pattern.
-  def self.user_entered_to_military(time_string)
+  def self.user_entered_to_military(time_string, zone = nil)
     return if time_string.blank? || time_string.length < 3
 
     subbed_string = time_string.gsub(/[a-zA-Z]/, "0")
@@ -68,7 +70,10 @@ class TimeConversion
     return if invalid_military?(new_string)
 
     datetime = time_string.to_datetime
-    absolute_to_hms(datetime) if datetime.present?
+    return if datetime.blank?
+
+    datetime = datetime.in_time_zone(zone) if zone
+    absolute_to_hms(datetime)
   rescue Date::Error
     nil
   end

--- a/spec/lib/time_conversion_spec.rb
+++ b/spec/lib/time_conversion_spec.rb
@@ -137,6 +137,22 @@ RSpec.describe TimeConversion do
       it { expect(result).to eq("06:34:12") }
     end
 
+    context "when provided as a UTC timestamp and a zone argument is given" do
+      let(:result) { described_class.user_entered_to_military(time_string, "Mountain Time (US & Canada)") }
+      let(:time_string) { "2014-07-11T10:45:00Z" }
+      it "localizes the timestamp to the given zone" do
+        expect(result).to eq("04:45:00")
+      end
+    end
+
+    context "when provided in hh:mm:ss format and a zone argument is given" do
+      let(:result) { described_class.user_entered_to_military(time_string, "Mountain Time (US & Canada)") }
+      let(:time_string) { "12:30:45" }
+      it "leaves the already-local military time untouched" do
+        expect(result).to eq("12:30:45")
+      end
+    end
+
     context "when provided in hh:mm:ss format" do
       let(:time_string) { "12:30:45" }
       it { expect(result).to eq("12:30:45") }

--- a/spec/models/raw_time_spec.rb
+++ b/spec/models/raw_time_spec.rb
@@ -133,6 +133,15 @@ RSpec.describe RawTime, type: :model do
       let(:entered_time) { "2025-16-08 05:01:55.61" } # Day and month are switched
       it { expect(subject).to be_nil }
     end
+
+    context "when absolute_time is not present and entered_time is a UTC timestamp" do
+      let(:entered_time) { "2014-07-11T10:45:00Z" }
+      let(:time_zone) { "Mountain Time (US & Canada)" }
+
+      it "returns the time localized to the zone rather than UTC" do
+        expect(subject).to eq("04:45:00")
+      end
+    end
   end
 
   describe "#data_status" do


### PR DESCRIPTION
## Problem

Fixes #2131. On the Live Raw Times page, incoming times intermittently (~50%) displayed in UTC instead of the event's home time zone. Opening a runner's audit page showed the correct localized time.

## Root cause

Live raw times (e.g. from the RaceResult webhook, `process_raceresult_webhook.rb`) are saved with `entered_time` set to a **UTC timestamp string** and `absolute_time` computed **asynchronously afterward** by `ProcessImportedRawTimesJob`.

While `absolute_time` is still `nil`, `RawTime#military_time` falls back to `TimeConversion.user_entered_to_military`, which parsed the timestamp and rendered its **raw offset (UTC)** instead of the home time zone.

The `after_create_commit` broadcast that renders the new row races with the async job that sets `absolute_time` (and the create-prepend vs update-replace broadcasts can arrive out of order), so the page intermittently showed — and sometimes got stuck on — UTC clock times until a full reload. The audit page always reads `absolute_time` (set by then), so it was always correct.

## Fix

Thread the display zone through `TimeConversion.user_entered_to_military` so a parseable timestamp is localized to the home time zone before formatting. Already-local military strings (e.g. `"14:02"`) short-circuit earlier and are unchanged. The optional `zone` argument keeps all existing callers backward compatible.

This corrects the display at every stage regardless of broadcast timing, so the existing async processing pipeline is left untouched.

## Tests

Added (written test-first, confirmed failing before the fix):
- `TimeConversion.user_entered_to_military` localizes a UTC timestamp when given a zone, and leaves a local military string untouched.
- `RawTime#military_time` returns localized time (not UTC) when `absolute_time` is nil and `entered_time` is a UTC timestamp.

All related model/service/conversion/webhook specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)