### PR TITLE
Wire default_travel_buffer into gating location setup CRUD

### DIFF
--- a/app/controllers/event_groups/gating_locations_controller.rb
+++ b/app/controllers/event_groups/gating_locations_controller.rb
@@ -68,7 +68,7 @@ module EventGroups
       attrs = params.expect(
         gating_location: [:name,
                           { gating_location_events_attributes: [[:id, :event_id, :gating_aid_station_id,
-                                                                 :target_aid_station_id]] }],
+                                                                 :target_aid_station_id, :default_travel_buffer]] }],
       ).to_h
 
       attrs["gating_location_events_attributes"]&.each_value do |gle_attrs|

--- a/app/models/gating_location_event.rb
+++ b/app/models/gating_location_event.rb
@@ -6,6 +6,8 @@ class GatingLocationEvent < ApplicationRecord
 
   validates :event_id, uniqueness: { scope: :gating_location_id,
                                      message: "only one configuration permitted per event within a gating location" }
+  validates :default_travel_buffer,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 1200 }
   validate :aid_stations_belong_to_event
   validate :event_belongs_to_event_group
   validate :gating_precedes_target

--- a/app/views/event_groups/gating_locations/_form.html.erb
+++ b/app/views/event_groups/gating_locations/_form.html.erb
@@ -31,6 +31,10 @@
               <%= gle_fields.label :target_aid_station_id, "Target aid station", class: "mb-1" %>
               <%= gle_fields.select :target_aid_station_id, aid_station_options, { include_blank: "Not gated" }, { class: "form-select" } %>
             </div>
+            <div class="mb-3">
+              <%= gle_fields.label :default_travel_buffer, "Default travel buffer (minutes)", class: "mb-1" %>
+              <%= gle_fields.number_field :default_travel_buffer, min: 0, max: 1200, class: "form-control" %>
+            </div>
           </div>
         </div>
       <% end %>

--- a/app/views/event_groups/gating_locations/_gating_location.html.erb
+++ b/app/views/event_groups/gating_locations/_gating_location.html.erb
@@ -1,8 +1,26 @@
 <%# locals: (gating_location:, presenter:) -%>
 
-<tr id="<%= dom_id(gating_location) %>" class="align-middle">
-  <td><%= gating_location.name %></td>
-  <td>
+<div id="<%= dom_id(gating_location) %>" class="card bg-light mt-2">
+  <div class="card-header">
+    <div class="row align-items-center">
+      <div class="col">
+        <h5 class="fw-bold mb-0"><%= gating_location.name %></h5>
+      </div>
+      <div class="col-auto">
+        <%= button_tag fa_icon("ellipsis-h"),
+                       class: "dropdown-toggle no-caret btn btn-sm btn-light",
+                       data: { bs_toggle: "dropdown" } %>
+        <div class="dropdown-menu dropdown-menu-end" style="min-width:inherit">
+          <%= link_to "Edit", [:edit, presenter.organization, presenter.event_group, gating_location],
+                      class: "dropdown-item" %>
+          <%= link_to "Delete", [presenter.organization, presenter.event_group, gating_location],
+                      class: "dropdown-item",
+                      data: { turbo_method: :delete, turbo_confirm: "This will delete the gating location and its configuration for all events. Proceed?" } %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="card-body">
     <% gating_location.gating_location_events.sort_by { |gle| gle.event.guaranteed_short_name }.each do |gle| %>
       <div>
         <strong><%= gle.event.guaranteed_short_name %>:</strong>
@@ -10,17 +28,5 @@
         <span class="text-body-secondary">(<%= gle.default_travel_buffer %> min buffer)</span>
       </div>
     <% end %>
-  </td>
-  <td class="text-center">
-    <%= button_tag fa_icon("ellipsis-h"),
-                   class: "dropdown-toggle no-caret btn btn-sm btn-light",
-                   data: { bs_toggle: "dropdown" } %>
-    <div class="dropdown-menu dropdown-menu-end" style="min-width:inherit">
-      <%= link_to "Edit", [:edit, presenter.organization, presenter.event_group, gating_location],
-                  class: "dropdown-item" %>
-      <%= link_to "Delete", [presenter.organization, presenter.event_group, gating_location],
-                  class: "dropdown-item",
-                  data: { turbo_method: :delete, turbo_confirm: "This will delete the gating location and its configuration for all events. Proceed?" } %>
-    </div>
-  </td>
-</tr>
+  </div>
+</div>

--- a/app/views/event_groups/gating_locations/_gating_location.html.erb
+++ b/app/views/event_groups/gating_locations/_gating_location.html.erb
@@ -7,6 +7,7 @@
       <div>
         <strong><%= gle.event.guaranteed_short_name %>:</strong>
         <%= gle.gating_split.base_name %> &rarr; <%= gle.target_split.base_name %>
+        <span class="text-body-secondary">(<%= gle.default_travel_buffer %> min buffer)</span>
       </div>
     <% end %>
   </td>

--- a/app/views/event_groups/gating_locations/index.html.erb
+++ b/app/views/event_groups/gating_locations/index.html.erb
@@ -22,20 +22,11 @@
       </aside>
 
       <% if @presenter.event_group.gating_locations.exists? %>
-        <table class="table table-striped">
-          <thead>
-          <tr>
-            <th>Name</th>
-            <th>Gated Events</th>
-            <th class="text-center">Actions</th>
-          </tr>
-          </thead>
-          <tbody>
+        <div id="gating_locations">
           <%= render partial: "event_groups/gating_locations/gating_location",
                      collection: @presenter.event_group.gating_locations.includes(gating_location_events: [:event, { gating_aid_station: :split, target_aid_station: :split }]),
                      locals: { presenter: @presenter } %>
-          </tbody>
-        </table>
+        </div>
       <% else %>
         <br>
         <div class="callout callout-info">

--- a/spec/fixtures/gating_location_events.yml
+++ b/spec/fixtures/gating_location_events.yml
@@ -4,6 +4,7 @@ sum_bandera_gate_100k:
   event: sum_100k
   gating_aid_station: aid_station_0021
   target_aid_station: aid_station_0020
+  default_travel_buffer: 45
 sum_bandera_gate_55k:
   gating_location: sum_bandera_gate
   event: sum_55k

--- a/spec/models/gating_location_event_spec.rb
+++ b/spec/models/gating_location_event_spec.rb
@@ -82,6 +82,38 @@ RSpec.describe GatingLocationEvent, type: :model do
           .to include("must be farther along the course than the gating aid station")
       end
     end
+
+    describe "default_travel_buffer" do
+      it "defaults to 30" do
+        expect(gating_location_event.default_travel_buffer).to eq(30)
+      end
+
+      it "is valid at the bounds" do
+        gating_location_event.default_travel_buffer = 0
+        expect(gating_location_event).to be_valid
+
+        gating_location_event.default_travel_buffer = 1200
+        expect(gating_location_event).to be_valid
+      end
+
+      it "is invalid below 0" do
+        gating_location_event.default_travel_buffer = -1
+        expect(gating_location_event).not_to be_valid
+        expect(gating_location_event.errors[:default_travel_buffer]).to be_present
+      end
+
+      it "is invalid above 1200" do
+        gating_location_event.default_travel_buffer = 1201
+        expect(gating_location_event).not_to be_valid
+        expect(gating_location_event.errors[:default_travel_buffer]).to be_present
+      end
+
+      it "is invalid when non-integer" do
+        gating_location_event.default_travel_buffer = 15.5
+        expect(gating_location_event).not_to be_valid
+        expect(gating_location_event.errors[:default_travel_buffer]).to be_present
+      end
+    end
   end
 
   describe "fixtures" do

--- a/spec/requests/event_groups/gating_locations_spec.rb
+++ b/spec/requests/event_groups/gating_locations_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe "EventGroups::GatingLocations" do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Bandera Gate")
+        expect(response.body).to include("45 min buffer")
       end
     end
 

--- a/spec/requests/event_groups/gating_locations_spec.rb
+++ b/spec/requests/event_groups/gating_locations_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe "EventGroups::GatingLocations" do
                 event_id: events(:sum_100k).id,
                 gating_aid_station_id: aid_stations(:aid_station_0017).id,
                 target_aid_station_id: aid_stations(:aid_station_0019).id,
+                default_travel_buffer: 45,
               },
               "1" => {
                 event_id: events(:sum_55k).id,
@@ -118,6 +119,29 @@ RSpec.describe "EventGroups::GatingLocations" do
 
           gating_location = GatingLocation.find_by(name: "Engineer Gate")
           expect(gating_location.events).to contain_exactly(events(:sum_100k))
+          expect(gating_location.gating_location_events.first.default_travel_buffer).to eq(45)
+        end
+      end
+
+      context "with a travel buffer out of range" do
+        let(:params) do
+          {
+            name: "Engineer Gate",
+            gating_location_events_attributes: {
+              "0" => {
+                event_id: events(:sum_100k).id,
+                gating_aid_station_id: aid_stations(:aid_station_0017).id,
+                target_aid_station_id: aid_stations(:aid_station_0019).id,
+                default_travel_buffer: 1201,
+              },
+            },
+          }
+        end
+
+        it "does not create a gating location and renders an error" do
+          expect { make_request }.not_to change(GatingLocation, :count)
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include("must be less than or equal to 1200")
         end
       end
 


### PR DESCRIPTION
Step 2 of the gating-buffer roadmap (after #2139 added the column). Exposes the persisted per-event travel buffer in the steward/owner setup UI.

## Changes

- **Setup form** (`_form.html.erb`): a "Default travel buffer (minutes)" number field per gated event, alongside the gating/target aid-station selects. `min: 0, max: 1200`.
- **Strong params**: permit `default_travel_buffer` in `gating_location_events_attributes`.
- **Model validation**: `default_travel_buffer` numericality, integer, **0–1200** (raised from the originally-planned 0–120 for flexibility on long events — up to 20 hours).

## Specs

- Model: defaults to 30, valid at bounds (0 / 1200), invalid below 0 / above 1200 / non-integer.
- Request: create persists the submitted buffer; an out-of-range buffer (1201) is rejected with `422` and the error message.
- `bundle exec rspec spec/models/gating_location_event_spec.rb spec/requests/event_groups/gating_locations_spec.rb` → 29 examples, 0 failures. Rubocop + erb_lint clean.

## Roadmap

1. ✅ Migration: `default_travel_buffer` column (#2139)
2. **(this PR)** Wire into setup CRUD + validation
3. Private steward Live list view — seeds buffer from the default, official can override
4. Public per-effort Crew Access view (read-only, fixed buffer)

Part of #2118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)