### PR TITLE
Fix projection backtest crash on single-effort projections

### DIFF
--- a/lib/projection_assessments/runner.rb
+++ b/lib/projection_assessments/runner.rb
@@ -84,10 +84,12 @@ module ProjectionAssessments
       current_assessment.assign_attributes(actual: projected_absolute_time)
       return unless projection
 
+      # low/high_seconds are nil when only one historical effort matched (Postgres
+      # stddev of a single row is NULL), so guard each before adding to a Time.
       current_assessment.assign_attributes(
-        projected_early: completed_absolute_time + projection.low_seconds,
-        projected_best: completed_absolute_time + projection.average_seconds,
-        projected_late: completed_absolute_time + projection.high_seconds,
+        projected_early: projection.low_seconds && (completed_absolute_time + projection.low_seconds),
+        projected_best: projection.average_seconds && (completed_absolute_time + projection.average_seconds),
+        projected_late: projection.high_seconds && (completed_absolute_time + projection.high_seconds),
       )
     end
 

--- a/spec/lib/projection_assessments/runner_spec.rb
+++ b/spec/lib/projection_assessments/runner_spec.rb
@@ -85,4 +85,27 @@ RSpec.describe ProjectionAssessments::Runner do
       expect(assessment_run.reload).to be_finished
     end
   end
+
+  describe "#perform! when the projection has nil low/high seconds" do
+    let(:effort) { efforts(:hardrock_2016_lavon_paucek) }
+
+    # Postgres stddev of a single matching historical effort is NULL, so the
+    # projection comes back with an average but no low/high seconds.
+    before do
+      allow(Projection).to receive(:execute_query).and_return(
+        [Projection.new(low_seconds: nil, average_seconds: 3600, high_seconds: nil)]
+      )
+    end
+
+    it "records the average projection and the actual time without crashing" do
+      subject.perform!
+
+      assessment = assessment_run.assessments.find_by(effort_id: effort.id)
+      expect(assessment.projected_early).to be_nil
+      expect(assessment.projected_best).to be_present
+      expect(assessment.projected_late).to be_nil
+      expect(assessment.actual).to eq("2016-07-15 20:36:00 -0600")
+      expect(assessment_run.reload).to be_finished
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`projection_assessments:export` aborted partway through assessing 2019 High Lonesome 100:

```
TypeError: can't convert NilClass into an exact number
  lib/projection_assessments/runner.rb:88:in 'assess_effort'
```

When a projected split has only **one** matching historical effort, Postgres `stddev()` of a single row returns `NULL`. `Projection` then yields a row with a valid `average_seconds` but `nil` `low_seconds`/`high_seconds`, and the runner did `completed_absolute_time + nil`. The existing `return unless projection` guard only handled a *missing* projection, not one with nil percentile bounds. Sparse early race years hit this immediately.

## Fix

Guard each `projected_*` assignment so a nil bound becomes a nil column instead of a crash. `projected_best` (the average) is still recorded, and `actual` is unaffected, so the backtest completes and the run finishes normally.

## Tests

Added a runner spec covering the single-effort case (average present, low/high nil). All `runner_spec` examples pass; rubocop clean on touched files.