### PR TITLE
Add simulate:in_progress rake task for in-progress test data

### DIFF
--- a/app/services/random_effort_attributes.rb
+++ b/app/services/random_effort_attributes.rb
@@ -1,0 +1,22 @@
+# Fabricated, anonymized effort identity attributes for test data (random name + demographics).
+# Shared by the create_records and simulate_records rake tasks.
+class RandomEffortAttributes
+  def self.generate
+    new.to_h
+  end
+
+  def to_h
+    gender = %w[male female].sample
+    {
+      first_name: FFaker::Name.send("first_name_#{gender}"),
+      last_name: FFaker::Name.last_name,
+      gender: gender,
+      birthdate: FFaker::Time.between(16.years.ago, 75.years.ago).to_date,
+      country_code: "US",
+      state_code: Carmen::Country.coded("US").subregions.map(&:code).sample,
+      city: FFaker::Address.city,
+      emergency_contact: FFaker::Name.name,
+      emergency_phone: FFaker::PhoneNumber.short_phone_number,
+    }
+  end
+end

--- a/app/services/simulate_in_progress_event_group.rb
+++ b/app/services/simulate_in_progress_event_group.rb
@@ -1,0 +1,111 @@
+# Testing tool: duplicates an event group and populates each event with `count` fabricated-identity
+# runners whose split times are real progressions from a past run, truncated at `cutoff_time` and
+# shifted so that cutoff lands at `current_time` — producing a live, in-progress event group.
+#
+# Unlike DuplicateEventGroup (structure only, current-year-from-past-year), this copies efforts + times.
+class SimulateInProgressEventGroup
+  def self.perform(**)
+    new(**).perform
+  end
+
+  def initialize(source_event_group:, cutoff_time:, count:, current_time: Time.current)
+    @source_event_group = source_event_group
+    @cutoff_time = cutoff_time
+    @count = count
+    @current_time = current_time
+    @simulated_efforts_count = 0
+  end
+
+  attr_reader :new_event_group, :simulated_efforts_count
+
+  def perform
+    ActiveRecord::Base.transaction do
+      build_event_group
+      new_event_group.save!
+      conform_splits
+      populate_efforts
+    end
+    self
+  end
+
+  private
+
+  attr_reader :source_event_group, :cutoff_time, :count, :current_time, :event_pairs
+
+  # Seconds to add to every source time so the cutoff moment maps to now.
+  def offset
+    @offset ||= current_time - cutoff_time
+  end
+
+  def build_event_group
+    @new_event_group = source_event_group.dup
+    new_event_group.assign_attributes(
+      name: "#{source_event_group.name} (Simulated #{current_time.strftime('%Y-%m-%d %H:%M')})",
+      concealed: true,
+      available_live: true,
+      webhook_token: nil,
+    )
+    @event_pairs = source_event_group.events.map do |source_event|
+      new_event = source_event.dup
+      new_event.assign_attributes(
+        scheduled_start_time: source_event.scheduled_start_time + offset,
+        historical_name: nil,
+        beacon_url: nil,
+        efforts_count: 0,
+        topic_resource_key: nil,
+      )
+      new_event_group.events << new_event
+      [source_event, new_event]
+    end
+  end
+
+  # Saving the events attaches all course splits to each, so prune those not in the source event.
+  def conform_splits
+    event_pairs.each do |source_event, new_event|
+      new_event.aid_stations.each do |aid_station|
+        aid_station.destroy unless aid_station.split_id.in?(source_event.split_ids)
+      end
+    end
+  end
+
+  def populate_efforts
+    bib_number = 1
+    event_pairs.each do |source_event, new_event|
+      started_source_efforts(source_event).sample(count).each do |source_effort|
+        create_simulated_effort(new_event, source_effort, bib_number)
+        bib_number += 1
+      end
+    end
+  end
+
+  # Source efforts that had recorded their start on or before the cutoff (i.e. in progress at that moment).
+  def started_source_efforts(source_event)
+    source_event.efforts.includes(split_times: :split).select do |effort|
+      earliest = effort.split_times.map(&:absolute_time).min
+      earliest.present? && earliest <= cutoff_time
+    end
+  end
+
+  def create_simulated_effort(new_event, source_effort, bib_number)
+    attributes = RandomEffortAttributes.generate.merge(bib_number: bib_number)
+    if source_effort.scheduled_start_time
+      attributes[:scheduled_start_time] = source_effort.scheduled_start_time + offset
+    end
+
+    effort = new_event.efforts.new(attributes)
+    source_effort.split_times.select { |split_time| split_time.absolute_time <= cutoff_time }.each do |split_time|
+      effort.split_times.new(
+        split_id: split_time.split_id,
+        lap: split_time.lap,
+        sub_split_bitkey: split_time.sub_split_bitkey,
+        absolute_time: split_time.absolute_time + offset,
+        stopped_here: split_time.stopped_here,
+        pacer: split_time.pacer,
+      )
+    end
+
+    effort.save!
+    Results::SetEffortPerformanceData.perform!(effort.id)
+    @simulated_efforts_count += 1
+  end
+end

--- a/app/services/simulate_in_progress_event_group.rb
+++ b/app/services/simulate_in_progress_event_group.rb
@@ -1,9 +1,8 @@
-# Testing tool: duplicates an event group and stages it as an in-progress race. The duplicate's
-# group start is placed at `start_time`, and each event is populated with `count` runners frozen at
-# their position `elapsed_seconds` into the race — fabricated identities but real split-time
-# progressions from a past run, truncated at the elapsed cutoff and shifted onto the new start.
-#
-# Unlike DuplicateEventGroup (structure only, current-year-from-past-year), this copies efforts + times.
+# Testing tool: duplicates an event group and stages it as an in-progress race. Reuses
+# DuplicateEventGroup for the structure copy, then shifts the duplicate's group start to
+# `start_time` and populates each event with `count` runners frozen at their position
+# `elapsed_seconds` into the race — fabricated identities but real split-time progressions from a
+# past run, truncated at the elapsed cutoff and shifted onto the new start.
 class SimulateInProgressEventGroup
   def self.perform(**)
     new(**).perform
@@ -22,8 +21,6 @@ class SimulateInProgressEventGroup
   def perform
     ActiveRecord::Base.transaction do
       build_event_group
-      new_event_group.save!
-      conform_splits
       populate_efforts
     end
     self
@@ -31,7 +28,7 @@ class SimulateInProgressEventGroup
 
   private
 
-  attr_reader :source_event_group, :start_time, :elapsed_seconds, :count, :event_pairs
+  attr_reader :source_event_group, :start_time, :elapsed_seconds, :count
 
   # Seconds to add to every source time so the source group's start lands at the requested start_time.
   def offset
@@ -43,35 +40,20 @@ class SimulateInProgressEventGroup
     @source_cutoff ||= source_event_group.scheduled_start_time + elapsed_seconds
   end
 
+  # Reuse DuplicateEventGroup for the structure copy (group + events + conformed splits), then place the
+  # duplicate's start exactly at start_time (DuplicateEventGroup only offsets by whole days) and enable live.
   def build_event_group
-    @new_event_group = source_event_group.dup
-    new_event_group.assign_attributes(
-      name: "#{source_event_group.name} (Simulated)",
-      concealed: true,
-      available_live: true,
-      webhook_token: nil,
-    )
-    @event_pairs = source_event_group.events.map do |source_event|
-      new_event = source_event.dup
-      new_event.assign_attributes(
-        scheduled_start_time: source_event.scheduled_start_time + offset,
-        historical_name: nil,
-        beacon_url: nil,
-        efforts_count: 0,
-        topic_resource_key: nil,
-      )
-      new_event_group.events << new_event
-      [source_event, new_event]
+    duplicate = DuplicateEventGroup.create(existing_id: source_event_group.id,
+                                           new_name: "#{source_event_group.name} (Simulated)",
+                                           new_start_date: start_time.to_date)
+    @new_event_group = duplicate.new_event_group
+    unless new_event_group&.persisted?
+      raise "Could not duplicate event group: #{duplicate.errors.full_messages.to_sentence}"
     end
-  end
 
-  # Saving the events attaches all course splits to each, so prune those not in the source event.
-  def conform_splits
-    event_pairs.each do |source_event, new_event|
-      new_event.aid_stations.each do |aid_station|
-        aid_station.destroy unless aid_station.split_id.in?(source_event.split_ids)
-      end
-    end
+    shift = start_time - new_event_group.scheduled_start_time
+    new_event_group.events.each { |event| event.update!(scheduled_start_time: event.scheduled_start_time + shift) }
+    new_event_group.update!(available_live: true)
   end
 
   def populate_efforts
@@ -81,6 +63,12 @@ class SimulateInProgressEventGroup
         create_simulated_effort(new_event, source_effort, bib_number)
         bib_number += 1
       end
+    end
+  end
+
+  def event_pairs
+    new_event_group.events.map do |new_event|
+      [source_event_group.events.find { |source_event| source_event.short_name == new_event.short_name }, new_event]
     end
   end
 

--- a/app/services/simulate_in_progress_event_group.rb
+++ b/app/services/simulate_in_progress_event_group.rb
@@ -1,6 +1,7 @@
-# Testing tool: duplicates an event group and populates each event with `count` fabricated-identity
-# runners whose split times are real progressions from a past run, truncated at `cutoff_time` and
-# shifted so that cutoff lands at `current_time` — producing a live, in-progress event group.
+# Testing tool: duplicates an event group and stages it as an in-progress race. The duplicate's
+# group start is placed at `start_time`, and each event is populated with `count` runners frozen at
+# their position `elapsed_seconds` into the race — fabricated identities but real split-time
+# progressions from a past run, truncated at the elapsed cutoff and shifted onto the new start.
 #
 # Unlike DuplicateEventGroup (structure only, current-year-from-past-year), this copies efforts + times.
 class SimulateInProgressEventGroup
@@ -8,11 +9,11 @@ class SimulateInProgressEventGroup
     new(**).perform
   end
 
-  def initialize(source_event_group:, cutoff_time:, count:, current_time: Time.current)
+  def initialize(source_event_group:, start_time:, elapsed_seconds:, count:)
     @source_event_group = source_event_group
-    @cutoff_time = cutoff_time
+    @start_time = start_time
+    @elapsed_seconds = elapsed_seconds
     @count = count
-    @current_time = current_time
     @simulated_efforts_count = 0
   end
 
@@ -30,17 +31,22 @@ class SimulateInProgressEventGroup
 
   private
 
-  attr_reader :source_event_group, :cutoff_time, :count, :current_time, :event_pairs
+  attr_reader :source_event_group, :start_time, :elapsed_seconds, :count, :event_pairs
 
-  # Seconds to add to every source time so the cutoff moment maps to now.
+  # Seconds to add to every source time so the source group's start lands at the requested start_time.
   def offset
-    @offset ||= current_time - cutoff_time
+    @offset ||= start_time - source_event_group.scheduled_start_time
+  end
+
+  # The simulated "current moment", in source terms: `elapsed_seconds` into the race from the group start.
+  def source_cutoff
+    @source_cutoff ||= source_event_group.scheduled_start_time + elapsed_seconds
   end
 
   def build_event_group
     @new_event_group = source_event_group.dup
     new_event_group.assign_attributes(
-      name: "#{source_event_group.name} (Simulated #{current_time.strftime('%Y-%m-%d %H:%M')})",
+      name: "#{source_event_group.name} (Simulated)",
       concealed: true,
       available_live: true,
       webhook_token: nil,
@@ -78,11 +84,11 @@ class SimulateInProgressEventGroup
     end
   end
 
-  # Source efforts that had recorded their start on or before the cutoff (i.e. in progress at that moment).
+  # Source efforts that had recorded their start on or before the cutoff (in progress at that moment).
   def started_source_efforts(source_event)
     source_event.efforts.includes(split_times: :split).select do |effort|
       earliest = effort.split_times.map(&:absolute_time).min
-      earliest.present? && earliest <= cutoff_time
+      earliest.present? && earliest <= source_cutoff
     end
   end
 
@@ -93,7 +99,7 @@ class SimulateInProgressEventGroup
     end
 
     effort = new_event.efforts.new(attributes)
-    source_effort.split_times.select { |split_time| split_time.absolute_time <= cutoff_time }.each do |split_time|
+    source_effort.split_times.select { |split_time| split_time.absolute_time <= source_cutoff }.each do |split_time|
       effort.split_times.new(
         split_id: split_time.split_id,
         lap: split_time.lap,

--- a/lib/tasks/create_records.rake
+++ b/lib/tasks/create_records.rake
@@ -22,20 +22,10 @@ namespace :create_records do
     events.each_with_index do |event, i|
       bib_number = (i * 100) + 1
       effort_count.times do
-        gender = %w[male female].sample
-        first_name = FFaker::Name.send("first_name_#{gender}")
-        last_name = FFaker::Name.last_name
-        birthdate = FFaker::Time.between(16.years.ago, 75.years.ago).to_date
-        country_code = "US"
-        state_code = Carmen::Country.coded("US").subregions.map(&:code).sample
-        city = FFaker::Address.city
-        emergency_contact = FFaker::Name.name
-        emergency_phone = FFaker::PhoneNumber.short_phone_number
-
-        effort = event.efforts.new(bib_number: bib_number, first_name: first_name, last_name: last_name, gender: gender,
-                                   birthdate: birthdate, country_code: country_code, state_code: state_code, city: city,
-                                   scheduled_start_time: event.scheduled_start_time, emergency_phone: emergency_phone,
-                                   emergency_contact: emergency_contact)
+        effort = event.efforts.new(RandomEffortAttributes.generate.merge(
+                                     bib_number: bib_number,
+                                     scheduled_start_time: event.scheduled_start_time,
+                                   ))
 
         effort_description = "#{effort.full_name} using bib number #{bib_number} for #{event.name}"
 

--- a/lib/tasks/simulate_records.rake
+++ b/lib/tasks/simulate_records.rake
@@ -1,8 +1,9 @@
 namespace :simulate do
-  desc "Duplicate an event group with N in-progress runners as of a cutoff time"
-  task :in_progress, [:event_group_id, :cutoff, :count] => :environment do |_, args|
-    if args.event_group_id.blank? || args.cutoff.blank?
-      abort "Usage: rake simulate:in_progress[event_group_id, cutoff, count]"
+  desc "Duplicate an event group as an in-progress race (start time + elapsed H:MM)"
+  task :in_progress, [:event_group_id, :start_time, :elapsed, :count] => :environment do |_, args|
+    if args.event_group_id.blank? || args.start_time.blank? || args.elapsed.blank?
+      abort "Usage: rake simulate:in_progress[event_group_id, start_time, elapsed, count]\n  " \
+            "e.g. rake simulate:in_progress[high-lonesome-100, \"2026-07-01 06:00\", 6:30, 40]"
     end
 
     source_event_group =
@@ -12,14 +13,21 @@ namespace :simulate do
         abort "Event group '#{args.event_group_id}' not found"
       end
 
+    start_time = Time.use_zone(source_event_group.home_time_zone) { Time.zone.parse(args.start_time.to_s) }
+    abort "Could not parse start time '#{args.start_time}'" if start_time.nil?
+
+    unless args.elapsed.to_s.match?(/\A\d+(:\d+){0,2}\z/)
+      abort "Could not parse elapsed '#{args.elapsed}' (use H:MM, e.g. 6:30)"
+    end
+    hours, minutes, seconds = args.elapsed.split(":").map(&:to_i)
+    elapsed_seconds = hours.hours + minutes.to_i.minutes + seconds.to_i.seconds
+
     count = (args.count || 40).to_i
-    cutoff_time = Time.use_zone(source_event_group.home_time_zone) { Time.zone.parse(args.cutoff.to_s) }
-    abort "Could not parse cutoff time '#{args.cutoff}'" if cutoff_time.nil?
 
-    puts "Simulating '#{source_event_group.name}' with #{count} runners per event, in progress as of #{cutoff_time}..."
-
-    result = SimulateInProgressEventGroup.perform(source_event_group: source_event_group, cutoff_time: cutoff_time,
-                                                  count: count)
+    puts "Simulating '#{source_event_group.name}': start #{start_time}, #{args.elapsed} into the race, " \
+         "#{count} runners per event..."
+    result = SimulateInProgressEventGroup.perform(source_event_group: source_event_group, start_time: start_time,
+                                                  elapsed_seconds: elapsed_seconds, count: count)
 
     puts "Created '#{result.new_event_group.name}' with #{result.simulated_efforts_count} efforts."
     puts "Setup: #{Rails.application.routes.url_helpers.setup_event_group_path(result.new_event_group)}"

--- a/lib/tasks/simulate_records.rake
+++ b/lib/tasks/simulate_records.rake
@@ -1,0 +1,27 @@
+namespace :simulate do
+  desc "Duplicate an event group with N in-progress runners as of a cutoff time"
+  task :in_progress, [:event_group_id, :cutoff, :count] => :environment do |_, args|
+    if args.event_group_id.blank? || args.cutoff.blank?
+      abort "Usage: rake simulate:in_progress[event_group_id, cutoff, count]"
+    end
+
+    source_event_group =
+      begin
+        EventGroup.friendly.find(args.event_group_id)
+      rescue ActiveRecord::RecordNotFound
+        abort "Event group '#{args.event_group_id}' not found"
+      end
+
+    count = (args.count || 40).to_i
+    cutoff_time = Time.use_zone(source_event_group.home_time_zone) { Time.zone.parse(args.cutoff.to_s) }
+    abort "Could not parse cutoff time '#{args.cutoff}'" if cutoff_time.nil?
+
+    puts "Simulating '#{source_event_group.name}' with #{count} runners per event, in progress as of #{cutoff_time}..."
+
+    result = SimulateInProgressEventGroup.perform(source_event_group: source_event_group, cutoff_time: cutoff_time,
+                                                  count: count)
+
+    puts "Created '#{result.new_event_group.name}' with #{result.simulated_efforts_count} efforts."
+    puts "Setup: #{Rails.application.routes.url_helpers.setup_event_group_path(result.new_event_group)}"
+  end
+end

--- a/spec/services/random_effort_attributes_spec.rb
+++ b/spec/services/random_effort_attributes_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe RandomEffortAttributes do
+  subject(:attributes) { described_class.generate }
+
+  it "returns a fabricated, valid identity without a bib number" do
+    expect(attributes[:first_name]).to be_present
+    expect(attributes[:last_name]).to be_present
+    expect(attributes[:gender]).to be_in(%w[male female])
+    expect(attributes[:country_code]).to eq("US")
+    expect(Carmen::Country.coded("US").subregions.map(&:code)).to include(attributes[:state_code])
+    expect(attributes).not_to have_key(:bib_number)
+  end
+end

--- a/spec/services/simulate_in_progress_event_group_spec.rb
+++ b/spec/services/simulate_in_progress_event_group_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe SimulateInProgressEventGroup do
+  subject(:result) do
+    described_class.perform(source_event_group: source, cutoff_time: cutoff, count: count, current_time: current_time)
+  end
+
+  let(:source) { event_groups(:sum) }
+  let(:count) { 50 }
+  let(:current_time) { Time.zone.parse("2026-07-01 12:00:00") }
+  # Anchor the cutoff to the latest recorded time so every started runner is included and the
+  # newest simulated time lands at current_time.
+  let(:cutoff) do
+    SplitTime.joins(effort: :event).where(events: { event_group_id: source.id }).maximum(:absolute_time)
+  end
+
+  it "creates a concealed duplicate group distinct from the source" do
+    expect(result.new_event_group).to be_persisted
+    expect(result.new_event_group).to be_concealed
+    expect(result.new_event_group.id).not_to eq(source.id)
+    expect(result.new_event_group.name).to include("Simulated")
+  end
+
+  it "copies real split times (shifted so the newest lands at now) for started runners" do
+    new_group = result.new_event_group
+    new_split_times = SplitTime.joins(effort: :event).where(events: { event_group_id: new_group.id })
+
+    expect(result.simulated_efforts_count).to be_positive
+    expect(new_group.events.flat_map(&:efforts)).to all(be_started)
+    expect(new_split_times.count).to be_positive
+    expect(new_split_times.maximum(:absolute_time)).to be_within(1.second).of(current_time)
+    expect(new_split_times.maximum(:absolute_time)).to be <= current_time
+  end
+
+  it "gives the simulated runners fabricated identities" do
+    new_efforts = result.new_event_group.events.flat_map(&:efforts)
+
+    expect(new_efforts).to all(have_attributes(first_name: be_present, last_name: be_present))
+  end
+
+  context "with a small count" do
+    let(:count) { 1 }
+
+    it "limits each event to `count` efforts" do
+      expect(result.simulated_efforts_count).to be_positive
+      expect(result.new_event_group.events.map { |event| event.efforts.count }).to all(be <= 1)
+    end
+  end
+end

--- a/spec/services/simulate_in_progress_event_group_spec.rb
+++ b/spec/services/simulate_in_progress_event_group_spec.rb
@@ -2,17 +2,14 @@ require "rails_helper"
 
 RSpec.describe SimulateInProgressEventGroup do
   subject(:result) do
-    described_class.perform(source_event_group: source, cutoff_time: cutoff, count: count, current_time: current_time)
+    described_class.perform(source_event_group: source, start_time: start_time,
+                            elapsed_seconds: elapsed_seconds, count: count)
   end
 
   let(:source) { event_groups(:sum) }
   let(:count) { 50 }
-  let(:current_time) { Time.zone.parse("2026-07-01 12:00:00") }
-  # Anchor the cutoff to the latest recorded time so every started runner is included and the
-  # newest simulated time lands at current_time.
-  let(:cutoff) do
-    SplitTime.joins(effort: :event).where(events: { event_group_id: source.id }).maximum(:absolute_time)
-  end
+  let(:start_time) { Time.zone.parse("2026-07-01 06:00:00") }
+  let(:elapsed_seconds) { 100.hours }
 
   it "creates a concealed duplicate group distinct from the source" do
     expect(result.new_event_group).to be_persisted
@@ -21,21 +18,35 @@ RSpec.describe SimulateInProgressEventGroup do
     expect(result.new_event_group.name).to include("Simulated")
   end
 
-  it "copies real split times (shifted so the newest lands at now) for started runners" do
-    new_group = result.new_event_group
-    new_split_times = SplitTime.joins(effort: :event).where(events: { event_group_id: new_group.id })
+  it "places the group start at the requested start time" do
+    expect(result.new_event_group.events.map(&:scheduled_start_time).min).to be_within(1.second).of(start_time)
+  end
+
+  it "copies started runners' real split times, shifted onto the new start" do
+    new_split_times = SplitTime.joins(effort: :event).where(events: { event_group_id: result.new_event_group.id })
 
     expect(result.simulated_efforts_count).to be_positive
-    expect(new_group.events.flat_map(&:efforts)).to all(be_started)
+    expect(result.new_event_group.events.flat_map(&:efforts)).to all(be_started)
     expect(new_split_times.count).to be_positive
-    expect(new_split_times.maximum(:absolute_time)).to be_within(1.second).of(current_time)
-    expect(new_split_times.maximum(:absolute_time)).to be <= current_time
+    # The earliest recorded time (the group start) shifts to the requested start time.
+    expect(new_split_times.minimum(:absolute_time)).to be_within(1.second).of(start_time)
   end
 
   it "gives the simulated runners fabricated identities" do
     new_efforts = result.new_event_group.events.flat_map(&:efforts)
 
     expect(new_efforts).to all(have_attributes(first_name: be_present, last_name: be_present))
+  end
+
+  context "with a short elapsed cutoff" do
+    let(:elapsed_seconds) { 6.hours }
+
+    it "keeps every simulated time at or before the elapsed moment" do
+      new_times = SplitTime.joins(effort: :event).where(events: { event_group_id: result.new_event_group.id })
+
+      expect(result.simulated_efforts_count).to be_positive
+      expect(new_times.pluck(:absolute_time)).to all(be <= start_time + elapsed_seconds)
+    end
   end
 
   context "with a small count" do


### PR DESCRIPTION
A testing tool that duplicates an event group and stages it as a **live, in-progress race** — the realistic data the live/gating views (Crew Access, progress, live entry) need. Distinct from `DuplicateEventGroup` (which copies structure only and serves the current-year-from-past-year use case), but **reuses it** for the structure copy.

## Usage

```
rake simulate:in_progress[event_group_id, start_time, elapsed, count]
# e.g.
rake simulate:in_progress[high-lonesome-100, "2026-07-01 06:00", 6:30, 40]
```

- **`start_time`** — the exact race start (absolute, parsed in the event group's home zone), e.g. today 6:00 AM.
- **`elapsed`** — the cutoff expressed as `H:MM` into the race, e.g. `6:30` (6 h 30 m in).
- **`count`** — runners per event (default 40).

## What it does

- **Reuses `DuplicateEventGroup`** to copy the group + events + conform splits (duplicated events keep the same `course_id`, so they **share the source's splits** — copied split times keep their `split_id`, no FK remapping). Then shifts the duplicate's events so the **group start lands exactly at `start_time`** (`DuplicateEventGroup` only offsets by whole days) and enables `available_live`.
- For each event, copies **`count` random source efforts** whose start is at or before the elapsed cutoff (i.e. in progress at that moment).
- Each copied runner gets a **fabricated identity** (random FFaker name/demographics, fresh bib) but a **real split-time progression**, **truncated at `start_time + elapsed`** and shifted by `offset = start_time − source_group_start` onto the new timeline.
- Recomputes `Results::SetEffortPerformanceData` per effort so `started` / `data_status` are correct.

The simulated "current moment" is `start_time + elapsed` — under the caller's control, not force-anchored to `Time.current`. To have the live views treat it as in progress *now*, pick `start_time + elapsed ≈ now` (which "6:00 AM today" + "6:30" gives if run/viewed around 12:30 PM). If that moment is in the past, runners appear frozen there (release times show "Now" since the clock has passed them).

## Reuse

- **Structure copy**: `DuplicateEventGroup` (called as-is, untouched).
- **Fabricated identities**: the FFaker generator that `create_records.rake` already used, extracted into `RandomEffortAttributes` and shared by both tasks.

## Structure

- `app/services/random_effort_attributes.rb` — shared fabricated-identity generator.
- `app/services/simulate_in_progress_event_group.rb` — the core (PORO, testable) logic; delegates the structure copy to `DuplicateEventGroup`.
- `lib/tasks/simulate_records.rake` — thin CLI wrapper (parses `start_time` in the group's home zone and `elapsed` as `H:MM`; prints a summary + setup URL).
- `create_records.rake` refactored to use the shared generator.

## Specs

- `random_effort_attributes_spec.rb`: valid fabricated identity, no bib.
- `simulate_in_progress_event_group_spec.rb`: concealed duplicate distinct from source; the group start lands at `start_time`; started runners only; every simulated time ≤ `start_time + elapsed`; fabricated identities; `count` limit. Deterministic (explicit `start_time`/`elapsed_seconds`, no `Time.current` dependency).
- Rubocop clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)