### PR TITLE
Fix simulate:in_progress effort count (rename count arg to effort_count)

### DIFF
--- a/app/services/simulate_in_progress_event_group.rb
+++ b/app/services/simulate_in_progress_event_group.rb
@@ -1,6 +1,6 @@
 # Testing tool: duplicates an event group and stages it as an in-progress race. Reuses
 # DuplicateEventGroup for the structure copy, then shifts the duplicate's group start to
-# `start_time` and populates each event with `count` runners frozen at their position
+# `start_time` and populates each event with `effort_count` runners frozen at their position
 # `elapsed_seconds` into the race — fabricated identities but real split-time progressions from a
 # past run, truncated at the elapsed cutoff and shifted onto the new start.
 class SimulateInProgressEventGroup
@@ -8,11 +8,11 @@ class SimulateInProgressEventGroup
     new(**).perform
   end
 
-  def initialize(source_event_group:, start_time:, elapsed_seconds:, count:)
+  def initialize(source_event_group:, start_time:, elapsed_seconds:, effort_count:)
     @source_event_group = source_event_group
     @start_time = start_time
     @elapsed_seconds = elapsed_seconds
-    @count = count
+    @effort_count = effort_count
     @simulated_efforts_count = 0
   end
 
@@ -28,7 +28,7 @@ class SimulateInProgressEventGroup
 
   private
 
-  attr_reader :source_event_group, :start_time, :elapsed_seconds, :count
+  attr_reader :source_event_group, :start_time, :elapsed_seconds, :effort_count
 
   # Seconds to add to every source time so the source group's start lands at the requested start_time.
   def offset
@@ -59,7 +59,7 @@ class SimulateInProgressEventGroup
   def populate_efforts
     bib_number = 1
     event_pairs.each do |source_event, new_event|
-      started_source_efforts(source_event).sample(count).each do |source_effort|
+      started_source_efforts(source_event).sample(effort_count).each do |source_effort|
         create_simulated_effort(new_event, source_effort, bib_number)
         bib_number += 1
       end

--- a/lib/tasks/simulate_records.rake
+++ b/lib/tasks/simulate_records.rake
@@ -22,7 +22,9 @@ namespace :simulate do
     hours, minutes, seconds = args.elapsed.split(":").map(&:to_i)
     elapsed_seconds = hours.hours + minutes.to_i.minutes + seconds.to_i.seconds
 
-    count = (args.count || 40).to_i
+    # NB: use args[:count], not args.count — Rake::TaskArguments includes Enumerable, so args.count
+    # returns the number of arguments (Enumerable#count), not the :count value.
+    count = (args[:count] || 40).to_i
 
     puts "Simulating '#{source_event_group.name}': start #{start_time}, #{args.elapsed} into the race, " \
          "#{count} runners per event..."

--- a/lib/tasks/simulate_records.rake
+++ b/lib/tasks/simulate_records.rake
@@ -1,8 +1,8 @@
 namespace :simulate do
   desc "Duplicate an event group as an in-progress race (start time + elapsed H:MM)"
-  task :in_progress, [:event_group_id, :start_time, :elapsed, :count] => :environment do |_, args|
+  task :in_progress, [:event_group_id, :start_time, :elapsed, :effort_count] => :environment do |_, args|
     if args.event_group_id.blank? || args.start_time.blank? || args.elapsed.blank?
-      abort "Usage: rake simulate:in_progress[event_group_id, start_time, elapsed, count]\n  " \
+      abort "Usage: rake simulate:in_progress[event_group_id, start_time, elapsed, effort_count]\n  " \
             "e.g. rake simulate:in_progress[high-lonesome-100, \"2026-07-01 06:00\", 6:30, 40]"
     end
 
@@ -22,14 +22,14 @@ namespace :simulate do
     hours, minutes, seconds = args.elapsed.split(":").map(&:to_i)
     elapsed_seconds = hours.hours + minutes.to_i.minutes + seconds.to_i.seconds
 
-    # NB: use args[:count], not args.count — Rake::TaskArguments includes Enumerable, so args.count
-    # returns the number of arguments (Enumerable#count), not the :count value.
-    count = (args[:count] || 40).to_i
+    # Named effort_count, not count: Rake::TaskArguments includes Enumerable, so args.count would
+    # return the number of arguments (Enumerable#count) rather than this value.
+    effort_count = (args.effort_count || 40).to_i
 
     puts "Simulating '#{source_event_group.name}': start #{start_time}, #{args.elapsed} into the race, " \
-         "#{count} runners per event..."
+         "#{effort_count} runners per event..."
     result = SimulateInProgressEventGroup.perform(source_event_group: source_event_group, start_time: start_time,
-                                                  elapsed_seconds: elapsed_seconds, count: count)
+                                                  elapsed_seconds: elapsed_seconds, effort_count: effort_count)
 
     puts "Created '#{result.new_event_group.name}' with #{result.simulated_efforts_count} efforts."
     puts "Setup: #{Rails.application.routes.url_helpers.setup_event_group_path(result.new_event_group)}"

--- a/spec/services/simulate_in_progress_event_group_spec.rb
+++ b/spec/services/simulate_in_progress_event_group_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 RSpec.describe SimulateInProgressEventGroup do
   subject(:result) do
     described_class.perform(source_event_group: source, start_time: start_time,
-                            elapsed_seconds: elapsed_seconds, count: count)
+                            elapsed_seconds: elapsed_seconds, effort_count: effort_count)
   end
 
   let(:source) { event_groups(:sum) }
-  let(:count) { 50 }
+  let(:effort_count) { 50 }
   let(:start_time) { Time.zone.parse("2026-07-01 06:00:00") }
   let(:elapsed_seconds) { 100.hours }
 
@@ -49,10 +49,10 @@ RSpec.describe SimulateInProgressEventGroup do
     end
   end
 
-  context "with a small count" do
-    let(:count) { 1 }
+  context "with a small effort_count" do
+    let(:effort_count) { 1 }
 
-    it "limits each event to `count` efforts" do
+    it "limits each event to `effort_count` efforts" do
       expect(result.simulated_efforts_count).to be_positive
       expect(result.new_event_group.events.map { |event| event.efforts.count }).to all(be <= 1)
     end


### PR DESCRIPTION
## Problem

`bin/rails "simulate:in_progress[2025-high-lonesome-100,2026-07-01 06:00:00,8:30,100]"` created only **4** efforts instead of 100. Diagnosis against the source event confirmed all 225 efforts qualify by the cutoff — the selection logic was fine.

## Cause

`Rake::TaskArguments` includes `Enumerable`, and `Enumerable#count` shadows the `:count` named argument. So `args.count` returned the *number of arguments* (event_group_id, start_time, elapsed, count = **4**), never the value passed. Every run produced exactly 4 efforts. The other args are unaffected because nothing on Enumerable collides with those names.

```
args.count   => 4      # Enumerable#count — the bug
args[:count] => "100"  # named lookup
```

## Fix

Rename the argument (and the `SimulateInProgressEventGroup` keyword) from `count` to **`effort_count`**. This is clearer and sidesteps the collision entirely — matching the existing `create_records:efforts` task, which already uses `effort_count`.

Usage is now:

```
rake simulate:in_progress[event_group_id, start_time, elapsed, effort_count]
```

Service spec updated; all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)