### PR TITLE
Gating: wait for the Out time before computing a crew release

### DIFF
--- a/app/models/gating_location_event.rb
+++ b/app/models/gating_location_event.rb
@@ -22,10 +22,16 @@ class GatingLocationEvent < ApplicationRecord
     target_aid_station&.split
   end
 
+  # The bitkey at the gating aid station that marks a runner as past the gate: Out when the station
+  # records one, otherwise In. A release determination is made only once this time is recorded.
+  def gating_bitkey
+    gating_split&.sub_split_bitkeys&.max
+  end
+
   # "In" or "Out" — the gating aid station's departure sub-split (Out when it records one),
   # i.e. the point at which a runner is considered past the gate.
   def gating_sub_split_kind
-    SubSplit.kind(gating_split.sub_split_bitkeys.max) if gating_split
+    SubSplit.kind(gating_bitkey) if gating_bitkey
   end
 
   private

--- a/app/view_models/gating_location_row.rb
+++ b/app/view_models/gating_location_row.rb
@@ -18,13 +18,16 @@ class GatingLocationRow
     gating_location_event.event.guaranteed_short_name
   end
 
-  # The runner's recorded time at the gating aid station, latest lap, OUT preferred over IN.
+  # The runner's recorded time at the gating aid station's gate sub-split (its Out when the station
+  # records one, otherwise its In), latest lap. Nil until that time exists: a runner who has only
+  # checked In could still be at the aid station for a while, so anchoring the release projection on
+  # the In time would release the crew too early.
   def gating_split_time
     return @gating_split_time if defined?(@gating_split_time)
 
-    @gating_split_time = effort.split_times
-                               .select { |split_time| split_time.split_id == gating_split.id }
-                               .max_by { |split_time| [split_time.lap, split_time.bitkey] }
+    @gating_split_time = effort.split_times.select do |split_time|
+      split_time.split_id == gating_split.id && split_time.bitkey == gating_bitkey
+    end.max_by(&:lap)
   end
 
   def passed_gating?
@@ -120,7 +123,7 @@ class GatingLocationRow
 
   attr_reader :effort, :gating_location_event
 
-  delegate :gating_split, :target_split, to: :gating_location_event
+  delegate :gating_split, :target_split, :gating_bitkey, to: :gating_location_event
 
   def home_time_zone
     gating_location_event.event.home_time_zone

--- a/spec/view_models/gating_location_row_spec.rb
+++ b/spec/view_models/gating_location_row_spec.rb
@@ -35,9 +35,23 @@ RSpec.describe GatingLocationRow do
     end
   end
 
-  context "when the runner has reached the gating aid station" do
+  context "when the runner has only checked In at a gating aid station that records an Out" do
     before do
       build_split_time(split: gating_split, bitkey: SubSplit::IN_BITKEY, absolute_time: gating_time)
+    end
+
+    it "is not yet gated and makes no release determination until the Out time is recorded" do
+      expect(gating_split.out_bitkey).to be_present
+      expect(row.passed_gating?).to be(false)
+      expect(row.gating_split_time).to be_nil
+      expect(row.predicted_target_arrival).to be_nil
+    end
+  end
+
+  context "when the runner has departed the gating aid station" do
+    before do
+      build_split_time(split: gating_split, bitkey: SubSplit::IN_BITKEY, absolute_time: gating_time - 5.minutes)
+      build_split_time(split: gating_split, bitkey: SubSplit::OUT_BITKEY, absolute_time: gating_time)
       allow(Projection).to receive(:execute_query).and_return([instance_double(Projection, low_seconds: 3600)])
     end
 


### PR DESCRIPTION
## Bug report (from an RD)

For a gating aid station that has both **In** and **Out** times, the release determination shouldn't be made until the runner has recorded an **Out**. Otherwise a runner can sit in the aid station for a while, and a projection anchored on the In time releases the crew far too early.

## Cause

`GatingLocationRow#gating_split_time` picked the runner's latest time at the gating split with `max_by { [lap, bitkey] }`, which falls back to the **In** time whenever no Out is recorded yet. The release projection is anchored on that split time, so a checked-in-but-not-departed runner produced a premature release time — exactly the case the RD flagged.

Notably, the gate is *already* defined as the Out sub-split: `gating_sub_split_kind` uses `sub_split_bitkeys.max`, and the column header already reads e.g. "Engineer Mtn TH Out". Only the projection anchor disagreed.

## Fix

- Add `GatingLocationEvent#gating_bitkey` (`sub_split_bitkeys.max`) as the single source of truth for the gate sub-split; `gating_sub_split_kind` now derives from it.
- Anchor `gating_split_time` on that bitkey — the station's **Out** when it records one, otherwise its **In**. Until that time exists the runner is not "gated" (`passed_gating?` is false) and no `predicted_target_arrival` / `release_time` is computed.

Both consumers — the private steward Live view and the public per-effort Crew Access tab — go through `GatingLocationRow`, so both are fixed.

## Display note (scoped out)

A runner who has checked **In** but not **Out** at the gate now reads as not-yet-gated ("Insufficient data" / "Available once … is reached"), rather than showing a bad release time. That's correct per the RD, but it doesn't yet distinguish "hasn't arrived at the gate" from "at the gate, awaiting departure." If you'd like an explicit "in aid station" state on the row, I can add it as a follow-up.

## Tests

Updated `gating_location_row_spec` — In-only at an Out-recording gate makes no determination; the projection anchors on the Out. Full gating suite (row, live display, event model, both request specs, public crew-access spec) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)