### PR TITLE
Unblock CI: ignore unpatched webrick advisory (CVE-2026-38969)

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,10 @@
+---
+# Advisories intentionally ignored by bundler-audit (`bin/bundle-audit check`).
+# Revisit each entry when a patched gem version becomes available.
+ignore:
+  # CVE-2026-38969 / GHSA-h4w6-wx8r-p68v — WEBrick reparses HTTP trailers.
+  # webrick is a test-only transitive dependency (pulled in by ferrum, our headless-Chrome
+  # driver for system specs); we never run WEBrick as an application server. No patched
+  # version exists as of 2026-07-06 (the advisory affects webrick through 1.9.2, the latest
+  # release). Remove this once a fixed webrick ships and the bundle picks it up.
+  - CVE-2026-38969


### PR DESCRIPTION
## Problem

CI's **Run security checks** step (`bin/bundle-audit check --update`) started failing on every branch after the ruby-advisory-db picked up a new advisory today:

```
Name: webrick
Version: 1.9.2
CVE: CVE-2026-38969
GHSA: GHSA-h4w6-wx8r-p68v
Title: ruby webrick through v1.9.2 WEBrick reparses trailer
Solution: remove or disable this gem until a patch is available!
```

This is unrelated to any recent change — it's a newly published advisory that now trips `bundler-audit`.

## Why ignore rather than upgrade

- **Not exposed:** `webrick` is a **test-only transitive dependency**, pulled in by `ferrum` (our headless-Chrome driver for system specs). We never run WEBrick as an application server, so the HTTP-trailer reparsing issue doesn't affect us.
- **No fix available:** the advisory covers `webrick` **through 1.9.2**, which is the latest release. There's nothing to upgrade to, and it can't be removed (ferrum requires it).

## Fix

Add a documented `.bundler-audit.yml` ignoring `CVE-2026-38969`. bundler-audit (0.9.3) auto-loads this file from the repo root, so the existing CI command picks it up with no workflow change. Verified locally: `bin/bundle-audit check --update` → **No vulnerabilities found**.

The comment notes to remove the entry once a patched `webrick` ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)