### PR TITLE
Crew access: treat the gate as the earliest projection anchor

### DIFF
--- a/app/view_models/gating_location_row.rb
+++ b/app/view_models/gating_location_row.rb
@@ -192,7 +192,9 @@ class GatingLocationRow
   end
 
   def projected_low_seconds_from(split_time)
-    cache_key = ["gating_prediction", gating_location_event.id, split_time.id, split_time.updated_at]
+    # Keyed on the anchor split time (id + updated_at, so a correction busts it) and the target split
+    # (so re-pointing the gate's target busts it). Reaching a new station is a new split_time id.
+    cache_key = ["gating_prediction", gating_location_event.id, target_split.id, split_time.id, split_time.updated_at]
     Rails.cache.fetch(cache_key) do
       Projection.execute_query(
         split_time: split_time,

--- a/app/view_models/gating_location_row.rb
+++ b/app/view_models/gating_location_row.rb
@@ -68,8 +68,10 @@ class GatingLocationRow
     "#{verb} #{split_time.split.base_name}"
   end
 
-  # The runner's earliest predicted arrival at the target aid station, or nil when no
-  # release time applies (not yet gated, stopped, already arrived, or no projection).
+  # The runner's earliest predicted arrival at the target aid station, or nil when no release time
+  # applies (not yet gated, stopped, already arrived, or no projection). The projection is anchored
+  # on the runner's furthest recorded point between the gate and the target (see #projection_anchor),
+  # so it refines as the runner progresses toward the target.
   def predicted_target_arrival
     return @predicted_target_arrival if defined?(@predicted_target_arrival)
 
@@ -77,13 +79,28 @@ class GatingLocationRow
       if stopped? || reached_target? || !passed_gating?
         nil
       else
-        low_seconds = projected_low_seconds
-        low_seconds && (gating_split_time.absolute_time + low_seconds.seconds)
+        anchor = projection_anchor
+        anchor && (anchor.split_time.absolute_time + anchor.low_seconds.seconds)
       end
   end
 
   def predicted_target_arrival_local
     predicted_target_arrival&.in_time_zone(home_time_zone)
+  end
+
+  # The base name of the aid station the current projection is anchored on, e.g. "Cascade Creek Rd".
+  def projection_anchor_label
+    projection_anchor_split_time&.split&.base_name
+  end
+
+  def projection_anchor_time_local
+    projection_anchor_split_time&.absolute_time&.in_time_zone(home_time_zone)
+  end
+
+  # True when the projection is anchored beyond the gating aid station — on an intermediate aid
+  # station the runner has since reached — i.e. the estimate has been refined since leaving the gate.
+  def anchored_beyond_gate?
+    projection_anchor_split_time.present? && projection_anchor_split_time.split_id != gating_split.id
   end
 
   # Predicted target arrival minus the travel buffer, or nil when no release time applies.
@@ -119,11 +136,17 @@ class GatingLocationRow
     [rank, secondary, bib_number.to_i]
   end
 
+  ProjectionAnchor = Struct.new(:split_time, :low_seconds)
+
   private
 
   attr_reader :effort, :gating_location_event
 
   delegate :gating_split, :target_split, :gating_bitkey, to: :gating_location_event
+
+  def projection_anchor_split_time
+    projection_anchor&.split_time
+  end
 
   def home_time_zone
     gating_location_event.event.home_time_zone
@@ -138,13 +161,43 @@ class GatingLocationRow
     @furthest_target_split_time = at_or_beyond.max_by { |st| [st.split.distance_from_start, st.bitkey] }
   end
 
-  def projected_low_seconds
-    cache_key = ["gating_prediction", gating_location_event.id, gating_split_time.id, gating_split_time.updated_at]
+  # The point the release projection is anchored on: the runner's furthest recorded time between the
+  # gate (inclusive) and the target (exclusive) that yields a projection, walking back toward the gate
+  # when a nearer point has no prior-year data. The gating aid station is only the *earliest* possible
+  # anchor; a runner who has reached intermediate stations gets a more up-to-date estimate.
+  def projection_anchor
+    return @projection_anchor if defined?(@projection_anchor)
+
+    ordered = anchor_candidates.sort_by { |st| [st.lap, st.split.distance_from_start, st.bitkey] }.reverse
+    @projection_anchor = ordered.lazy.filter_map do |split_time|
+      low_seconds = projected_low_seconds_from(split_time)
+      ProjectionAnchor.new(split_time, low_seconds) if low_seconds
+    end.first
+  end
+
+  # Recorded split times eligible to anchor the projection: those at or beyond the gate and before the
+  # target. At the gating aid station only its gate sub-split counts (an In-only runner has not left
+  # the gate); at intermediate stations any recorded time counts.
+  def anchor_candidates
+    gating_distance = gating_split.distance_from_start
+    target_distance = target_split.distance_from_start
+
+    effort.split_times.select do |split_time|
+      distance = split_time.split.distance_from_start
+      next false unless distance >= gating_distance && distance < target_distance
+      next false if split_time.split_id == gating_split.id && split_time.bitkey != gating_bitkey
+
+      true
+    end
+  end
+
+  def projected_low_seconds_from(split_time)
+    cache_key = ["gating_prediction", gating_location_event.id, split_time.id, split_time.updated_at]
     Rails.cache.fetch(cache_key) do
       Projection.execute_query(
-        split_time: gating_split_time,
+        split_time: split_time,
         starting_time_point: gating_location_event.event.starting_time_point,
-        subject_time_points: [TimePoint.new(gating_split_time.lap, target_split.id, SubSplit::IN_BITKEY)],
+        subject_time_points: [TimePoint.new(split_time.lap, target_split.id, SubSplit::IN_BITKEY)],
       ).first&.low_seconds
     end
   end

--- a/app/views/efforts/_crew_access_location.html.erb
+++ b/app/views/efforts/_crew_access_location.html.erb
@@ -24,6 +24,12 @@
           Arrived <%= day_time_military_format(row.target_progress_time_local) %>
         <% elsif row.predicted_target_arrival %>
           <%= day_time_military_format(row.predicted_target_arrival_local) %>
+          <% if row.anchored_beyond_gate? %>
+            <div class="small text-body-secondary">
+              Based on your time at <%= row.projection_anchor_label %>
+              (<%= day_time_military_format(row.projection_anchor_time_local) %>)
+            </div>
+          <% end %>
         <% else %>
           <span class="text-body-secondary">&mdash;</span>
         <% end %>

--- a/app/views/live/gating_locations/_row.html.erb
+++ b/app/views/live/gating_locations/_row.html.erb
@@ -13,6 +13,11 @@
       Arrived at <%= day_time_military_format(row.target_progress_time_local) %>
     <% elsif row.predicted_target_arrival %>
       <%= day_time_military_format(row.predicted_target_arrival_local) %>
+      <% if row.anchored_beyond_gate? %>
+        <div class="small text-body-secondary">
+          from <%= row.projection_anchor_label %> at <%= day_time_military_format(row.projection_anchor_time_local) %>
+        </div>
+      <% end %>
     <% end %>
   </td>
 

--- a/docs/management/crew-access.md
+++ b/docs/management/crew-access.md
@@ -21,8 +21,11 @@ time that runner's crew should be released to make the drive.
 1. **Gating location:** A place where a race official controls when crews may begin driving toward an aid
 station with limited access. A single gating location can apply to more than one Event in your Event Group.
 
-1. **Gating aid station:** The station where runners are timed and where the gate is enforced. This is often
-the aid station the crews are waiting at, or a checkpoint the runners pass on the way.
+1. **Gating aid station:** The station where the gate is enforced — the **earliest** point from which
+OpenSplitTime will project a release. It is often chosen for its long drive to the target, so it may sit well
+before the target rather than being the station nearest to it. As a runner reaches later stations between the
+gate and the target, the release estimate re-anchors on the runner's most recent point and refines (see
+[Estimates refine as the runner progresses](#estimates-refine-as-the-runner-progresses)).
 
 1. **Target aid station:** The aid station the crews are driving toward.
 
@@ -99,6 +102,18 @@ at the gate, but on the moment the runner leaves it.
 This matters because a runner can spend a long time in an aid station. Calculating the release from the arrival
 time would release the crew too early. Until the runner's departure is recorded, the runner's Release column
 shows **Insufficient data**.
+
+### Estimates Refine as the Runner Progresses
+
+The gating aid station is only the **earliest** point from which a release is calculated, not the only one. As a
+runner reaches aid stations **between** the gate and the target, OpenSplitTime re-anchors the projection on the
+runner's most recent recorded point, producing a more accurate release time. When the estimate is based on a
+station beyond the gate, the board notes it (for example, "from Cascade Creek Rd at 13:05").
+
+This is why a distant gate still works well: a fast runner who has only reached the gate gets a release computed
+from that early point, while a slower runner's crew benefits from updated releases as the runner passes closer
+stations. If a later station has no prior-year data of its own, OpenSplitTime falls back to the most recent
+earlier point that does, so a release remains available.
 
 ### Adjusting the View
 

--- a/spec/view_models/gating_location_row_spec.rb
+++ b/spec/view_models/gating_location_row_spec.rb
@@ -108,6 +108,58 @@ RSpec.describe GatingLocationRow do
     it "anchors on the OUT time" do
       expect(row.gating_split_time.bitkey).to eq(SubSplit::OUT_BITKEY)
       expect(row.predicted_target_arrival).to eq(gating_time + 5.minutes)
+      expect(row.anchored_beyond_gate?).to be(false)
+    end
+  end
+
+  # A gate far from its target, with intermediate aid stations in between, exercises the progressive
+  # projection: the gate is only the earliest anchor, and the estimate re-anchors on the runner's
+  # furthest recorded intermediate point.
+  context "with intermediate aid stations between the gate and target" do
+    subject(:row) { described_class.new(effort: effort, gating_location_event: wide_gate) }
+
+    let(:wide_gate) do
+      GatingLocationEvent.new(gating_location: gating_locations(:sum_bandera_gate), event: event,
+                              gating_aid_station: aid_stations(:aid_station_0017), # Molas Pass, distance 18347
+                              target_aid_station: aid_stations(:aid_station_0020), # Bandera Mine, distance 80741
+                              default_travel_buffer: 60)
+    end
+    let(:gate_split) { splits(:sum_100k_course_molas_pass_aid1) }
+    let(:intermediate_split) { splits(:sum_100k_course_cascade_creek_rd_aid3) } # distance 46317
+    let(:beyond_intermediate_split) { splits(:sum_100k_course_engineer_mtn_th_aid4) } # distance 59642
+
+    before { build_split_time(split: gate_split, bitkey: SubSplit::OUT_BITKEY, absolute_time: gating_time) }
+
+    context "when the runner has reached an intermediate station" do
+      before do
+        build_split_time(split: intermediate_split, bitkey: SubSplit::OUT_BITKEY, absolute_time: gating_time + 2.hours)
+        allow(Projection).to receive(:execute_query).and_return([instance_double(Projection, low_seconds: 3600)])
+      end
+
+      it "re-anchors the projection on the furthest intermediate point" do
+        expect(row.anchored_beyond_gate?).to be(true)
+        expect(row.projection_anchor_label).to eq(intermediate_split.base_name)
+        # Projected from the intermediate time (gate + 2h), not the gate time.
+        expect(row.predicted_target_arrival).to eq(gating_time + 2.hours + 3600.seconds)
+      end
+    end
+
+    context "when the furthest intermediate point has no prior-year data" do
+      before do
+        build_split_time(split: intermediate_split, bitkey: SubSplit::OUT_BITKEY, absolute_time: gating_time + 2.hours)
+        build_split_time(split: beyond_intermediate_split, bitkey: SubSplit::IN_BITKEY,
+                         absolute_time: gating_time + 3.hours)
+        # No projection from the furthest point (Engineer Mtn); the intermediate (Cascade Creek) has data.
+        allow(Projection).to receive(:execute_query) do |split_time:, **|
+          projected = split_time.split_id == intermediate_split.id ? instance_double(Projection, low_seconds: 3600) : nil
+          [projected].compact
+        end
+      end
+
+      it "falls back to the nearest earlier point that has a projection" do
+        expect(row.projection_anchor_label).to eq(intermediate_split.base_name)
+        expect(row.predicted_target_arrival).to eq(gating_time + 2.hours + 3600.seconds)
+      end
     end
   end
 end


### PR DESCRIPTION
## Mindset shift (from the RD)

A gating aid station isn't necessarily the station nearest the target — it's often chosen because there's a **long drive** from the gate to the target. So the gate should be the *earliest* point from which we project a release, not the *only* one:

> Faster runners may need a release calculated at the earlier aid station, while slower runners' crews benefit from updates at closer aid stations subsequent to the gate. Times are subject to update if other time points exist between the gating aid station and the target.

## What changed

All in `GatingLocationRow`, so both the steward board and the public per-runner tab inherit it:

- **Progressive projection anchor.** The release is now projected from the runner's **furthest recorded point between the gate (inclusive) and the target (exclusive)** — `#projection_anchor` — instead of always the gate. As the runner reaches intermediate stations, the estimate re-anchors and refines.
- **Graceful fallback.** If the furthest point has no prior-year data, it walks back toward the gate to the most recent point that *does*, so a release stays available (the gate is the floor).
- **Gate trigger unchanged.** The gating station's Out time still governs "past the gate" (from #2148); an In-only runner still gets no release.
- **No new setup.** Intermediate stations aren't configured — they're simply whatever aid stations lie between the gate and target. Construction UI is untouched.
- **Anchor is shown.** When a projection is anchored beyond the gate, both views note it (e.g. "from Cascade Creek Rd at 13:05" / "Based on your time at Cascade Creek Rd").

## Design decisions (confirmed with the RD)

- Missing data → **fall back to the nearest earlier point with data**.
- **Show** which point the estimate is anchored on.

## Tests & docs

- `gating_location_row_spec`: added a wide-gate context (Molas Pass → Bandera, with intermediates) covering re-anchoring on an intermediate point and the walk-back fallback; existing gate/Out behavior preserved.
- Full gating + crew-access suites green; rubocop/erb_lint clean.
- `docs/management/crew-access.md` updated: the gate is now described as the earliest anchor, with a new "Estimates refine as the runner progresses" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)