### PR TITLE
Retry browser specs on transient Ferrum startup/crash errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ group :test do
   gem "cuprite"
   gem "factory_bot_rails", require: false
   gem "pry"
+  gem "rspec-retry"
   gem "vcr", "~> 6.4"
   gem "webmock", "~> 3.5"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -647,6 +647,8 @@ GEM
       rspec-expectations (>= 3.13.0, < 5.0.0)
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-support (3.13.7)
     rubocop (1.88.0)
       json (~> 2.3)
@@ -857,6 +859,7 @@ DEPENDENCIES
   rails_real_favicon (>= 0.1.0)
   rspec
   rspec-rails (>= 4.0.2)
+  rspec-retry
   rubocop
   rubocop-rails
   rubocop-rspec

--- a/spec/support/rspec_retry.rb
+++ b/spec/support/rspec_retry.rb
@@ -1,0 +1,19 @@
+require "rspec/retry"
+
+RSpec.configure do |config|
+  # Surface retries in the output so browser flakiness stays visible rather than silently masked
+  # (tracked in issue #2146).
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+
+  # Retry browser (:js) specs, and only on transient Chrome/Ferrum startup or crash errors — never on
+  # an assertion failure, which is not in the list and so still fails on the first attempt. Retries
+  # only run on CI; locally a flake surfaces immediately. A retry spins up a fresh Chrome process,
+  # which is exactly what these errors need.
+  config.around(:each, :js) do |example|
+    example.run_with_retry(
+      retry: ENV["CI"] ? 3 : 1,
+      exceptions_to_retry: [Ferrum::ProcessTimeoutError, Ferrum::DeadBrowserError],
+    )
+  end
+end


### PR DESCRIPTION
## Problem

The recurring CI flake (#2146) in `spec/system` is Chrome failing to **boot**:

```
Ferrum::ProcessTimeoutError: Browser did not produce websocket url within 30 seconds
```

It happens before any assertion runs, always on the heaviest JS specs, and is unrelated to PR content. It's cost several reruns across recent PRs.

## Approach (Option A: `rspec-retry`, scoped narrowly)

Rather than a blanket "retry failures" (which masks real bugs) or bumping `process_timeout` (declined), this retries **only** the transient browser-boot failure mode:

- **`:js` specs only** — unit/request specs still fail fast.
- **CI only** — locally a flake surfaces immediately (`retry: 1`).
- **Only `Ferrum::ProcessTimeoutError` / `Ferrum::DeadBrowserError`** — an assertion failure isn't in the list, so a genuine regression still fails on the first attempt and is never retried away.

A retry spins up a fresh Chrome process, which is exactly what these errors need. `verbose_retry` logs each retry so flakiness stays visible and measurable.

```ruby
config.around(:each, :js) do |example|
  example.run_with_retry(
    retry: ENV["CI"] ? 3 : 1,
    exceptions_to_retry: [Ferrum::ProcessTimeoutError, Ferrum::DeadBrowserError],
  )
end
```

## Verification

Confirmed with a throwaway spec (since removed):
- A whitelisted `Ferrum::ProcessTimeoutError` → `1st Try error` → `2nd try` → `3rd try` → **passes**.
- A non-whitelisted error → **fails on the first attempt**, no retry.

`process_timeout` is left at 30 as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)