### PR TITLE
Fix Delete person end-to-end: Turbo trigger + 303 redirect

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -6,7 +6,7 @@ class PeopleController < ApplicationController
   def index
     # Sort will destroy fuzzy match ranking, so don't automatically
     # set it if a search param exists
-    params[:sort] ||= "last_name,first_name" unless prepared_params[:search].present?
+    params[:sort] ||= "last_name,first_name" if prepared_params[:search].blank?
 
     people_scope = policy_class::Scope.new(current_user, controller_class).viewable.with_age_and_effort_count
     people_scope = people_scope.search(prepared_params[:search])
@@ -43,7 +43,8 @@ class PeopleController < ApplicationController
     authorize @person
     @person.destroy
 
-    redirect_to people_path
+    # 303 See Other so Turbo follows the redirect with a GET after the DELETE (a 302 is refetched as DELETE).
+    redirect_to people_path, status: :see_other
   end
 
   def avatar_claim
@@ -56,10 +57,10 @@ class PeopleController < ApplicationController
   def merge
     authorize @person
     @person_merge = PersonMergeView.new(@person, params[:proposed_match])
-    if @person_merge.proposed_match.nil?
-      flash[:success] = "No potential matches detected."
-      redirect_to person_path(@person)
-    end
+    return unless @person_merge.proposed_match.nil?
+
+    flash[:success] = "No potential matches detected."
+    redirect_to person_path(@person)
   end
 
   def combine

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -17,7 +17,10 @@ class PeopleController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.turbo_stream
+      # Only the "Show More" pager (which carries a page param) wants the append-rows stream. A Turbo
+      # request without a page — e.g. the GET that follows a delete redirect, which inherits the
+      # turbo-stream Accept header — falls through to the full HTML page so Turbo does a real navigation.
+      format.turbo_stream if params[:page].present?
     end
   end
 

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -376,8 +376,7 @@ module DropdownHelper
         name: "Delete person",
         link: person_path(view_object.person),
         visible: view_object.current_user.admin?,
-        method: :delete,
-        data: { confirm: "This action cannot be undone. Proceed?" },
+        data: { turbo_method: :delete, turbo_confirm: "This action cannot be undone. Proceed?" },
         class: "text-danger",
       }
     ]
@@ -533,7 +532,7 @@ module DropdownHelper
         link: reconcile_event_group_path(view_object.event_group) },
       { name: "Set data status",
         link: set_data_status_event_group_path(view_object.event_group),
-        method: :patch },
+        data: { turbo_method: :patch } },
       { role: :separator },
       { name: "Import entrants",
         link: new_import_job_path(import_job: { parent_type: "EventGroup", parent_id: view_object.event_group.id,

--- a/spec/helpers/dropdown_helper_spec.rb
+++ b/spec/helpers/dropdown_helper_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe DropdownHelper, type: :helper do
+  describe "#person_actions_dropdown_menu" do
+    subject(:menu) { Capybara.string(helper.person_actions_dropdown_menu(view_object)) }
+
+    let(:view_object) { Struct.new(:person, :current_user).new(people(:alfreda_cruickshank), users(:admin_user)) }
+
+    it "wires the Delete person link for Turbo, not legacy UJS attributes" do
+      link = menu.find_link("Delete person")
+
+      expect(link["data-turbo-method"]).to eq("delete")
+      expect(link["data-turbo-confirm"]).to be_present
+      expect(link["data-method"]).to be_nil
+      expect(link["data-confirm"]).to be_nil
+    end
+  end
+
+  describe "#roster_actions_dropdown" do
+    subject(:menu) { Capybara.string(helper.roster_actions_dropdown(view_object)) }
+
+    let(:view_object) { Struct.new(:event_group).new(event_groups(:sum)) }
+
+    it "wires the Set data status link for Turbo, not legacy UJS attributes" do
+      link = menu.find_link("Set data status")
+
+      expect(link["data-turbo-method"]).to eq("patch")
+      expect(link["data-method"]).to be_nil
+    end
+  end
+end

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "PeopleController" do
+  include Warden::Test::Helpers
+
+  after { Warden.test_reset! }
+
+  describe "DELETE /people/:id" do
+    let(:admin) { users(:admin_user) }
+    let(:person) { people(:alfreda_cruickshank) }
+
+    before { login_as admin, scope: :user }
+
+    it "deletes the person and redirects to the index with a 303 so Turbo follows with a GET" do
+      delete person_path(person)
+
+      expect(response).to have_http_status(:see_other)
+      expect(response).to redirect_to(people_path)
+      expect(Person.exists?(person.id)).to be(false)
+    end
+  end
+end

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -3,6 +3,9 @@ require "rails_helper"
 RSpec.describe "PeopleController" do
   include Warden::Test::Helpers
 
+  # Turbo submits mutations (and follows their redirects) with this Accept header.
+  let(:turbo_headers) { { "Accept" => "text/vnd.turbo-stream.html, text/html, application/xhtml+xml" } }
+
   after { Warden.test_reset! }
 
   describe "DELETE /people/:id" do
@@ -17,6 +20,26 @@ RSpec.describe "PeopleController" do
       expect(response).to have_http_status(:see_other)
       expect(response).to redirect_to(people_path)
       expect(Person.exists?(person.id)).to be(false)
+    end
+
+    it "follows the delete redirect to a full HTML page, not a turbo stream" do
+      delete person_path(person), headers: turbo_headers
+      expect(response).to have_http_status(:see_other)
+
+      # The redirected GET inherits the turbo-stream Accept header; it must still render full HTML
+      # so Turbo performs a real navigation to the index rather than applying a stream in place.
+      get response.location, headers: turbo_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/html")
+    end
+  end
+
+  describe "GET /people" do
+    it "serves the paginated Show More request as a turbo stream" do
+      get people_path(page: 2), headers: turbo_headers
+
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
     end
   end
 end


### PR DESCRIPTION
Resolves #2153

Fixes the **Delete person** action end to end. It had three layered bugs — each fix revealed the next.

## 1. The action didn't fire (client-side)

The dropdown item used legacy Rails UJS attributes (`method: :delete` → `data-method`, `data: { confirm: }` → `data-confirm`), inert in this Turbo-only app, so the click fell through to a GET. Same bug found on **Roster > Actions > Set data status**.

**Fix:** both now use `data: { turbo_method:, turbo_confirm: }`.

## 2. The redirect used 302 (server-side)

`people#destroy` redirected with a default 302. After a Turbo DELETE, the browser refetches a 302 with the same DELETE method, so the redirect failed.

**Fix:** `redirect_to people_path, status: :see_other` (303).

## 3. The redirect landed as a turbo stream, not a page (format negotiation)

With the 303 in place, the follow-up `GET /people` inherited the DELETE's `text/vnd.turbo-stream.html` Accept header, so the index rendered `index.turbo_stream.erb` (append rows) instead of a full page — Turbo applied a stream in place and never navigated, leaving you on the deleted person's page.

The index turbo_stream is only for the "Show More" pager, which always carries a `page` param. **Fix:** register the turbo_stream response only when `params[:page]` is present; otherwise fall through to full HTML so a Turbo redirect landing on the index performs a real navigation.

## Tests

- `spec/helpers/dropdown_helper_spec.rb` — links render `data-turbo-method`, no legacy attributes.
- `spec/requests/people_spec.rb` — `DELETE /people/:id` returns 303 + destroys; the delete-redirect GET (with turbo-stream Accept) renders `text/html`; a paginated request still renders a turbo stream.

Also autocorrects two pre-existing rubocop offenses in the touched controller.

## Notes

- The #2153 console CSP errors were all `[Report Only]` and not the cause.
- **Broader finding:** ~20 other `destroy` actions redirect without `status: :see_other` (same 302-after-DELETE issue when Turbo-triggered). Left for a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)