### PR TITLE
Add /up health check route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   draw :madmin
 
+  get "up" => "rails/health#show", as: :rails_health_check
+
   root to: "visitors#index"
   get "photo_credits", to: "visitors#photo_credits"
   get "about", to: "visitors#about"

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "Health Check" do
+  describe "GET /up" do
+    it "returns 200" do
+      get "/up"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds the `/up` health check route using Rails' built-in `Rails::HealthController`, so the Caddy load balancer on elbee can run active health checks against each backend independently of user traffic.

Relates to #2155 (covers the Rails portion; the remaining checklist items — Caddy active health check config on elbee, verifying `/up` in production, and the DB firewall whitelisting checklist item — are infrastructure tasks outside this repo).

## Changes

- `config/routes.rb`: `get "up" => "rails/health#show", as: :rails_health_check`
- Request spec asserting `GET /up` returns 200

## Note

`Rails::HealthController` returns 200 once the app has booted; it does not probe the database. It would still have caught the app2 incident (Puma holding the port but the app unable to boot), since the active check hits the backend directly and a hung/unbootable app can't return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)