### PR TITLE
Restore BestEffortSegment#place so best-efforts export succeeds

### DIFF
--- a/app/models/best_effort_segment.rb
+++ b/app/models/best_effort_segment.rb
@@ -45,6 +45,13 @@ class BestEffortSegment < ::ApplicationRecord
     end_split_kind == Split.kinds[:finish]
   end
 
+  # "Place" is the user-facing label for a segment's rank within its event (the Place column on the
+  # course-group best-efforts view and the CSV export). event_rank is a runtime select alias, added by
+  # a ranking scope — not a schema attribute — so this delegates by method rather than alias_attribute.
+  def place
+    event_rank
+  end
+
   def to_param
     slug
   end

--- a/app/views/course_group_best_efforts/_best_effort_segment.html.erb
+++ b/app/views/course_group_best_efforts/_best_effort_segment.html.erb
@@ -9,6 +9,6 @@
   <td><%= best_effort_segment.flexible_geolocation %></td>
   <td><%= best_effort_segment.course_name %></td>
   <td class="text-center"><%= best_effort_segment.year_and_lap %></td>
-  <td class="text-center"><%= best_effort_segment.event_rank %></td>
+  <td class="text-center"><%= best_effort_segment.place %></td>
   <td class="text-end"><%= best_effort_segment.elapsed_time %></td>
 </tr>

--- a/app/views/course_group_finishers/_best_effort_segment.html.erb
+++ b/app/views/course_group_finishers/_best_effort_segment.html.erb
@@ -6,6 +6,6 @@
   </td>
   <td><%= best_effort_segment.course_name %></td>
   <td class="text-center"><%= link_to best_effort_segment.year_and_lap, best_effort_segment.effort %></td>
-  <td class="text-center"><%= best_effort_segment.event_rank %></td>
+  <td class="text-center"><%= best_effort_segment.place %></td>
   <td class="text-end"><%= best_effort_segment.elapsed_time %></td>
 </tr>

--- a/spec/models/best_effort_segment_spec.rb
+++ b/spec/models/best_effort_segment_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe BestEffortSegment do
+  describe "#place" do
+    # event_rank is a runtime select alias added by a ranking scope, so a plain record won't carry it.
+    subject(:segment) { described_class.new.tap { |s| s.define_singleton_method(:event_rank) { 3 } } }
+
+    it "returns the segment's event_rank, so the course-group CSV export can serialize `place`" do
+      expect(segment.place).to eq(3)
+    end
+
+    it "is one of the configured CSV export attributes" do
+      expect(BestEffortSegmentParameters.csv_export_attributes).to include("place")
+    end
+  end
+end

--- a/spec/requests/course_group_best_efforts_spec.rb
+++ b/spec/requests/course_group_best_efforts_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe "CourseGroupBestEfforts" do
+  include ActiveJob::TestHelper
+  include Warden::Test::Helpers
+
+  let(:course_group) { course_groups(:both_directions) }
+  let(:organization) { course_group.organization }
+  let(:user) { users(:admin_user) }
+
+  # Populate the effort_segments the best_effort_segments view reads from, so the export has real rows.
+  before { EffortSegment.set_all }
+  after { Warden.test_reset! }
+
+  describe "POST /organizations/:organization_id/course_groups/:course_group_id/best_efforts/export_async" do
+    subject(:make_request) do
+      post export_async_organization_course_group_best_efforts_path(organization, course_group),
+           headers: { "HTTP_REFERER" => organization_course_group_best_efforts_url(organization, course_group) }
+    end
+
+    before { login_as user, scope: :user }
+
+    it "runs the async export end to end and writes a CSV with every configured attribute" do
+      expect { perform_enqueued_jobs { make_request } }.to change(user.export_jobs, :count).by(1)
+
+      export_job = user.export_jobs.last
+      expect(export_job).to be_finished
+      expect(export_job.file).to be_attached
+
+      csv = CSV.parse(export_job.file.download, headers: true)
+      expected_headers = BestEffortSegmentParameters.csv_export_attributes.map(&:humanize)
+
+      # Serializing a real segment exercises every attribute — "Place" is the one that regressed (#2157).
+      expect(csv.headers).to match_array(expected_headers)
+      expect(csv.size).to be_positive
+      expect(csv.first.fetch("Place")).to be_present
+    end
+  end
+end


### PR DESCRIPTION
Resolves #2157

## Bug

Every course-group best-efforts CSV export failed with `NoMethodError: undefined method 'place' for an instance of BestEffortSegment` (Scout #117425, 4× on 7-14). `ExportService#serialized_record` calls `record.public_send(attr)` for each attribute in `BestEffortSegmentParameters.csv_export_attributes`, and that list includes `place` — which the model no longer defines.

## Root cause

`place` is the user-facing label for a segment's **rank within its event** (`event_rank`) — the on-screen course-group table has a "Place" column (`_best_efforts_list.html.erb:13`) rendering `event_rank`. Commit `6c2c53b5` (2022) added `alias_attribute :place, :event_rank` alongside the export attribute. A later refactor switched the view to read `event_rank` directly and dropped the alias, but left `place` in the export list — so the export broke while the page kept working.

## Fix

Re-add `place`, delegating to `event_rank`:

```ruby
def place
  event_rank
end
```

Not `alias_attribute` — `event_rank` is a runtime **select alias** (added by the ranking scope), not a schema column, and Rails 8's `alias_attribute` raises `ArgumentError: ... event_rank is not an attribute` when a record is instantiated. A plain method resolves `event_rank` at call time, exactly like the view does. Keeping the export attribute named `place` preserves the "Place" CSV header, consistent with the on-screen column.

## Verification

- New `spec/models/best_effort_segment_spec.rb`: `#place` returns `event_rank`, and `place` stays in the export attribute list.
- End-to-end check mirroring the export's query path — a record loaded with `event_rank` as a select alias returns `place == event_rank`:
  ```
  BestEffortSegment.find_by_sql("SELECT 42 AS event_rank").first.place  # => 42
  ```
- Existing `export_service_spec` still green.

## Note

I kept this targeted. #2157 also floated guarding `serialized_record` against attributes the resource doesn't respond to (so a future mis-config degrades instead of 500-ing). That's a reasonable separate hardening but I left it out to keep the fix focused — happy to do it as a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)