### PR TITLE
Fix Organization scopes: subquery instead of join+distinct

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,19 +22,24 @@ class Organization < ApplicationRecord
   has_many :results_templates, dependent: :destroy
 
   scope :owned_by, ->(user) { where(created_by: user.id) }
+  # Match by a stewardship subquery rather than a join, so results are naturally unique without
+  # `distinct`. A `distinct` here breaks when the relation is later ordered by a joined column — e.g.
+  # FriendlyId history's `find` orders by friendly_id_slugs.id, which SELECT DISTINCT organizations.*
+  # rejects (see #2158).
   scope :authorized_for, lambda { |user|
-    left_joins(:stewardships)
-      .where("organizations.created_by = ? or stewardships.user_id = ?", user.id, user.id)
-      .distinct
+    where(
+      "organizations.created_by = :user_id or organizations.id in (:steward_org_ids)",
+      user_id: user.id,
+      steward_org_ids: Stewardship.where(user_id: user.id).select(:organization_id),
+    )
   }
   scope :visible_or_authorized_for, lambda { |user|
-    left_joins(:stewardships)
-      .where(
-        "organizations.concealed is not true or organizations.created_by = ? or stewardships.user_id = ?",
-        user.id,
-        user.id,
-      )
-      .distinct
+    where(
+      "organizations.concealed is not true or organizations.created_by = :user_id " \
+      "or organizations.id in (:steward_org_ids)",
+      user_id: user.id,
+      steward_org_ids: Stewardship.where(user_id: user.id).select(:organization_id),
+    )
   }
   scope :with_visible_event_count, lambda {
     left_joins(event_groups: :events)

--- a/spec/fixtures/friendly_id_slugs.yml
+++ b/spec/fixtures/friendly_id_slugs.yml
@@ -1,6 +1,0 @@
-# A historical (renamed-from) slug for the hardrock organization, whose current slug is "hardrock".
-# Looking it up exercises FriendlyId's history finder (see Organization .visible_or_authorized_for spec).
-hardrock_historical:
-  slug: hardrock-original
-  sluggable: hardrock (Organization)
-  created_at: 2020-01-01 00:00:00

--- a/spec/fixtures/friendly_id_slugs.yml
+++ b/spec/fixtures/friendly_id_slugs.yml
@@ -1,0 +1,6 @@
+# A historical (renamed-from) slug for the hardrock organization, whose current slug is "hardrock".
+# Looking it up exercises FriendlyId's history finder (see Organization .visible_or_authorized_for spec).
+hardrock_historical:
+  slug: hardrock-original
+  sluggable: hardrock (Organization)
+  created_at: 2020-01-01 00:00:00

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -97,4 +97,22 @@ RSpec.describe Organization, type: :model do
       end
     end
   end
+
+  describe ".visible_or_authorized_for" do
+    subject(:found) { described_class.visible_or_authorized_for(user).friendly.find(historical_slug) }
+
+    let(:user) { users(:third_user) }
+    let(:existing_organization) { organizations(:hardrock) }
+    let(:historical_slug) { "hardrock-original" }
+
+    # Give the (currently "hardrock") org a prior slug, so the lookup goes through FriendlyId history.
+    before { existing_organization.slugs.create!(slug: historical_slug) }
+
+    # Regression for #2158: the scope must not `distinct`, or FriendlyId history's `find` (which orders
+    # by friendly_id_slugs.id) raises PG::InvalidColumnReference against a SELECT DISTINCT.
+    it "finds an organization by a historical slug without a DISTINCT/ORDER BY error" do
+      expect { found }.not_to raise_error
+      expect(found).to eq(existing_organization)
+    end
+  end
 end


### PR DESCRIPTION
Resolves #2158

## Bug

`courses#show` (and any endpoint resolving an org through `policy_scope(Organization)`) could 500 with `PG::InvalidColumnReference: for SELECT DISTINCT, ORDER BY expressions must appear in select list` (Scout #116802).

## Root cause

`Organization.visible_or_authorized_for` (and `authorized_for`) used `left_joins(:stewardships).where(...).distinct` — i.e. `SELECT DISTINCT organizations.*`. Organization uses `friendly_id :name, use: [:slugged, :history]`, and when an org is resolved by an **old** slug (e.g. `couch-to-coast` after a rename), FriendlyId's history finder appends `.joins(:slugs).order(friendly_id_slugs.id DESC)`. Chained onto the scope, that's `SELECT DISTINCT organizations.* … ORDER BY friendly_id_slugs.id DESC`, which Postgres rejects. Rare because it needs a renamed org accessed by its historical slug.

## Fix

Replace the join+`distinct` with an `id IN (stewardship subquery)`:

```ruby
where("organizations.concealed is not true or organizations.created_by = :user_id " \
      "or organizations.id in (:steward_org_ids)",
      user_id: user.id, steward_org_ids: Stewardship.where(user_id: user.id).select(:organization_id))
```

Results are naturally unique (no join fan-out), so there's no `distinct` to conflict with a later `ORDER BY`. Same result set; nothing downstream referenced the joined `stewardships` columns (the scopes are only used via `find`/`pluck`).

## Verification

- New `Organization.visible_or_authorized_for` regression spec: finds an org by a **historical slug** without raising. Confirmed it fails with the exact `PG::InvalidColumnReference` when the old `distinct` scope is restored.
- Reproduced the original error and the fix directly in a console.
- Org/course model + API specs (121) and the org index/courses/request specs green — listings and lookups unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)