### PR TITLE
Add update_release_times column to gating_location_events

### DIFF
--- a/db/migrate/20260717205108_add_update_release_times_to_gating_location_events.rb
+++ b/db/migrate/20260717205108_add_update_release_times_to_gating_location_events.rb
@@ -1,0 +1,5 @@
+class AddUpdateReleaseTimesToGatingLocationEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :gating_location_events, :update_release_times, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_28_195206) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_17_205108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -334,6 +334,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_195206) do
     t.integer "gating_aid_station_id", null: false
     t.bigint "gating_location_id", null: false
     t.integer "target_aid_station_id", null: false
+    t.boolean "update_release_times", default: true, null: false
     t.datetime "updated_at", null: false
     t.index ["event_id"], name: "index_gating_location_events_on_event_id"
     t.index ["gating_aid_station_id"], name: "index_gating_location_events_on_gating_aid_station_id"

--- a/erd.mmd
+++ b/erd.mmd
@@ -212,6 +212,7 @@ erDiagram
 	}
 	GatingLocationEvent {
 		integer default_travel_buffer
+		boolean update_release_times
 	}
 	HistoricalFact {
 		string address


### PR DESCRIPTION
Part of #2162 (PR 1 of 3).

## What

Adds a per-gate boolean **`update_release_times`** (`default: true, null: false`) to `gating_location_events`. It will later control whether crew-access release times refine as a runner reaches interim aid stations between the gate and target (today's behavior, from #2151) or hold constant from the gating time — the RD-requested "consistency over accuracy" option.

## Scope

**Column only.** Default `true` preserves current behavior for every existing gate. No model, view, or behavior changes here — the setup-form toggle (PR 2) and the updating/non-updating release-time logic + effort-view notice (PR 3) follow separately, per #2162.

## Notes

- Migration mirrors `AddDefaultTravelBufferToGatingLocationEvents` (`[8.1]`, `def change`); reversible.
- `db/schema.rb` and `erd.mmd` regenerated (the ERD auto-regenerates on `db:migrate`).
- Fixtures unchanged — they rely on DB defaults.
- Verified: rollback/re-migrate clean, `GatingLocationEvent.new.update_release_times # => true`, existing gating specs green (29 examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)