### PR TITLE
Honor update_release_times: constant vs. updating crew releases

### DIFF
--- a/app/models/gating_location_event.rb
+++ b/app/models/gating_location_event.rb
@@ -39,10 +39,10 @@ class GatingLocationEvent < ApplicationRecord
   def interim_splits
     return [] if gating_split.blank? || target_split.blank?
 
-    event.aid_stations.map(&:split).select do |split|
+    event.ordered_splits.select do |split|
       split.distance_from_start > gating_split.distance_from_start &&
         split.distance_from_start < target_split.distance_from_start
-    end.sort_by(&:distance_from_start)
+    end
   end
 
   private

--- a/app/models/gating_location_event.rb
+++ b/app/models/gating_location_event.rb
@@ -34,6 +34,17 @@ class GatingLocationEvent < ApplicationRecord
     SubSplit.kind(gating_bitkey) if gating_bitkey
   end
 
+  # Aid-station splits strictly between the gate and the target — the interim time points whose data
+  # refines the release when update_release_times is on. Empty when the gate and target are adjacent.
+  def interim_splits
+    return [] if gating_split.blank? || target_split.blank?
+
+    event.aid_stations.map(&:split).select do |split|
+      split.distance_from_start > gating_split.distance_from_start &&
+        split.distance_from_start < target_split.distance_from_start
+    end.sort_by(&:distance_from_start)
+  end
+
   private
 
   def aid_stations_belong_to_event

--- a/app/models/gating_location_event.rb
+++ b/app/models/gating_location_event.rb
@@ -34,8 +34,7 @@ class GatingLocationEvent < ApplicationRecord
     SubSplit.kind(gating_bitkey) if gating_bitkey
   end
 
-  # Aid-station splits strictly between the gate and the target — the interim time points whose data
-  # refines the release when update_release_times is on. Empty when the gate and target are adjacent.
+  # Aid-station splits strictly between the gate and target — the interim time points that refine the release.
   def interim_splits
     return [] if gating_split.blank? || target_split.blank?
 

--- a/app/view_models/effort_crew_access_view.rb
+++ b/app/view_models/effort_crew_access_view.rb
@@ -5,7 +5,8 @@ class EffortCrewAccessView < EffortWithLapSplitRows
   def gating_location_events
     @gating_location_events ||=
       event.gating_location_events
-           .includes(:gating_location, gating_aid_station: :split, target_aid_station: :split)
+           .includes(:gating_location, gating_aid_station: :split, target_aid_station: :split,
+                                       event: { aid_stations: :split })
            .sort_by { |gle| gle.gating_location.name }
   end
 

--- a/app/view_models/effort_crew_access_view.rb
+++ b/app/view_models/effort_crew_access_view.rb
@@ -5,8 +5,7 @@ class EffortCrewAccessView < EffortWithLapSplitRows
   def gating_location_events
     @gating_location_events ||=
       event.gating_location_events
-           .includes(:gating_location, gating_aid_station: :split, target_aid_station: :split,
-                                       event: { aid_stations: :split })
+           .includes(:gating_location, gating_aid_station: :split, target_aid_station: :split, event: :splits)
            .sort_by { |gle| gle.gating_location.name }
   end
 

--- a/app/view_models/gating_location_row.rb
+++ b/app/view_models/gating_location_row.rb
@@ -191,6 +191,10 @@ class GatingLocationRow
   # target. At the gating aid station only its gate sub-split counts (an In-only runner has not left
   # the gate); at intermediate stations any recorded time counts.
   def anchor_candidates
+    # A non-updating gate holds its release constant from the gating time, so only the gate anchors it
+    # — interim progress is ignored (a drop still nullifies the release via the stopped? guard).
+    return [gating_split_time].compact unless update_release_times
+
     gating_distance = gating_split.distance_from_start
     target_distance = target_split.distance_from_start
 
@@ -198,9 +202,6 @@ class GatingLocationRow
       distance = split_time.split.distance_from_start
       next false unless distance >= gating_distance && distance < target_distance
       next false if split_time.split_id == gating_split.id && split_time.bitkey != gating_bitkey
-      # A non-updating gate holds its release constant from the gating time, so only the gate anchors
-      # it — interim progress is ignored (a drop still nullifies the release via the stopped? guard).
-      next false if !update_release_times && split_time.split_id != gating_split.id
 
       true
     end

--- a/app/view_models/gating_location_row.rb
+++ b/app/view_models/gating_location_row.rb
@@ -18,10 +18,8 @@ class GatingLocationRow
     gating_location_event.event.guaranteed_short_name
   end
 
-  # The runner's recorded time at the gating aid station's gate sub-split (its Out when the station
-  # records one, otherwise its In), latest lap. Nil until that time exists: a runner who has only
-  # checked In could still be at the aid station for a while, so anchoring the release projection on
-  # the In time would release the crew too early.
+  # The gate's time — its Out when the station records one, else In, latest lap. Nil until recorded, so
+  # an In-only runner (possibly lingering at the aid station) doesn't release the crew early.
   def gating_split_time
     return @gating_split_time if defined?(@gating_split_time)
 
@@ -38,14 +36,12 @@ class GatingLocationRow
     gating_split_time&.absolute_time&.in_time_zone(home_time_zone)
   end
 
-  # True once the runner has any recorded time at or beyond the target aid station,
-  # at which point a release time is moot.
+  # True once the runner has a recorded time at or beyond the target, making a release moot.
   def reached_target?
     furthest_target_split_time.present?
   end
 
-  # True once the runner has progressed past the target aid station's In time — its Out time,
-  # or any later aid station.
+  # True once the runner is past the target's In — its Out, or any later station.
   def departed_target?
     split_time = furthest_target_split_time
     return false if split_time.nil?
@@ -53,7 +49,6 @@ class GatingLocationRow
     split_time.split_id != target_split.id || split_time.bitkey != SubSplit::IN_BITKEY
   end
 
-  # The runner's most recent recorded time at or beyond the target aid station.
   def target_progress_time_local
     furthest_target_split_time&.absolute_time&.in_time_zone(home_time_zone)
   end
@@ -68,10 +63,8 @@ class GatingLocationRow
     "#{verb} #{split_time.split.base_name}"
   end
 
-  # The runner's earliest predicted arrival at the target aid station, or nil when no release time
-  # applies (not yet gated, stopped, already arrived, or no projection). The projection is anchored
-  # on the runner's furthest recorded point between the gate and the target (see #projection_anchor),
-  # so it refines as the runner progresses toward the target.
+  # Earliest predicted arrival at the target, or nil (not gated, stopped, arrived, or no projection).
+  # Anchored on the runner's furthest recorded point between gate and target (see #projection_anchor).
   def predicted_target_arrival
     return @predicted_target_arrival if defined?(@predicted_target_arrival)
 
@@ -97,14 +90,12 @@ class GatingLocationRow
     projection_anchor_split_time&.absolute_time&.in_time_zone(home_time_zone)
   end
 
-  # True when the projection is anchored beyond the gating aid station — on an intermediate aid
-  # station the runner has since reached — i.e. the estimate has been refined since leaving the gate.
+  # True when the projection is anchored on an intermediate station — the estimate has refined past the gate.
   def anchored_beyond_gate?
     projection_anchor_split_time.present? && projection_anchor_split_time.split_id != gating_split.id
   end
 
-  # True when the shown release time can still change as the runner reaches interim stations, so the
-  # effort view can warn crews. Only when this gate updates and has interim time points to update from.
+  # Whether the shown release can still change as the runner reaches interim stations — to warn crews.
   def release_may_update?
     update_release_times && interim_splits.present?
   end
@@ -172,11 +163,8 @@ class GatingLocationRow
     @furthest_target_split_time = at_or_beyond.max_by { |st| [st.split.distance_from_start, st.bitkey] }
   end
 
-  # The point the release projection is anchored on: the runner's furthest recorded time between the
-  # gate (inclusive) and the target (exclusive) that yields a projection, walking back toward the gate
-  # when a nearer point has no prior-year data. The gating aid station is only the *earliest* possible
-  # anchor; a runner who has reached intermediate stations gets a more up-to-date estimate. A
-  # non-updating gate offers only the gate as a candidate, so its release stays constant.
+  # The projection's anchor: the runner's furthest recorded point between gate (inclusive) and target
+  # (exclusive) that yields a projection, walking back toward the gate when a nearer point has no data.
   def projection_anchor
     return @projection_anchor if defined?(@projection_anchor)
 
@@ -187,12 +175,10 @@ class GatingLocationRow
     end.first
   end
 
-  # Recorded split times eligible to anchor the projection: those at or beyond the gate and before the
-  # target. At the gating aid station only its gate sub-split counts (an In-only runner has not left
-  # the gate); at intermediate stations any recorded time counts.
+  # Split times eligible to anchor the projection, gate (inclusive) to target (exclusive), counting only
+  # the gate's sub-split at the gate. A non-updating gate uses just the gate, holding its release
+  # constant (interim progress ignored; a drop still nullifies via the stopped? guard).
   def anchor_candidates
-    # A non-updating gate holds its release constant from the gating time, so only the gate anchors it
-    # — interim progress is ignored (a drop still nullifies the release via the stopped? guard).
     return [gating_split_time].compact unless update_release_times
 
     gating_distance = gating_split.distance_from_start
@@ -207,9 +193,8 @@ class GatingLocationRow
     end
   end
 
+  # Cache key busts on an anchor time correction (id + updated_at) or a re-pointed target.
   def projected_low_seconds_from(split_time)
-    # Keyed on the anchor split time (id + updated_at, so a correction busts it) and the target split
-    # (so re-pointing the gate's target busts it). Reaching a new station is a new split_time id.
     cache_key = ["gating_prediction", gating_location_event.id, target_split.id, split_time.id, split_time.updated_at]
     Rails.cache.fetch(cache_key) do
       Projection.execute_query(

--- a/app/view_models/gating_location_row.rb
+++ b/app/view_models/gating_location_row.rb
@@ -103,6 +103,16 @@ class GatingLocationRow
     projection_anchor_split_time.present? && projection_anchor_split_time.split_id != gating_split.id
   end
 
+  # True when the shown release time can still change as the runner reaches interim stations, so the
+  # effort view can warn crews. Only when this gate updates and has interim time points to update from.
+  def release_may_update?
+    update_release_times && interim_splits.present?
+  end
+
+  def interim_split_names
+    interim_splits.map(&:base_name)
+  end
+
   # Predicted target arrival minus the travel buffer, or nil when no release time applies.
   def release_time(buffer_minutes)
     arrival = predicted_target_arrival
@@ -142,7 +152,8 @@ class GatingLocationRow
 
   attr_reader :effort, :gating_location_event
 
-  delegate :gating_split, :target_split, :gating_bitkey, to: :gating_location_event
+  delegate :gating_split, :target_split, :gating_bitkey, :update_release_times, :interim_splits,
+           to: :gating_location_event
 
   def projection_anchor_split_time
     projection_anchor&.split_time
@@ -164,7 +175,8 @@ class GatingLocationRow
   # The point the release projection is anchored on: the runner's furthest recorded time between the
   # gate (inclusive) and the target (exclusive) that yields a projection, walking back toward the gate
   # when a nearer point has no prior-year data. The gating aid station is only the *earliest* possible
-  # anchor; a runner who has reached intermediate stations gets a more up-to-date estimate.
+  # anchor; a runner who has reached intermediate stations gets a more up-to-date estimate. A
+  # non-updating gate offers only the gate as a candidate, so its release stays constant.
   def projection_anchor
     return @projection_anchor if defined?(@projection_anchor)
 
@@ -186,6 +198,9 @@ class GatingLocationRow
       distance = split_time.split.distance_from_start
       next false unless distance >= gating_distance && distance < target_distance
       next false if split_time.split_id == gating_split.id && split_time.bitkey != gating_bitkey
+      # A non-updating gate holds its release constant from the gating time, so only the gate anchors
+      # it — interim progress is ignored (a drop still nullifies the release via the stopped? guard).
+      next false if !update_release_times && split_time.split_id != gating_split.id
 
       true
     end

--- a/app/views/efforts/_crew_access_location.html.erb
+++ b/app/views/efforts/_crew_access_location.html.erb
@@ -48,6 +48,12 @@
             <span class="badge bg-success">Now</span>
           <% else %>
             <strong><%= day_time_military_format(row.release_time_local(buffer)) %></strong>
+            <% if row.release_may_update? %>
+              <div class="small text-body-secondary">
+                Best estimate available now; subject to change based on your times at
+                <%= row.interim_split_names.to_sentence %>.
+              </div>
+            <% end %>
           <% end %>
         <% else %>
           <span class="text-body-secondary">Insufficient data</span>

--- a/docs/management/crew-access.md
+++ b/docs/management/crew-access.md
@@ -115,6 +115,17 @@ from that early point, while a slower runner's crew benefits from updated releas
 stations. If a later station has no prior-year data of its own, OpenSplitTime falls back to the most recent
 earlier point that does, so a release remains available.
 
+### Constant vs. Updating Release Times
+
+Each gate has an **Update release times as the runner progresses** switch (in the construction form, per event).
+It only matters when there are aid stations between the gate and the target.
+
+- **On (the default):** releases refine as described above. On the runner's public Crew Access tab, the release
+  time is labeled as the best estimate available now and subject to change based on the runner's interim times.
+- **Off:** the release time is computed once from the gating time and held **constant** — it does not change as
+  the runner passes interim stations. Choose this when it's more important to give a crew a time and stick with
+  it than to refine it. A runner who **drops** at an interim station still clears the release either way.
+
 ### Adjusting the View
 
 Controls above each Event's table let you tailor the board:

--- a/spec/view_models/gating_location_row_spec.rb
+++ b/spec/view_models/gating_location_row_spec.rb
@@ -118,11 +118,12 @@ RSpec.describe GatingLocationRow do
   context "with intermediate aid stations between the gate and target" do
     subject(:row) { described_class.new(effort: effort, gating_location_event: wide_gate) }
 
+    let(:update_release_times) { true }
     let(:wide_gate) do
       GatingLocationEvent.new(gating_location: gating_locations(:sum_bandera_gate), event: event,
                               gating_aid_station: aid_stations(:aid_station_0017), # Molas Pass, distance 18347
                               target_aid_station: aid_stations(:aid_station_0020), # Bandera Mine, distance 80741
-                              default_travel_buffer: 60)
+                              default_travel_buffer: 60, update_release_times: update_release_times)
     end
     let(:gate_split) { splits(:sum_100k_course_molas_pass_aid1) }
     let(:intermediate_split) { splits(:sum_100k_course_cascade_creek_rd_aid3) } # distance 46317
@@ -141,6 +142,32 @@ RSpec.describe GatingLocationRow do
         expect(row.projection_anchor_label).to eq(intermediate_split.base_name)
         # Projected from the intermediate time (gate + 2h), not the gate time.
         expect(row.predicted_target_arrival).to eq(gating_time + 2.hours + 3600.seconds)
+      end
+
+      it "flags the release as subject to change and lists the interim stations" do
+        expect(row.release_may_update?).to be(true)
+        expect(row.interim_split_names).to include(intermediate_split.base_name, beyond_intermediate_split.base_name)
+      end
+    end
+
+    context "when the gate does not update release times" do
+      let(:update_release_times) { false }
+
+      before do
+        build_split_time(split: intermediate_split, bitkey: SubSplit::OUT_BITKEY, absolute_time: gating_time + 2.hours)
+        allow(Projection).to receive(:execute_query).and_return([instance_double(Projection, low_seconds: 3600)])
+      end
+
+      it "holds the release constant from the gating time, ignoring interim progress" do
+        expect(row.anchored_beyond_gate?).to be(false)
+        # Anchored on the gate time, not the intermediate (gate + 2h).
+        expect(row.predicted_target_arrival).to eq(gating_time + 3600.seconds)
+        expect(row.release_may_update?).to be(false)
+      end
+
+      it "still nullifies the release when the runner drops at an interim station" do
+        allow(effort).to receive(:stopped?).and_return(true)
+        expect(row.predicted_target_arrival).to be_nil
       end
     end
 


### PR DESCRIPTION
Resolves #2162 (PR 3 of 3 — the behavior). Follows #2163 (column) and #2165 (setup toggle).

## What

Makes the `update_release_times` flag actually drive release-time behavior per gate:

- **On (default):** unchanged — the release re-anchors on the runner's furthest recorded point between the gate and target (#2151's progressive projection).
- **Off:** only the gate anchors the projection, so the release is computed **once from the gating time and held constant** as the runner passes interim stations. A runner who **drops** still clears the release (via the existing `stopped?` guard) — the one exception the RD asked for.

Implemented as a one-line gate in `GatingLocationRow#anchor_candidates` (drop interim points when the gate doesn't update), so non-updating naturally also suppresses the "anchored beyond the gate" annotations.

## Effort-view notice

On the public per-runner Crew Access tab, when a gate **updates** and has interim aid stations, the shown release time now carries: *"Best estimate available now; subject to change based on your times at …"* (lists the interim stations). Added `GatingLocationEvent#interim_splits` (aid stations strictly between gate and target) and preloaded it in `EffortCrewAccessView` to avoid N+1.

## Tests & docs

- `gating_location_row_spec`: non-updating holds the release constant from the gating time (ignores an interim point), still nullifies on a drop, and reports `release_may_update? == false`; updating flags the release subject to change and lists the interim stations. Full gating + crew-access suites green (52 examples).
- `docs/management/crew-access.md`: new "Constant vs. Updating Release Times" subsection.

## Note

The setup-form UX wart (toggle shown on un-gated event cards) is tracked separately as a follow-up on #2162 and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)