### PR TITLE
Gracefully handle photo-less show_photo and bogus health-check formats

### DIFF
--- a/app/views/efforts/_show_photo.html.erb
+++ b/app/views/efforts/_show_photo.html.erb
@@ -1,5 +1,9 @@
 <%= turbo_frame_tag "form_modal" do %>
   <div class="text-center m-3">
-    <%= image_tag(@effort.photo.variant(:medium)) %>
+    <% if @effort.photo.attached? %>
+      <%= image_tag(@effort.photo.variant(:medium)) %>
+    <% else %>
+      <p class="text-body-secondary mb-0">No photo available.</p>
+    <% end %>
   </div>
 <% end %>

--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -1,0 +1,7 @@
+# Bots probe paths like /up.php. The ".php" makes the stock health-check route
+# (get "up" => "rails/health#show") negotiate an unknown format and raise ActionController::UnknownFormat,
+# which would 500. ApplicationController already turns that into a 406, but the framework health
+# controller doesn't inherit it — so extend it here to respond 406 as well.
+Rails.application.config.to_prepare do
+  Rails::HealthController.rescue_from(ActionController::UnknownFormat) { head :not_acceptable }
+end

--- a/spec/requests/efforts/show_photo_spec.rb
+++ b/spec/requests/efforts/show_photo_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Efforts show_photo" do
+  describe "GET show_photo" do
+    let(:effort) { efforts(:ggd30_50k_bad_finish) }
+
+    it "renders without error when the effort has no photo" do
+      expect(effort.photo).not_to be_attached
+
+      get show_photo_effort_path(effort)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("No photo available")
+    end
+  end
+end

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -7,4 +7,12 @@ RSpec.describe "Health Check" do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  # Bots probe /up.php etc.; the format extension must not 500 the health controller.
+  describe "GET /up.php" do
+    it "returns 406 rather than raising" do
+      get "/up.php"
+      expect(response).to have_http_status(:not_acceptable)
+    end
+  end
 end


### PR DESCRIPTION
Fixes two production 500s from edge/bot requests (Scout #76347 and #118025).

## 1. `efforts#show_photo` 500 on a photo-less effort (Scout #76347, 90×)

`_show_photo.html.erb` did `image_tag(@effort.photo.variant(:medium))` with no guard, so an effort with **no photo attached** raised `ActionView::Template::Error: "Nil location provided. Can't build URI."` (e.g. `.../carrie-stafford/show_photo`, hit repeatedly).

**Fix:** guard on `@effort.photo.attached?` and render "No photo available." otherwise.

*(This is distinct from #2161 — that's the `active_storage/representations/redirect` endpoint serving entrant_photos variants, an orphan-blob/S3 issue. This one is a missing attachment on `effort.photo`.)*

## 2. `/up.php` 500 (Scout #118025)

A bot probing `/up.php` matches `get "up" => "rails/health#show"` with format `:php`, which raises `ActionController::UnknownFormat` and 500s. `ApplicationController` already rescues that into a **406**, but the framework `Rails::HealthController` doesn't inherit it.

**Fix:** a `to_prepare` initializer extends `Rails::HealthController` to return **406** on `UnknownFormat`, matching the app's convention. The health check stays stock and DB-free (consistent with the #2155/#2156 decision) — this only affects junk-format probes.

## Tests

- `spec/requests/efforts/show_photo_spec.rb`: a photo-less public effort renders 200 with "No photo available" (would 500 before).
- `spec/requests/health_check_spec.rb`: `GET /up.php` returns 406; `GET /up` still 200.

rubocop/erb_lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)