### PR TITLE
Back AidStation uniqueness with a composite unique index

### DIFF
--- a/app/models/aid_station.rb
+++ b/app/models/aid_station.rb
@@ -8,7 +8,8 @@ class AidStation < ApplicationRecord
   has_many :gating_location_events_as_target, class_name: "GatingLocationEvent", foreign_key: :target_aid_station_id,
                                               dependent: :destroy, inverse_of: :target_aid_station
 
-  validates :split_id, uniqueness: { scope: :event_id, message: "only one of any given split permitted within an event" } # rubocop:disable Rails/UniqueValidationWithoutIndex, Layout/LineLength
+  validates :split_id,
+            uniqueness: { scope: :event_id, message: "only one of any given split permitted within an event" }
   validates_with AidStationAttributesValidator
 
   attr_accessor :efforts_dropped_at_station, :efforts_in_aid, :efforts_recorded_out,

--- a/db/migrate/20260721221108_add_unique_index_to_aid_stations.rb
+++ b/db/migrate/20260721221108_add_unique_index_to_aid_stations.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToAidStations < ActiveRecord::Migration[8.1]
+  def change
+    add_index :aid_stations, [:event_id, :split_id], unique: true
+
+    # Redundant once the composite exists: (event_id, split_id) also serves event_id-prefix lookups.
+    remove_index :aid_stations, :event_id
+
+    change_column_null :aid_stations, :event_id, false
+    change_column_null :aid_stations, :split_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_17_205108) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_221108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -47,10 +47,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_17_205108) do
 
   create_table "aid_stations", id: :serial, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
-    t.integer "event_id"
-    t.integer "split_id"
+    t.integer "event_id", null: false
+    t.integer "split_id", null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.index ["event_id"], name: "index_aid_stations_on_event_id"
+    t.index ["event_id", "split_id"], name: "index_aid_stations_on_event_id_and_split_id", unique: true
     t.index ["split_id"], name: "index_aid_stations_on_split_id"
   end
 

--- a/spec/models/aid_station_spec.rb
+++ b/spec/models/aid_station_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe AidStation, type: :model do
         expect(aid_station).not_to be_valid
         expect(aid_station.errors.full_messages.first).to include("only one of any given split permitted within an event")
       end
+
+      it "is rejected by the database unique index even when the validation is bypassed" do
+        expect { aid_station.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+      end
     end
 
     context "with event_group split location validations" do


### PR DESCRIPTION
Resolves #2122.

## Summary

`AidStation` validates uniqueness of `split_id` scoped to `event_id`, but nothing at the DB level enforced it — only single-column non-unique indexes — so two concurrent saves could both pass the app validation and create duplicates. This adds the backing unique index and drops the rubocop disable that was masking the gap (flagged during #2121).

## Changes

- **Migration** (`add_unique_index_to_aid_stations`):
  - `add_index :aid_stations, [:event_id, :split_id], unique: true`
  - drop the now-redundant single-column `event_id` index (the composite serves `event_id`-prefix lookups); keep the `split_id` index
  - `event_id` / `split_id` set `NOT NULL` (both `belongs_to` are already required, so the app has enforced this on writes for years)
- **Model**: split the validation onto two lines and remove the `# rubocop:disable Rails/UniqueValidationWithoutIndex, Layout/LineLength` — neither is needed once the index backs the validation and the line fits.
- **Spec**: adds a test that the DB index rejects a duplicate `(event_id, split_id)` even when the model validation is bypassed (the race-protection the index provides).

Fully reversible (verified `db:rollback` restores the original schema). `erd.mmd` is unchanged — indexes and nullability aren't represented in the ERD.

## ⚠️ Before deploying — production data must be clean

The migration will **fail** if production has duplicate or null rows. Please run these against production/staging first and clean up any hits:

```sql
-- duplicate (event_id, split_id) pairs — must be empty for the unique index
select event_id, split_id, count(*) from aid_stations group by 1, 2 having count(*) > 1;

-- null rows — must be empty for the NOT NULL constraints
select count(*) from aid_stations where event_id is null or split_id is null;
```

My local DB was clean (0 dups, 0 nulls); staging will exercise the migration on deploy from master, so any issue surfaces there before production.

## Note (out of scope)

`event_group.rb`, `split.rb`, and `organization.rb` carry the same inline disable for case-insensitive / message-customized uniqueness validations — left for a separate follow-up as the issue suggests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)