### PR TITLE
Add an operations runbook (LB health checks, provisioning)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -14,7 +14,8 @@ Cloudflare  ->  load balancer (Caddy)  ->  web backend 1 (Caddy -> Puma)
 ```
 
 Hostnames, IPs, and tokens are intentionally written as placeholders here (`<load-balancer-host>`,
-`<backend-host>`, `<backend-ip>`, `<db-host>`) — this file is in a public repository. Keep it that way.
+`<backend-host>`, `<backend-ip>`, `<site>`, `<db-host>`) — this file is in a public repository. Keep it
+that way.
 
 ---
 
@@ -39,87 +40,93 @@ backend that never finishes booting). See the design discussion on issue #2155 /
 
 **Why this matters (real incident).** When a new backend was added to the LB but couldn't boot (its IP
 wasn't whitelisted in the database firewall — see the provisioning checklist below), it held its port
-without accepting connections and returned 502 for every request. The LB kept sending it ~half the
-traffic and the origin overloaded. The Caddy journal for that window shows **no health-check activity at
-all** — nothing removed the bad backend automatically, and the outage lasted ~40 minutes until it was
-removed **by hand** via the admin API. Passive checks alone don't catch this: a 502 *is* a response, so
-the LB counts the backend as "responding."
+without accepting connections and its own Caddy returned 502 for every request. The LB kept sending it
+~half the traffic and the origin overloaded; the site was down for **~25 minutes** until the backend was
+removed **by hand** via the admin API.
 
-**Active** health checks fix exactly this — the LB probes each backend's `/up` directly on a fixed
-interval, independent of user traffic, and pulls a backend that fails the probe within seconds.
+The reason it wasn't pulled automatically is in the LB's *passive* health check. Hatchbox configures
+passive as `{fail_duration, max_fails}` with **no `unhealthy_status`**, so Caddy only counts
+*connection-level* failures — an HTTP 502 is a completed response, not a failure. The bad backend's 502s
+counted as "responding," so passive never removed it.
 
-### Configuration
+**Active** health checks close that gap: the LB probes each backend's `/up` on an interval and treats a
+non-2xx (or a refused/timed-out connection) as unhealthy — exactly the 502-from-the-backend's-own-Caddy
+case that passive ignored.
 
-Caddy on the LB runs its config via the admin API (there may be no static Caddyfile — the live config is
-`curl -s localhost:2019/config/`). The health-check block lives on the `reverse_proxy` handler. Expressed
-as a Caddyfile fragment (map to JSON if that's how the config is managed; **verify directive names against
-the running Caddy version** — check `caddy version`):
+### Enabling — Hatchbox does this natively; don't hand-edit Caddy
 
-```
-reverse_proxy <backend-1>:<port> <backend-2>:<port> {
-    # active checks
-    health_uri      /up
-    health_interval 10s
-    health_timeout  5s
-    health_status   2xx
+Hatchbox generates the LB's Caddy config — the `reverse_proxy` block and its `health_checks` — inside an
+opaque `%{apps}` template. **Do not** patch the running Caddy via the admin API to add active checks; the
+next deploy regenerates the config and wipes it. Instead, set the app's **health-check path to `/up`** in
+Hatchbox; it then emits the `health_checks.active` block (and sets the correct upstream `Host` header so
+the probe routes to the app).
 
-    # passive checks (backstop)
-    fail_duration    10s
-    max_fails        3
-    unhealthy_status 5xx
-}
-```
+Two things Hatchbox does **not** let you tune, worth knowing:
+- **No interval is set, so Caddy defaults to ~30s.** Failover takes up to ~30s — far better than the
+  ~25-minute outage, but during that window the bad backend still gets ~half the traffic. Tighten only if
+  Hatchbox ever exposes an interval/timeout setting.
+- The **passive block stays `max_fails: 10` with no `unhealthy_status`** — effectively inert for a 502, as
+  above. Active is doing the real work; don't rely on passive.
 
-Equivalent JSON on the reverse_proxy handler (durations are integer **nanoseconds**; `10s = 10000000000`):
+### Verifying (tested procedure)
 
-```json
-"health_checks": {
-  "active":  { "path": "/up", "interval": 10000000000, "timeout": 5000000000, "expect_status": 200 },
-  "passive": { "fail_duration": 10000000000, "max_fails": 3, "unhealthy_status": [500, 502, 503, 504] }
-}
-```
+Run on the LB host. Step 3 downs a backend, so do it in low traffic (or on staging) with the *other*
+backend confirmed healthy first.
 
-### Applying it
+1. **Confirm the active block is live** (Hatchbox generated it):
+   ```bash
+   curl -s localhost:2019/config/ | jq '.. | objects | select(.handler? == "reverse_proxy") | .health_checks'
+   ```
+   Expect an `active` object with `uri: "/up"` (and a `Host` header) alongside `passive`.
 
-Caddy on the LB is managed by Hatchbox. Apply the change through Hatchbox's Caddy configuration so it is
-**persisted** — a raw `curl` push to the admin API works until the next deploy, which regenerates the
-config and wipes it. If you must push directly for a quick test, snapshot first (see below) and
-re-persist through Hatchbox afterward.
+2. **Confirm every backend currently reads healthy** — proves the probe *succeeds* against a good backend,
+   catching a mis-set Host/path that would false-positive a healthy node:
+   ```bash
+   curl -s localhost:2019/reverse_proxy/upstreams | jq   # each upstream should show fails: 0
+   ```
 
-### Verifying
+3. **Down one backend; confirm it's pulled within ~an interval while the site stays 200.** Two ways:
 
-```bash
-# from the LB host
-curl -f http://<backend-host>:<port>/up            # 200 from each backend directly
-curl -s localhost:2019/reverse_proxy/upstreams | jq # per-backend health + in-flight request counts
-```
+   *Cleanest — block the LB's probe (no app touched, one-line toggle):* on the target backend,
+   ```bash
+   sudo iptables -I INPUT -p tcp --dport 80 -j DROP    # down (only port 80 — SSH stays open)
+   sudo iptables -D INPUT -p tcp --dport 80 -j DROP    # up
+   ```
 
-Then simulate a failure: stop Puma on one backend and confirm Caddy marks it unhealthy in
-`/reverse_proxy/upstreams` and the site keeps serving 200 from the rest (no 502s). Bring it back and
-confirm it re-enters rotation.
+   *Truer 502 reproduction — stop the app.* Hatchbox runs the app as **user** systemd services under the
+   deploy account, and web is **socket-activated** — you must stop the `.socket` too or the next probe
+   re-spawns Puma. Find the unit names first (`systemctl --user list-units --type=service` — e.g.
+   `<app>-web.service` + `<app>-web.socket`), then:
+   ```bash
+   systemctl --user stop  <app>-web.socket <app>-web.service   # down (no sudo — these are user units)
+   systemctl --user start <app>-web.socket <app>-web.service   # up
+   ```
+   (Leave the `<app>-worker` unit alone — it doesn't serve `/up`.)
+
+   Watch from the LB while it's down:
+   ```bash
+   watch -n2 'curl -s localhost:2019/reverse_proxy/upstreams | jq'                   # backend drops out
+   sudo journalctl -u caddy -f | grep -iE 'unhealthy|healthy|upstream'              # "marking upstream … unhealthy"
+   for i in $(seq 1 40); do curl -so /dev/null -w "%{http_code}\n" https://<site>/up; sleep 1; done  # stays 200
+   ```
+   The downed backend should leave the healthy set within ~30s and the site should never 502; restore it
+   and it rejoins within ~30s. (Watch for Hatchbox restarting the app on its own; the firewall method is
+   the more controllable of the two.)
 
 ---
 
-## Reverse-proxy hardening
+## Reverse-proxy hardening (not tunable on Hatchbox)
 
-In the same incident the origin didn't just return clean 502s — it **overloaded** ("Timeout after
-connect (your server may be slow or overloaded)"), because a backend that holds its port without
-accepting hangs the LB's connections rather than failing fast. Two settings on the `reverse_proxy` make
-a bad backend fail fast instead of swamping the LB (belt-and-suspenders with active checks — even before
-a probe marks a backend down, requests to it fail fast):
+In the same incident the origin didn't just return clean 502s — it **overloaded** ("Timeout after connect
+(your server may be slow or overloaded)"), because a backend that holds its port without accepting hangs
+the LB's connections rather than failing fast. Bounded backend timeouts (`dial_timeout`,
+`response_header_timeout`) plus capped retries (`lb_try_duration`, `lb_retries`) would make a bad backend
+fail fast instead of swamping the LB — belt-and-suspenders with active checks.
 
-```
-reverse_proxy <backend-1>:<port> <backend-2>:<port> {
-    transport http {
-        dial_timeout            5s   # give up quickly on a backend that isn't accepting
-        response_header_timeout 10s  # don't wait forever for a hung backend
-    }
-    lb_try_duration 5s               # cap how long a single request cycles upstreams
-    lb_retries      2                # cap failover amplification onto healthy backends
-}
-```
-
-Verify directive names/semantics against the running Caddy version before applying.
+But these live inside Hatchbox's generated `reverse_proxy` block (the opaque `%{apps}`), so there's **no
+supported way to set them on Hatchbox** — a direct admin-API push is wiped on the next deploy. Leave them
+to a Hatchbox feature/config request, or apply them directly only if the proxy is ever self-managed (e.g.
+a move to Kamal + kamal-proxy). Active health checks already cover the primary failure mode.
 
 ---
 
@@ -153,9 +160,10 @@ Safe ordering:
 3. Update the **LB first**, in a low-traffic window. Its Caddy restarts (brief blip). Verify the site
    loads and both backends show in `/reverse_proxy/upstreams`; diff the live config against the snapshot
    (watch the `reverse_proxy` and TLS/ACME sections for anything the update changed).
-4. **Re-apply** the active-health-check + hardening config if the update reset it, persisted through
-   Hatchbox.
-5. Update **backends only after** active health checks are in place — the checks turn each backend's
+4. **Confirm the active health check survived** — it's a Hatchbox app setting, so the regenerated config
+   should still contain `health_checks.active` (re-run the step-2 `jq` check). There's no manual config to
+   re-apply; that's Hatchbox's job.
+5. Update **backends only after** active health checks are confirmed — the checks turn each backend's
    restart into a graceful drain instead of a passively-handled failure. **Never update a backend while
    it is the only healthy one.**
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,179 @@
+# Operations Runbook
+
+Internal operations notes for running OpenSplitTime in production. This is **not** end-user or product
+documentation (that lives in `docs/`, published to docs.opensplittime.org) — it's a runbook for whoever
+is operating the infrastructure.
+
+The app is hosted on DigitalOcean droplets, managed by Hatchbox, fronted by Cloudflare, with a Caddy
+load balancer in front of the web backends:
+
+```
+Cloudflare  ->  load balancer (Caddy)  ->  web backend 1 (Caddy -> Puma)
+                                        ->  web backend 2 (Caddy -> Puma)
+                                        ->  ...
+```
+
+Hostnames, IPs, and tokens are intentionally written as placeholders here (`<load-balancer-host>`,
+`<backend-host>`, `<backend-ip>`, `<db-host>`) — this file is in a public repository. Keep it that way.
+
+---
+
+## Health check: `/up`
+
+The app exposes `GET /up`, wired in `config/routes.rb` to the stock `Rails::HealthController`:
+
+```ruby
+get "up" => "rails/health#show", as: :rails_health_check
+```
+
+It returns **200** once the app has booted, and 503 only if rendering itself raises. **It deliberately
+does not query the database.** A per-probe `SELECT 1` was considered and rejected: because every backend
+shares one Postgres, a DB blip — or merely a slow DB under load — could time out *every* backend's probe
+at once and pull the whole fleet from rotation, turning a database hiccup into a total outage. The stock
+check can never take the entire fleet down, and it still catches the failure class we actually hit (a
+backend that never finishes booting). See the design discussion on issue #2155 / PR #2156.
+
+---
+
+## Load-balancer active health checks
+
+**Why this matters (real incident).** When a new backend was added to the LB but couldn't boot (its IP
+wasn't whitelisted in the database firewall — see the provisioning checklist below), it held its port
+without accepting connections and returned 502 for every request. The LB kept sending it ~half the
+traffic and the origin overloaded. The Caddy journal for that window shows **no health-check activity at
+all** — nothing removed the bad backend automatically, and the outage lasted ~40 minutes until it was
+removed **by hand** via the admin API. Passive checks alone don't catch this: a 502 *is* a response, so
+the LB counts the backend as "responding."
+
+**Active** health checks fix exactly this — the LB probes each backend's `/up` directly on a fixed
+interval, independent of user traffic, and pulls a backend that fails the probe within seconds.
+
+### Configuration
+
+Caddy on the LB runs its config via the admin API (there may be no static Caddyfile — the live config is
+`curl -s localhost:2019/config/`). The health-check block lives on the `reverse_proxy` handler. Expressed
+as a Caddyfile fragment (map to JSON if that's how the config is managed; **verify directive names against
+the running Caddy version** — check `caddy version`):
+
+```
+reverse_proxy <backend-1>:<port> <backend-2>:<port> {
+    # active checks
+    health_uri      /up
+    health_interval 10s
+    health_timeout  5s
+    health_status   2xx
+
+    # passive checks (backstop)
+    fail_duration    10s
+    max_fails        3
+    unhealthy_status 5xx
+}
+```
+
+Equivalent JSON on the reverse_proxy handler (durations are integer **nanoseconds**; `10s = 10000000000`):
+
+```json
+"health_checks": {
+  "active":  { "path": "/up", "interval": 10000000000, "timeout": 5000000000, "expect_status": 200 },
+  "passive": { "fail_duration": 10000000000, "max_fails": 3, "unhealthy_status": [500, 502, 503, 504] }
+}
+```
+
+### Applying it
+
+Caddy on the LB is managed by Hatchbox. Apply the change through Hatchbox's Caddy configuration so it is
+**persisted** — a raw `curl` push to the admin API works until the next deploy, which regenerates the
+config and wipes it. If you must push directly for a quick test, snapshot first (see below) and
+re-persist through Hatchbox afterward.
+
+### Verifying
+
+```bash
+# from the LB host
+curl -f http://<backend-host>:<port>/up            # 200 from each backend directly
+curl -s localhost:2019/reverse_proxy/upstreams | jq # per-backend health + in-flight request counts
+```
+
+Then simulate a failure: stop Puma on one backend and confirm Caddy marks it unhealthy in
+`/reverse_proxy/upstreams` and the site keeps serving 200 from the rest (no 502s). Bring it back and
+confirm it re-enters rotation.
+
+---
+
+## Reverse-proxy hardening
+
+In the same incident the origin didn't just return clean 502s — it **overloaded** ("Timeout after
+connect (your server may be slow or overloaded)"), because a backend that holds its port without
+accepting hangs the LB's connections rather than failing fast. Two settings on the `reverse_proxy` make
+a bad backend fail fast instead of swamping the LB (belt-and-suspenders with active checks — even before
+a probe marks a backend down, requests to it fail fast):
+
+```
+reverse_proxy <backend-1>:<port> <backend-2>:<port> {
+    transport http {
+        dial_timeout            5s   # give up quickly on a backend that isn't accepting
+        response_header_timeout 10s  # don't wait forever for a hung backend
+    }
+    lb_try_duration 5s               # cap how long a single request cycles upstreams
+    lb_retries      2                # cap failover amplification onto healthy backends
+}
+```
+
+Verify directive names/semantics against the running Caddy version before applying.
+
+---
+
+## New-server provisioning checklist
+
+Hatchbox handles most provisioning. The items below are the ones that have bitten us and must be checked
+explicitly when adding a web backend:
+
+- [ ] **Whitelist the new droplet's IP in the DigitalOcean managed-Postgres firewall _before_ adding it
+      to the LB.** This was the root cause of the outage above — the backend couldn't reach the DB, never
+      finished booting, and served 502s from behind its own Caddy.
+- [ ] `curl -f http://<new-backend-host>:<port>/up` returns 200 on the new backend directly.
+- [ ] The backend shows **healthy** in `curl -s localhost:2019/reverse_proxy/upstreams` on the LB before
+      it takes user traffic.
+
+---
+
+## Keeping servers current (Hatchbox config updates)
+
+When Hatchbox flags a server as "outdated," its **Update configuration** action re-runs the managed
+config and restarts services (including Caddy). Treat the LB with the same care as any LB change; a
+freshly provisioned node is already on the latest config and doesn't need this.
+
+Safe ordering:
+
+1. Confirm the other backend is **healthy and in rotation** — it's your safety net for the restart.
+2. Snapshot the LB's live config first:
+   ```bash
+   curl -s localhost:2019/config/ > caddy-before-update.json
+   ```
+3. Update the **LB first**, in a low-traffic window. Its Caddy restarts (brief blip). Verify the site
+   loads and both backends show in `/reverse_proxy/upstreams`; diff the live config against the snapshot
+   (watch the `reverse_proxy` and TLS/ACME sections for anything the update changed).
+4. **Re-apply** the active-health-check + hardening config if the update reset it, persisted through
+   Hatchbox.
+5. Update **backends only after** active health checks are in place — the checks turn each backend's
+   restart into a graceful drain instead of a passively-handled failure. **Never update a backend while
+   it is the only healthy one.**
+
+---
+
+## Diagnosing an outage on the LB
+
+The LB is `<load-balancer-host>` (Caddy runs as a systemd service, logs to the journal):
+
+```bash
+systemctl status caddy                                   # running? config path? recent lines
+sudo journalctl -u caddy --since "<start>" --until "<end>" --no-pager \
+  | grep -iE 'health|unhealthy|upstream|dial|timeout|refused|no upstreams|"status":5'
+curl -s localhost:2019/reverse_proxy/upstreams | jq       # current per-backend health
+curl -s localhost:2019/config/ | jq '.apps.http'          # live reverse_proxy config
+```
+
+`marking upstream … unhealthy` for a *good* backend points at overload/cascade; hung/timed-out upstream
+dials point at a backend holding its port without accepting. Note that per-request access logs may not be
+in the journal (only errors/admin/TLS), so attributing individual requests to a specific backend may not
+be possible from the LB alone.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ OpenSplitTime is hosted on [Digital Ocean](https://www.digitalocean.com/) and de
 
 The infrastructure includes Digital Ocean droplets for web and worker processes, and a Digital Ocean managed PostgreSQL database. Deployments are managed through the Hatchbox dashboard.
 
+Operational procedures — load-balancer health checks, new-server provisioning, and diagnosing an outage — are documented in [OPERATIONS.md](OPERATIONS.md).
+
 Email
 -------------------------
 


### PR DESCRIPTION
Part of #2155.

## Summary

Gives the load-balancer health-check and provisioning procedures a durable, versioned home as `OPERATIONS.md`, grounded in the real ~25-minute outage they came from — and now reflecting how active health checks actually get enabled.

Adding a backend that couldn't boot (its IP wasn't whitelisted in the Postgres firewall) took the site down for ~25 minutes. The load-balancer's Caddy journal for that window showed **no health-check activity** — Hatchbox's *passive* check has no `unhealthy_status`, so it counted the bad backend's 502s as "responding" and never pulled it; it was removed by hand.

## Contents of `OPERATIONS.md`

- **`/up` health check** — and why it deliberately skips a DB query (a shared-DB probe could pull the whole fleet at once).
- **LB active health checks** — **enabled natively in Hatchbox** by setting the health-check path to `/up` (Hatchbox emits `health_checks.active` with the right upstream `Host` header). Documents the two things Hatchbox doesn't let you tune (interval defaults to ~30s; passive stays inert without `unhealthy_status`), and the **verification procedure we actually ran and validated** — config check, both-healthy check, and downing a backend via a firewall rule or the socket-activated user services.
- **Reverse-proxy hardening** — noted as **not tunable on Hatchbox** (it lives in the opaque `%{apps}`); left for a self-managed proxy or a Hatchbox request.
- **New-server provisioning checklist** — whitelist the droplet IP in the DB firewall **before** joining the LB (the outage's root cause), then verify `/up` and Caddy-healthy status.
- **Keeping servers current** — safe ordering for Hatchbox config updates; confirm the active health check survived the regenerate.
- **Outage-diagnosis commands** for the LB.

## Notes

- New file at repo root, **not** under `docs/` (that's the public Jekyll product-docs site). Placeholders only — no hostnames, IPs, or secrets (this repo is public).
- Linked from the README's Hosting & Deployment section.
- Docs-only change; no app code. Active health checks are now enabled and verified on Hatchbox, so the #2155 checklist items can be ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)