### PR TITLE
Batch the per-effort query cascade in StartEfforts

### DIFF
--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -359,11 +359,11 @@ class Effort < ApplicationRecord
     ordered_split_times.rfind(&:stopped_here)
   end
 
-  private
-
   def broadcast_update
     broadcast_render_later_to event_group, partial: "efforts/updated", locals: { effort: self }
   end
+
+  private
 
   def generate_new_topic_resource?
     !finished? && progress_notifications_timely?

--- a/app/models/effort_segment.rb
+++ b/app/models/effort_segment.rb
@@ -20,6 +20,11 @@ class EffortSegment < ApplicationRecord
     ActiveRecord::Base.connection.execute(query)
   end
 
+  def self.set_for_efforts(effort_ids)
+    query = EffortSegmentQuery.set_for_efforts(effort_ids)
+    ActiveRecord::Base.connection.execute(query)
+  end
+
   def self.set_for_split_time(split_time)
     query = EffortSegmentQuery.set_for_split_time(split_time)
     ActiveRecord::Base.connection.execute(query)

--- a/app/models/split_time.rb
+++ b/app/models/split_time.rb
@@ -65,12 +65,18 @@ class SplitTime < ApplicationRecord
                             includes(split: :aid_stations).includes(:effort).where(aid_stations: { id: aid_station_id })
                           }
 
+  # Set by batch operations (e.g. Interactors::StartEfforts) that run the
+  # set-based equivalents of the derived-data callbacks once after saving
+  # many records. Any new callback added below must decide whether it also
+  # needs deferral and a batch equivalent.
+  attr_accessor :defer_derived_data
+
   before_validation :destroy_if_blank
   before_update :set_matching_raw_time, if: :matching_raw_time_id_changed?
   after_destroy :sync_elapsed_seconds
   after_destroy :delete_effort_segments
-  after_save :sync_elapsed_seconds
-  after_save :set_effort_segments
+  after_save :sync_elapsed_seconds, unless: :defer_derived_data
+  after_save :set_effort_segments, unless: :defer_derived_data
 
   validates :sub_split_bitkey, :absolute_time, :lap, presence: true
   validates :split_id, uniqueness: { scope: [:effort_id, :sub_split_bitkey, :lap],

--- a/app/queries/effort_segment_query.rb
+++ b/app/queries/effort_segment_query.rb
@@ -1,13 +1,18 @@
 class EffortSegmentQuery < BaseQuery
   def self.set_for_effort(effort)
-    set(effort.id)
+    set([effort.id])
+  end
+
+  def self.set_for_efforts(effort_ids)
+    set(effort_ids)
   end
 
   def self.set_for_split_time(split_time)
-    set(split_time.effort_id, split_time.lap, split_time.split_id, split_time.bitkey)
+    set([split_time.effort_id], split_time.lap, split_time.split_id, split_time.bitkey)
   end
 
-  def self.set(effort_id, lap = nil, split_id = nil, bitkey = nil)
+  def self.set(effort_ids, lap = nil, split_id = nil, bitkey = nil)
+    ids = effort_ids.map(&:to_i).join(",")
     scoping_sql =
       if lap.nil? || split_id.nil? || bitkey.nil?
         # Update all effort_segments for the entire effort
@@ -31,7 +36,7 @@ class EffortSegmentQuery < BaseQuery
                        elapsed_seconds
                 from split_times
                          join splits on splits.id = split_times.split_id
-                where split_times.effort_id = #{effort_id}),
+                where split_times.effort_id in (#{ids})),
 
            sub_split_segments as
                (select ss1.course_id,
@@ -48,7 +53,8 @@ class EffortSegmentQuery < BaseQuery
                        ss2.kind                                  as end_split_kind
                 from sub_splits ss1
                          cross join sub_splits ss2
-                where ss1.lap = ss2.lap
+                where ss1.effort_id = ss2.effort_id
+                  and ss1.lap = ss2.lap
                   #{scoping_sql}
                   and ((ss1.distance_from_start = ss2.distance_from_start and ss1.sub_split_bitkey < ss2.sub_split_bitkey)
                     or (ss1.distance_from_start < ss2.distance_from_start)))

--- a/app/queries/split_time_query.rb
+++ b/app/queries/split_time_query.rb
@@ -223,23 +223,29 @@ class SplitTimeQuery < BaseQuery
   end
 
   def self.set_effort_elapsed_times(effort_id)
+    set_efforts_elapsed_times([effort_id])
+  end
+
+  def self.set_efforts_elapsed_times(effort_ids)
+    ids = effort_ids.map(&:to_i).join(",")
     start_lap = 1
     start_kind = ::Split.kinds[:start]
     in_bitkey = ::SubSplit::IN_BITKEY
 
     <<~SQL.squish
-      with start_time as
-               (select absolute_time
+      with start_times as
+               (select effort_id, absolute_time
                 from split_times
                          join splits on splits.id = split_times.split_id
-                where effort_id = #{effort_id}
+                where effort_id in (#{ids})
                   and lap = #{start_lap}
                   and kind = #{start_kind}
                   and sub_split_bitkey = #{in_bitkey})
 
       update split_times
-      set elapsed_seconds = extract(epoch from (split_times.absolute_time - (select absolute_time from start_time)))
-      where effort_id = #{effort_id};
+      set elapsed_seconds = extract(epoch from (split_times.absolute_time -
+            (select absolute_time from start_times where start_times.effort_id = split_times.effort_id)))
+      where effort_id in (#{ids});
     SQL
   end
 

--- a/app/services/interactors/start_efforts.rb
+++ b/app/services/interactors/start_efforts.rb
@@ -158,7 +158,7 @@ module Interactors
         return
       end
 
-      errors << multiple_event_groups_error(event_group_ids) if event_group_ids.uniq.many?
+      errors << multiple_event_groups_error(event_group_ids) if event_group_ids.many?
       errors << invalid_start_time_error(start_time) if invalid_start_time?
       errors << invalid_start_time_error(start_time || "nil") unless converted_start_time ||
                                                                      efforts.all?(&:scheduled_start_time?) ||
@@ -166,7 +166,7 @@ module Interactors
     end
 
     def event_group_ids
-      @event_group_ids ||= efforts.map { |effort| effort.event.event_group_id }
+      @event_group_ids ||= events.map(&:event_group_id).uniq
     end
 
     def invalid_start_time?

--- a/app/services/interactors/start_efforts.rb
+++ b/app/services/interactors/start_efforts.rb
@@ -31,7 +31,10 @@ module Interactors
 
           update_derived_data
         end
-        enqueue_event_notifications if errors.blank?
+        if errors.blank?
+          enqueue_event_notifications
+          broadcast_effort_updates
+        end
       end
       Interactors::Response.new(errors, response_message)
     end
@@ -98,6 +101,13 @@ module Interactors
     def enqueue_event_notifications
       events.select { |event| changed_event_ids.include?(event.id) && event.topic_resource_key? }
             .each { |event| NotifyEventUpdateJob.perform_later(event.id) }
+    end
+
+    # The roster page relies on per-effort broadcasts to update its rows;
+    # the suppressed touch chain would otherwise have fired these
+    def broadcast_effort_updates
+      changed_ids = changed_effort_ids.to_set
+      efforts.select { |effort| changed_ids.include?(effort.id) }.each(&:broadcast_update)
     end
 
     def changed_event_ids

--- a/app/services/interactors/start_efforts.rb
+++ b/app/services/interactors/start_efforts.rb
@@ -10,41 +10,100 @@ module Interactors
     def initialize(efforts:, start_time: nil)
       raise ArgumentError, "start_efforts must include efforts" unless efforts
 
-      @efforts = efforts
+      @efforts = efforts.to_a
       @start_time = start_time
       @errors = []
       @saved_split_times = []
+      @changed_effort_ids = []
+      preload_events
       validate_setup
     end
 
     def perform!
       if errors.blank?
         SplitTime.transaction do
-          efforts.each(&method(:start_effort))
+          # Touches and the two derived-data callbacks are deferred and run
+          # in batch in update_derived_data; see SplitTime#defer_derived_data
+          ActiveRecord::Base.no_touching do
+            efforts.each(&method(:start_effort))
+          end
           raise ActiveRecord::Rollback if errors.present?
+
+          update_derived_data
         end
+        enqueue_event_notifications if errors.blank?
       end
       Interactors::Response.new(errors, response_message)
     end
 
     private
 
-    attr_reader :efforts, :start_time, :errors, :saved_split_times
+    attr_reader :efforts, :start_time, :errors, :saved_split_times, :changed_effort_ids
+
+    def preload_events
+      ActiveRecord::Associations::Preloader.new(records: efforts, associations: :event).call
+    end
 
     def start_effort(effort)
-      split_time = SplitTime.find_or_initialize_by(
-        effort_id: effort.id,
-        lap: 1,
-        split_id: effort.start_split_id,
-        bitkey: SubSplit::IN_BITKEY,
-      )
+      start_split_id = start_split_ids_by_event_id.fetch(effort.event_id)
+      split_time = existing_start_split_times[effort.id]
+
+      unless split_time && split_time.split_id == start_split_id
+        split_time = SplitTime.new(
+          effort_id: effort.id,
+          lap: 1,
+          split_id: start_split_id,
+          bitkey: SubSplit::IN_BITKEY,
+        )
+      end
 
       split_time.absolute_time = effort_start_time(effort)
+      split_time.defer_derived_data = true
 
       if split_time.save
         saved_split_times << split_time
+        changed_effort_ids << effort.id if split_time.saved_changes.present?
       else
         errors << resource_error_object(split_time)
+      end
+    end
+
+    def events
+      @events ||= efforts.map(&:event).uniq
+    end
+
+    def start_split_ids_by_event_id
+      @start_split_ids_by_event_id ||= events.to_h { |event| [event.id, event.start_split.id] }
+    end
+
+    def existing_start_split_times
+      @existing_start_split_times ||= SplitTime.where(
+        effort_id: efforts.map(&:id),
+        lap: 1,
+        split_id: start_split_ids_by_event_id.values.uniq,
+        bitkey: SubSplit::IN_BITKEY,
+      ).index_by(&:effort_id)
+    end
+
+    def update_derived_data
+      return if changed_effort_ids.empty?
+
+      ActiveRecord::Base.connection.execute(SplitTimeQuery.set_efforts_elapsed_times(changed_effort_ids))
+      EffortSegment.set_for_efforts(changed_effort_ids)
+      ::Results::SetEffortPerformanceData.perform!(changed_effort_ids)
+      Effort.where(id: changed_effort_ids).touch_all
+      Event.where(id: changed_event_ids).touch_all
+    end
+
+    def enqueue_event_notifications
+      events.select { |event| changed_event_ids.include?(event.id) && event.topic_resource_key? }
+            .each { |event| NotifyEventUpdateJob.perform_later(event.id) }
+    end
+
+    def changed_event_ids
+      @changed_event_ids ||= begin
+        changed_ids = changed_effort_ids.to_set
+        efforts.select { |effort| changed_ids.include?(effort.id) }.map(&:event_id).uniq
       end
     end
 

--- a/app/services/results/set_effort_performance_data.rb
+++ b/app/services/results/set_effort_performance_data.rb
@@ -1,36 +1,44 @@
 module Results
   class SetEffortPerformanceData
-    def self.perform!(effort_id)
-      new(effort_id).perform!
+    def self.perform!(effort_ids)
+      new(effort_ids).perform!
     end
 
-    def initialize(effort_id)
-      @effort_id = effort_id
+    def initialize(effort_ids)
+      @effort_ids = Array.wrap(effort_ids)
     end
 
     def perform!
+      return if effort_ids.empty?
+
       ::ActiveRecord::Base.connection.execute(query)
     end
 
     private
 
-    attr_reader :effort_id
+    attr_reader :effort_ids
+
+    def ids
+      effort_ids.map(&:to_i).join(",")
+    end
 
     def query
       <<~SQL.squish
-        with relevant_effort as (select * from efforts where id = #{effort_id}),
+        with relevant_efforts as (select id, event_id from efforts where id in (#{ids})),
 
-             starting_split_time as (
-                 select st.id, st.absolute_time
-                 from relevant_effort e
-                          left join split_times st on st.effort_id = e.id
-                          left join splits s on st.split_id = s.id
+             starting_split_times as (
+                 select st.effort_id, st.id, st.absolute_time
+                 from relevant_efforts e
+                          join split_times st on st.effort_id = e.id
+                          join splits s on st.split_id = s.id
                  where st.lap = 1
                    and s.kind = 0
              ),
 
-             last_split_time as (
-                 select st.id,
+             last_split_times as (
+                 select distinct on (e.id)
+                        e.id as effort_id,
+                        st.id,
                         st.lap,
                         st.sub_split_bitkey,
                         st.absolute_time,
@@ -39,22 +47,22 @@ module Results
                         case
                             when ev.laps_required = 0 then null
                             else ((s.kind = 1 and st.lap = ev.laps_required) or st.lap > ev.laps_required) end as fixed_lap_finish
-                 from relevant_effort e
+                 from relevant_efforts e
                           join events ev on ev.id = e.event_id
                           left join split_times st on st.effort_id = e.id
                           left join splits s on st.split_id = s.id
-                 order by st.lap desc, s.distance_from_start desc, st.sub_split_bitkey desc
-                 limit 1
+                 order by e.id, st.lap desc, s.distance_from_start desc, st.sub_split_bitkey desc
              ),
 
-             stopped_split_time as (
-                 select st.id
-                 from relevant_effort e
-                          left join split_times st on st.effort_id = e.id
-                          left join splits s on st.split_id = s.id
-                 where st.stopped_here
-                 order by st.lap desc, s.distance_from_start desc, st.sub_split_bitkey desc
-                 limit 1
+             stopped_split_times as (
+                 select distinct on (st.effort_id)
+                        st.effort_id,
+                        st.id
+                 from split_times st
+                          join splits s on st.split_id = s.id
+                 where st.effort_id in (#{ids})
+                   and st.stopped_here
+                 order by st.effort_id, st.lap desc, s.distance_from_start desc, st.sub_split_bitkey desc
              )
 
         update efforts
@@ -74,10 +82,10 @@ module Results
                                                             last_st.sub_split_bitkey::bit(7) ||
                                                             coalesce(~(extract(epoch from (last_st.absolute_time - start_st.absolute_time)) * 1000)::bigint, 0)::bigint::bit(44)
                                         else 0::bit(96) end
-        from relevant_effort ef
-                 left join starting_split_time start_st on true
-                 left join last_split_time last_st on true
-                 left join stopped_split_time stop_st on true
+        from relevant_efforts ef
+                 left join starting_split_times start_st on start_st.effort_id = ef.id
+                 left join last_split_times last_st on last_st.effort_id = ef.id
+                 left join stopped_split_times stop_st on stop_st.effort_id = ef.id
         where efforts.id = ef.id
       SQL
     end

--- a/spec/models/effort_segment_spec.rb
+++ b/spec/models/effort_segment_spec.rb
@@ -59,6 +59,25 @@ RSpec.describe EffortSegment do
     end
   end
 
+  describe ".set_for_efforts" do
+    let(:effort_3) { efforts(:hardrock_2015_benedict_davis) }
+
+    it "sets effort_segments for each indicated effort, identical to setting each individually" do
+      expect do
+        described_class.set_for_efforts([effort_1.id, effort_2.id])
+      end.to change(described_class, :count).from(0).to(182)
+
+      expect(effort_1.effort_segments.count).to eq(91)
+      expect(effort_2.effort_segments.count).to eq(91)
+    end
+
+    it "does not set effort_segments for other efforts" do
+      expect do
+        described_class.set_for_efforts([effort_1.id, effort_2.id])
+      end.not_to(change { effort_3.effort_segments.count })
+    end
+  end
+
   describe ".set_for_split_time" do
     let(:split_time_1) { effort_1.split_times.last }
     let(:split_time_2) { effort_2.split_times.last }

--- a/spec/models/split_time_spec.rb
+++ b/spec/models/split_time_spec.rb
@@ -299,6 +299,43 @@ RSpec.describe SplitTime, kind: :model do
     end
   end
 
+  describe "defer_derived_data" do
+    subject { split_times(:hardrock_2016_brinda_fisher_start_1) }
+
+    let(:effort) { subject.effort }
+
+    context "when set" do
+      before { subject.defer_derived_data = true }
+
+      it "saves the record" do
+        expect { subject.update(absolute_time: "2016-07-15 11:00:00") }
+          .to(change { subject.reload.absolute_time })
+      end
+
+      it "does not sync elapsed seconds for the effort's split times" do
+        expect { subject.update(absolute_time: "2016-07-15 11:00:00") }
+          .not_to(change { effort.split_times.order(:id).pluck(:elapsed_seconds) })
+      end
+
+      it "does not set effort segments for the effort" do
+        expect { subject.update(absolute_time: "2016-07-15 11:00:00") }
+          .not_to(change { EffortSegment.where(effort_id: effort.id).count })
+      end
+    end
+
+    context "when not set" do
+      it "syncs elapsed seconds for the effort's split times" do
+        expect { subject.update(absolute_time: "2016-07-15 11:00:00") }
+          .to(change { effort.split_times.order(:id).pluck(:elapsed_seconds) })
+      end
+
+      it "sets effort segments for the effort" do
+        expect { subject.update(absolute_time: "2016-07-15 11:00:00") }
+          .to change { EffortSegment.where(effort_id: effort.id).count }.from(0)
+      end
+    end
+  end
+
   describe "before destroy" do
     context "when the starting split time has later split times" do
       subject { split_times(:hardrock_2016_brinda_fisher_start_1) }

--- a/spec/queries/split_time_query_spec.rb
+++ b/spec/queries/split_time_query_spec.rb
@@ -5,8 +5,35 @@ RSpec.describe SplitTimeQuery do
 
   let(:lap_1) { 1 }
 
+  describe ".set_efforts_elapsed_times" do
+    let(:effort_with_start) { efforts(:hardrock_2015_tuan_jacobs) }
+    let(:effort_without_start) { efforts(:hardrock_2014_without_start) }
+
+    before do
+      SplitTime.where(effort_id: [effort_with_start.id, effort_without_start.id]).update_all(elapsed_seconds: 123.0)
+      execute_query
+    end
+
+    it "computes elapsed seconds from each effort's starting split time" do
+      start_absolute_time = effort_with_start.starting_split_time.absolute_time
+      effort_with_start.split_times.reload.each do |split_time|
+        expect(split_time.elapsed_seconds).to eq(split_time.absolute_time - start_absolute_time)
+      end
+    end
+
+    it "nullifies elapsed seconds for an effort having no starting split time" do
+      expect(effort_without_start.split_times.reload.map(&:elapsed_seconds)).to all be_nil
+    end
+
+    def execute_query
+      query = SplitTimeQuery.set_efforts_elapsed_times([effort_with_start.id, effort_without_start.id])
+      ActiveRecord::Base.connection.execute(query)
+    end
+  end
+
   describe ".typical_segment_time" do
-    subject { SplitTimeQuery.typical_segment_time(segment, effort_ids) }
+    subject { described_class.typical_segment_time(segment, effort_ids) }
+
     let(:count) { subject[:effort_count] }
     let(:time) { subject[:average] }
 
@@ -21,7 +48,7 @@ RSpec.describe SplitTimeQuery do
     let(:start_to_cunningham_in) { Segment.new(begin_point: start, end_point: cunningham_in) }
     let(:in_aid_sherman) { Segment.new(begin_point: sherman_in, end_point: sherman_out) }
 
-    context "for a course segment" do
+    context "when effort_ids are not provided" do
       let(:segment) { start_to_cunningham_in }
       let(:effort_ids) { nil }
 

--- a/spec/services/interactors/start_efforts_spec.rb
+++ b/spec/services/interactors/start_efforts_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Interactors::StartEfforts do
   include BitkeyDefinitions
 
   describe ".perform!" do
-    subject { Interactors::StartEfforts.new(efforts: subject_efforts, start_time: start_time) }
+    subject { described_class.new(efforts: subject_efforts, start_time: start_time) }
+
     let(:home_time_zone) { subject_efforts.first.home_time_zone }
 
     context "when all provided efforts are valid" do
@@ -109,7 +110,7 @@ RSpec.describe Interactors::StartEfforts do
         let(:start_time) { "2017-09-23 08:00:00" }
 
         it "creates or updates starting split times as needed" do
-          expect { subject.perform! }.to change { SplitTime.count }.by(1)
+          expect { subject.perform! }.to change(SplitTime, :count).by(1)
 
           subject_efforts.each(&:reload)
           split_times = subject_efforts.map(&:starting_split_time)
@@ -120,6 +121,76 @@ RSpec.describe Interactors::StartEfforts do
 
         it "returns a successful response" do
           expect(subject.perform!).to be_successful
+        end
+
+        it "recalculates elapsed_seconds for all of the effort's split times" do
+          subject.perform!
+
+          effort = subject_efforts.second.reload
+          start_absolute_time = effort.starting_split_time.absolute_time
+          effort.split_times.each do |split_time|
+            expect(split_time.elapsed_seconds).to eq(split_time.absolute_time - start_absolute_time)
+          end
+        end
+
+        it "rebuilds effort segments from the new start time" do
+          subject.perform!
+
+          effort = subject_efforts.second.reload
+          start_split_id = effort.starting_split_time.split_id
+          start_segments = EffortSegment.where(effort_id: effort.id, begin_split_id: start_split_id)
+          expect(start_segments).to be_present
+          expect(start_segments.map(&:begin_time)).to all eq(start_time.in_time_zone(home_time_zone))
+        end
+      end
+
+      context "with respect to derived data and touches" do
+        let(:subject_efforts) { [efforts(:sum_55k_not_started), efforts(:sum_100k_un_started)] }
+        let(:start_time) { "2017-09-23 08:00:00" }
+
+        it "sets elapsed_seconds on the new starting split times" do
+          subject.perform!
+
+          split_times = subject_efforts.map { |effort| effort.reload.starting_split_time }
+          expect(split_times.map(&:elapsed_seconds)).to all eq(0)
+        end
+
+        it "sets performance data on the efforts" do
+          expect(subject_efforts.map(&:started)).to all be(false)
+          subject.perform!
+
+          subject_efforts.each(&:reload)
+          expect(subject_efforts.map(&:started)).to all be(true)
+        end
+
+        it "touches the efforts and their events" do
+          expect { subject.perform! }
+            .to change { subject_efforts.map { |effort| effort.reload.updated_at } }
+            .and(change { subject_efforts.map { |effort| effort.event.reload.updated_at } })
+        end
+
+        context "when an event has a topic resource key" do
+          let(:subscribed_event) { subject_efforts.first.event }
+
+          before { subscribed_event.update_column(:topic_resource_key, "test-resource-key") }
+
+          it "enqueues a notification job for that event only" do
+            expect(NotifyEventUpdateJob).to receive(:perform_later).with(subscribed_event.id).once
+            subject.perform!
+          end
+        end
+
+        context "when the efforts were already started at the given time" do
+          before { described_class.perform!(efforts: subject_efforts, start_time: start_time) }
+
+          it "returns a successful response but does not touch efforts or events" do
+            expect(NotifyEventUpdateJob).not_to receive(:perform_later)
+            response = nil
+            expect { response = subject.perform! }
+              .to not_change { subject_efforts.map { |effort| effort.reload.updated_at } }
+              .and(not_change { subject_efforts.map { |effort| effort.event.reload.updated_at } })
+            expect(response).to be_successful
+          end
         end
       end
     end

--- a/spec/services/interactors/start_efforts_spec.rb
+++ b/spec/services/interactors/start_efforts_spec.rb
@@ -8,6 +8,39 @@ RSpec.describe Interactors::StartEfforts do
 
     let(:home_time_zone) { subject_efforts.first.home_time_zone }
 
+    context "when one effort fails to save mid-batch" do
+      let(:subject_efforts) { [efforts(:sum_55k_not_started), efforts(:sum_100k_un_started)] }
+      let(:start_time) { nil }
+
+      before do
+        # The event must be updated first; effort callbacks memoize event_start_time
+        subject_efforts.second.event.update_column(:scheduled_start_time, nil)
+        subject_efforts.first.update(scheduled_start_time: "2017-09-23 07:00:00".in_time_zone(home_time_zone))
+        subject_efforts.second.update(scheduled_start_time: nil)
+      end
+
+      it "rolls back all created split times and returns a failure response" do
+        response = nil
+        expect { response = subject.perform! }.not_to change(SplitTime, :count)
+
+        expect(response).not_to be_successful
+        expect(response.message).to eq("No efforts were started")
+      end
+
+      it "does not touch efforts or events" do
+        expect { subject.perform! }
+          .to not_change { subject_efforts.map { |effort| effort.reload.updated_at } }
+          .and(not_change { subject_efforts.map { |effort| effort.event.reload.updated_at } })
+      end
+
+      it "does not broadcast or enqueue notifications" do
+        subject_efforts.each { |effort| expect(effort).not_to receive(:broadcast_update) }
+        expect(NotifyEventUpdateJob).not_to receive(:perform_later)
+
+        subject.perform!
+      end
+    end
+
     context "when all provided efforts are valid" do
       context "when no efforts have a starting split time" do
         let(:subject_efforts) { [efforts(:sum_55k_not_started), efforts(:sum_100k_un_started)] }

--- a/spec/services/results/set_effort_performance_data_spec.rb
+++ b/spec/services/results/set_effort_performance_data_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Results::SetEffortPerformanceData do
   describe "#perform!" do
     let(:effort_id) { effort.id }
 
-    context "for a single lap event" do
+    context "when the event is a single-lap event" do
       before { clear_performance_attributes(effort) }
 
       context "when the effort is not started" do
@@ -105,7 +105,7 @@ RSpec.describe Results::SetEffortPerformanceData do
       end
     end
 
-    context "for a multi-lap event" do
+    context "when the event is a multi-lap event" do
       before { clear_performance_attributes(effort) }
 
       context "when the effort is not started" do
@@ -182,6 +182,40 @@ RSpec.describe Results::SetEffortPerformanceData do
           expect(effort.dropped).to eq(false)
           expect(effort.finished).to eq(true)
         end
+      end
+    end
+
+    context "when given multiple effort ids" do
+      let(:subject_efforts) do
+        [
+          efforts(:hardrock_2014_not_started),
+          efforts(:hardrock_2016_start_only),
+          efforts(:hardrock_2014_progress_sherman),
+          efforts(:hardrock_2014_drop_ouray),
+          efforts(:hardrock_2014_finished_first),
+        ]
+      end
+      let(:performance_attributes) do
+        %w[overall_performance stopped_split_time_id final_split_time_id completed_laps
+           started beyond_start stopped dropped finished]
+      end
+
+      it "sets attributes for each effort identically to setting each individually" do
+        subject_efforts.each do |effort|
+          clear_performance_attributes(effort)
+          described_class.perform!(effort.id)
+        end
+        individual_results = subject_efforts.map { |effort| effort.reload.attributes.slice(*performance_attributes) }
+
+        subject_efforts.each { |effort| clear_performance_attributes(effort) }
+        described_class.perform!(subject_efforts.map(&:id))
+        batch_results = subject_efforts.map { |effort| effort.reload.attributes.slice(*performance_attributes) }
+
+        expect(batch_results).to eq(individual_results)
+      end
+
+      it "returns without error when given an empty array" do
+        expect { described_class.perform!([]) }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
Resolves #2186

## What this does

`Interactors::StartEfforts` previously ran ~5+ queries per effort (~1,500 queries / ~9 s for a ~280-effort event group): a `find_or_initialize_by`, a start split lookup, and a save whose derived-data callbacks and touch cascade all ran per record. Per the approach agreed in #2186, this batches the reads and the derived-data writes while keeping per-record saves so model behavior stays intact.

### Batched reads
- One start split lookup **per event** (the action can span multiple events on different courses), replacing one per effort
- One bulk query for existing start split times, replacing per-effort `find_or_initialize_by`
- One preload of the efforts' events

### Per-record saves preserved
Each `split_time.save` still runs validations and all model callbacks except the two known-heavy ones, which are deferred via a flag colocated with the callback declarations in `SplitTime`:

```ruby
after_save :sync_elapsed_seconds, unless: :defer_derived_data
after_save :set_effort_segments, unless: :defer_derived_data
```

Anyone adding a callback to `SplitTime` sees the deferral machinery next to where they are working and must consciously decide whether their callback joins it.

### Set-based derived data, once per operation
After the loop, for efforts whose start split time actually changed:
- `SplitTimeQuery.set_efforts_elapsed_times` — batch generalization; the single-effort method now delegates to it
- `EffortSegment.set_for_efforts` — `EffortSegmentQuery.set` generalized to a list of effort ids (adding the `ss1.effort_id = ss2.effort_id` join condition that was implicit when scoped to one effort)
- `Results::SetEffortPerformanceData` — rewritten from per-effort `limit 1` CTEs to `distinct on (effort_id)` CTEs; accepts one id or many, so the `Effort` callback path uses the same single implementation (no drift)

### Touch chain reproduced explicitly
The loop runs under `no_touching`; afterward, changed efforts and their events get `touch_all` (busting the spread view fragment cache keyed on `event.updated_at`), and one `NotifyEventUpdateJob` is enqueued per changed subscribed event. Previously the job was enqueued once per saved split time (~187 times in the traced request), so one-per-event is a deliberate improvement. Per-effort Turbo `broadcast_update` (previously fired via the touch commit) is preserved: the roster page depends on it to update its rows, so the interactor broadcasts explicitly for changed efforts after the transaction (`broadcast_render_later_to` renders in background jobs, so this does not block the request).

No-op saves (effort already started at the given time) skip derived data, touches, and notifications entirely.

## Testing

- Existing `StartEfforts`, `SetEffortPerformanceData`, `SplitTimeQuery`, `EffortSegment`, and `SplitTime` specs pass unchanged (the multi-event case was already covered by the SUM 55k/100k fixtures)
- New specs cover: elapsed_seconds on new and recalculated split times, effort segment rebuild from a changed start time, performance data (`started`), effort/event touches, single notification job per subscribed event, and the no-op path (no touches, no notifications)
- 462 examples across the touched areas, 0 failures

Per #2186, final numbers should be confirmed in Scout after deploy rather than assumed, including whether `UpdateEffortsStatus` becomes the next bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

