### PR TITLE
Start efforts asynchronously via StartEffortsJob

### DIFF
--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -387,17 +387,28 @@ class EventGroupsController < ApplicationController
     authorize @event_group
 
     filter = prepared_params[:filter]
-    efforts = @event_group.efforts.includes(:event, split_times: :split).roster_subquery
-    filtered_efforts = Effort.from(efforts, :efforts).where(filter)
-    start_time = params[:actual_start_time]
+    context_key = start_efforts_context_key(filter[:assumed_start_time])
+    efforts = @event_group.efforts.roster_subquery
+    effort_ids = Effort.from(efforts, :efforts).where(filter).ids
 
-    start_response = ::Interactors::StartEfforts.perform!(efforts: filtered_efforts, start_time: start_time)
-
-    # Need to pick up the new start split time before setting status
-    filtered_efforts = filtered_efforts.includes(split_times: :split)
-    set_response = ::Interactors::UpdateEffortsStatus.perform!(filtered_efforts)
-    response = start_response.merge(set_response)
-    set_flash_message(response)
+    if effort_ids.empty?
+      flash.now[:warning] = "No entrants were ready to start."
+    elsif context_key && AsyncTask.active_for?(parent: @event_group, job_class: "StartEffortsJob",
+                                               context_key: context_key)
+      flash.now[:warning] = "Entrants for this start time are already being started."
+    else
+      task = AsyncTask.create!(
+        parent: @event_group,
+        user: current_user,
+        job_class: "StartEffortsJob",
+        context_key: context_key,
+        description: "Starting #{helpers.pluralize(effort_ids.size, 'entrant')}",
+      )
+      StartEffortsJob.perform_later(task, effort_ids: effort_ids, start_time: params[:actual_start_time],
+                                          current_user: current_user)
+      flash.now[:success] =
+        "Starting #{helpers.pluralize(effort_ids.size, 'entrant')}. This may take a minute for large events."
+    end
 
     respond_to do |format|
       format.html { redirect_to request.referrer }
@@ -472,6 +483,14 @@ class EventGroupsController < ApplicationController
   end
 
   private
+
+  def start_efforts_context_key(assumed_start_time)
+    return nil if assumed_start_time.blank?
+
+    Time.zone.parse(assumed_start_time.to_s)&.utc&.iso8601
+  rescue ArgumentError
+    nil
+  end
 
   def bib_assignment_hash(event_group_params)
     event_group_params.to_unsafe_h

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -392,10 +392,12 @@ class EventGroupsController < ApplicationController
     effort_ids = Effort.from(efforts, :efforts).where(filter).ids
 
     if effort_ids.empty?
-      flash.now[:warning] = "No entrants were ready to start."
+      level = :warning
+      message = "No entrants were found to start."
     elsif context_key && AsyncTask.active_for?(parent: @event_group, job_class: "StartEffortsJob",
                                                context_key: context_key)
-      flash.now[:warning] = "Entrants for this start time are already being started."
+      level = :warning
+      message = "Entrants for this start time are already being started."
     else
       task = AsyncTask.create!(
         parent: @event_group,
@@ -406,13 +408,19 @@ class EventGroupsController < ApplicationController
       )
       StartEffortsJob.perform_later(task, effort_ids: effort_ids, start_time: params[:actual_start_time],
                                           current_user: current_user)
-      flash.now[:success] =
-        "Starting #{helpers.pluralize(effort_ids.size, 'entrant')}. This may take a minute for large events."
+      level = :success
+      message = "Starting #{helpers.pluralize(effort_ids.size, 'entrant')}. This may take a minute for large events."
     end
 
     respond_to do |format|
-      format.html { redirect_to request.referrer }
-      format.turbo_stream { @presenter = EventGroupRosterPresenter.new(@event_group, view_context) }
+      format.html do
+        flash[level] = message
+        redirect_to request.referrer
+      end
+      format.turbo_stream do
+        flash.now[level] = message
+        @presenter = EventGroupRosterPresenter.new(@event_group, view_context)
+      end
     end
   end
 

--- a/app/controllers/event_groups_controller.rb
+++ b/app/controllers/event_groups_controller.rb
@@ -386,39 +386,21 @@ class EventGroupsController < ApplicationController
   def start_efforts
     authorize @event_group
 
-    filter = prepared_params[:filter]
-    context_key = start_efforts_context_key(filter[:assumed_start_time])
-    efforts = @event_group.efforts.roster_subquery
-    effort_ids = Effort.from(efforts, :efforts).where(filter).ids
-
-    if effort_ids.empty?
-      level = :warning
-      message = "No entrants were found to start."
-    elsif context_key && AsyncTask.active_for?(parent: @event_group, job_class: "StartEffortsJob",
-                                               context_key: context_key)
-      level = :warning
-      message = "Entrants for this start time are already being started."
-    else
-      task = AsyncTask.create!(
-        parent: @event_group,
-        user: current_user,
-        job_class: "StartEffortsJob",
-        context_key: context_key,
-        description: "Starting #{helpers.pluralize(effort_ids.size, 'entrant')}",
-      )
-      StartEffortsJob.perform_later(task, effort_ids: effort_ids, start_time: params[:actual_start_time],
-                                          current_user: current_user)
-      level = :success
-      message = "Starting #{helpers.pluralize(effort_ids.size, 'entrant')}. This may take a minute for large events."
-    end
+    response = ::Interactors::EnqueueStartEfforts.perform!(
+      event_group: @event_group,
+      filter: prepared_params[:filter],
+      start_time: params[:actual_start_time],
+      current_user: current_user,
+    )
+    level = response.successful? ? :success : :warning
 
     respond_to do |format|
       format.html do
-        flash[level] = message
+        flash[level] = response.message
         redirect_to request.referrer
       end
       format.turbo_stream do
-        flash.now[level] = message
+        flash.now[level] = response.message
         @presenter = EventGroupRosterPresenter.new(@event_group, view_context)
       end
     end
@@ -491,14 +473,6 @@ class EventGroupsController < ApplicationController
   end
 
   private
-
-  def start_efforts_context_key(assumed_start_time)
-    return nil if assumed_start_time.blank?
-
-    Time.zone.parse(assumed_start_time.to_s)&.utc&.iso8601
-  rescue ArgumentError
-    nil
-  end
 
   def bib_assignment_hash(event_group_params)
     event_group_params.to_unsafe_h

--- a/app/helpers/dropdown_helper.rb
+++ b/app/helpers/dropdown_helper.rb
@@ -46,13 +46,29 @@ module DropdownHelper
   end
 
   def start_entrants_dropdown_menu(view_object)
+    event_group = view_object.event_group
+    active_context_keys = AsyncTask.active
+                                   .where(parent: event_group, job_class: "StartEffortsJob")
+                                   .pluck(:context_key)
+                                   .to_set
+
     dropdown_items = view_object.ready_efforts.count_by(&:assumed_start_time_local).sort.map do |time, effort_count|
-      {
-        name: "(#{effort_count}) scheduled at #{l(time, format: :full_day_military_and_zone)}",
-        link: start_efforts_form_event_group_path(view_object.event_group, effort_count: effort_count,
-                                                                           scheduled_start_time_local: time),
-        data: { turbo_frame: "form_modal" }
-      }
+      scheduled_time = "(#{effort_count}) scheduled at #{l(time, format: :full_day_military_and_zone)}"
+
+      if active_context_keys.include?(time.utc.iso8601)
+        {
+          name: "#{scheduled_time} — starting now",
+          link: "#",
+          disabled: true
+        }
+      else
+        {
+          name: scheduled_time,
+          link: start_efforts_form_event_group_path(event_group, effort_count: effort_count,
+                                                                 scheduled_start_time_local: time),
+          data: { turbo_frame: "form_modal" }
+        }
+      end
     end
 
     build_dropdown_menu("Start Entrants", dropdown_items, button: true, button_type: "success")

--- a/app/jobs/start_efforts_job.rb
+++ b/app/jobs/start_efforts_job.rb
@@ -1,0 +1,42 @@
+class StartEffortsJob < ApplicationJob
+  include FlashBroadcastable
+
+  queue_as :default
+
+  def perform(task, effort_ids:, start_time:, current_user: nil)
+    set_current_user(current_user: current_user)
+    event_group = task.parent
+
+    efforts = event_group.efforts.where(id: effort_ids).includes(:event, split_times: :split)
+    start_response = ::Interactors::StartEfforts.perform!(efforts: efforts, start_time: start_time)
+
+    status_efforts = event_group.efforts.where(id: effort_ids).includes(split_times: :split)
+    set_response = ::Interactors::UpdateEffortsStatus.perform!(status_efforts)
+
+    response = start_response.merge(set_response)
+    if response.successful?
+      task.finished!
+      broadcast_flash(event_group, message: response.message)
+    else
+      task.update(status: :failed, error_message: response.message_with_error_report)
+      broadcast_flash(event_group, message: response.message_with_error_report, level: :danger)
+    end
+    broadcast_start_button(event_group)
+  rescue StandardError => e
+    task.update(status: :failed, error_message: e.message)
+    broadcast_flash(task.parent, message: "Could not start entrants: #{e.message}", level: :danger)
+    broadcast_start_button(task.parent)
+    raise
+  end
+
+  private
+
+  def broadcast_start_button(event_group)
+    ::Turbo::StreamsChannel.broadcast_replace_to(
+      event_group,
+      target: ::ActionView::RecordIdentifier.dom_id(event_group, :start_ready_efforts_button),
+      partial: "event_groups/start_ready_efforts_button",
+      locals: { presenter: ::EventGroupStartPresenter.new(event_group) },
+    )
+  end
+end

--- a/app/models/async_task.rb
+++ b/app/models/async_task.rb
@@ -1,0 +1,16 @@
+class AsyncTask < ApplicationRecord
+  STALENESS_THRESHOLD = 30.minutes
+
+  belongs_to :parent, polymorphic: true
+  belongs_to :user, optional: true
+
+  enum :status, { in_progress: 0, finished: 1, failed: 2 }
+
+  validates :job_class, presence: true
+
+  scope :active, -> { in_progress.where(created_at: STALENESS_THRESHOLD.ago..) }
+
+  def self.active_for?(parent:, job_class:, context_key: nil)
+    active.exists?(parent: parent, job_class: job_class.to_s, context_key: context_key)
+  end
+end

--- a/app/presenters/event_group_start_presenter.rb
+++ b/app/presenters/event_group_start_presenter.rb
@@ -1,0 +1,13 @@
+# Lightweight substitute for EventGroupRosterPresenter used where no
+# view_context exists (e.g. broadcast renders from a background job)
+class EventGroupStartPresenter
+  attr_reader :event_group
+
+  def initialize(event_group)
+    @event_group = event_group
+  end
+
+  def ready_efforts
+    @ready_efforts ||= event_group.efforts.roster_subquery.select(&:ready_to_start)
+  end
+end

--- a/app/services/interactors/enqueue_start_efforts.rb
+++ b/app/services/interactors/enqueue_start_efforts.rb
@@ -1,0 +1,74 @@
+module Interactors
+  class EnqueueStartEfforts
+    include Interactors::Errors
+    include ActionView::Helpers::TextHelper
+
+    JOB_CLASS = "StartEffortsJob".freeze
+
+    def self.perform!(event_group:, filter:, start_time:, current_user: nil)
+      new(event_group: event_group, filter: filter, start_time: start_time, current_user: current_user).perform!
+    end
+
+    def initialize(event_group:, filter:, start_time:, current_user: nil)
+      @event_group = event_group
+      @filter = filter || {}
+      @start_time = start_time
+      @current_user = current_user
+      @errors = []
+    end
+
+    def perform!
+      if effort_ids.empty?
+        errors << efforts_not_provided_error
+        message = "No entrants were found to start."
+      elsif duplicate_task?
+        errors << duplicate_async_task_error(JOB_CLASS)
+        message = "Entrants for this start time are already being started."
+      else
+        enqueue_job
+        message = "Starting #{pluralize(effort_ids.size, 'entrant')}. This may take a minute for large events."
+      end
+
+      Interactors::Response.new(errors, message)
+    end
+
+    private
+
+    attr_reader :event_group, :filter, :start_time, :current_user, :errors
+
+    def effort_ids
+      @effort_ids ||= begin
+        efforts = event_group.efforts.roster_subquery
+        Effort.from(efforts, :efforts).where(filter).ids
+      end
+    end
+
+    def duplicate_task?
+      context_key.present? &&
+        AsyncTask.active_for?(parent: event_group, job_class: JOB_CLASS, context_key: context_key)
+    end
+
+    def enqueue_job
+      task = AsyncTask.create!(
+        parent: event_group,
+        user: current_user,
+        job_class: JOB_CLASS,
+        context_key: context_key,
+        description: "Starting #{pluralize(effort_ids.size, 'entrant')}",
+      )
+      StartEffortsJob.perform_later(task, effort_ids: effort_ids, start_time: start_time,
+                                          current_user: current_user)
+    end
+
+    def context_key
+      return @context_key if defined?(@context_key)
+
+      @context_key = begin
+        assumed_start_time = filter[:assumed_start_time].presence
+        assumed_start_time && Time.zone.parse(assumed_start_time.to_s)&.utc&.iso8601
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/app/services/interactors/errors.rb
+++ b/app/services/interactors/errors.rb
@@ -48,6 +48,11 @@ module Interactors
         detail: { messages: [message] } }
     end
 
+    def duplicate_async_task_error(job_class)
+      { title: "Task already in progress",
+        detail: { messages: ["An active #{job_class} task already exists for this context"] } }
+    end
+
     def efforts_not_provided_error
       { title: "Efforts not provided",
         detail: { messages: ["No efforts were provided"] } }

--- a/app/views/event_groups/_start_efforts_modal.html.erb
+++ b/app/views/event_groups/_start_efforts_modal.html.erb
@@ -29,7 +29,8 @@
         </div>
 
         <div class="mb-3">
-          <%= f.submit "Start", class: "btn btn-success" %>
+          <%= f.button "Start", class: "btn btn-success",
+                                data: { turbo_submits_with: fa_icon("spinner", class: "fa-spin", text: "Starting") } %>
           <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
         </div>
       <% end %>

--- a/spec/fixtures/async_tasks.yml
+++ b/spec/fixtures/async_tasks.yml
@@ -1,0 +1,38 @@
+sum_start_efforts_in_progress:
+  parent: sum (EventGroup)
+  user: fifth_user
+  job_class: StartEffortsJob
+  context_key: "2017-09-23T13:00:00Z"
+  description: Starting 3 entrants
+  status: 0
+  created_at: <%= 5.minutes.ago %>
+  updated_at: <%= 5.minutes.ago %>
+
+sum_start_efforts_stale:
+  parent: sum (EventGroup)
+  user: fifth_user
+  job_class: StartEffortsJob
+  context_key: "2017-09-23T14:00:00Z"
+  description: Starting 2 entrants
+  status: 0
+  created_at: <%= 2.hours.ago %>
+  updated_at: <%= 2.hours.ago %>
+
+sum_start_efforts_finished:
+  parent: sum (EventGroup)
+  user: fifth_user
+  job_class: StartEffortsJob
+  context_key: "2017-09-23T12:00:00Z"
+  description: Starting 4 entrants
+  status: 1
+  created_at: <%= 10.minutes.ago %>
+  updated_at: <%= 2.minutes.ago %>
+
+hardrock_2016_status_update_in_progress:
+  parent: hardrock_2016 (EventGroup)
+  user: admin_user
+  job_class: UpdateEffortsStatusJob
+  description: Updating status for all efforts
+  status: 0
+  created_at: <%= 1.minute.ago %>
+  updated_at: <%= 1.minute.ago %>

--- a/spec/jobs/start_efforts_job_spec.rb
+++ b/spec/jobs/start_efforts_job_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe StartEffortsJob do
+  include ActiveJob::TestHelper
+
+  subject(:job) { described_class.perform_later(task, effort_ids: effort_ids, start_time: start_time, current_user: current_user) }
+
+  let(:task) do
+    AsyncTask.create!(
+      parent: event_group,
+      user: current_user,
+      job_class: "StartEffortsJob",
+      context_key: "2017-09-23T14:00:00Z",
+      description: "Starting 2 entrants",
+    )
+  end
+  let(:event_group) { event_groups(:sum) }
+  let(:subject_efforts) { [efforts(:sum_55k_not_started), efforts(:sum_100k_un_started)] }
+  let(:effort_ids) { subject_efforts.map(&:id) }
+  let(:start_time) { "2017-09-23 08:00:00" }
+  let(:current_user) { users(:admin_user) }
+
+  after do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
+  it "queues the job" do
+    expect { job }.to change(described_class.queue_adapter.enqueued_jobs, :size).by(1)
+  end
+
+  it "calls StartEfforts and UpdateEffortsStatus" do
+    expect(Interactors::StartEfforts).to receive(:perform!).and_call_original
+    expect(Interactors::UpdateEffortsStatus).to receive(:perform!).and_call_original
+    perform_enqueued_jobs { job }
+  end
+
+  it "creates starting split times for the given efforts" do
+    expect { perform_enqueued_jobs { job } }.to change(SplitTime, :count).by(2)
+
+    subject_efforts.each(&:reload)
+    expect(subject_efforts.map(&:starting_split_time)).to all be_present
+  end
+
+  it "marks the task finished" do
+    perform_enqueued_jobs { job }
+    expect(task.reload).to be_finished
+  end
+
+  it "broadcasts a completion flash and a start button replace" do
+    expect(Turbo::StreamsChannel).to receive(:broadcast_replace_to).with(
+      event_group,
+      target: "flash",
+      partial: "layouts/broadcast_flash",
+      locals: hash_including(level: :success, message: /Started 2 efforts/),
+    )
+    expect(Turbo::StreamsChannel).to receive(:broadcast_replace_to).with(
+      event_group,
+      target: "start_ready_efforts_button_event_group_#{event_group.id}",
+      partial: "event_groups/start_ready_efforts_button",
+      locals: hash_including(presenter: instance_of(EventGroupStartPresenter)),
+    )
+    perform_enqueued_jobs { job }
+  end
+
+  context "when the interactor response is unsuccessful" do
+    let(:start_time) { "not a parsable time" }
+
+    it "marks the task failed with an error message and broadcasts a danger flash" do
+      expect(Turbo::StreamsChannel).to receive(:broadcast_replace_to).with(
+        event_group,
+        target: "flash",
+        partial: "layouts/broadcast_flash",
+        locals: hash_including(level: :danger),
+      )
+      expect(Turbo::StreamsChannel).to receive(:broadcast_replace_to).with(
+        event_group,
+        target: "start_ready_efforts_button_event_group_#{event_group.id}",
+        partial: anything,
+        locals: anything,
+      )
+      expect { perform_enqueued_jobs { job } }.not_to change(SplitTime, :count)
+
+      task.reload
+      expect(task).to be_failed
+      expect(task.error_message).to be_present
+    end
+  end
+end

--- a/spec/models/async_task_spec.rb
+++ b/spec/models/async_task_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+
+RSpec.describe AsyncTask, kind: :model do
+  describe ".active" do
+    subject { described_class.active }
+
+    it "includes in_progress tasks created within the staleness threshold" do
+      expect(subject).to include(async_tasks(:sum_start_efforts_in_progress))
+      expect(subject).to include(async_tasks(:hardrock_2016_status_update_in_progress))
+    end
+
+    it "excludes in_progress tasks older than the staleness threshold" do
+      expect(subject).not_to include(async_tasks(:sum_start_efforts_stale))
+    end
+
+    it "excludes tasks that are not in_progress" do
+      expect(subject).not_to include(async_tasks(:sum_start_efforts_finished))
+    end
+  end
+
+  describe ".active_for?" do
+    let(:event_group) { event_groups(:sum) }
+
+    context "when an active task exists for the parent, job_class, and context_key" do
+      it "returns true" do
+        result = described_class.active_for?(
+          parent: event_group,
+          job_class: "StartEffortsJob",
+          context_key: "2017-09-23T13:00:00Z",
+        )
+        expect(result).to be(true)
+      end
+    end
+
+    context "when the matching task is stale" do
+      it "returns false" do
+        result = described_class.active_for?(
+          parent: event_group,
+          job_class: "StartEffortsJob",
+          context_key: "2017-09-23T14:00:00Z",
+        )
+        expect(result).to be(false)
+      end
+    end
+
+    context "when the matching task is finished" do
+      it "returns false" do
+        result = described_class.active_for?(
+          parent: event_group,
+          job_class: "StartEffortsJob",
+          context_key: "2017-09-23T12:00:00Z",
+        )
+        expect(result).to be(false)
+      end
+    end
+
+    context "when no task exists for the context_key" do
+      it "returns false" do
+        result = described_class.active_for?(
+          parent: event_group,
+          job_class: "StartEffortsJob",
+          context_key: "2017-09-23T15:00:00Z",
+        )
+        expect(result).to be(false)
+      end
+    end
+
+    context "when the job_class does not match" do
+      it "returns false" do
+        result = described_class.active_for?(
+          parent: event_group,
+          job_class: "UpdateEffortsStatusJob",
+          context_key: "2017-09-23T13:00:00Z",
+        )
+        expect(result).to be(false)
+      end
+    end
+
+    context "when the parent does not match" do
+      it "returns false" do
+        result = described_class.active_for?(
+          parent: event_groups(:hardrock_2016),
+          job_class: "StartEffortsJob",
+          context_key: "2017-09-23T13:00:00Z",
+        )
+        expect(result).to be(false)
+      end
+    end
+
+    context "when context_key is nil" do
+      it "matches only tasks having a nil context_key" do
+        expect(described_class.active_for?(parent: event_groups(:hardrock_2016), job_class: "UpdateEffortsStatusJob")).to be(true)
+        expect(described_class.active_for?(parent: event_group, job_class: "StartEffortsJob")).to be(false)
+      end
+    end
+
+    context "when job_class is passed as a class" do
+      it "matches by the class name" do
+        result = described_class.active_for?(
+          parent: event_group,
+          job_class: ActiveJob::Base,
+          context_key: "any",
+        )
+        expect(result).to be(false)
+        expect(described_class.active.where(job_class: "StartEffortsJob", parent: event_group)).to be_present
+      end
+    end
+  end
+
+  describe "validations" do
+    subject(:async_task) { described_class.new(parent: event_groups(:sum), job_class: "StartEffortsJob") }
+
+    it "is valid with a parent and a job_class" do
+      expect(async_task).to be_valid
+    end
+
+    it "is invalid without a job_class" do
+      async_task.job_class = nil
+      expect(async_task).not_to be_valid
+      expect(async_task.errors[:job_class]).to include("can't be blank")
+    end
+
+    it "is invalid without a parent" do
+      async_task.parent = nil
+      expect(async_task).not_to be_valid
+      expect(async_task.errors[:parent]).to include("must exist")
+    end
+
+    it "is valid without a user and without a context_key" do
+      expect(async_task.user).to be_nil
+      expect(async_task.context_key).to be_nil
+      expect(async_task).to be_valid
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,7 @@ end
 RSpec.configure do |config|
   config.global_fixtures = [
     :aid_stations,
+    :async_tasks,
     :connections,
     :course_groups,
     :crew_passages,

--- a/spec/services/interactors/enqueue_start_efforts_spec.rb
+++ b/spec/services/interactors/enqueue_start_efforts_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe Interactors::EnqueueStartEfforts do
+  include ActiveJob::TestHelper
+
+  subject do
+    described_class.new(event_group: event_group, filter: filter, start_time: start_time, current_user: current_user)
+  end
+
+  let(:event_group) { event_groups(:hardrock_2014) }
+  let(:effort) { efforts(:hardrock_2014_not_started) }
+  let(:filter) { { ready_to_start: true, assumed_start_time: assumed_start_time } }
+  let(:assumed_start_time) { "2014-07-11 12:00:00 UTC" }
+  let(:start_time) { "2014-07-11 06:02:00" }
+  let(:current_user) { users(:admin_user) }
+
+  before { effort.update(checked_in: true) }
+
+  after do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
+  context "when matching efforts exist and no task is active" do
+    it "creates an active AsyncTask keyed to the assumed start time" do
+      expect { subject.perform! }.to change(AsyncTask, :count).by(1)
+
+      task = AsyncTask.last
+      expect(task.parent).to eq(event_group)
+      expect(task.user).to eq(current_user)
+      expect(task.job_class).to eq("StartEffortsJob")
+      expect(task.context_key).to eq("2014-07-11T12:00:00Z")
+      expect(task.description).to eq("Starting 1 entrant")
+      expect(task).to be_in_progress
+    end
+
+    it "enqueues StartEffortsJob with the resolved effort ids" do
+      subject.perform!
+
+      expect(StartEffortsJob).to have_been_enqueued.with(
+        AsyncTask.last,
+        effort_ids: [effort.id],
+        start_time: start_time,
+        current_user: current_user,
+      )
+    end
+
+    it "returns a successful response with a starting message" do
+      response = subject.perform!
+
+      expect(response).to be_successful
+      expect(response.message).to eq("Starting 1 entrant. This may take a minute for large events.")
+    end
+  end
+
+  context "when no efforts match the filter" do
+    let(:filter) { { ready_to_start: true, assumed_start_time: "2020-01-01 12:00:00 UTC" } }
+
+    it "does not create a task or enqueue a job and returns an unsuccessful response" do
+      response = nil
+      expect { response = subject.perform! }.not_to change(AsyncTask, :count)
+
+      expect(StartEffortsJob).not_to have_been_enqueued
+      expect(response).not_to be_successful
+      expect(response.message).to eq("No entrants were found to start.")
+    end
+  end
+
+  context "when an active task exists for the same start time" do
+    before do
+      AsyncTask.create!(
+        parent: event_group,
+        job_class: "StartEffortsJob",
+        context_key: "2014-07-11T12:00:00Z",
+        description: "Starting 1 entrant",
+      )
+    end
+
+    it "does not create a task or enqueue a job and returns an unsuccessful response" do
+      response = nil
+      expect { response = subject.perform! }.not_to change(AsyncTask, :count)
+
+      expect(StartEffortsJob).not_to have_been_enqueued
+      expect(response).not_to be_successful
+      expect(response.message).to eq("Entrants for this start time are already being started.")
+    end
+
+    context "when the active task is stale" do
+      before { AsyncTask.last.update_column(:created_at, 1.hour.ago) }
+
+      it "enqueues a new task" do
+        expect { subject.perform! }.to change(AsyncTask, :count).by(1)
+        expect(StartEffortsJob).to have_been_enqueued
+      end
+    end
+  end
+
+  context "when the filter has no assumed start time" do
+    let(:filter) { { ready_to_start: true } }
+
+    it "creates a task with a nil context key and enqueues the job" do
+      response = nil
+      expect { response = subject.perform! }.to change(AsyncTask, :count).by(1)
+
+      expect(AsyncTask.last.context_key).to be_nil
+      expect(StartEffortsJob).to have_been_enqueued
+      expect(response).to be_successful
+    end
+  end
+
+  context "when the assumed start time is not parsable" do
+    let(:assumed_start_time) { "99:99:99" }
+
+    it "derives a nil context key rather than raising" do
+      expect(subject.send(:context_key)).to be_nil
+    end
+  end
+end

--- a/spec/system/event_group_construction/manage_start_times_spec.rb
+++ b/spec/system/event_group_construction/manage_start_times_spec.rb
@@ -1,20 +1,21 @@
 require "rails_helper"
 
 RSpec.describe "Manage start times", type: :system do
+  include ActiveJob::TestHelper
+
   let(:page_path) { manage_start_times_event_group_path(event_group) }
 
   let(:owner) { users(:fourth_user) }
   let(:steward) { users(:fifth_user) }
   let(:admin) { users(:admin_user) }
+  let(:organization) { organizations(:running_up_for_air) }
+  let(:event_group) { event_groups(:rufa_2017) }
+  let(:event) { events(:rufa_2017_12h) }
 
   before do
     organization.update(created_by: owner.id)
     organization.stewards << steward
   end
-
-  let(:organization) { organizations(:running_up_for_air) }
-  let(:event_group) { event_groups(:rufa_2017) }
-  let(:event) { events(:rufa_2017_12h) }
 
   scenario "The user is a visitor" do
     verify_unable_to_visit_page
@@ -59,7 +60,7 @@ RSpec.describe "Manage start times", type: :system do
     fill_in "actual_start_time", with: updated_actual_start_time_text
     cancel_button = turbo_frame.find_link(href: page_path)
 
-    expect { cancel_button.click }.not_to change { SplitTime.count }
+    expect { cancel_button.click }.not_to(change(SplitTime, :count))
     efforts = event.efforts.roster_subquery.where(actual_start_time: actual_start_time)
     efforts.each { |effort| expect(effort.actual_start_time).to eq(actual_start_time) }
 
@@ -68,7 +69,7 @@ RSpec.describe "Manage start times", type: :system do
     fill_in "actual_start_time", with: updated_actual_start_time_text
     submit_button = turbo_frame.find('button[type="submit"]')
 
-    expect { submit_button.click }.not_to change { SplitTime.count }
+    expect { perform_enqueued_jobs { submit_button.click } }.not_to(change(SplitTime, :count))
     efforts = event.efforts.roster_subquery.where(actual_start_time: actual_start_time)
     efforts.each { |effort| expect(effort.actual_start_time).to eq(updated_actual_start_time_text.in_time_zone(event_group.home_time_zone)) }
   end
@@ -87,7 +88,7 @@ RSpec.describe "Manage start times", type: :system do
     fill_in "actual_start_time", with: updated_actual_start_time_text
     cancel_button = turbo_frame.find_link(href: page_path)
 
-    expect { cancel_button.click }.not_to change { SplitTime.count }
+    expect { cancel_button.click }.not_to(change(SplitTime, :count))
     efforts = event.efforts.roster_subquery.where(actual_start_time: actual_start_time)
     efforts.each { |effort| expect(effort.actual_start_time).to eq(actual_start_time) }
 
@@ -96,7 +97,7 @@ RSpec.describe "Manage start times", type: :system do
     fill_in "actual_start_time", with: updated_actual_start_time_text
     submit_button = turbo_frame.find('button[type="submit"]')
 
-    expect { submit_button.click }.to change { SplitTime.count }.by(1)
+    expect { perform_enqueued_jobs { submit_button.click } }.to change(SplitTime, :count).by(1)
     efforts = event.efforts.roster_subquery.where(actual_start_time: actual_start_time)
     efforts.each { |effort| expect(effort.actual_start_time).to eq(updated_actual_start_time_text.in_time_zone(event_group.home_time_zone)) }
   end

--- a/spec/system/event_group_roster/start_ready_efforts_spec.rb
+++ b/spec/system/event_group_roster/start_ready_efforts_spec.rb
@@ -1,24 +1,23 @@
 require "rails_helper"
 
-RSpec.describe "start ready efforts from the event groups roster page", js: true do
+RSpec.describe "start ready efforts from the event groups roster page", :js do
   include ActionView::RecordIdentifier
   include ActiveJob::TestHelper
 
   let(:steward) { users(:fifth_user) }
-
-  before do
-    organization.stewards << steward
-  end
-
   let(:effort) { efforts(:hardrock_2014_not_started) }
   let(:event_group) { event_groups(:hardrock_2014) }
   let(:organization) { event_group.organization }
   let(:event_group_efforts) { event_group.efforts.roster_subquery }
 
-  context "when no efforts are ready to start" do
-    before { expect(event_group_efforts.map(&:ready_to_start)).to all eq(false) }
+  before do
+    organization.stewards << steward
+  end
 
+  context "when no efforts are ready to start" do
     scenario "start button is disabled" do
+      expect(event_group_efforts.map(&:ready_to_start)).to all eq(false)
+
       login_as steward, scope: :user
       visit_page
 
@@ -41,17 +40,40 @@ RSpec.describe "start ready efforts from the event groups roster page", js: true
           click_link("(1) scheduled at Friday, July 11, 2014 06:00 (MDT)")
         end
 
-        expect {
+        expect do
           within("#form_modal") do
             sleep 1
             fill_in "Actual start time", with: "07/11/2014 06:02"
             click_button "Start"
           end
 
-          expect(page).to have_content("Started 1 effort")
-        }.to change { effort.reload.split_times.count }.from(0).to(1)
+          expect(page).to have_content("Starting 1 entrant")
+        end.to change { effort.reload.split_times.count }.from(0).to(1)
 
         expect(effort.starting_split_time.absolute_time).to eq("2014-07-11 06:02:00".in_time_zone(event_group.home_time_zone))
+      end
+    end
+
+    scenario "the dropdown item is disabled while the batch is in progress" do
+      login_as steward, scope: :user
+      visit_page
+
+      within("##{dom_id(event_group, :start_ready_efforts_button)}") do
+        click_button("Start Entrants")
+        click_link("(1) scheduled at Friday, July 11, 2014 06:00 (MDT)")
+      end
+
+      within("#form_modal") do
+        sleep 1
+        fill_in "Actual start time", with: "07/11/2014 06:02"
+        click_button "Start"
+      end
+
+      expect(page).to have_content("Starting 1 entrant")
+
+      within("##{dom_id(event_group, :start_ready_efforts_button)}") do
+        click_button("Start Entrants")
+        expect(page).to have_css("a.dropdown-item.disabled", text: "starting now")
       end
     end
   end
@@ -73,7 +95,7 @@ RSpec.describe "start ready efforts from the event groups roster page", js: true
 
         sleep 0.5
 
-        expect {
+        expect do
           within("#form_modal") do
             expect(page).to have_button("Start")
             fill_in "Actual start time", with: "07/11/2014 06:02"
@@ -83,7 +105,7 @@ RSpec.describe "start ready efforts from the event groups roster page", js: true
           within("##{dom_id(effort, :roster_row)}") do
             expect(page).to have_content("Fri 06:02")
           end
-        }.to change { effort.reload.split_times.count }.by(1)
+        end.to change { effort.reload.split_times.count }.by(1)
 
         expect(effort.starting_split_time.absolute_time).to eq("2014-07-11 06:02:00".in_time_zone(event_group.home_time_zone))
       end


### PR DESCRIPTION
Resolves #2189. Second of two PRs — PR 1 (#2190, merged) added the `async_tasks` table.

## What this does

Moves `EventGroupsController#start_efforts` off the request thread. Staging showed ~17–21 s for ~400 efforts even after the #2187 batching, because the remaining cost is inherently linear per-effort I/O (11 s of broadcast-job enqueues + 7.6 s of split time inserts in the traced request). The request now returns immediately and the work runs in `StartEffortsJob`.

### Request cycle
- Controller snapshots the ready effort ids at request time, creates an `AsyncTask` (`parent` = event group, `job_class` = `"StartEffortsJob"`, `context_key` = the scheduled start time as a UTC ISO8601 string, `description` = "Starting N entrants"), enqueues the job, and responds with an instant "Starting N entrants" flash. The turbo_stream response re-renders the start button so the enqueued batch's dropdown item is disabled immediately.
- Guards: empty ready set → warning flash, no enqueue; an already-active task for the same start time → warning flash, no duplicate enqueue.
- The modal's submit button gains `turbo_submits_with` spinner protection (and moves from `f.submit` to `f.button` so the spinner HTML renders).

### The job
- Runs the **unchanged** `Interactors::StartEfforts` and `Interactors::UpdateEffortsStatus` (scoped to the snapshot ids) — per-effort roster row broadcasts continue to stream in real time as before.
- Marks the task `finished`, or `failed` with the error report, and broadcasts a completion flash ("Started 240 efforts at …" / danger message) via `FlashBroadcastable`, plus a start-button re-render so the finished batch's item reverts/disappears.
- Unexpected exceptions mark the task `failed`, broadcast a danger flash, and re-raise so Solid Queue records the failure.
- The button broadcast uses the new `EventGroupStartPresenter` — a view-context-free PORO that duck-types with `EventGroupRosterPresenter` for the button partial.

### Dropdown
`start_entrants_dropdown_menu` disables items whose start time has an active task ("— starting now") while other start times stay clickable — concurrent batches for different start times work; starting one batch does not lock the others. One `AsyncTask` query covers all items.

### AsyncTask model
The model layer for #2190's table: `active` scope (in_progress within a 30-minute staleness window, so a hard-killed job cannot gate its operation forever) and the `active_for?(parent:, job_class:, context_key:)` guard. Fixtures registered in global fixtures.

## Testing
- New `AsyncTask` model spec (staleness window, status filtering, all `active_for?` dimensions including nil `context_key`)
- New `StartEffortsJob` spec (interactors invoked, split times created, task transitions, completion/danger flash and button broadcasts, failure path)
- System spec updated for the async flow, plus a new scenario asserting the dropdown item is disabled ("starting now") while a batch is enqueued
- Interactor specs unchanged and green

After deploy, re-test the ~400-effort start in staging: the request should return in well under a second, with the job runtime visible under Scout Background Jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

