### PR TITLE
Prevent multi-word toggle button labels from wrapping

### DIFF
--- a/app/helpers/toggle_helper.rb
+++ b/app/helpers/toggle_helper.rb
@@ -3,7 +3,7 @@ module ToggleHelper
     if effort.beyond_start?
       button_id = "disabled-effort-#{effort.id}"
       icon_name = "caret-square-right"
-      button_text = "Beyond\u00A0start"
+      button_text = "Beyond start"
       url = "#"
       params = {}
       disabled = true
@@ -19,7 +19,7 @@ module ToggleHelper
     elsif effort.checked_in?
       button_id = "un-check-in-effort-#{effort.id}"
       icon_name = "check-square"
-      button_text = "Checked\u00A0in"
+      button_text = "Checked in"
       url = effort_path(effort)
       params = { effort: { checked_in: false } }
       disabled = false
@@ -27,7 +27,7 @@ module ToggleHelper
     else
       button_id = "check-in-effort-#{effort.id}"
       icon_name = "square"
-      button_text = "Check\u00A0in"
+      button_text = "Check in"
       url = effort_path(effort)
       params = { effort: { checked_in: true } }
       disabled = false
@@ -36,7 +36,7 @@ module ToggleHelper
 
     html_options = {
       id: button_id,
-      class: "btn btn-#{button_class}",
+      class: "btn btn-#{button_class} text-nowrap",
       method: :patch,
       disabled: disabled,
       params: params,
@@ -74,13 +74,13 @@ module ToggleHelper
       url = live_event_group_gating_location_crew_passages_path(display.event_group, display.gating_location)
       method = :post
       icon_name = "square"
-      button_text = "Mark\u00A0passed"
+      button_text = "Mark passed"
       button_class = "outline-secondary"
       params = control_params.merge(effort_id: row.effort_id)
     end
 
     html_options = {
-      class: "btn btn-sm btn-#{button_class}",
+      class: "btn btn-sm btn-#{button_class} text-nowrap",
       style: "min-width: 9rem;",
       method: method,
       params: params,

--- a/app/helpers/toggle_helper.rb
+++ b/app/helpers/toggle_helper.rb
@@ -3,7 +3,7 @@ module ToggleHelper
     if effort.beyond_start?
       button_id = "disabled-effort-#{effort.id}"
       icon_name = "caret-square-right"
-      button_text = "Beyond start"
+      button_text = "Beyond\u00A0start"
       url = "#"
       params = {}
       disabled = true
@@ -19,7 +19,7 @@ module ToggleHelper
     elsif effort.checked_in?
       button_id = "un-check-in-effort-#{effort.id}"
       icon_name = "check-square"
-      button_text = "Checked in"
+      button_text = "Checked\u00A0in"
       url = effort_path(effort)
       params = { effort: { checked_in: false } }
       disabled = false
@@ -27,7 +27,7 @@ module ToggleHelper
     else
       button_id = "check-in-effort-#{effort.id}"
       icon_name = "square"
-      button_text = "Check in"
+      button_text = "Check\u00A0in"
       url = effort_path(effort)
       params = { effort: { checked_in: true } }
       disabled = false
@@ -74,7 +74,7 @@ module ToggleHelper
       url = live_event_group_gating_location_crew_passages_path(display.event_group, display.gating_location)
       method = :post
       icon_name = "square"
-      button_text = "Mark passed"
+      button_text = "Mark\u00A0passed"
       button_class = "outline-secondary"
       params = control_params.merge(effort_id: row.effort_id)
     end


### PR DESCRIPTION
Resolves #2193

Adds Bootstrap's `text-nowrap` to the two `ToggleHelper` toggle buttons so their labels cannot wrap in narrow columns:

- The roster check-in toggle ("Check in" / "Checked in" / "Beyond start" / "Started")
- The crew access passage toggle ("Mark passed" / "Passed") — same vulnerability, same fix

CSS was chosen over ` ` non-breaking spaces in the label strings (the first commit tried that): the labels stay plainly readable in source, the rule self-applies to any future label change, and it also prevents a break between the icon and the text, which NBSP would not.

No specs match these buttons by text (the check-in system specs find them by CSS id); the roster check-in system spec passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

