### PR TITLE
Batch the per-effort persistence in UpdateEffortsStatus

### DIFF
--- a/app/jobs/start_efforts_job.rb
+++ b/app/jobs/start_efforts_job.rb
@@ -8,7 +8,8 @@ class StartEffortsJob < ApplicationJob
     event_group = task.parent
 
     efforts = event_group.efforts.where(id: effort_ids).includes(:event, split_times: :split)
-    start_response = ::Interactors::StartEfforts.perform!(efforts: efforts, start_time: start_time)
+    start_response = ::Interactors::StartEfforts.perform!(efforts: efforts, start_time: start_time,
+                                                          broadcast_rows: false)
 
     status_efforts = event_group.efforts.where(id: effort_ids).includes(split_times: :split)
     set_response = ::Interactors::UpdateEffortsStatus.perform!(status_efforts)
@@ -16,6 +17,7 @@ class StartEffortsJob < ApplicationJob
     response = start_response.merge(set_response)
     if response.successful?
       task.finished!
+      broadcast_remaining_rows(effort_ids, set_response)
       broadcast_flash(event_group, message: response.message)
     else
       task.update(status: :failed, error_message: response.message_with_error_report)
@@ -30,6 +32,16 @@ class StartEffortsJob < ApplicationJob
   end
 
   private
+
+  # UpdateEffortsStatus broadcasts its changed efforts; rows whose start
+  # changed but whose status did not still need a broadcast
+  def broadcast_remaining_rows(effort_ids, set_response)
+    broadcast_ids = set_response.resources.grep(::Effort).to_set(&:id)
+    remaining_ids = effort_ids.reject { |id| broadcast_ids.include?(id) }
+    return if remaining_ids.empty?
+
+    ::Effort.where(id: remaining_ids).includes(event: :event_group).find_each(&:broadcast_update)
+  end
 
   def broadcast_start_button(event_group)
     ::Turbo::StreamsChannel.broadcast_replace_to(

--- a/app/services/interactors/start_efforts.rb
+++ b/app/services/interactors/start_efforts.rb
@@ -3,15 +3,16 @@ module Interactors
     include Interactors::Errors
     include ActionView::Helpers::TextHelper
 
-    def self.perform!(efforts:, start_time: nil)
-      new(efforts: efforts, start_time: start_time).perform!
+    def self.perform!(efforts:, start_time: nil, broadcast_rows: true)
+      new(efforts: efforts, start_time: start_time, broadcast_rows: broadcast_rows).perform!
     end
 
-    def initialize(efforts:, start_time: nil)
+    def initialize(efforts:, start_time: nil, broadcast_rows: true)
       raise ArgumentError, "start_efforts must include efforts" unless efforts
 
       @efforts = efforts.to_a
       @start_time = start_time
+      @broadcast_rows = broadcast_rows
       @errors = []
       @saved_split_times = []
       @changed_effort_ids = []
@@ -41,7 +42,7 @@ module Interactors
 
     private
 
-    attr_reader :efforts, :start_time, :errors, :saved_split_times, :changed_effort_ids
+    attr_reader :efforts, :start_time, :broadcast_rows, :errors, :saved_split_times, :changed_effort_ids
 
     def preload_events
       ActiveRecord::Associations::Preloader.new(records: efforts, associations: :event).call
@@ -106,6 +107,8 @@ module Interactors
     # The roster page relies on per-effort broadcasts to update its rows;
     # the suppressed touch chain would otherwise have fired these
     def broadcast_effort_updates
+      return unless broadcast_rows
+
       changed_ids = changed_effort_ids.to_set
       efforts.select { |effort| changed_ids.include?(effort.id) }.each(&:broadcast_update)
     end

--- a/app/services/interactors/update_efforts_status.rb
+++ b/app/services/interactors/update_efforts_status.rb
@@ -16,9 +16,12 @@ module Interactors
     def perform!
       ActiveRecord::Base.transaction do
         Persist::BulkUpdateAll.perform!(SplitTime, changed_split_times, update_fields: :data_status)
-        Persist::SaveRecords.perform!(Effort, changed_efforts, update_fields: :data_status)
+        Persist::BulkUpdateAll.perform!(Effort, changed_efforts, update_fields: :data_status)
         raise ActiveRecord::Rollback if errors.present?
+
+        update_derived_data
       end
+      announce_changes if errors.blank?
       Interactors::Response.new(errors, message, changed_resources)
     end
 
@@ -26,12 +29,41 @@ module Interactors
 
     attr_reader :efforts, :times_container, :errors
 
+    # Bulk updates bypass the per-record callbacks that would otherwise
+    # set performance data, touch, notify, and broadcast; each is
+    # reproduced here in batch form
+    def update_derived_data
+      return if changed_efforts.empty?
+
+      ::Results::SetEffortPerformanceData.perform!(changed_effort_ids)
+      ::Effort.where(id: changed_effort_ids).touch_all
+      ::Event.where(id: changed_event_ids).touch_all
+    end
+
+    def announce_changes
+      return if changed_efforts.empty?
+
+      ActiveRecord::Associations::Preloader.new(records: changed_efforts, associations: { event: :event_group }).call
+      changed_efforts.each(&:broadcast_update)
+      ::Event.where(id: changed_event_ids).where.not(topic_resource_key: nil).find_each do |event|
+        NotifyEventUpdateJob.perform_later(event.id)
+      end
+    end
+
     def changed_resources
       @changed_resources ||= status_responses.flat_map(&:resources)
     end
 
     def changed_efforts
       changed_resources.grep(Effort)
+    end
+
+    def changed_effort_ids
+      @changed_effort_ids ||= changed_efforts.map(&:id)
+    end
+
+    def changed_event_ids
+      @changed_event_ids ||= changed_efforts.map(&:event_id).uniq
     end
 
     def changed_split_times

--- a/spec/jobs/start_efforts_job_spec.rb
+++ b/spec/jobs/start_efforts_job_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe StartEffortsJob do
     expect(task.reload).to be_finished
   end
 
+  it "broadcasts each started effort's row exactly once" do
+    row_broadcasts = []
+    allow(Turbo::StreamsChannel).to receive(:broadcast_render_later_to) do |_streamable, **rendering|
+      row_broadcasts << rendering.dig(:locals, :effort)&.id if rendering[:partial] == "efforts/updated"
+    end
+
+    perform_enqueued_jobs { job }
+
+    expect(row_broadcasts.sort).to eq(effort_ids.sort)
+  end
+
   it "broadcasts a completion flash and a start button replace" do
     expect(Turbo::StreamsChannel).to receive(:broadcast_replace_to).with(
       event_group,

--- a/spec/services/interactors/update_efforts_status_spec.rb
+++ b/spec/services/interactors/update_efforts_status_spec.rb
@@ -60,6 +60,49 @@ RSpec.describe Interactors::UpdateEffortsStatus do
         expect(response).to be_successful
         expect(response.message).to include("up to date")
       end
+
+      it "does not touch, broadcast, or notify" do
+        expect(NotifyEventUpdateJob).not_to receive(:perform_later)
+        expect { response }
+          .to not_change { effort.reload.updated_at }
+          .and(not_change { effort.event.reload.updated_at })
+      end
+    end
+
+    context "with respect to derived data and announcements" do
+      before do
+        effort.update(data_status: nil)
+        split_times.each { |st| st.update(data_status: nil) }
+      end
+
+      it "sets performance data for changed efforts" do
+        effort.update_columns(overall_performance: nil, final_split_time_id: nil)
+        response
+
+        effort.reload
+        expect(effort.overall_performance).to be_present
+        expect(effort.final_split_time_id).to eq(effort.ordered_split_times.last.id)
+      end
+
+      it "touches changed efforts and their events" do
+        expect { response }
+          .to change { effort.reload.updated_at }
+          .and(change { effort.event.reload.updated_at })
+      end
+
+      it "broadcasts each changed effort" do
+        expect(effort).to receive(:broadcast_update)
+        response
+      end
+
+      context "when the event has a topic resource key" do
+        before { effort.event.update_column(:topic_resource_key, "test-resource-key") }
+
+        it "enqueues a notification job for the event" do
+          expect(NotifyEventUpdateJob).to receive(:perform_later).with(effort.event_id).once
+          response
+        end
+      end
     end
 
     context "when multiple efforts are provided" do


### PR DESCRIPTION
Resolves #2194

## What this does

Staging testing of the async start flow showed `StartEffortsJob` taking **107 s** for 386 efforts, ~85 s of which was `Interactors::UpdateEffortsStatus` persisting efforts through `Persist::SaveRecords` — individual saves whose callbacks fired a heavyweight performance-data CTE, a touch cascade with a notification enqueue, and a roster-row broadcast for **every** changed effort. After a start batch, every effort is a changed effort.

### The interactor

Efforts now persist `data_status` via `Persist::BulkUpdateAll`, exactly as the interactor already did for split times. The per-record callbacks are reproduced once, in batch:

- One multi-id `Results::SetEffortPerformanceData` pass (exists since #2187)
- `touch_all` on changed efforts and their events
- One `NotifyEventUpdateJob` per subscribed changed event (previously one per save)
- One `broadcast_update` per changed effort **after** the touch — so rendered rows carry fresh `updated_at` values and the roster's 5-second highlight window works again (the "status updates don't flash yellow" symptom in #2194)

Behavior is preserved for all call sites — the single-effort controller flows and the ETL import get identical results from a batch of one. One deliberate change: `before_save :reset_age_from_birthdate` no longer runs incidentally during status updates (a status pass shouldn't rewrite age).

### The job

`StartEffortsJob` now tells `StartEfforts` to skip its row broadcasts (new `broadcast_rows:` option, default true) and, after the status pass, broadcasts only the started-but-status-unchanged remainder. Net effect: **each started effort's row is broadcast exactly once, carrying final status** — halving broadcast volume versus the double-broadcast (start + status callback) behavior, and fixing the ordering wart where rows were first broadcast without their data_status.

## Testing

- New interactor examples: performance data set for changed efforts, efforts/events touched, one broadcast per changed effort, one notification per subscribed event, and the no-change case doing none of it
- New job example asserting each started effort's row is broadcast exactly once (by intercepting `broadcast_render_later_to`)
- Full sweep green: 454 examples across interactors, jobs, and the roster/manage-start-times system specs

## Expected result

The 386-effort staging run should drop from ~107 s to roughly the ~19 s floor of the start work itself, and status rows should flash yellow again. Worth re-running the staging test after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

