### PR TITLE
Make the setup widget horizontally scrollable on narrow screens

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -49,5 +49,6 @@
 @import "./utilities/popover";
 @import "./utilities/saving";
 @import "./utilities/scroll_strip";
+@import "./utilities/setup_widget";
 @import "./utilities/sidebar";
 @import "./utilities/tables";

--- a/app/assets/stylesheets/utilities/_setup_widget.scss
+++ b/app/assets/stylesheets/utilities/_setup_widget.scss
@@ -1,21 +1,28 @@
-// Below md, the setup widget becomes a horizontally scrolling strip
-// (see scroll_strip_controller): percentage-based columns would shrink
-// to fit rather than overflow, so cards take content-based minimum
-// widths instead. Above md, the grid classes govern and nothing here
-// applies.
+// The setup widget is a horizontally scrolling strip at every width
+// (see scroll_strip_controller): cards take content-based minimum
+// widths and grow to fill spare room, so a group with many events
+// scrolls behind the arrows instead of squeezing its cards. Percentage
+// grid columns are unsuitable here because they shrink to fit inside a
+// nowrap container rather than overflow.
 .setup-widget-row {
-  @include media-breakpoint-down(md) {
-    width: max-content;
-    min-width: 100%;
+  width: max-content;
+  min-width: 100%;
 
-    > [class*="col"] {
-      flex: 0 0 auto;
-      width: auto;
-      min-width: 9rem;
-    }
+  > [class*="col"] {
+    flex: 1 0 auto;
+    width: auto;
+    min-width: 9rem;
+  }
 
-    > .setup-widget-card-wide {
-      min-width: 22rem;
-    }
+  > .setup-widget-card-wide {
+    min-width: max-content;
+  }
+}
+
+.setup-widget-events-row {
+  > [class*="col"] {
+    flex: 1 0 auto;
+    width: auto;
+    min-width: 5rem;
   }
 }

--- a/app/assets/stylesheets/utilities/_setup_widget.scss
+++ b/app/assets/stylesheets/utilities/_setup_widget.scss
@@ -1,0 +1,21 @@
+// Below md, the setup widget becomes a horizontally scrolling strip
+// (see scroll_strip_controller): percentage-based columns would shrink
+// to fit rather than overflow, so cards take content-based minimum
+// widths instead. Above md, the grid classes govern and nothing here
+// applies.
+.setup-widget-row {
+  @include media-breakpoint-down(md) {
+    width: max-content;
+    min-width: 100%;
+
+    > [class*="col"] {
+      flex: 0 0 auto;
+      width: auto;
+      min-width: 9rem;
+    }
+
+    > .setup-widget-card-wide {
+      min-width: 22rem;
+    }
+  }
+}

--- a/app/presenters/event_group_setup_presenter.rb
+++ b/app/presenters/event_group_setup_presenter.rb
@@ -118,6 +118,10 @@ class EventGroupSetupPresenter < BasePresenter
     params[:service_identifier]
   end
 
+  def active_event
+    nil
+  end
+
   def active_widget_card
     if controller_name == "event_groups" && action_name.in?(%w[setup new])
       :overview

--- a/app/presenters/event_setup_course_presenter.rb
+++ b/app/presenters/event_setup_course_presenter.rb
@@ -7,8 +7,13 @@ class EventSetupCoursePresenter < BasePresenter
   end
 
   attr_reader :course, :event, :event_group
+
   delegate :description, :name, :ordered_splits, :organization, to: :course
-  delegate :concealed?, :status, to: :event_group
+  delegate :concealed?, to: :event_group
+
+  def active_event
+    event
+  end
 
   def active_widget_card
     :events_and_courses
@@ -49,5 +54,4 @@ class EventSetupCoursePresenter < BasePresenter
   private
 
   attr_reader :view_context
-
 end

--- a/app/presenters/event_setup_presenter.rb
+++ b/app/presenters/event_setup_presenter.rb
@@ -15,6 +15,10 @@ class EventSetupPresenter < BasePresenter
     @current_user = view_context.current_user
   end
 
+  def active_event
+    event
+  end
+
   def active_widget_card
     :events_and_courses
   end

--- a/app/presenters/reconcile_presenter.rb
+++ b/app/presenters/reconcile_presenter.rb
@@ -1,5 +1,6 @@
 class ReconcilePresenter < BasePresenter
   attr_reader :event_group, :view_context
+
   delegate :available_live?,
            :concealed?,
            :efforts,
@@ -18,6 +19,10 @@ class ReconcilePresenter < BasePresenter
     unreconciled_batch.each(&:suggest_close_match)
   end
 
+  def active_event
+    nil
+  end
+
   def active_widget_card
     :entrants
   end
@@ -31,7 +36,7 @@ class ReconcilePresenter < BasePresenter
   end
 
   def no_persisted_events?
-    @persisted_events ||= events.none?(&:persisted?)
+    @no_persisted_events ||= events.none?(&:persisted?)
   end
 
   def status

--- a/app/views/event_groups/_setup_widget.html.erb
+++ b/app/views/event_groups/_setup_widget.html.erb
@@ -1,46 +1,68 @@
 <%# locals: (presenter:) -%>
 
-<div id="<%= dom_id(presenter.event_group, "setup_widget") %>">
-  <div class="row bg-white border border-2 border-primary rounded">
+<% active_card = presenter.active_widget_card %>
 
-    <!-- Event Group Card-->
-    <div class="col border-end">
-      <%= render "event_groups/setup_widget_header", title: "Overview" %>
-      <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_event_group(presenter) %>
-    </div>
+<div id="<%= dom_id(presenter.event_group, "setup_widget") %>" data-controller="scroll-strip">
+  <div class="d-flex align-items-stretch">
+    <button type="button"
+            class="btn btn-link text-secondary px-2 d-none"
+            aria-label="Scroll setup cards left"
+            data-scroll-strip-target="prevButton"
+            data-action="scroll-strip#prev">
+      <i class="far fa-chevron-left"></i>
+    </button>
+    <div class="scroll-strip flex-grow-1"
+         data-scroll-strip-target="viewport"
+         data-action="scroll->scroll-strip#updateArrows">
+      <div class="row flex-nowrap mx-0 setup-widget-row bg-white border border-2 border-primary rounded">
 
-    <!-- Events Card-->
-    <div class="col-5 border-end">
-      <%= render "event_groups/setup_widget_header", title: "Events and Courses" %>
-      <% if presenter.event_group.new_record? %>
-        <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_new_event(presenter) %>
-      <% else %>
-        <%= render "event_groups/setup_widget_events", presenter: presenter %>
-      <% end %>
-    </div>
+        <!-- Event Group Card-->
+        <div class="col border-end" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :overview %>>
+          <%= render "event_groups/setup_widget_header", title: "Overview" %>
+          <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_event_group(presenter) %>
+        </div>
 
-    <!-- Entrants Card-->
-    <div class="col border-end">
-      <%= render "event_groups/setup_widget_header", title: "Entrants" %>
-      <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_entrants(presenter) %>
-    </div>
+        <!-- Events Card-->
+        <div class="col-5 border-end setup-widget-card-wide" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :events_and_courses %>>
+          <%= render "event_groups/setup_widget_header", title: "Events and Courses" %>
+          <% if presenter.event_group.new_record? %>
+            <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_new_event(presenter) %>
+          <% else %>
+            <%= render "event_groups/setup_widget_events", presenter: presenter %>
+          <% end %>
+        </div>
 
-    <!-- Partners Card-->
-    <div class="col border-end">
-      <%= render "event_groups/setup_widget_header", title: "Partners" %>
-      <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_partners(presenter) %>
-    </div>
+        <!-- Entrants Card-->
+        <div class="col border-end" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :entrants %>>
+          <%= render "event_groups/setup_widget_header", title: "Entrants" %>
+          <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_entrants(presenter) %>
+        </div>
 
-    <!-- Crew Access Card-->
-    <div class="col-2 border-end">
-      <%= render "event_groups/setup_widget_header", title: "Crew Access" %>
-      <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_gating_locations(presenter) %>
-    </div>
+        <!-- Partners Card-->
+        <div class="col border-end" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :partners %>>
+          <%= render "event_groups/setup_widget_header", title: "Partners" %>
+          <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_partners(presenter) %>
+        </div>
 
-    <!-- Summary Card-->
-    <div class="col">
-      <%= render "event_groups/setup_widget_header", title: "Status" %>
-      <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_summary(presenter) %>
+        <!-- Crew Access Card-->
+        <div class="col-2 border-end" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :gating_locations %>>
+          <%= render "event_groups/setup_widget_header", title: "Crew Access" %>
+          <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_gating_locations(presenter) %>
+        </div>
+
+        <!-- Summary Card-->
+        <div class="col" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :status %>>
+          <%= render "event_groups/setup_widget_header", title: "Status" %>
+          <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_summary(presenter) %>
+        </div>
+      </div>
     </div>
+    <button type="button"
+            class="btn btn-link text-secondary px-2 d-none"
+            aria-label="Scroll setup cards right"
+            data-scroll-strip-target="nextButton"
+            data-action="scroll-strip#next">
+      <i class="far fa-chevron-right"></i>
+    </button>
   </div>
 </div>

--- a/app/views/event_groups/_setup_widget.html.erb
+++ b/app/views/event_groups/_setup_widget.html.erb
@@ -23,7 +23,7 @@
         </div>
 
         <!-- Events Card-->
-        <div class="col-5 border-end setup-widget-card-wide" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :events_and_courses %>>
+        <div class="col border-end setup-widget-card-wide" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :events_and_courses %>>
           <%= render "event_groups/setup_widget_header", title: "Events and Courses" %>
           <% if presenter.event_group.new_record? %>
             <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_new_event(presenter) %>
@@ -45,7 +45,7 @@
         </div>
 
         <!-- Crew Access Card-->
-        <div class="col-2 border-end" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :gating_locations %>>
+        <div class="col border-end" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :gating_locations %>>
           <%= render "event_groups/setup_widget_header", title: "Crew Access" %>
           <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_gating_locations(presenter) %>
         </div>

--- a/app/views/event_groups/_setup_widget.html.erb
+++ b/app/views/event_groups/_setup_widget.html.erb
@@ -1,6 +1,7 @@
 <%# locals: (presenter:) -%>
 
 <% active_card = presenter.active_widget_card %>
+<% selected_event = presenter.respond_to?(:event) ? presenter.event : nil %>
 
 <div id="<%= dom_id(presenter.event_group, "setup_widget") %>" data-controller="scroll-strip">
   <div class="d-flex align-items-stretch">
@@ -23,7 +24,7 @@
         </div>
 
         <!-- Events Card-->
-        <div class="col border-end setup-widget-card-wide" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :events_and_courses %>>
+        <div class="col border-end setup-widget-card-wide" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if active_card == :events_and_courses && (selected_event.nil? || selected_event.new_record?) %>>
           <%= render "event_groups/setup_widget_header", title: "Events and Courses" %>
           <% if presenter.event_group.new_record? %>
             <%= render "event_groups/setup_widget_body", link: link_to_setup_widget_new_event(presenter) %>

--- a/app/views/event_groups/_setup_widget.html.erb
+++ b/app/views/event_groups/_setup_widget.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (presenter:) -%>
 
 <% active_card = presenter.active_widget_card %>
-<% selected_event = presenter.respond_to?(:event) ? presenter.event : nil %>
+<% selected_event = presenter.active_event %>
 
 <div id="<%= dom_id(presenter.event_group, "setup_widget") %>" data-controller="scroll-strip">
   <div class="d-flex align-items-stretch">

--- a/app/views/event_groups/_setup_widget_event.html.erb
+++ b/app/views/event_groups/_setup_widget_event.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (presenter:, event:, css_class:) -%>
 
-<div class="col text-center <%= css_class %>">
+<div class="col text-center <%= css_class %>" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if presenter.respond_to?(:event) && presenter.event == event %>>
   <div>
     <%= link_to_setup_widget_event(presenter, event) %>
   </div>

--- a/app/views/event_groups/_setup_widget_event.html.erb
+++ b/app/views/event_groups/_setup_widget_event.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (presenter:, event:, css_class:) -%>
 
-<div class="col text-center <%= css_class %>" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if presenter.respond_to?(:event) && presenter.event == event %>>
+<div class="col text-center <%= css_class %>" <%= tag.attributes(data: { scroll_strip_target: "selected" }) if presenter.active_event == event %>>
   <div>
     <%= link_to_setup_widget_event(presenter, event) %>
   </div>

--- a/app/views/event_groups/_setup_widget_events.html.erb
+++ b/app/views/event_groups/_setup_widget_events.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (presenter:) -%>
 
-<div class="row py-3">
+<div class="row py-3 flex-nowrap setup-widget-events-row">
   <% presenter.event_group.events.each do |event| %>
     <% next if event.new_record? %>
     <!-- Event-->


### PR DESCRIPTION
Resolves #2138

## What this does

Implements option 1 from the issue (horizontal scroll) using the `scroll-strip` Stimulus controller merged in #2199. The setup widget keeps its tuned single-row desktop layout at every width; on narrow screens it scrolls sideways behind chevron arrows instead of `flex-wrap`ping into the jumbled grid with orphaned cards and clipped icons.

- **Desktop is unchanged** (acceptance criterion): above the `md` breakpoint the existing grid classes govern, the strip doesn't overflow, and the arrows don't render — verified with a browser probe at 1400px (zero overflow, arrows hidden) and a screenshot matching the current design. The only intentional delta is `mx-0` on the row: its negative margins would place content before the scrollport's clip edge, where it would be unreachable.
- **Below `md`**, a new `.setup-widget-row` utility gives cards content-based minimum widths (`9rem`, `22rem` for Events and Courses) — necessary because percentage-based `col-*` widths shrink to fit inside a nowrap container rather than overflow, so without them the strip would never scroll.
- **The active section's card is the strip's `selected` target** (via `presenter.active_widget_card`), so opening e.g. the Entrants page on a phone lands with the Entrants card centered — same behavior as the event strip. Verified via probe at 390px: overflow detected, arrows shown, active card auto-centered and fully visible.
- The Events and Courses card's internal sub-columns — the main risk under the stacking option — are untouched.

All behavior (arrows on overflow only, per-end hiding, edge snapping, font re-settle, resize handling) comes from the shared controller; this PR adds no JS.

## Testing

- All 92 event-group-construction system specs pass (the widget renders on every setup page they cover)
- Strip interaction verified with authenticated headless-browser probes at desktop and phone widths, per the approach used for #2199