### PR TITLE
Handle legacy flat filter params on the spread view

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -151,6 +151,12 @@ class EventsController < ApplicationController
 
   # GET /events/1/spread
   def spread
+    if params[:filter].is_a?(String)
+      gender = params[:filter].presence_in(Effort.genders.keys << "combined")
+      return redirect_to request.params.merge(filter: gender ? { gender: gender } : nil),
+                         status: :moved_permanently
+    end
+
     @presenter = EventSpreadDisplay.new(event: @event, params: prepared_params, current_user: current_user)
     respond_to do |format|
       format.html

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -75,7 +75,7 @@ module EventsHelper
 
   def spread_path_without_search(view_object)
     query = request.query_parameters.deep_dup
-    query["filter"]&.delete("search")
+    query["filter"] = query["filter"].except("search") if query["filter"].is_a?(Hash)
     query.delete("filter") if query["filter"].blank?
     spread_event_path(view_object.event, query)
   end

--- a/app/views/events/spread.html.erb
+++ b/app/views/events/spread.html.erb
@@ -40,17 +40,18 @@
         </div>
       </div>
       <div class="col-12 col-md-4 col-lg-3 order-last order-md-0 mb-2 mb-md-0">
+        <% gender_param = params[:filter].is_a?(ActionController::Parameters) ? params[:filter][:gender] : nil %>
         <%= form_tag spread_event_path(@presenter.event), method: :get do %>
           <%= hidden_field_tag :display_style, params[:display_style] if params[:display_style].present? %>
           <%= hidden_field_tag :sort, params[:sort] if params[:sort].present? %>
-          <%= hidden_field_tag "filter[gender]", params.dig(:filter, :gender) if params.dig(:filter, :gender).present? %>
+          <%= hidden_field_tag "filter[gender]", gender_param if gender_param.present? %>
           <div class="input-group">
             <%= text_field_tag "filter[search]",
-                               params.dig(:filter, :search),
+                               prepared_params[:search],
                                placeholder: "Name or bib number",
                                autocomplete: "off",
                                class: "form-control" %>
-            <% if params.dig(:filter, :search).present? %>
+            <% if prepared_params[:search].present? %>
               <%= link_to spread_path_without_search(@presenter),
                           id: "spread-search-clear",
                           class: "btn btn-outline-secondary input-group-text" do %>
@@ -83,7 +84,7 @@
 
 <article class="ost-article container-fluid">
   <% cache @presenter.cache_key do %>
-    <% if @presenter.effort_times_rows.empty? && params.dig(:filter, :search).present? %>
+    <% if @presenter.effort_times_rows.empty? && prepared_params[:search].present? %>
       <div class="text-center my-5">
         <h4>No entrants match this search</h4>
         <p>

--- a/spec/system/results/spread_view_spec.rb
+++ b/spec/system/results/spread_view_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe "visit the spread page" do
   scenario "A visitor arrives via a legacy URL with a flat filter param" do
     visit spread_event_path(event, filter: "combined", display_style: "elapsed", sort: "-overall_rank")
 
+    expect(page).to have_current_path(%r{/spread\?.*filter%5Bgender%5D=combined}, url: true)
+    expect(page).to have_content(event.name)
+    verify_efforts_present(subject_efforts)
+  end
+
+  scenario "A visitor arrives via a legacy URL with an unrecognized flat filter param" do
+    visit spread_event_path(event, filter: "bogus", display_style: "elapsed")
+
+    expect(page).not_to have_current_path(/filter/, url: true)
     expect(page).to have_content(event.name)
     verify_efforts_present(subject_efforts)
   end

--- a/spec/system/results/spread_view_spec.rb
+++ b/spec/system/results/spread_view_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe "visit the spread page" do
     verify_efforts_present(subject_efforts)
   end
 
+  scenario "A visitor arrives via a legacy URL with a flat filter param" do
+    visit spread_event_path(event, filter: "combined", display_style: "elapsed", sort: "-overall_rank")
+
+    expect(page).to have_content(event.name)
+    verify_efforts_present(subject_efforts)
+  end
+
   scenario "A visitor searches for an entrant by name" do
     subject_effort = efforts(:hardrock_2015_tuan_jacobs)
     visit spread_event_path(event)


### PR DESCRIPTION
Fixes the production 500 surfaced in Scout (error group 94101, 129 occurrences since 2026-08-01): `ActionView::Template::Error: String does not have #dig method` on `events/spread`.

## Root cause

Legacy URLs use a flat filter format — `?filter=combined`, a String — rather than the nested `filter[gender]=...` hash. These arrive mostly from crawlers following old cached links (the trigger URI is a 2023 event page). The app has always tolerated them because every `PreparedParams` filter accessor guards with `is_a?(ActionController::Parameters)` checks and returns empty defaults. The #2199 search bar bypassed those guards by calling `params.dig(:filter, :search)` on raw params in the view — and `Parameters#dig` into a String raises.

## The fix, in two layers

**1. Permanently redirect the known legacy shape.** `events#spread` now 301-redirects flat string filters, following the existing `events#traffic` precedent for legacy params: a recognized gender value (`combined`, `male`, `female`, `nonbinary`) maps to the canonical `filter[gender]=...` URL with all other params preserved; an unrecognized string redirects with the param dropped. Since this traffic is predominantly crawlers, the 301 lets their indexes converge on canonical URLs instead of the legacy shape being served forever.

**2. Guard the view as defense in depth.** Arbitrary malformed params (beyond the known legacy shape) still must not 500:

- The template's three search reads use `prepared_params[:search]` — crash-safe via the existing `PreparedParams` guards, and semantically "the search that was actually applied"
- The gender hidden field uses an explicitly guarded raw read (it can't use `prepared_params[:filter][:gender]`, whose `prepare_gender` transform would convert `"female"` into enum values and corrupt the form round-trip)
- `spread_path_without_search` only manipulates the filter when it's a Hash

## Testing

- Redirect scenarios: the exact production trigger (`filter: "combined", display_style: "elapsed", sort: "-overall_rank"`) lands on the canonical `filter[gender]=combined` URL with the page rendered; an unrecognized flat filter (`filter: "bogus"`) lands with the param dropped
- The original crash regression is covered by the same scenarios (they raised `Template::Error` before the fix)
- All 11 spread system scenarios green; rubocop and erb_lint clean

After merge and deploy, Scout error group 94101 should be marked resolved so any recurrence re-alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

