### PR TITLE
Use Preloader in place of hand-rolled person preloading

### DIFF
--- a/app/presenters/course_best_efforts_display.rb
+++ b/app/presenters/course_best_efforts_display.rb
@@ -29,8 +29,7 @@ class CourseBestEffortsDisplay < BasePresenter
       page: page
     )
 
-    indexed_people = Person.where(id: @filtered_segments.map(&:person_id).compact).index_by(&:id)
-    @filtered_segments.each { |segment| segment.person = indexed_people[segment.person_id] }
+    ActiveRecord::Associations::Preloader.new(records: @filtered_segments, associations: :person).call
 
     @filtered_segments
   end

--- a/app/presenters/course_group_best_efforts_display.rb
+++ b/app/presenters/course_group_best_efforts_display.rb
@@ -22,8 +22,7 @@ class CourseGroupBestEffortsDisplay < BasePresenter
       page: page
     )
 
-    indexed_people = Person.where(id: @filtered_segments.map(&:person_id).compact).index_by(&:id)
-    @filtered_segments.each { |segment| segment.person = indexed_people[segment.person_id] }
+    ActiveRecord::Associations::Preloader.new(records: @filtered_segments, associations: :person).call
 
     @filtered_segments
   end

--- a/app/presenters/event_spread_display.rb
+++ b/app/presenters/event_spread_display.rb
@@ -27,14 +27,16 @@ class EventSpreadDisplay < EventWithEffortsPresenter
   end
 
   def effort_times_rows
-    @effort_times_rows ||=
-      filtered_ranked_efforts.map do |effort|
-        effort.person = indexed_people[effort.person_id]
+    @effort_times_rows ||= begin
+      efforts = filtered_ranked_efforts.to_a
+      ActiveRecord::Associations::Preloader.new(records: efforts, associations: :person).call
+      efforts.map do |effort|
         EffortTimesRow.new(effort: effort,
                            lap_splits: lap_splits,
                            split_times: split_times_by_effort.fetch(effort.id, []),
                            display_style: display_style)
       end
+    end
   end
 
   def effort_times_row_ids

--- a/app/presenters/event_with_efforts_presenter.rb
+++ b/app/presenters/event_with_efforts_presenter.rb
@@ -21,9 +21,10 @@ class EventWithEffortsPresenter < BasePresenter
   end
 
   def ranked_effort_rows
-    @ranked_effort_rows ||= filtered_ranked_efforts.map do |effort|
-      effort.person = indexed_people[effort.person_id]
-      EffortRow.new(effort)
+    @ranked_effort_rows ||= begin
+      efforts = filtered_ranked_efforts.to_a
+      ActiveRecord::Associations::Preloader.new(records: efforts, associations: :person).call
+      efforts.map { |effort| EffortRow.new(effort) }
     end
   end
 
@@ -81,14 +82,6 @@ class EventWithEffortsPresenter < BasePresenter
 
   def filtered_ids
     @filtered_ids ||= event_efforts.where(filter_hash).search(search_text).ids.to_set
-  end
-
-  def indexed_people
-    @indexed_people ||= Person.where(id: person_ids).index_by(&:id)
-  end
-
-  def person_ids
-    @person_ids ||= filtered_ranked_efforts.map(&:person_id).compact
   end
 
   def validate_setup

--- a/app/presenters/finish_history_presenter.rb
+++ b/app/presenters/finish_history_presenter.rb
@@ -12,9 +12,10 @@ class FinishHistoryPresenter < BasePresenter
   end
 
   def effort_rows
-    @effort_rows ||= efforts.map do |effort|
-      effort.person = indexed_people[effort.person_id]
-      EffortRow.new(effort)
+    @effort_rows ||= begin
+      efforts_list = efforts.to_a
+      ActiveRecord::Associations::Preloader.new(records: efforts_list, associations: :person).call
+      efforts_list.map { |effort| EffortRow.new(effort) }
     end
   end
 
@@ -33,10 +34,6 @@ class FinishHistoryPresenter < BasePresenter
 
   def efforts
     @efforts ||= event.efforts.ranking_subquery
-  end
-
-  def indexed_people
-    @indexed_people ||= Person.where(id: efforts.map(&:person_id).compact).index_by(&:id)
   end
 
   # @return [Array<FinishHistory>]

--- a/spec/presenters/course_best_efforts_display_spec.rb
+++ b/spec/presenters/course_best_efforts_display_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe CourseBestEffortsDisplay do
 
       expect(segments.size).to be > 1
       expect(person_queries).to eq(0)
+      expect(segments).to all(satisfy { |segment| segment.association(:person).loaded? && segment.person&.id == segment.person_id })
     ensure
       ActiveSupport::Notifications.unsubscribe(subscription) if subscription
     end

--- a/spec/presenters/course_group_best_efforts_display_spec.rb
+++ b/spec/presenters/course_group_best_efforts_display_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe CourseGroupBestEffortsDisplay do
 
       expect(segments.size).to be > 1
       expect(person_queries).to eq(0)
+      expect(segments).to all(satisfy { |segment| segment.association(:person).loaded? && segment.person&.id == segment.person_id })
     ensure
       ActiveSupport::Notifications.unsubscribe(subscription) if subscription
     end

--- a/spec/presenters/event_with_efforts_presenter_spec.rb
+++ b/spec/presenters/event_with_efforts_presenter_spec.rb
@@ -24,6 +24,33 @@ RSpec.describe EventWithEffortsPresenter do
     end
   end
 
+  describe "#ranked_effort_rows" do
+    let(:event) { events(:hardrock_2015) }
+    let(:prepared_params) { build(:prepared_params, params: ActionController::Parameters.new({})) }
+
+    it "attaches each effort's person without issuing a SELECT people query per row" do
+      person_queries = 0
+      subscription = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
+        next if payload[:name] == "SCHEMA" || payload[:cached]
+
+        person_queries += 1 if payload[:sql] =~ /FROM "people"/
+      end
+
+      rows = subject.ranked_effort_rows
+      rows.each do |row|
+        row.display_full_name
+        row.bio_historic
+        row.flexible_geolocation
+      end
+
+      expect(rows.size).to be > 1
+      expect(person_queries).to be <= 1
+      expect(rows).to all(satisfy { |row| row.effort.association(:person).loaded? && row.effort.person&.id == row.effort.person_id })
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+    end
+  end
+
   describe "#sort_hash" do
     it "returns a hash containing sort data" do
       expect(subject.sort_hash).to eq({ "name" => :asc, "age" => :desc })

--- a/spec/presenters/finish_history_presenter_spec.rb
+++ b/spec/presenters/finish_history_presenter_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe FinishHistoryPresenter do
 
       expect(rows.size).to be > 1
       expect(person_queries).to be <= 1
+      expect(rows).to all(satisfy { |row| row.effort.association(:person).loaded? && row.effort.person&.id == row.effort.person_id })
     ensure
       ActiveSupport::Notifications.unsubscribe(subscription) if subscription
     end

--- a/spec/view_models/event_spread_display_spec.rb
+++ b/spec/view_models/event_spread_display_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe EventSpreadDisplay do
 
       expect(rows.size).to be > 1
       expect(person_queries).to be <= 1
+      expect(rows).to all(satisfy { |row| row.effort.association(:person).loaded? && row.effort.person&.id == row.effort.person_id })
     ensure
       ActiveSupport::Notifications.unsubscribe(subscription) if subscription
     end


### PR DESCRIPTION
Resolves #2188

## What this does

Converts the five presenters that hand-rolled person preloading (`Person.where(id: ...).index_by(&:id)` + a reattach loop) to a single `ActiveRecord::Associations::Preloader` call, following the precedent in `Interactors::StartEfforts` and `EventGroupRawTimesPresenter`:

1. `EventWithEffortsPresenter#ranked_effort_rows` — also deletes its `indexed_people` / `person_ids` private methods
2. `EventSpreadDisplay#effort_times_rows`
3. `FinishHistoryPresenter#effort_rows` — also deletes its `indexed_people`
4. `CourseBestEffortsDisplay#filtered_segments`
5. `CourseGroupBestEffortsDisplay#filtered_segments`

Query behavior is identical (one people query per collection); the `RawTime` sites remain out of scope per the issue (their `effort`/`event`/`split` are attr_writers, not associations).

## Coverage, verified against both implementations

Four of the five sites already had per-row query-count regression specs; `ranked_effort_rows` had none and now has one. All five specs additionally assert **correct attachment**: every record's `person` association is loaded and matches its `person_id` — catching a conversion that silently attached nothing (which lazy-loading would otherwise mask after the query-count window closes).

To confirm the specs assert behavior rather than implementation, the full set was run against the converted code (25 examples green), then with the presenter changes stashed against the original hand-rolled code (same 25 green), then again after restoring the conversion — plus the broader sweep of results/course system specs and the course-group request spec (86 examples, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

