### PR TITLE
Document the watches feature

### DIFF
--- a/app/views/event_groups/follow.html.erb
+++ b/app/views/event_groups/follow.html.erb
@@ -75,6 +75,20 @@
     </div>
     <br>
 
+    <div class="card">
+      <h4 class="card-header">Watching Entrants</h4>
+      <div class="card-body">
+        <p>To pick your entrants out of the field at a glance, click the star next to an entrant's name on
+          <%= @presenter.multiple_events? ? "any of the Live Results pages" : "the Live Results page" %> above. Watched
+          entrants are highlighted, and the filter menu gains a "Watched" option that limits the table to only the
+          entrants you are watching.</p>
+        <p>Watches are saved on your device, and if you are signed in, entrants you follow by email or text are watched
+          automatically. See <%= link_to "Watching Entrants", docs_url("user-info/watching-entrants/"), target: "_blank", rel: "noopener" %>
+          for full details.</p>
+      </div>
+    </div>
+    <br>
+
     <% if @presenter.effort_planning_available? %>
       <div class="card">
         <h4 class="card-header">Live Time Projections</h4>

--- a/docs/user-info/watching-entrants.md
+++ b/docs/user-info/watching-entrants.md
@@ -1,0 +1,29 @@
+---
+title: Watching Entrants
+parent: User Information
+nav_order: 3
+---
+
+# Watching Entrants
+
+When you are crewing or spectating, you usually care about a handful of entrants in a much larger field. Watches let you mark those entrants on the live results page so you can pick them out at a glance.
+
+## Watching and unwatching
+
+On any live results page, each entrant's row has a star at the left edge. Click the star to watch that entrant — the row is highlighted and the star fills in. Click it again to unwatch.
+
+## Seeing only your watched entrants
+
+Once you are watching at least one entrant, the gender menu (Combined / Male / Female) gains a **Watched** option. Choose it to limit the table to only your watched entrants. Choose Combined, Male, or Female to return to the full field.
+
+## Clearing all watches
+
+When you have watches, a half-filled star appears at the top of the star column. Click it to clear every watch for the event group at once.
+
+## Automatic watches for followed entrants
+
+If you are signed in and have subscribed to email or text updates for an entrant, that entrant is watched automatically when you open the live results page. Watches you add by hand are kept alongside these automatic ones.
+
+## Where watches are stored
+
+Watches are saved in your browser, on your device — not in your OpenSplitTime account. They persist across visits on the same device, but they do not follow you to other devices or browsers, and clearing your browser's site data removes them. Automatic watches for subscribed entrants reappear on any device where you are signed in.


### PR DESCRIPTION
## Summary

Documentation for the watches feature shipped in #2205 and #2207:

- **New docs page** `user-info/watching-entrants` (Jekyll, User Information section): watching/unwatching, the Watched filter option, clear-all, automatic watches for followed entrants, and where watches are stored (device-local, with the honest caveats about other devices and cleared browser data).
- **Follow page card**: a "Watching Entrants" card after Live Text and Email Updates — spectators and crew are on this page mid-race, so it gets a two-paragraph summary plus a link to the full docs page via `docs_url`.

## Testing

- Jekyll site builds locally; the page renders and appears in the User Information nav.
- `erb_lint` clean; follow view system specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)