### PR TITLE
Restore table striping at the bg-state level

### DIFF
--- a/app/assets/stylesheets/utilities/_highlight.scss
+++ b/app/assets/stylesheets/utilities/_highlight.scss
@@ -9,6 +9,31 @@
     initial-value: transparent;
 }
 
+// The registration above means --bs-table-bg-state is never unset, which kills
+// the var() fallback chain Bootstrap paints cell state with — striping sets
+// --bs-table-bg-type and relies on that chain. Re-supply stripes at the state
+// level, then restate hover after them so it wins on odd rows just as it does
+// in Bootstrap's own source order.
+.table-striped > tbody > tr:nth-of-type(odd) > * {
+    --bs-table-bg-state: var(--bs-table-striped-bg);
+}
+
+.table-hover > tbody > tr:hover > * {
+    --bs-table-bg-state: var(--bs-table-hover-bg);
+}
+
+// The flash (.bg-highlight, see _colors.scss) and watch tints set the variable
+// on the <tr> and reach cells by inheritance, which the direct cell-level
+// stripe rule above defeats. Restate them on the cells themselves; the .table
+// prefix matches the stripe rule's specificity so source order decides.
+.table > tbody > tr.bg-highlight > * {
+    --bs-table-bg-state: #{lighten($yellow, 20%)};
+}
+
+.table > tbody > tr.effort-watched > * {
+    --bs-table-bg-state: #{lighten($orange, 33%)};
+}
+
 .bg-highlight-faded {
     transition: background 4s linear;
 }


### PR DESCRIPTION
Resolves #2206

## Problem

Table striping has been broken app-wide since PR #1987 (2026-05-02). That PR registered `--bs-table-bg-state` via `@property` so the roster highlight could fade smoothly — but a registered property with an `initial-value` is never unset, which kills Bootstrap 5.3's fallback chain:

```css
box-shadow: inset 0 0 0 9999px var(--bs-table-bg-state, var(--bs-table-bg-type, var(--bs-table-accent-bg)));
```

Striping sets `--bs-table-bg-type` and relies on `--bs-table-bg-state` being unset to reach it. Post-registration, every stripe painted transparent.

## Fix (option B from the issue)

Keep the registration (removing it would regress the fade) and re-supply the affected rules at the state level, in cascade order:

1. **Stripes**: `.table-striped > tbody > tr:nth-of-type(odd) > * { --bs-table-bg-state: var(--bs-table-striped-bg) }`
2. **Hover restated after stripes** — both selectors weigh (0,2,2), and Bootstrap's own source order has hover win on odd rows; without this restatement our stripe rule (later in the cascade than Bootstrap) would invert that.
3. **Flash (`.bg-highlight`) and watch (`.effort-watched`) tints restated at cell level** — they set the variable on the `<tr>` and reach cells by inheritance, which any direct cell-level set defeats. The `.table > tbody >` prefix matches the stripe rule's (0,2,2) specificity so source order decides. (The issue's note that bare equal specificity would suffice was wrong — `tr.bg-highlight > *` weighs only (0,1,2).)

## Verification (browser probes on the dev server)

- Odd rows compute `rgba(0,0,0,0.05)` inset, even rows transparent — stripes alternate on the spread
- Watched tint wins over the stripe on both odd and even rows
- Flash: the registered var snaps to `rgb(255,219,109)` while the cell box-shadow transitions from the stripe color to that target over 4s — the fade the registration exists for still works, and now fades from the stripe rather than from white on odd rows
- Hover on an odd striped row: `0.05` → `0.075` — Bootstrap's hover-beats-stripe precedence preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)