### PR TITLE
Switch repair job to failure-only reporting

### DIFF
--- a/app/jobs/repair_stale_performance_data_job.rb
+++ b/app/jobs/repair_stale_performance_data_job.rb
@@ -1,8 +1,6 @@
 class RepairStalePerformanceDataJob < ApplicationJob
   queue_as :default
 
-  # Reports by email on every run for now; switch to failure-only
-  # reporting once the job has a track record
   def perform
     healed = []
     failures = []
@@ -23,14 +21,14 @@ class RepairStalePerformanceDataJob < ApplicationJob
 
     total = healed.size + failures.size
     Rails.logger.info("RepairStalePerformanceDataJob healed #{healed.size} of #{total} stale events")
+    return if failures.empty?
+
     AdminMailer.job_report(self.class.name, report_text(healed, failures)).deliver_later
   end
 
   private
 
   def report_text(healed, failures)
-    return "The performance data repair job found no stale events." if healed.empty? && failures.empty?
-
     <<~TEXT
       The performance data repair job found #{healed.size + failures.size} stale events.
 
@@ -38,7 +36,7 @@ class RepairStalePerformanceDataJob < ApplicationJob
       #{healed.presence&.join("\n") || '(none)'}
 
       Failed:
-      #{failures.presence&.join("\n") || '(none)'}
+      #{failures.join("\n")}
     TEXT
   end
 end

--- a/spec/jobs/repair_stale_performance_data_job_spec.rb
+++ b/spec/jobs/repair_stale_performance_data_job_spec.rb
@@ -10,21 +10,17 @@ RSpec.describe RepairStalePerformanceDataJob do
     effort.update_columns(overall_performance: bits[0...15] + field + bits[45..])
   end
 
-  it "heals stale events and reports them as healed" do
+  it "heals stale events without sending mail" do
     perturb_distance(effort)
 
-    expect { described_class.perform_now }
-      .to have_enqueued_mail(AdminMailer, :job_report)
-      .with(described_class.name, a_string_including("Healed:\n#{event.slug}"))
+    expect { described_class.perform_now }.not_to have_enqueued_mail(AdminMailer, :job_report)
     expect(event.performance_data_stale?).to be(false)
   end
 
-  it "issues no recomputes and reports a clean run when no events are stale" do
+  it "issues no recomputes and sends no mail when no events are stale" do
     expect(Results::SetEffortPerformanceData).not_to receive(:perform!)
 
-    expect { described_class.perform_now }
-      .to have_enqueued_mail(AdminMailer, :job_report)
-      .with(described_class.name, a_string_including("no stale events"))
+    expect { described_class.perform_now }.not_to have_enqueued_mail(AdminMailer, :job_report)
   end
 
   it "reports an event that fails to heal" do


### PR DESCRIPTION
Follow-up to #2211, as planned there: `RepairStalePerformanceDataJob` was emailing an admin report on every run while it earned trust. Now that it has a production track record, quiet runs (nothing stale, or everything healed) only log; the email goes out solely when an event fails to heal — still stale after recompute, or the recompute raised. Failure reports keep the healed list for context.

Specs updated to the new contract: heal-without-mail, clean-run-without-mail (and without recomputes), and the two failure modes still mail with the event slug and error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)