### PR TITLE
Auto-refresh the live Crew Access board

### DIFF
--- a/app/controllers/live/gating_locations_controller.rb
+++ b/app/controllers/live/gating_locations_controller.rb
@@ -20,6 +20,14 @@ module Live
 
       @presenter = EventGroupPresenter.new(@event_group, params, current_user)
       @display = build_gating_display(@event_group.gating_locations.find(params[:id]))
+
+      # Controls submissions and periodic refreshes target a single card's
+      # frame; rendering just that card skips row computation for the others
+      requested_gle = @display.gated_events.find { |gle| gle.id.to_s == params[:gating_location_event_id].to_s }
+      return unless turbo_frame_request? && requested_gle
+
+      render partial: "live/gating_locations/event_rows",
+             locals: { gating_location_event: requested_gle, display: @display }
     end
 
     private

--- a/app/javascript/controllers/gating_controls_controller.js
+++ b/app/javascript/controllers/gating_controls_controller.js
@@ -4,8 +4,21 @@ import { Controller } from "@hotwired/stimulus"
 // change; the buffer and search inputs submit after a short debounce so the table updates
 // live as the steward types or steps the value. The form targets the table's turbo frame,
 // so only the runner table reloads — the controls (and search focus) stay put.
+//
+// The form also re-submits itself periodically, so the runner table stays live during a
+// race — new arrivals appear and future release times flip to "Now" — while each viewer
+// keeps their own buffer, sort, filters, and search.
 export default class extends Controller {
-  static values = { delay: { type: Number, default: 300 } }
+  static values = {
+    delay: { type: Number, default: 300 },
+    refreshInterval: { type: Number, default: 30_000 },
+  }
+
+  connect() {
+    if (this.refreshIntervalValue > 0) {
+      this.refreshTimer = setInterval(() => this.refresh(), this.refreshIntervalValue)
+    }
+  }
 
   submit() {
     this.element.requestSubmit()
@@ -16,7 +29,14 @@ export default class extends Controller {
     this.timer = setTimeout(() => this.submit(), this.delayValue)
   }
 
+  refresh() {
+    if (document.hidden) return
+
+    this.submit()
+  }
+
   disconnect() {
     clearTimeout(this.timer)
+    clearInterval(this.refreshTimer)
   }
 }

--- a/docs/management/crew-access.md
+++ b/docs/management/crew-access.md
@@ -144,8 +144,9 @@ crews you need to act on soonest at the top.
 
 1. **Hide passed:** hide runners whose crews you have already marked as passed.
 
-The board reflects the data OpenSplitTime has at the moment you load it. Refresh the page to pick up newly
-recorded times, much as you would with the other [monitoring tools](../monitor/).
+The board keeps itself current: each event's table refreshes automatically about every half minute, picking up
+newly recorded times and flipping future release times to **Now** as the clock passes them. Your buffer, sort,
+filters, and search stay put across refreshes, so you can leave the page open at the gate all day.
 
 ### Marking a Crew as Passed
 

--- a/spec/requests/live/gating_locations_spec.rb
+++ b/spec/requests/live/gating_locations_spec.rb
@@ -98,6 +98,31 @@ RSpec.describe "Live::GatingLocations" do
 
         expect(response).to have_http_status(:ok)
       end
+
+      context "when requested for a single card's turbo frame" do
+        let(:gle_100k) { gating_location_events(:sum_bandera_gate_100k) }
+        let(:gle_55k) { gating_location_events(:sum_bandera_gate_55k) }
+
+        it "renders only that card's frame" do
+          get live_event_group_gating_location_path(event_group, gating_location),
+              params: { gating_location_event_id: gle_100k.id },
+              headers: { "Turbo-Frame" => "crew_access_rows_gating_location_event_#{gle_100k.id}" }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("crew_access_rows_gating_location_event_#{gle_100k.id}")
+          expect(response.body).not_to include("crew_access_rows_gating_location_event_#{gle_55k.id}")
+          expect(response.body).not_to include("<html")
+        end
+
+        it "renders the full page when no matching event is identified" do
+          get live_event_group_gating_location_path(event_group, gating_location),
+              headers: { "Turbo-Frame" => "crew_access_rows_gating_location_event_#{gle_100k.id}" }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("crew_access_rows_gating_location_event_#{gle_100k.id}")
+          expect(response.body).to include("crew_access_rows_gating_location_event_#{gle_55k.id}")
+        end
+      end
     end
 
     context "when live entry is not available for the event group" do


### PR DESCRIPTION
Resolves #2118 — this is the last open item ("PR 4 — Live updating") on the tracking checklist; the PR 5 polish items (empty states, insufficient-data indicator, stopped-runner handling, user docs) all shipped incrementally in the earlier PRs.

## Design

The issue's original PR-4 sketch (Turbo Stream broadcasts + client-side release rendering) predates the shipped architecture, which renders each card's runner table server-side inside a Turbo Frame with per-viewer controls (buffer, sort, filters, search) as form params. A broadcast would render one canonical table and clobber every viewer's control state. Instead:

- **Periodic self-refresh**: the existing `gating-controls` Stimulus controller re-submits its form every 30 seconds (configurable via a Stimulus value, paused while the tab is hidden). One mechanism covers both new runner data and server-rendered "Now" flips, and each viewer keeps their own control state. Projections stay cheap across refreshes — they are cached per split time, so only runners with new data recompute.
- **Frame-only responses**: controls submissions and refreshes carry the card's `gating_location_event_id` and a `Turbo-Frame` header, so `Live::GatingLocationsController#show` now renders just that card's `_event_rows` partial — skipping row computation for the location's other events on every refresh.
- **Docs**: the management guide's "refresh the page to pick up newly recorded times" paragraph now describes the self-refreshing behavior.

## Verification

- Request specs: frame requests get a frame-only response containing exactly the requested card; requests without a matching event id still render the full page.
- Browser probe against a fresh `simulate:in_progress` Hardrock group (25 runners, gate Cunningham → target Telluride): periodic refreshes observed at the 30s cadence as lightweight frame-only responses; hide-filter toggles round-trip through the new response path; release times, progressive anchors, and the Stopped badge all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)