### PR TITLE
Promote crew access board controls to the URL

### DIFF
--- a/app/views/live/crew_access_boards/_controls.html.erb
+++ b/app/views/live/crew_access_boards/_controls.html.erb
@@ -1,7 +1,10 @@
 <%# locals: (board:) -%>
 
+<%# turbo_action: "replace" promotes each frame navigation to the page URL, so the
+    address bar always reproduces the current view (bookmarkable, reload-safe) %>
 <%= form_with url: live_event_group_crew_access_board_path(board.event_group, board.gating_location_event), method: :get,
-              data: { controller: "gating-controls", turbo_frame: dom_id(board.gating_location_event, :crew_access_rows) },
+              data: { controller: "gating-controls", turbo_frame: dom_id(board.gating_location_event, :crew_access_rows),
+                      turbo_action: "replace" },
               class: "row gx-3 gy-2 align-items-end" do |form| %>
   <div class="col-auto">
     <%= form.label :buffer, "Buffer (min)", class: "form-label mb-0 small" %>

--- a/spec/system/live/crew_access_board_spec.rb
+++ b/spec/system/live/crew_access_board_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "crew access board URL state", :js do
+  let(:event_group) { event_groups(:sum) }
+  let(:gle) { gating_location_events(:sum_bandera_gate_100k) }
+
+  before { allow(Projection).to receive(:execute_query).and_return([]) }
+
+  scenario "control changes land in the URL and a reload reproduces the view" do
+    sign_in users(:admin_user)
+    visit live_event_group_crew_access_board_path(event_group, gle)
+
+    select "Bib number", from: "Sort by"
+    expect(page).to have_current_path(/sort=bib/, url: true)
+
+    fill_in "Find runner", with: "anvil"
+    expect(page).to have_current_path(/search=anvil/, url: true)
+
+    page.refresh
+    expect(page).to have_select("Sort by", selected: "Bib number")
+    expect(find_field("Find runner").value).to eq("anvil")
+  end
+end


### PR DESCRIPTION
Part of #2118 — PR 2 of the live-update arc, stacked on #2216. One attribute plus a system spec.

`data-turbo-action="replace"` on the controls form promotes each turbo-frame navigation to a page visit, so every control change (buffer, sort, filters, search) lands in the address bar via `replaceState` — no history spam. Boards become bookmarkable and reload-safe, and the load-bearing consequence: a Turbo 8 page refresh re-fetches the page URL, which now reproduces the steward's exact view. That property is what makes broadcast-driven refresh (the next PR) lossless.

Spiked in the browser before committing (framework-native promotion works on Turbo 8.0.23 — no `history.replaceState` fallback needed): sort/search changes update the URL with zero history entries, search keeps focus while typing, and a hard reload reproduces the filtered view exactly.

## Testing

- New system spec (first for crew access): sort and search changes appear in the URL; `page.refresh` reproduces the select and field state from the URL alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)