### PR TITLE
Live-update crew access boards via Turbo 8 refresh

### DIFF
--- a/app/models/crew_passage.rb
+++ b/app/models/crew_passage.rb
@@ -19,7 +19,12 @@ class CrewPassage < ApplicationRecord
   private
 
   def broadcast_crew_access_refresh
-    broadcast_refresh_later_to(event_group, :crew_access)
+    # In a cascading destroy (event group teardown), the gating location or its
+    # event group may already be gone by the time this commit callback fires
+    target_event_group = gating_location&.event_group
+    return if target_event_group.blank?
+
+    broadcast_refresh_later_to(target_event_group, :crew_access)
   end
 
   def effort_event_is_gated_at_location

--- a/app/models/crew_passage.rb
+++ b/app/models/crew_passage.rb
@@ -7,9 +7,20 @@ class CrewPassage < ApplicationRecord
                                       message: "only one crew passage permitted per gating location" }
   validate :effort_event_is_gated_at_location
 
+  # Other stewards' open boards learn of passage marks by refresh; the marking
+  # steward's own board already updated via the toggle's turbo_stream response.
+  # A single registration is deliberate: separate after_create_commit and
+  # after_destroy_commit calls naming the same method would deduplicate, leaving
+  # only the last one active.
+  after_commit :broadcast_crew_access_refresh, on: [:create, :destroy]
+
   delegate :event_group, to: :gating_location
 
   private
+
+  def broadcast_crew_access_refresh
+    broadcast_refresh_later_to(event_group, :crew_access)
+  end
 
   def effort_event_is_gated_at_location
     return if effort.blank? || gating_location.blank?

--- a/app/models/effort.rb
+++ b/app/models/effort.rb
@@ -361,6 +361,7 @@ class Effort < ApplicationRecord
 
   def broadcast_update
     broadcast_render_later_to event_group, partial: "efforts/updated", locals: { effort: self }
+    broadcast_refresh_later_to(event_group, :crew_access) if event_group.gating_locations.exists?
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
   <%= csrf_meta_tags %>
   <%= render "layouts/cloudflare_analytics" if OstConfig.cloudflare_analytics_enabled? %>
   <%= render "layouts/favicon" %>
+  <%= yield :head %>
 </head>
 
 <body class="<%= controller_name %> <%= action_name %>">

--- a/app/views/live/crew_access_boards/_controls.html.erb
+++ b/app/views/live/crew_access_boards/_controls.html.erb
@@ -8,9 +8,11 @@
               class: "row gx-3 gy-2 align-items-end" do |form| %>
   <div class="col-auto">
     <%= form.label :buffer, "Buffer (min)", class: "form-label mb-0 small" %>
+    <%# data-turbo-permanent (with a stable id) keeps a background morph refresh
+        from clobbering a value the steward is mid-editing %>
     <%= form.number_field :buffer, value: board.controls.buffer, min: 0, max: 1200,
                                    class: "form-control form-control-sm", style: "width: 6rem;", autocomplete: "off",
-                                   data: { action: "input->gating-controls#debounce" } %>
+                                   data: { action: "input->gating-controls#debounce", turbo_permanent: true } %>
   </div>
   <div class="col-auto">
     <%= form.label :sort, "Sort by", class: "form-label mb-0 small" %>
@@ -22,7 +24,7 @@
     <%= form.label :search, "Find runner", class: "form-label mb-0 small" %>
     <%= form.search_field :search, value: board.controls.search, placeholder: "Bib or name…",
                                    class: "form-control form-control-sm", autocomplete: "off",
-                                   data: { action: "input->gating-controls#debounce" } %>
+                                   data: { action: "input->gating-controls#debounce", turbo_permanent: true } %>
   </div>
   <div class="col-auto">
     <div class="form-check form-switch">

--- a/app/views/live/crew_access_boards/show.html.erb
+++ b/app/views/live/crew_access_boards/show.html.erb
@@ -2,6 +2,13 @@
   <% "OpenSplitTime: Crew Access - #{@board.name} - #{@board.event.guaranteed_short_name}" %>
 <% end %>
 
+<%# Effort and crew passage changes broadcast a refresh on this stream; the page
+    re-fetches its own URL (which carries the steward's control state) and morphs %>
+<% content_for :head do %>
+  <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+<% end %>
+<%= turbo_stream_from @board.event_group, :crew_access %>
+
 <header class="ost-header">
   <div class="container">
     <div class="ost-heading row">

--- a/spec/models/crew_passage_spec.rb
+++ b/spec/models/crew_passage_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe CrewPassage, type: :model do
   end
 
   describe "crew access refresh broadcasts" do
+    it "does not raise when destroyed in an event group cascade" do
+      # The gating location dies before effort-owned crew passages in the
+      # cascade, so the commit callback must tolerate a vanished parent
+      expect { event_groups(:sum).destroy! }.not_to raise_error
+    end
+
     it "broadcasts on create" do
       expect(Turbo::StreamsChannel).to receive(:broadcast_refresh_later_to)
         .with(gating_location.event_group, :crew_access, request_id: anything)

--- a/spec/models/crew_passage_spec.rb
+++ b/spec/models/crew_passage_spec.rb
@@ -53,4 +53,20 @@ RSpec.describe CrewPassage, type: :model do
       expect { efforts(:sum_100k_progress_cascade).destroy }.to change(described_class, :count).by(-1)
     end
   end
+
+  describe "crew access refresh broadcasts" do
+    it "broadcasts on create" do
+      expect(Turbo::StreamsChannel).to receive(:broadcast_refresh_later_to)
+        .with(gating_location.event_group, :crew_access, request_id: anything)
+      described_class.create!(gating_location: gating_location, effort: effort, passed_at: passed_at)
+    end
+
+    it "broadcasts on destroy" do
+      crew_passage = described_class.create!(gating_location: gating_location, effort: effort, passed_at: passed_at)
+
+      expect(Turbo::StreamsChannel).to receive(:broadcast_refresh_later_to)
+        .with(gating_location.event_group, :crew_access, request_id: anything)
+      crew_passage.destroy!
+    end
+  end
 end

--- a/spec/models/effort_spec.rb
+++ b/spec/models/effort_spec.rb
@@ -111,6 +111,27 @@ RSpec.describe Effort, type: :model do
   end
 
   describe "callbacks" do
+    describe "broadcasting a crew access refresh on update" do
+      context "when the event group has gating locations" do
+        let(:effort) { efforts(:sum_100k_drop_anvil) }
+
+        it "broadcasts a refresh on the event group's crew_access stream" do
+          expect(Turbo::StreamsChannel).to receive(:broadcast_refresh_later_to)
+            .with(effort.event_group, :crew_access, request_id: anything)
+          effort.update!(comments: "steady at the gate")
+        end
+      end
+
+      context "when the event group has no gating locations" do
+        let(:effort) { efforts(:hardrock_2015_tuan_jacobs) }
+
+        it "does not broadcast a crew access refresh" do
+          expect(Turbo::StreamsChannel).not_to receive(:broadcast_refresh_later_to)
+          effort.update!(comments: "no gates here")
+        end
+      end
+    end
+
     describe "sets age based on birthdate" do
       subject { build(:effort, event: event, age: age, birthdate: birthdate) }
 

--- a/spec/requests/live/crew_access_boards_spec.rb
+++ b/spec/requests/live/crew_access_boards_spec.rb
@@ -82,6 +82,14 @@ RSpec.describe "Live::CrewAccessBoards" do
         expect(response.body).to include("Hide passed")
       end
 
+      it "subscribes to the crew access refresh stream and opts into morph refreshes" do
+        get live_event_group_crew_access_board_path(event_group, gle_100k)
+
+        expect(response.body).to include("turbo-cable-stream-source")
+        expect(response.body).to include(%(name="turbo-refresh-method" content="morph"))
+        expect(response.body).to include(%(name="turbo-refresh-scroll" content="preserve"))
+      end
+
       it "accepts the control params without error" do
         get live_event_group_crew_access_board_path(event_group, gle_100k),
             params: { buffer: "90", sort: "release", hide_departed: "1", hide_passed: "1", search: "999" }

--- a/spec/requests/live/gating_locations_spec.rb
+++ b/spec/requests/live/gating_locations_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe "Live::GatingLocations" do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Bandera Gate")
+        expect(response.body).not_to include("turbo-refresh-method")
       end
     end
 


### PR DESCRIPTION
Part of #2118 — PR 3 of the live-update arc, stacked on #2217.

## How it works

- The board page subscribes `turbo_stream_from @event_group, :crew_access` and opts into `turbo_refreshes_with method: :morph, scroll: :preserve` (via a new `yield :head` hook in the application layout — inert for every other page).
- `Effort#broadcast_update` additionally does `broadcast_refresh_later_to(event_group, :crew_access)` when the group has gating locations — the guard keeps refresh jobs out of the queue for the vast majority of groups, and the dedicated stream name leaves the four pages subscribed to the bare event-group stream (roster, reconcile, setup, raw times) byte-for-byte unaffected.
- `CrewPassage` broadcasts the same refresh on create/destroy, so a second steward's open board learns of passage marks. (Gotcha worth noting: separate `after_create_commit`/`after_destroy_commit` registrations naming the same method deduplicate to just the last one — this uses a single `after_commit on: [:create, :destroy]`, with a comment.)
- On refresh, each open board re-fetches **its own URL** — which carries that steward's buffer/sort/filters/search since #2217 — and morphs the result. The search and buffer inputs are `data-turbo-permanent`, so a background morph can't clobber mid-typed text.

## Verification

Browser probes against a simulated in-progress Hardrock group:

- Server-side effort update → exactly one board refetch, changed data visible in the morphed table within seconds; search focus, typed value, and active filtering all survived the morph.
- Two browser contexts: steward B marks a crew passed → steward A's board shows the Passed badge within ~5s.
- A 20-effort bulk update burst collapsed to **one** refetch (Turbo per-stream refresh debouncing).
- One probe artifact worth recording: `bin/rails runner` one-shots exit before Turbo's 0.5s refresh debouncer fires on its background thread, silently dropping the broadcast — a `sleep` keep-alive fixes the probe; Puma is unaffected.

## Testing

- Model specs: effort update in a gated group broadcasts on the `:crew_access` stream (asserted at the `Turbo::StreamsChannel` seam — the debouncer's background thread makes job-level matchers racy); no broadcast for ungated groups; crew passage create and destroy both broadcast.
- Request specs: the board response carries the signed stream source and both morph meta tags; the index carries neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)