### PR TITLE
Flip releases to Now client-side; rewrite Crew Access docs

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -103,6 +103,9 @@ application.register("popover", PopoverController)
 import RawTimeFilterController from "./raw_time_filter_controller"
 application.register("raw-time-filter", RawTimeFilterController)
 
+import ReleaseFlipController from "./release_flip_controller"
+application.register("release-flip", ReleaseFlipController)
+
 import RawTimesPushController from "./raw_times_push_controller"
 application.register("raw-times-push", RawTimesPushController)
 

--- a/app/javascript/controllers/release_flip_controller.js
+++ b/app/javascript/controllers/release_flip_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Flips a pending release time to the green "Now" badge as the wall clock
+// passes it, since no data change (and therefore no refresh broadcast) occurs
+// at that moment. Purely presentational: the epoch is server-computed, and any
+// subsequent refresh renders the badge server-side, on which this controller
+// never attaches.
+export default class extends Controller {
+  static values = { epoch: Number }
+
+  connect() {
+    this.flipWhenDue()
+    this.timer = setInterval(() => this.flipWhenDue(), 10_000)
+  }
+
+  flipWhenDue() {
+    if (Date.now() / 1000 < this.epochValue) return
+
+    this.element.innerHTML = '<span class="badge bg-success">Now</span>'
+    clearInterval(this.timer)
+  }
+
+  disconnect() {
+    clearInterval(this.timer)
+  }
+}

--- a/app/views/live/crew_access_boards/_row.html.erb
+++ b/app/views/live/crew_access_boards/_row.html.erb
@@ -35,7 +35,10 @@
       <% if row.released?(board.controls.buffer) %>
         <span class="badge bg-success">Now</span>
       <% else %>
-        <%= day_time_military_format(row.release_time_local(board.controls.buffer)) %>
+        <span data-controller="release-flip"
+              data-release-flip-epoch-value="<%= row.release_time(board.controls.buffer).to_i %>">
+          <%= day_time_military_format(row.release_time_local(board.controls.buffer)) %>
+        </span>
       <% end %>
     <% else %>
       <span class="text-body-secondary">Insufficient data</span>

--- a/docs/management/crew-access.md
+++ b/docs/management/crew-access.md
@@ -145,8 +145,16 @@ crews you need to act on soonest at the top.
 
 1. **Hide passed:** hide runners whose crews you have already marked as passed.
 
-The board reflects the data OpenSplitTime has at the moment you load it. Refresh the page to pick up newly
-recorded times, much as you would with the other [monitoring tools](../monitor/).
+Every control you change is reflected in the page's address, so your tailored view survives a reload — you can
+bookmark the board with your preferred buffer, sort, and filters, or share the exact view with another official.
+
+### The Board Keeps Itself Current
+
+There is no need to refresh the page. As new times are recorded for runners in your Event Group, the board
+updates itself within a few seconds, keeping your buffer, sort, filters, search, and scroll position exactly as
+you left them. A release time in the **Release** column flips to the green **Now** badge on its own as the clock
+passes it. If another official marks a crew as passed on their own device, your board shows it moments later, so
+several officials can work the same gate without stepping on each other.
 
 ### Marking a Crew as Passed
 

--- a/spec/requests/live/crew_access_boards_spec.rb
+++ b/spec/requests/live/crew_access_boards_spec.rb
@@ -90,6 +90,31 @@ RSpec.describe "Live::CrewAccessBoards" do
         expect(response.body).to include(%(name="turbo-refresh-scroll" content="preserve"))
       end
 
+      describe "release rendering" do
+        # sum_55k_progress_rolling sits between the 55k gate and target, so it gets a projected release
+        let(:gle_55k) { gating_location_events(:sum_bandera_gate_55k) }
+
+        it "renders a pending release with the flip controller and its epoch" do
+          allow(Projection).to receive(:execute_query)
+            .and_return([instance_double(Projection, low_seconds: 20.years.to_i)])
+
+          get live_event_group_crew_access_board_path(event_group, gle_55k)
+
+          expect(response.body).to include(%(data-controller="release-flip"))
+          expect(response.body).to match(/data-release-flip-epoch-value="\d+"/)
+        end
+
+        it "renders a released row as the badge, without the flip controller" do
+          allow(Projection).to receive(:execute_query)
+            .and_return([instance_double(Projection, low_seconds: 3600)])
+
+          get live_event_group_crew_access_board_path(event_group, gle_55k)
+
+          expect(response.body).to include(">Now<")
+          expect(response.body).not_to include("release-flip")
+        end
+      end
+
       it "accepts the control params without error" do
         get live_event_group_crew_access_board_path(event_group, gle_100k),
             params: { buffer: "90", sort: "release", hide_departed: "1", hide_passed: "1", search: "999" }


### PR DESCRIPTION
Resolves #2118 — PR 4 of the live-update arc, stacked on #2218, and the last item on the tracking checklist.

## Release flips

A release time flips to "Now" purely because the clock passed it — no data changes, so no refresh broadcast fires. The pending-release cell now carries a `release-flip` Stimulus controller with a server-computed `data-release-flip-epoch-value`; the controller checks every ten seconds (plus once on connect) and swaps in the green badge when due, then stops. Purely presentational — the epoch is server truth, and the only duplicated markup is one badge span. Already-released rows render the badge server-side, where the controller never attaches; after any morph refresh the server may render the badge itself, which simply means the controller has nothing to do.

## Docs

The Crew Access management guide's live-view section is rewritten for the new architecture: per-event boards, control state carried in the URL (bookmarkable/shareable tuned views), the board keeping itself current with no page refreshes, releases flipping to Now on their own, and several officials working the same gate in sync.

## Verification

- Request specs: a pending release renders the flip controller with a numeric epoch; a released row renders the badge with no flip controller anywhere in the body.
- Browser probe on the simulated Hardrock board: tuned the buffer to pull a real release to ~50 seconds out, watched the cell flip to the Now badge client-side with **zero** network requests during the wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)