### PR TITLE
Return a 422 error when not_expected is called without a split name

### DIFF
--- a/app/services/find_not_expected_bibs.rb
+++ b/app/services/find_not_expected_bibs.rb
@@ -1,8 +1,8 @@
-require "ostruct"
-
 class FindNotExpectedBibs
   include Interactors::Errors
   include SplitAnalyzable
+
+  Response = Struct.new(:errors, :bib_numbers, keyword_init: true)
 
   def self.perform(event_group, split_name)
     new(event_group, split_name).perform
@@ -10,13 +10,13 @@ class FindNotExpectedBibs
 
   def initialize(event_group, split_name)
     @event_group = event_group
-    @parameterized_split_name = split_name.parameterize
+    @parameterized_split_name = split_name.to_s.parameterize
     @errors = []
     validate_setup
   end
 
   def perform
-    OpenStruct.new(errors: errors, bib_numbers: bib_numbers)
+    Response.new(errors: errors, bib_numbers: bib_numbers)
   end
 
   private
@@ -31,8 +31,8 @@ class FindNotExpectedBibs
   end
 
   def validate_setup
-    unless parameterized_split_names.include?(parameterized_split_name)
-      errors << invalid_split_name_error(parameterized_split_name, parameterized_split_names)
-    end
+    return if parameterized_split_names.include?(parameterized_split_name)
+
+    errors << invalid_split_name_error(parameterized_split_name, parameterized_split_names)
   end
 end

--- a/spec/services/find_not_expected_bibs_spec.rb
+++ b/spec/services/find_not_expected_bibs_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe FindNotExpectedBibs do
+  subject { described_class.perform(event_group, split_name) }
+
+  let(:event_group) { event_groups(:hardrock_2015) }
+
+  context "when the split name is valid for the event group" do
+    let(:split_name) { "Sherman" }
+
+    it "returns bib numbers without errors" do
+      expect(subject.errors).to be_empty
+      expect(subject.bib_numbers).to be_an(Array)
+    end
+  end
+
+  context "when the split name is not found in the event group" do
+    let(:split_name) { "Nonexistent" }
+
+    it "returns an invalid split name error" do
+      expect(subject.errors.first[:title]).to eq("Invalid split name")
+      expect(subject.bib_numbers).to eq([])
+    end
+  end
+
+  context "when the split name is nil" do
+    let(:split_name) { nil }
+
+    it "returns an invalid split name error instead of raising" do
+      expect { subject }.not_to raise_error
+      expect(subject.errors.first[:title]).to eq("Invalid split name")
+      expect(subject.bib_numbers).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the production 500 captured in Scout error group [123521](https://scoutapm.com/apps/356008/error_groups/123521): `GET /api/v1/event_groups/:id/not_expected` without a `split_name` param crashed with `NoMethodError: undefined method 'parameterize' for nil`.

- `FindNotExpectedBibs` now parameterizes the split name nil-safely, so a missing split name falls through to the existing `validate_setup` inclusion check and the controller renders its normal 422 with the "Invalid split name" error body.
- Adds a spec for the service (valid, invalid, and nil split names) — there was none. The nil case was verified to fail against the pre-fix code.
- Clears the two pre-existing rubocop offenses in the touched service: replaces `OpenStruct` with a `Response` struct (matching the `Struct.new` convention used elsewhere in the app) and converts `validate_setup` to a guard clause.

Resolves #2224

## Testing

- `bundle exec rspec spec/services/find_not_expected_bibs_spec.rb` — 3 examples, 0 failures
- rubocop clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)