### PR TITLE
Fail fast and retry when apt hangs installing libvips

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -185,7 +185,17 @@ jobs:
           cache-version: ${{ steps.runner-image.outputs.fingerprint }}
 
       - name: Install libvips
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libvips42
+        timeout-minutes: 5
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 90 sudo apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=15 &&
+               timeout 90 sudo apt-get install -y --no-install-recommends -o Acquire::Retries=3 -o Acquire::http::Timeout=15 libvips42; then
+              exit 0
+            fi
+            echo "apt attempt ${attempt} failed or timed out; retrying"
+            sleep 5
+          done
+          exit 1
 
       - name: Download assets
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

The "Install libvips" step in verify.yml has hung indefinitely on a wedged apt mirror twice in two days (2026-08-18 run 32157036515 and 2026-08-19 run 32275921605, two shards each time), sitting at 40+ minutes until manually cancelled and rerun while every other shard passed in under 5 minutes.

This bounds the step so mirror trouble self-heals instead of wedging the job:

- Each `apt-get update` / `apt-get install` invocation runs under a 90-second `timeout` with `Acquire::Retries=3` and a 15-second HTTP timeout
- The whole sequence retries up to three times with a short pause between attempts
- `timeout-minutes: 5` on the step as a hard ceiling, so the worst case is a fast, retryable failure rather than a silent hang

## Testing

Not testable locally; the happy path is unchanged (`apt-get update && apt-get install libvips42`) and will be exercised by this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)