### PR TITLE
Add use_for_projections to events

### DIFF
--- a/db/data/20260820162538_backfill_use_for_projections_from_concealment.rb
+++ b/db/data/20260820162538_backfill_use_for_projections_from_concealment.rb
@@ -1,0 +1,21 @@
+class BackfillUseForProjectionsFromConcealment < ActiveRecord::Migration[8.1]
+  # Per #2229: use_for_projections replaces the concealment predicate in the
+  # projection engine's event selection. Seed it from the current behavior
+  # (concealed event groups are excluded) so the flag's introduction is
+  # invisible at rollout; after this, the two move independently.
+  def up
+    updated = execute(<<~SQL.squish)
+      update events
+      set use_for_projections = false
+      from event_groups
+      where event_groups.id = events.event_group_id
+        and event_groups.concealed is true
+    SQL
+    say "Set use_for_projections = false on #{updated.cmd_tuples} events in concealed event groups"
+  end
+
+  def down
+    # No-op. The flag decouples from concealment going forward, so there is
+    # no prior state to restore beyond the column default.
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_05_09_033127)
+DataMigrate::Data.define(version: 2026_08_20_162538)

--- a/db/migrate/20260820162536_add_use_for_projections_to_events.rb
+++ b/db/migrate/20260820162536_add_use_for_projections_to_events.rb
@@ -1,0 +1,5 @@
+class AddUseForProjectionsToEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :events, :use_for_projections, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_29_185523) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_162536) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
   enable_extension "pg_catalog.plpgsql"
@@ -308,6 +308,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_29_185523) do
     t.string "slug", null: false
     t.string "topic_resource_key"
     t.datetime "updated_at", precision: nil, null: false
+    t.boolean "use_for_projections", default: true, null: false
     t.index ["course_id"], name: "index_events_on_course_id"
     t.index ["event_group_id", "short_name"], name: "index_events_on_event_group_id_and_short_name", unique: true
     t.index ["event_group_id"], name: "index_events_on_event_group_id"

--- a/erd.mmd
+++ b/erd.mmd
@@ -183,6 +183,7 @@ erDiagram
 		string short_name
 		string slug
 		string topic_resource_key
+		boolean use_for_projections
 	}
 	EventGroup {
 		boolean available_live


### PR DESCRIPTION
## Summary

Migration-only PR for #2229 (decoupling projection/planning data inclusion from event group concealment). No model or business logic — that comes in a follow-up PR after this has merged and run in production.

- `db/migrate`: adds `events.use_for_projections`, boolean, `default: true, null: false`
- `db/data`: backfills `use_for_projections = false` for events in concealed event groups, seeding the flag from the projection engine's current concealment predicate so its introduction is behavior-invisible; after the backfill the flag and concealment move independently
- `db/schema.rb`, `db/data_schema.rb`, `erd.mmd` regenerated by the migrations

The backfill's `down` is a deliberate no-op: the column default is the only prior state.

Relates to #2229

## Testing

- `bin/rails db:migrate` and `bin/rails data:migrate` run clean locally (backfill flipped 1 event in the dev database's one concealed group)

🤖 Generated with [Claude Code](https://claude.com/claude-code)