### PR TITLE
Gate the projection engine on use_for_projections

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -68,6 +68,11 @@ class Course < ApplicationRecord
     events.visible
   end
 
+  # @return [Event::ActiveRecord_AssociationRelation]
+  def projectable_events
+    events.used_for_projections
+  end
+
   # @return [String, nil]
   def home_time_zone
     events.latest&.home_time_zone

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -43,6 +43,7 @@ class Event < ApplicationRecord
   after_touch :notify_event_update, if: :topic_resource_key?
 
   scope :name_search, ->(search_param) { where("events.name ILIKE ?", "%#{search_param}%") }
+  scope :used_for_projections, -> { where(use_for_projections: true) }
   scope :select_with_params, lambda { |search_param|
     search(search_param)
       .left_joins(:efforts).left_joins(:event_group)

--- a/app/models/projection.rb
+++ b/app/models/projection.rb
@@ -39,11 +39,10 @@ class Projection < ::ApplicationQuery
         relevant_event_ids as (
           select events.id as event_id
           from events
-            join event_groups on event_groups.id = events.event_group_id
             join courses on courses.id = events.course_id
             join splits on splits.course_id = courses.id
           where splits.id = #{starting_split_id}
-            and (event_groups.concealed is false or event_groups.concealed is null)
+            and events.use_for_projections is true
             and (#{ignore_timestamp} is null or events.scheduled_start_time <= #{ignore_timestamp})
           order by scheduled_start_time desc
           limit #{EVENT_LOOKBACK_COUNT}

--- a/app/parameters/event_parameters.rb
+++ b/app/parameters/event_parameters.rb
@@ -14,6 +14,7 @@ class EventParameters < BaseParameters
       :results_template_id,
       :notice_text,
       :lottery_id,
+      :use_for_projections,
     ]
   end
 

--- a/app/view_models/plan_display.rb
+++ b/app/view_models/plan_display.rb
@@ -3,16 +3,24 @@ class PlanDisplay < EffortWithLapSplitRows
 
   include CourseAnalysisMethods
   include TimeFormats
+
   attr_reader :course, :error_messages
 
   delegate :name, :organization, :simple?, to: :course
   delegate :multiple_laps?, to: :event, allow_nil: true
 
-  def initialize(args)
+  def initialize(args) # rubocop:disable Lint/MissingSuper
     @course = args[:course]
     @params = args[:params]
     @error_messages = []
     validate_setup
+  end
+
+  # Overrides CourseAnalysisMethods#event: planning anchors on the same
+  # events the projection engine draws data from, so a course whose only
+  # events are concealed seed events can still plan
+  def event
+    @event ||= course.projectable_events.latest
   end
 
   def effort
@@ -103,7 +111,7 @@ class PlanDisplay < EffortWithLapSplitRows
   end
 
   def validate_setup
-    error_messages << "No events have been held on this course." if course.visible_events.empty?
+    error_messages << "No events on this course are available for planning." if course.projectable_events.empty?
     AssignSegmentTimes.perform(ordered_split_times) if error_messages.empty?
   rescue ArgumentError => e
     error_messages << e.message

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -197,6 +197,17 @@
               <%= form.text_field :beacon_url, class: "form-control", placeholder: "example.com/tracking/my-event" %>
             </div>
           </div>
+
+          <div class="row">
+            <div class="mb-3 col">
+              <%= form.label :use_for_projections, "Use this event's times for projections", class: "me-2" %>
+              <span tabindex="-1"
+                    data-controller="tooltip"
+                    data-bs-placement="bottom"
+                    data-bs-original-title="When checked, this event's split times help power pacing plans and live projections for events on this course, even if this event is not public. Uncheck if this event's times are unreliable (shortened course, timing problems) and should not influence predictions."><i class="fas fa-circle-question"></i></span>
+              <%= form.check_box :use_for_projections %>
+            </div>
+          </div>
         </div>
 
         <br>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -204,7 +204,7 @@
               <span tabindex="-1"
                     data-controller="tooltip"
                     data-bs-placement="bottom"
-                    data-bs-original-title="When checked, this event's split times help power pacing plans and live projections for events on this course, even if this event is not public. Uncheck if this event's times are unreliable (shortened course, timing problems) and should not influence predictions."><i class="fas fa-circle-question"></i></span>
+                    data-bs-original-title="When checked, this event's split times help power pacing plans and live projections for events on this course, even if this event is not public. Uncheck if this event's times are unreliable (for example, unrealistic test data or serious timing problems) and should not influence predictions."><i class="fas fa-circle-question"></i></span>
               <%= form.check_box :use_for_projections %>
             </div>
           </div>

--- a/spec/models/projection_spec.rb
+++ b/spec/models/projection_spec.rb
@@ -85,6 +85,22 @@ RSpec.describe ::Projection, type: :model do
       end
     end
 
+    context "when an event on the course is flagged not to be used for projections" do
+      before { events(:hardrock_2014).update_column(:use_for_projections, false) }
+
+      it "does not draw from that event's efforts" do
+        expect(subject.first.effort_years).to eq([2016])
+      end
+    end
+
+    context "when an event in a concealed event group is flagged for projections" do
+      before { event_groups(:hardrock_2014).update_column(:concealed, true) }
+
+      it "draws from that event's efforts" do
+        expect(subject.first.effort_years).to eq([2014, 2016])
+      end
+    end
+
     context "when given a starting split time" do
       let(:split_time) { effort.ordered_split_times.first }
       it "returns an empty array" do

--- a/spec/system/plan_effort_flow_spec.rb
+++ b/spec/system/plan_effort_flow_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe "visit the plan efforts page and plan an effort" do
       visit_page
 
       verify_content_present(course)
-      expect(page).to have_content("No events have been held on this course.")
+      expect(page).to have_content("No events on this course are available for planning.")
     end
   end
 
-  scenario "Inputmask works", js: true do
+  scenario "Inputmask works", :js do
     visit_page
 
     expected_values = {

--- a/spec/view_models/plan_display_spec.rb
+++ b/spec/view_models/plan_display_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe PlanDisplay do
+  subject { described_class.new(course: course, params: ActionController::Parameters.new(params)) }
+
+  let(:course) { courses(:hardrock_ccw) }
+  let(:params) { { expected_time: "38:00" } }
+
+  context "when the course has visible events with relevant data" do
+    it "returns no errors and builds projected split times" do
+      expect(subject.error_messages).to be_empty
+      expect(subject.ordered_split_times).to be_present
+    end
+  end
+
+  context "when the course's only event is in a concealed event group but flagged for projections" do
+    before { event_groups(:hardrock_2015).update_column(:concealed, true) }
+
+    it "returns no errors and builds projected split times" do
+      expect(subject.error_messages).to be_empty
+      expect(subject.ordered_split_times).to be_present
+    end
+  end
+
+  context "when no events on the course are flagged for projections" do
+    before { course.events.each { |event| event.update_column(:use_for_projections, false) } }
+
+    it "returns an error message" do
+      expect(subject.error_messages).to include("No events on this course are available for planning.")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Second PR of the #2229 pair, following the merged migration #2230. Before deploying, confirm both migrations from #2230 (`db:migrate` and `data:migrate`) have run in production.

- `Projection.sql`'s `relevant_event_ids` CTE now filters on `events.use_for_projections` instead of event group concealment (the `event_groups` join is no longer needed). This carries automatically to every consumer of the engine: planning, live effort projections, crew access arrival estimates, and projection assessments.
- `PlanDisplay` anchors on `course.projectable_events.latest` instead of `course.visible_events.latest`, and errors with "No events on this course are available for planning." when nothing is flagged — so a course whose only event is a concealed seed event can plan, and a course whose events are all excluded reports correctly rather than projecting from nothing.
- New `Event.used_for_projections` scope and `Course#projectable_events`.
- Event form exposes the checkbox (default checked) with tooltip help text covering both directions: concealed events can feed projections, unreliable visible events can be kept out.
- `EventParameters.permitted` includes the new attribute.

Not in scope: `SplitTimeQuery.typical_segment_time` (the data-status pooling from #2169) still has no visibility filter; applying this flag there is a natural follow-up per the discussion on that issue.

Resolves #2229

## Testing

- New `Projection` spec contexts: an event flagged off is excluded from the pool; an event in a concealed group is included. New `PlanDisplay` spec: plans build normally, still build when the course's only event group is concealed, and error when no events are flagged.
- All four behavior-differentiating examples verified to fail against the pre-change code.
- Affected suites green: projection, plan display, plan effort flow (system), gating location row, projection assessments runner, event and course models — 133 examples, 0 failures.
- rubocop and erb_lint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)