### PR TITLE
Fix 500 when editing an event whose course is in another organization

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -164,6 +164,8 @@ class Event < ApplicationRecord
 
   def conform_changed_course
     return unless persisted? && course_id_changed?
+    # Let the belongs_to presence validation reject a blank course_id
+    return if course.nil?
 
     response = Interactors::ChangeEventCourse.perform!(event: self, new_course: course)
     response.errors.each { |error| errors.add(:base, error[:title]) }

--- a/app/presenters/event_setup_presenter.rb
+++ b/app/presenters/event_setup_presenter.rb
@@ -40,11 +40,19 @@ class EventSetupPresenter < BasePresenter
   end
 
   def courses_for_select
-    available_courses = organization.courses.includes(:splits).order(:name).map do |course|
+    available_courses = organization.courses.includes(:splits).order(:name).to_a
+    # An event's course can belong to another organization; without it in the
+    # options, the selector falls back to "Create a new course" and the form
+    # submits a blank course_id
+    if event.course.present? && available_courses.exclude?(event.course)
+      available_courses = [event.course] + available_courses
+    end
+
+    course_options = available_courses.map do |course|
       [course.name, course.id, distance_component(course)]
     end
 
-    [["Create a new course", nil, nil]] + available_courses
+    [["Create a new course", nil, nil]] + course_options
   end
 
   def distance_component(course)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -126,6 +126,17 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "clearing the course on a persisted event" do
+    it "is invalid rather than raising from the course-change conforming" do
+      event = events(:hardrock_2016)
+      event.course_id = nil
+
+      expect { event.valid? }.not_to raise_error
+      expect(event).not_to be_valid
+      expect(event.errors[:course]).to include("must exist")
+    end
+  end
+
   describe "methods that produce lap_splits and time_points" do
     let(:event) { build_stubbed(:event, laps_required: laps_required) }
     let(:laps_required) { 2 }

--- a/spec/presenters/event_setup_presenter_spec.rb
+++ b/spec/presenters/event_setup_presenter_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe EventSetupPresenter do
+  subject { described_class.new(event, view_context) }
+
+  let(:event) { events(:hardrock_2016) }
+  let(:view_context) do
+    double("view_context", # rubocop:disable RSpec/VerifiedDoubles
+           params: {},
+           current_user: users(:admin_user))
+  end
+
+  describe "#courses_for_select" do
+    let(:option_ids) { subject.courses_for_select.map(&:second) }
+
+    context "when the event's course belongs to the event group's organization" do
+      it "lists the organization's courses with a create-new option" do
+        expect(option_ids).to include(event.course_id)
+        expect(option_ids.first).to be_nil
+      end
+    end
+
+    context "when the event's course belongs to another organization" do
+      let(:foreign_course) { courses(:d30_12m_course) }
+
+      before { event.update_column(:course_id, foreign_course.id) }
+
+      it "includes the event's course so the selector does not blank the course_id" do
+        expect(option_ids).to include(foreign_course.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the staging 500 hit while testing #2233 (Scout error group 124190 on ost-staging: `ArgumentError: change_event_course must include new_course` from `PATCH /event_groups/2023-marathon-test/events/2023-marathon-test-100k`).

The bug predates the projections work — the new checkbox was just the first reason anyone submitted the edit form for that event. The chain:

1. `EventSetupPresenter#courses_for_select` offers only the event group organization's courses, and this event's course belongs to a different organization, so the selector had no option matching the event's `course_id` and booted showing "Create a new course" (value blank).
2. The event-setup Stimulus controller syncs the selector into the hidden `course_id` field on connect, blanking it before the user touches anything.
3. On submit, `course_id` is blank, `conform_changed_course` fires as a `before_validation` — ahead of the `belongs_to :course` presence validation — and `ChangeEventCourse.perform!` raises.

Two-layer fix:

- **Form**: `courses_for_select` now prepends the event's own course when it is missing from the organization's list, so the selector always reflects reality and the hidden field is never silently blanked.
- **Model**: `conform_changed_course` returns early when `course` is nil, letting the presence validation reject the record with a normal 422 re-render instead of a 500 — covering any other path that blanks `course_id`.

## Testing

- New `EventSetupPresenter` spec: options include the event's cross-organization course (fails pre-fix); ordinary org courses still listed with the create-new option first.
- New `Event` spec: clearing `course_id` on a persisted event is invalid with "must exist" rather than raising (fails pre-fix).
- Wider suites green: event model, all presenters, edit event flow system spec — 178 examples, 0 failures.
- rubocop clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)