### PR TITLE
Gate data-status statistics on use_for_projections

### DIFF
--- a/app/models/segment_times_container.rb
+++ b/app/models/segment_times_container.rb
@@ -21,8 +21,13 @@ class SegmentTimesContainer
   def limits(segment)
     return @limits_hashes[segment] if @limits_hashes.key?(segment)
 
+    typical_time = segment_time(segment)
     @limits_hashes[segment] =
-      segment_time(segment) ? DataStatus.limits(segment_time(segment), limits_type(segment)) : {}
+      if typical_time.nil? || (!typical_time.positive? && scaling_limits_type?(segment))
+        {}
+      else
+        DataStatus.limits(typical_time, limits_type(segment))
+      end
   end
 
   def data_status(segment, seconds)
@@ -35,6 +40,13 @@ class SegmentTimesContainer
 
   def limits_type(segment)
     segment.special_limits_type || calc_model
+  end
+
+  # zero_start bands are intentionally all-zero, and in_aid adds a fixed
+  # positive allowance, so a zero typical time still yields a usable band
+  # for those types; all others scale purely with the typical time
+  def scaling_limits_type?(segment)
+    !limits_type(segment).to_s.in?(%w[zero_start in_aid])
   end
 
   def validate_setup

--- a/app/queries/split_time_query.rb
+++ b/app/queries/split_time_query.rb
@@ -16,9 +16,12 @@ class SplitTimeQuery < BaseQuery
            (select extract(epoch from(st2.absolute_time - st1.absolute_time)) as seconds
             from (select st.effort_id, st.absolute_time
                  from split_times st
+                   inner join efforts ef on ef.id = st.effort_id
+                   inner join events ev on ev.id = ef.event_id
                  where st.lap = #{begin_lap}
                    and st.split_id = #{begin_id}
                    and st.sub_split_bitkey = #{begin_bitkey}
+                   and ev.use_for_projections is true
                    and (st.data_status in (#{valid_statuses_list}) or st.data_status is null))
                  as st1,
                  (select st.effort_id, st.absolute_time
@@ -28,7 +31,9 @@ class SplitTimeQuery < BaseQuery
                    and st.sub_split_bitkey = #{end_bitkey}
                    and (st.data_status in (#{valid_statuses_list}) or st.data_status is null))
                  as st2
-            where st1.effort_id = st2.effort_id and #{focus_clause}),
+            where st1.effort_id = st2.effort_id
+              and st2.absolute_time >= st1.absolute_time
+              and #{focus_clause}),
 
         quartiles as
           (select percentile_cont(0.25) within group (order by seconds) as q1,

--- a/app/services/simulate_in_progress_event_group.rb
+++ b/app/services/simulate_in_progress_event_group.rb
@@ -52,7 +52,9 @@ class SimulateInProgressEventGroup
     end
 
     shift = start_time - new_event_group.scheduled_start_time
-    new_event_group.events.each { |event| event.update!(scheduled_start_time: event.scheduled_start_time + shift) }
+    new_event_group.events.each do |event|
+      event.update!(scheduled_start_time: event.scheduled_start_time + shift, use_for_projections: false)
+    end
     new_event_group.update!(available_live: true)
   end
 

--- a/spec/models/duplicate_event_group_spec.rb
+++ b/spec/models/duplicate_event_group_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe DuplicateEventGroup, type: :model do
       it "sets created_by to the provided user" do
         expect(subject.new_event_group.created_by).to eq(user.id)
       end
+
+      it "keeps use_for_projections on the duplicated events" do
+        # UI duplicates are next year's real races; their live times must
+        # feed projections and statistics when the race runs
+        expect(subject.new_event_group.events).to all(have_attributes(use_for_projections: true))
+      end
     end
 
     context "when the source event group has a webhook token" do

--- a/spec/models/segment_times_container_spec.rb
+++ b/spec/models/segment_times_container_spec.rb
@@ -143,6 +143,27 @@ RSpec.describe SegmentTimesContainer do
       expect(container.limits(segment)).to eq({})
     end
 
+    it "returns an empty hash instead of a degenerate band when a scaling typical time is zero" do
+      segment = lap_1_start_to_lap_2_finish
+      container = described_class.new(calc_model: :stats)
+      allow(container).to receive(:segment_time).and_return(0.0)
+      expect(container.limits(segment)).to eq({})
+    end
+
+    it "returns an empty hash when a scaling typical time is negative" do
+      segment = lap_1_start_to_lap_2_finish
+      container = described_class.new(calc_model: :stats)
+      allow(container).to receive(:segment_time).and_return(-100.0)
+      expect(container.limits(segment)).to eq({})
+    end
+
+    it "still returns a usable band for an in-aid segment with a zero typical time" do
+      segment = lap_1_in_aid_1
+      container = described_class.new(calc_model: :stats)
+      allow(container).to receive(:segment_time).and_return(0.0)
+      expect(container.limits(segment)[:high_bad]).to be_positive
+    end
+
     def validate_limits(segment, expected_time, expected_limits_type, calc_model)
       allow(DataStatus).to receive(:limits)
       container = SegmentTimesContainer.new(calc_model: calc_model, effort_ids: [1, 2, 3])

--- a/spec/queries/split_time_query_spec.rb
+++ b/spec/queries/split_time_query_spec.rb
@@ -67,5 +67,47 @@ RSpec.describe SplitTimeQuery do
         expect(time).to be_within(100).of(300)
       end
     end
+
+    context "when the event is not used for projections" do
+      before { events(:hardrock_2015).update_column(:use_for_projections, false) }
+
+      context "when effort_ids are not provided" do
+        let(:segment) { start_to_cunningham_in }
+        let(:effort_ids) { nil }
+
+        it "excludes the event's efforts from the pool" do
+          expect(count).to eq(0)
+          expect(time).to be_nil
+        end
+      end
+
+      context "when effort_ids are provided" do
+        let(:event) { events(:hardrock_2015) }
+        let(:segment) { in_aid_sherman }
+        let(:effort_ids) { event.efforts.order(:bib_number).ids.first(2) }
+
+        it "excludes the event's efforts even when focused" do
+          expect(count).to eq(0)
+          expect(time).to be_nil
+        end
+      end
+    end
+
+    context "when a segment time is negative" do
+      let(:segment) { in_aid_sherman }
+      let(:effort_ids) { [effort.id] }
+      let(:effort) { events(:hardrock_2015).efforts.order(:bib_number).first }
+
+      before do
+        in_time = effort.split_times.find_by(split: sherman_split, bitkey: in_bitkey)
+        out_time = effort.split_times.find_by(split: sherman_split, bitkey: out_bitkey)
+        out_time.update_column(:absolute_time, in_time.absolute_time - 1.minute)
+      end
+
+      it "excludes the negative pair from the pool" do
+        expect(count).to eq(0)
+        expect(time).to be_nil
+      end
+    end
   end
 end

--- a/spec/services/simulate_in_progress_event_group_spec.rb
+++ b/spec/services/simulate_in_progress_event_group_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe SimulateInProgressEventGroup do
     expect(result.new_event_group.name).to include("Simulated")
   end
 
+  it "excludes the simulated events from projections and statistics" do
+    expect(result.new_event_group.events).to all(have_attributes(use_for_projections: false))
+  end
+
   it "places the group start at the requested start time" do
     expect(result.new_event_group.events.map(&:scheduled_start_time).min).to be_within(1.second).of(start_time)
   end


### PR DESCRIPTION
## Summary

Implements #2169 using the `use_for_projections` flag from #2229 rather than course deep-copying. Three parts, one commit each:

**1. `SplitTimeQuery.typical_segment_time` gains event scoping.** The data-status statistics pool previously drew from every split time on a course — no event, concealment, or flag filter — which is how fabricated test times dragged a pooled segment average to ~880 days and flagged every real finisher "bad" in the incident. The begin-side subquery now joins efforts → events and requires `use_for_projections is true`, the same predicate `Projection.sql` uses (filtering one side of the st1/st2 pair suffices since they inner-join on effort_id). The pool also now discards negative segment pairs (`st2.absolute_time >= st1.absolute_time`; `>=` preserves legitimate zero-elapsed in-aid pass-throughs).

**2. Simulated groups opt out automatically.** `SimulateInProgressEventGroup` sets `use_for_projections: false` on the events it creates — this also closes a live hole where simulated events (default flag true) were feeding `Projection`. `DuplicateEventGroup` is deliberately unchanged: UI duplicates are next year's real races whose live times must feed the stream, and nothing warns in the false→true direction; a regression spec pins that behavior.

**3. Degenerate baseline degrades to unknown, never all-bad.** `SegmentTimesContainer#limits` returns empty limits for a non-positive typical time on scaling limit types, and `DataStatus.determine` returns nil for empty limits — so a garbage baseline now yields "unknown" statuses instead of flagging everything bad. `zero_start` (intentionally all-zero band) and `in_aid` (fixed 15-minute allowance keeps the band usable) are exempted, preserving current behavior.

Out of scope, per review of the plan: the `TimePredictor` pace-factor hardening (positive-pace guard for a latent `FloatDomainError` when the typical completed time is exactly 0.0, plus a clamp) — follow-up ticket to come. Also noted: `SplitTimeQuery.effort_times` still filters on concealment but is dead code (its only wrapper, `SplitTime.effort_times`, has no callers) — left untouched here; deleting it is a separate cleanup.

## Behavior changes worth knowing

- Events backfilled to flag-false (concealed groups at rollout) no longer self-pool: their own efforts produce "unknown" data statuses instead of stats-based ones. This matches the flag's semantics, and the event-form checkbox opts back in (as the Twisted Branch seed event does).
- `:focused` (similar-effort) baselines are gated too — flag-false events feed no baseline of any kind.

Resolves #2169

## Testing

- New query specs: flag-false event excluded from the pool (unfocused and focused), negative segment pair excluded.
- New simulate spec: created events all have the flag false. New duplicate spec: duplicated events keep it true.
- New container specs: zero/negative typical time on a scaling type returns empty limits; in-aid zero typical still yields a usable band.
- All six behavior-differentiating examples verified to fail against pre-change code.
- Wider suites green: time predictor, segment time calculator, all interactors, projection, enrich/verify raw time row — 436 examples total, 0 failures. rubocop clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)