### PR TITLE
Guard the TimePredictor pace factor against non-positive baselines

### DIFF
--- a/app/services/time_predictor.rb
+++ b/app/services/time_predictor.rb
@@ -1,4 +1,10 @@
 class TimePredictor
+  # Bounds on how far a runner's imputed pace may scale the limits band;
+  # real pace factors fall roughly within 0.3..3, so the clamp binds only
+  # when the pooled baseline is corrupt
+  MIN_PACE_FACTOR = 0.1
+  MAX_PACE_FACTOR = 10.0
+
   def self.segment_time(segment:, effort:, lap_splits: nil, completed_split_time: nil,
                         calc_model: nil, similar_effort_ids: nil, times_container: nil)
     new(
@@ -52,11 +58,18 @@ class TimePredictor
   end
 
   def pace_factor
-    @pace_factor ||= measurable_pace? ? actual_completed_time / typical_completed_time : 1
+    @pace_factor ||=
+      if measurable_pace?
+        (actual_completed_time / typical_completed_time).clamp(MIN_PACE_FACTOR, MAX_PACE_FACTOR)
+      else
+        1
+      end
   end
 
   def measurable_pace?
-    completed_lap_split.distance_from_start.positive? && actual_completed_time && typical_completed_time
+    completed_lap_split.distance_from_start.positive? &&
+      actual_completed_time&.positive? &&
+      typical_completed_time&.positive?
   end
 
   def actual_completed_time

--- a/app/services/time_predictor.rb
+++ b/app/services/time_predictor.rb
@@ -1,10 +1,4 @@
 class TimePredictor
-  # Bounds on how far a runner's imputed pace may scale the limits band;
-  # real pace factors fall roughly within 0.3..3, so the clamp binds only
-  # when the pooled baseline is corrupt
-  MIN_PACE_FACTOR = 0.1
-  MAX_PACE_FACTOR = 10.0
-
   def self.segment_time(segment:, effort:, lap_splits: nil, completed_split_time: nil,
                         calc_model: nil, similar_effort_ids: nil, times_container: nil)
     new(
@@ -58,12 +52,7 @@ class TimePredictor
   end
 
   def pace_factor
-    @pace_factor ||=
-      if measurable_pace?
-        (actual_completed_time / typical_completed_time).clamp(MIN_PACE_FACTOR, MAX_PACE_FACTOR)
-      else
-        1
-      end
+    @pace_factor ||= measurable_pace? ? actual_completed_time / typical_completed_time : 1
   end
 
   def measurable_pace?

--- a/spec/services/time_predictor_spec.rb
+++ b/spec/services/time_predictor_spec.rb
@@ -259,4 +259,55 @@ RSpec.describe TimePredictor do
       completed_split_time.time_from_start / completed_typical_time
     end
   end
+
+  describe "#data_status with a degenerate stats baseline" do
+    subject do
+      described_class.new(segment: segment, effort: effort, lap_splits: lap_splits,
+                          completed_split_time: completed_split_time, calc_model: :stats)
+    end
+
+    let(:segment) { aid_2_to_aid_5 }
+    let(:completed_split_time) { subject_split_times.first(5).last }
+    let(:subject_segment_average) { 10_000.0 }
+
+    before do
+      allow(SplitTimeQuery).to receive(:typical_segment_time) do |queried_segment, _effort_ids|
+        average = queried_segment == segment ? subject_segment_average : completed_segment_average
+        { "effort_count" => 10, "average" => average }.with_indifferent_access
+      end
+    end
+
+    context "when the completed-segment pool is poisoned with an absurdly slow average" do
+      let(:completed_segment_average) { 76_000_000.0 }
+
+      it "clamps the pace factor so a typical time is not flagged bad" do
+        expect(subject.data_status(1_000)).to eq("good")
+      end
+    end
+
+    context "when the completed-segment pool is poisoned with an absurdly fast average" do
+      let(:completed_segment_average) { 1.0 }
+
+      it "clamps the pace factor so a typical time is not flagged bad" do
+        expect(subject.data_status(100_000)).to eq("good")
+      end
+    end
+
+    context "when the completed-segment average is zero" do
+      let(:completed_segment_average) { 0.0 }
+
+      it "treats the pace as unmeasurable instead of raising" do
+        expect { subject.data_status(9_999) }.not_to raise_error
+        expect(subject.data_status(9_999)).to eq("good")
+      end
+    end
+
+    context "when the completed-segment average is negative" do
+      let(:completed_segment_average) { -100.0 }
+
+      it "treats the pace as unmeasurable" do
+        expect(subject.data_status(9_999)).to eq("good")
+      end
+    end
+  end
 end

--- a/spec/services/time_predictor_spec.rb
+++ b/spec/services/time_predictor_spec.rb
@@ -277,22 +277,6 @@ RSpec.describe TimePredictor do
       end
     end
 
-    context "when the completed-segment pool is poisoned with an absurdly slow average" do
-      let(:completed_segment_average) { 76_000_000.0 }
-
-      it "clamps the pace factor so a typical time is not flagged bad" do
-        expect(subject.data_status(1_000)).to eq("good")
-      end
-    end
-
-    context "when the completed-segment pool is poisoned with an absurdly fast average" do
-      let(:completed_segment_average) { 1.0 }
-
-      it "clamps the pace factor so a typical time is not flagged bad" do
-        expect(subject.data_status(100_000)).to eq("good")
-      end
-    end
-
     context "when the completed-segment average is zero" do
       let(:completed_segment_average) { 0.0 }
 


### PR DESCRIPTION
## Summary

Implements the surviving piece of #2238 after design review (the clamp was considered and deliberately dropped — see below). Written TDD-style: the failing specs were committed first, then the fix.

`measurable_pace?` checked truthiness only, and `0.0` is truthy, so:

- A **zero typical completed time** produced `Infinity` via float division, and `limits`' `(limit * pace_factor).to_i` raised `FloatDomainError` — an unrescued exception in `SetEffortStatus`, which runs in the live-entry submission path. Reproduced verbatim in the first commit's spec run.
- A **negative actual completed time** (times imported before the effort's start) produced a negative pace and therefore a negative limits band, silently flagging every subsequent healthy time "bad" with nonsense reasons — pointing reviewers away from the actually-broken time.

`measurable_pace?` now requires positive actual and typical completed times, falling back to the existing unmeasurable-pace convention of `1`, so per-segment checks flag the genuinely broken times instead.

## Why no clamp

A `[0.1, 10]` pace-factor clamp was implemented and then removed during review. Rationale: with #2237's pool gating in place, a corrupt flag-true baseline is rare — and when it happens, the un-clamped failure mode (mass bad flags) is loud and self-announcing, which is exactly how the #2169 incident was discovered. Clamping without an observability channel would convert that rare loud failure into a rare silent one, asserting "good" precisely when the evidence is least trustworthy. Scout capture on clamp engagement was also considered and rejected as alert-fatigue noise.

Resolves #2238

## Testing

- New `#data_status with a degenerate stats baseline` specs (stubbed per-segment pool averages): zero completed-segment average → no raise, evaluates against the unscaled band (pre-fix: `FloatDomainError: Infinity`); negative average → same (pre-fix: everything "bad" via a negative band).
- All 20 time predictor examples pass; wider suites green (interactors, intended time calculator, enrich/verify raw time row, segment container/calculator). rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)