### PR TITLE
Clamp non-positive page and per_page params to their defaults

### DIFF
--- a/app/controllers/concerns/prepared_params.rb
+++ b/app/controllers/concerns/prepared_params.rb
@@ -53,7 +53,7 @@ class PreparedParams
 
   def page
     result = params[:page]&.to_i || FIRST_PAGE
-    result.zero? ? FIRST_PAGE : result
+    result < 1 ? FIRST_PAGE : result
   end
 
   def search

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -41,12 +41,12 @@ class BasePresenter
 
   def page
     result = params[:page]&.to_i || FIRST_PAGE
-    result.zero? ? FIRST_PAGE : result
+    result < 1 ? FIRST_PAGE : result
   end
 
   def per_page
     result = params[:per_page]&.to_i || DEFAULT_PER_PAGE
-    result.zero? ? DEFAULT_PER_PAGE : result
+    result < 1 ? DEFAULT_PER_PAGE : result
   end
 
   def search_text

--- a/spec/controllers/concerns/prepared_params_spec.rb
+++ b/spec/controllers/concerns/prepared_params_spec.rb
@@ -449,6 +449,21 @@ RSpec.describe PreparedParams do
       it { expect(result).to eq(1) }
     end
 
+    context "when page is a negative integer" do
+      let(:page) { -11 }
+      it { expect(result).to eq(1) }
+    end
+
+    context "when page is a negative string" do
+      let(:page) { "-11" }
+      it { expect(result).to eq(1) }
+    end
+
+    context "when page is a SQL injection probe" do
+      let(:page) { "-11' UNION ALL SELECT NULL,NULL--" }
+      it { expect(result).to eq(1) }
+    end
+
     context "when page is integer 1" do
       let(:page) { 1 }
       it { expect(result).to eq(1) }

--- a/spec/presenters/base_presenter_spec.rb
+++ b/spec/presenters/base_presenter_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe BasePresenter do
+  subject { presenter_class.new(prepared_params) }
+
+  let(:presenter_class) do
+    Class.new(described_class) do
+      def initialize(params)
+        @params = params
+      end
+
+      private
+
+      attr_reader :params
+    end
+  end
+
+  let(:prepared_params) { PreparedParams.new(ActionController::Parameters.new(query_params), [], []) }
+
+  describe "#page" do
+    let(:result) { subject.page }
+
+    context "when page is not provided" do
+      let(:query_params) { {} }
+      it { expect(result).to eq(1) }
+    end
+
+    context "when page is zero" do
+      let(:query_params) { { page: "0" } }
+      it { expect(result).to eq(1) }
+    end
+
+    context "when page is positive" do
+      let(:query_params) { { page: "3" } }
+      it { expect(result).to eq(3) }
+    end
+
+    context "when page is negative" do
+      let(:query_params) { { page: "-11" } }
+      it { expect(result).to eq(1) }
+    end
+
+    context "when page is a SQL injection probe" do
+      let(:query_params) { { page: "-11' UNION ALL SELECT NULL,NULL--" } }
+      it { expect(result).to eq(1) }
+    end
+  end
+
+  describe "#per_page" do
+    let(:result) { subject.per_page }
+
+    context "when per_page is not provided" do
+      let(:query_params) { {} }
+      it { expect(result).to eq(described_class::DEFAULT_PER_PAGE) }
+    end
+
+    context "when per_page is zero" do
+      let(:query_params) { { per_page: "0" } }
+      it { expect(result).to eq(described_class::DEFAULT_PER_PAGE) }
+    end
+
+    context "when per_page is positive" do
+      let(:query_params) { { per_page: "25" } }
+      it { expect(result).to eq(25) }
+    end
+
+    context "when per_page is negative" do
+      let(:query_params) { { per_page: "-5" } }
+      it { expect(result).to eq(described_class::DEFAULT_PER_PAGE) }
+    end
+  end
+end

--- a/spec/presenters/base_presenter_spec.rb
+++ b/spec/presenters/base_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BasePresenter do
 
   let(:presenter_class) do
     Class.new(described_class) do
-      def initialize(params)
+      def initialize(params) # rubocop:disable Lint/MissingSuper -- the parent initializer raises NotImplementedError
         @params = params
       end
 


### PR DESCRIPTION
## Summary

Fixes the ~34/day production 500s from SQL-injection scanner bots probing the `page` param (Scout error group 91205, 7,400+ occurrences: `ActionView::Template::Error: expected :page >= 1; got -11`).

The injection payloads accomplish nothing — `to_i` reduces `-11' UNION ALL SELECT...` to `-11` — but both page guards handled zero without handling negatives, so the value flowed into pagy, which raises on a non-positive page mid-render:

- `PreparedParams#page` (`result.zero?` → `result < 1`)
- `BasePresenter#page` — the path the course best efforts page actually uses — and `BasePresenter#per_page`, which had the identical gap

A bot asking for page -11 now gets page 1 (a 200), matching the existing zero-value behavior, and the Scout error group goes quiet.

Written spec-first: the six negative-input examples (negative integer, negative string, and the verbatim injection probe, against both classes) were committed failing, then the three one-line guards.

## Testing

- New specs in `prepared_params_spec` and a new `base_presenter_spec` (via a minimal concrete subclass, since `BasePresenter` is abstract) — 78 examples, 0 failures across both files, plus the course best efforts display spec.
- rubocop clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)