### PR TITLE
Validate that an event's course belongs to the event group's organization

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -35,6 +35,7 @@ class Event < ApplicationRecord
   validates :scheduled_start_time, :laps_required, presence: true
   validates :short_name, uniqueness: { case_sensitive: false, scope: :event_group_id }
   validate :course_is_consistent
+  validate :course_matches_event_group_organization
 
   before_validation :add_default_results_template
   before_validation :conform_changed_course
@@ -93,6 +94,13 @@ class Event < ApplicationRecord
     return unless splits.any? { |split| split.course_id != course_id }
 
     errors.add(:course_id, "does not reconcile with one or more splits")
+  end
+
+  def course_matches_event_group_organization
+    return unless course && event_group&.organization_id
+    return if course.organization_id == event_group.organization_id
+
+    errors.add(:course_id, "must belong to the same organization as the event group")
   end
 
   def to_s
@@ -164,6 +172,8 @@ class Event < ApplicationRecord
 
   def conform_changed_course
     return unless persisted? && course_id_changed?
+    # Let the belongs_to presence validation reject a blank course_id
+    return if course.nil?
 
     response = Interactors::ChangeEventCourse.perform!(event: self, new_course: course)
     response.errors.each { |error| errors.add(:base, error[:title]) }

--- a/spec/controllers/api/v1/aid_stations_controller_spec.rb
+++ b/spec/controllers/api/v1/aid_stations_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Api::V1::AidStationsController do
   let(:course) { create(:course) }
   let(:split) { create(:split, course: course) }
-  let(:event) { create(:event, course: course) }
+  let(:event) { create(:event, course: course, event_group: create(:event_group, organization: course.organization)) }
   let(:aid_station) { create(:aid_station, split: split, event: event) }
   let(:type) { "aid_stations" }
 
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::AidStationsController do
 
     via_login_and_jwt do
       context "when an existing aid_station.id is provided" do
-        let(:params) { {id: aid_station} }
+        let(:params) { { id: aid_station } }
 
         it "returns a successful 200 response" do
           make_request
@@ -21,18 +21,18 @@ RSpec.describe Api::V1::AidStationsController do
 
         it "returns data of a single aid_station" do
           make_request
-          parsed_response = JSON.parse(response.body)
+          parsed_response = response.parsed_body
           expect(parsed_response["data"]["id"].to_i).to eq(aid_station.id)
           expect(response.body).to be_jsonapi_response_for(type)
         end
       end
 
-      context "if the aid_station does not exist" do
-        let(:params) { {id: 0} }
+      context "when the aid_station does not exist" do
+        let(:params) { { id: 0 } }
 
         it "returns an error" do
           make_request
-          parsed_response = JSON.parse(response.body)
+          parsed_response = response.parsed_body
           expect(parsed_response["errors"]).to include(/not found/)
           expect(response.status).to eq(404)
         end
@@ -45,25 +45,25 @@ RSpec.describe Api::V1::AidStationsController do
 
     via_login_and_jwt do
       context "when provided data is valid" do
-        let(:params) { {data: {type: type, attributes: {split_id: split.id, event_id: event.id}}} }
+        let(:params) { { data: { type: type, attributes: { split_id: split.id, event_id: event.id } } } }
 
         it "returns a successful json response" do
           make_request
           expect(response.body).to be_jsonapi_response_for(type)
-          parsed_response = JSON.parse(response.body)
+          parsed_response = response.parsed_body
           expect(parsed_response["data"]["id"]).not_to be_nil
           expect(response.status).to eq(201)
         end
 
         it "creates a aid_station record" do
-          expect { make_request }.to change { AidStation.count }.by(1)
+          expect { make_request }.to change(AidStation, :count).by(1)
         end
       end
     end
   end
 
   describe "#destroy" do
-    subject(:make_request) { delete :destroy, params: {id: aid_station_id} }
+    subject(:make_request) { delete :destroy, params: { id: aid_station_id } }
 
     via_login_and_jwt do
       context "when the record exists" do
@@ -76,7 +76,7 @@ RSpec.describe Api::V1::AidStationsController do
         end
 
         it "destroys the aid_station record" do
-          expect { make_request }.to change { AidStation.count }.by(-1)
+          expect { make_request }.to change(AidStation, :count).by(-1)
         end
       end
 
@@ -85,7 +85,7 @@ RSpec.describe Api::V1::AidStationsController do
 
         it "returns an error if the aid_station does not exist" do
           make_request
-          parsed_response = JSON.parse(response.body)
+          parsed_response = response.parsed_body
           expect(parsed_response["errors"]).to include(/not found/)
           expect(response.status).to eq(404)
         end

--- a/spec/controllers/api/v1/events_controller_spec.rb
+++ b/spec/controllers/api/v1/events_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Api::V1::EventsController do
   let(:type) { "events" }
   let(:event) { create(:event, course: course, event_group: event_group) }
-  let(:course) { create(:course) }
+  let(:course) { create(:course, organization: event_group.organization) }
   let(:event_group) { create(:event_group) }
 
   let(:parsed_response) { response.parsed_body }

--- a/spec/controllers/api/v1/splits_controller_spec.rb
+++ b/spec/controllers/api/v1/splits_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::V1::SplitsController do
 
     via_login_and_jwt do
       context "when an existing split.id is provided" do
-        let(:params) { {id: split} }
+        let(:params) { { id: split } }
 
         it "returns a successful 200 response" do
           make_request
@@ -19,18 +19,18 @@ RSpec.describe Api::V1::SplitsController do
 
         it "returns data of a single split" do
           make_request
-          parsed_response = JSON.parse(response.body)
+          parsed_response = response.parsed_body
           expect(parsed_response["data"]["id"].to_i).to eq(split.id)
           expect(response.body).to be_jsonapi_response_for(type)
         end
       end
 
-      context "if the split does not exist" do
-        let(:params) { {id: 0} }
+      context "when the split does not exist" do
+        let(:params) { { id: 0 } }
 
         it "returns an error" do
           make_request
-          parsed_response = JSON.parse(response.body)
+          parsed_response = response.parsed_body
           expect(parsed_response["errors"]).to include(/not found/)
           expect(response.status).to eq(404)
         end
@@ -40,25 +40,26 @@ RSpec.describe Api::V1::SplitsController do
 
   describe "#create" do
     subject(:make_request) { post :create, params: params }
-    let(:params) { {data: {type: "splits", attributes: attributes}} }
+
+    let(:params) { { data: { type: "splits", attributes: attributes } } }
 
     via_login_and_jwt do
       context "when provided data is valid" do
         let(:attributes) do
-          {base_name: "Test Split", course_id: course.id, distance_from_start: 100,
-           kind: "intermediate", sub_split_bitkey: 1}
+          { base_name: "Test Split", course_id: course.id, distance_from_start: 100,
+            kind: "intermediate", sub_split_bitkey: 1 }
         end
 
         it "returns a successful json response" do
           make_request
           expect(response.body).to be_jsonapi_response_for(type)
-          parsed_response = JSON.parse(response.body)
+          parsed_response = response.parsed_body
           expect(parsed_response["data"]["id"]).not_to be_nil
           expect(response.status).to eq(201)
         end
 
         it "creates a split record" do
-          expect { make_request }.to change { Split.count }.by(1)
+          expect { make_request }.to change(Split, :count).by(1)
         end
       end
     end
@@ -66,8 +67,9 @@ RSpec.describe Api::V1::SplitsController do
 
   describe "#update" do
     subject(:make_request) { put :update, params: params }
-    let(:params) { {id: split_id, data: {type: type, attributes: attributes}} }
-    let(:attributes) { {base_name: "Updated Split Name", latitude: 40, longitude: -105, elevation: 2000} }
+
+    let(:params) { { id: split_id, data: { type: type, attributes: attributes } } }
+    let(:attributes) { { base_name: "Updated Split Name", latitude: 40, longitude: -105, elevation: 2000 } }
 
     via_login_and_jwt do
       context "when the split exists" do
@@ -93,7 +95,7 @@ RSpec.describe Api::V1::SplitsController do
 
         it "returns an error if the split does not exist" do
           make_request
-          parsed_response = JSON.parse(response.body)
+          parsed_response = response.parsed_body
           expect(parsed_response["errors"]).to include(/not found/)
           expect(response.status).to eq(404)
         end
@@ -102,7 +104,7 @@ RSpec.describe Api::V1::SplitsController do
   end
 
   describe "#destroy" do
-    subject(:make_request) { delete :destroy, params: {id: split_id} }
+    subject(:make_request) { delete :destroy, params: { id: split_id } }
 
     via_login_and_jwt do
       context "when the record exists" do
@@ -115,7 +117,7 @@ RSpec.describe Api::V1::SplitsController do
         end
 
         it "destroys the split record" do
-          expect { make_request }.to change { Split.count }.by(-1)
+          expect { make_request }.to change(Split, :count).by(-1)
         end
       end
 
@@ -123,11 +125,11 @@ RSpec.describe Api::V1::SplitsController do
         let(:split_id) { split.id }
 
         it "returns an error message" do
-          event = create(:event, course: course)
+          event = create(:event, course: course, event_group: create(:event_group, organization: course.organization))
           effort = create(:effort, event: event)
           create(:split_time, split: split, effort: effort)
           make_request
-          parsed_response = JSON.parse(response.body)
+          parsed_response = response.parsed_body
           expect(parsed_response["errors"].first["detail"]["messages"]).to include(/Split has 1 associated split times/)
           expect(response.status).to eq(422)
         end
@@ -138,7 +140,7 @@ RSpec.describe Api::V1::SplitsController do
 
         it "returns an error if the split does not exist" do
           make_request
-          parsed_response = JSON.parse(response.body)
+          parsed_response = response.parsed_body
           expect(parsed_response["errors"]).to include(/not found/)
           expect(response.status).to eq(404)
         end

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :event do
     scheduled_start_time { FFaker::Time.datetime }
     laps_required { 1 }
-    course
     event_group
+    course { association :course, organization: event_group&.organization }
 
     trait :with_short_name do
       short_name { "#{rand(25..2000)}#{%w[-mile -kilo k M].sample}" }

--- a/spec/lib/etl/importer_spec.rb
+++ b/spec/lib/etl/importer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Etl::Importer do
     let(:source_data) { file_fixture("test_splits.csv") }
     let(:data_format) { :csv_splits }
     let(:options) { { parent: event, current_user_id: 1 } }
-    let(:event) { create(:event, course: course) }
+    let(:event) { create(:event, course: course, event_group: create(:event_group, organization: course.organization)) }
     let(:course) { create(:course) }
 
     it "creates all new splits within the given course" do
@@ -40,7 +40,7 @@ RSpec.describe Etl::Importer do
     let(:source_data) { file_fixture("test_splits.csv") }
     let(:data_format) { :csv_splits }
     let(:options) { { parent: event, current_user_id: 1 } }
-    let(:event) { create(:event, course: course) }
+    let(:event) { create(:event, course: course, event_group: create(:event_group, organization: course.organization)) }
     let(:course) { create(:course) }
     before do
       create(:split, :start, course: course)
@@ -61,7 +61,7 @@ RSpec.describe Etl::Importer do
     let(:source_data) { file_fixture("test_splits_minimal.csv") }
     let(:data_format) { :csv_splits }
     let(:options) { { parent: event, current_user_id: 1 } }
-    let(:event) { create(:event, course: course) }
+    let(:event) { create(:event, course: course, event_group: create(:event_group, organization: course.organization)) }
     let(:course) { create(:course) }
     before do
       create(:split, :start, base_name: "Start", course: course)

--- a/spec/lib/etl/loaders/upsert_strategy_spec.rb
+++ b/spec/lib/etl/loaders/upsert_strategy_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Etl::Loaders::UpsertStrategy do
   subject { described_class.new(proto_records, options) }
 
   let(:course) { create(:course, id: 10) }
-  let(:event) { create(:event, id: 1, course: course) }
+  let(:event) { create(:event, id: 1, course: course, event_group: create(:event_group, organization: course.organization)) }
   let(:options) { { parent: course, event: event, unique_key: [:course_id, :distance_from_start], current_user_id: 111 } }
   let(:valid_proto_records) do
     [ProtoRecord.new({ record_type: :split, kind: 0, sub_split_bitmap: 1, base_name: "Start", distance_from_start: 0, course_id: 10 }),

--- a/spec/models/aid_station_spec.rb
+++ b/spec/models/aid_station_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe AidStation, type: :model do
       let(:event_1) { create(:event, :with_short_name, course: course_1, event_group: event_group) }
       let(:event_2) { create(:event, :with_short_name, course: course_2, event_group: event_group) }
       let(:event_group) { create(:event_group, home_time_zone: "Arizona") }
-      let(:course_1) { create(:course) }
+      let(:course_1) { create(:course, organization: event_group.organization) }
       let(:course_1_split_1) { create(:split, :start, course: course_1, base_name: "Start", latitude: 40, longitude: -105) }
       let(:course_1_split_2) { create(:split, :finish, course: course_1, base_name: "Finish", latitude: 42, longitude: -107) }
-      let(:course_2) { create(:course) }
+      let(:course_2) { create(:course, organization: event_group.organization) }
       let(:course_2_split_1) { create(:split, :start, course: course_2, base_name: "Start", latitude: 40, longitude: -105) }
       before do
         event_1.splits << course_1_split_1

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -126,6 +126,48 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe "course organization consistency" do
+    it "is invalid when the course belongs to a different organization than the event group" do
+      event = build(:event, :with_short_name, course: courses(:d30_12m_course), event_group: event_groups(:hardrock_2016))
+      expect(event).not_to be_valid
+      expect(event.errors[:course_id]).to include("must belong to the same organization as the event group")
+    end
+
+    it "is valid when the course belongs to the event group's organization" do
+      event = build(:event, :with_short_name, course: courses(:hardrock_ccw), event_group: event_groups(:hardrock_2016))
+      expect(event).to be_valid
+    end
+
+    it "gives factory-built events a course in the event group's organization" do
+      event = build(:event)
+      expect(event.course.organization).to eq(event.event_group.organization)
+    end
+
+    context "when changing a persisted event's course to another organization's course" do
+      it "is invalid and does not persist the change" do
+        event = events(:hardrock_2016)
+        original_course = event.course
+
+        response = event.update(course_id: courses(:d30_12m_course).id)
+
+        expect(response).to eq(false)
+        expect(event.errors[:course_id]).to include("must belong to the same organization as the event group")
+        expect(event.reload.course).to eq(original_course)
+      end
+    end
+  end
+
+  describe "clearing the course on a persisted event" do
+    it "is invalid rather than raising from the course-change conforming" do
+      event = events(:hardrock_2016)
+      event.course_id = nil
+
+      expect { event.valid? }.not_to raise_error
+      expect(event).not_to be_valid
+      expect(event.errors[:course]).to include("must exist")
+    end
+  end
+
   describe "methods that produce lap_splits and time_points" do
     let(:event) { build_stubbed(:event, laps_required: laps_required) }
     let(:laps_required) { 2 }

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -189,10 +189,10 @@ RSpec.describe Split, kind: :model do
       let(:event_1) { create(:event, :with_short_name, course: course_1, event_group: event_group) }
       let(:event_2) { create(:event, :with_short_name, course: course_2, event_group: event_group) }
       let(:event_group) { create(:event_group) }
-      let(:course_1) { create(:course) }
+      let(:course_1) { create(:course, organization: event_group.organization) }
       let(:course_1_split_1) { create(:split, :start, course: course_1, base_name: "Start", latitude: 40, longitude: -105) }
       let(:course_1_split_2) { create(:split, :finish, course: course_1, base_name: "Finish", latitude: 42, longitude: -107) }
-      let(:course_2) { create(:course) }
+      let(:course_2) { create(:course, organization: event_group.organization) }
       let(:course_2_split_1) { create(:split, :start, course: course_2, base_name: "Start", latitude: 40, longitude: -105) }
       let(:course_2_split_2) { create(:split, :finish, course: course_2, base_name: "Finish", latitude: 42, longitude: -107) }
       before do

--- a/spec/services/interactors/change_event_course_spec.rb
+++ b/spec/services/interactors/change_event_course_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Interactors::ChangeEventCourse do
   end
 
   describe "#perform!" do
-    let(:event) { create(:event, course: old_course) }
+    let(:event) { create(:event, course: old_course, event_group: create(:event_group, organization: old_course.organization)) }
     let!(:old_course) { create(:course, splits: old_splits) }
     let(:old_split_1) { create(:split, :start, base_name: "Start") }
     let(:old_split_2) { create(:split, distance_from_start: 1000, base_name: "Aid 1") }
@@ -38,7 +38,7 @@ RSpec.describe Interactors::ChangeEventCourse do
     let!(:efforts) { create_list(:effort, 2, event: event) }
 
     context "when the new course has splits with the same distances as the old" do
-      let(:new_course) { create(:course, splits: new_splits) }
+      let(:new_course) { create(:course, splits: new_splits, organization: old_course.organization) }
       let(:new_split_1) { create(:split, :start, base_name: "Start") }
       let(:new_split_2) { create(:split, base_name: old_course.ordered_splits.second.base_name) }
       let(:new_split_3) { create(:split, base_name: old_course.ordered_splits.third.base_name) }
@@ -57,7 +57,7 @@ RSpec.describe Interactors::ChangeEventCourse do
         response = subject.perform!
         expect(event.course_id).to eq(new_course.id)
         expect(response).to be_successful
-        expect(response.message).to match(/was changed from/)
+        expect(response.message).to include("was changed from")
       end
 
       it "changes the split_ids of event split_times to the corresponding split_ids of the new course" do

--- a/spec/services/interactors/destroy_effort_split_times_spec.rb
+++ b/spec/services/interactors/destroy_effort_split_times_spec.rb
@@ -3,23 +3,26 @@ require "rails_helper"
 RSpec.describe Interactors::DestroyEffortSplitTimes do
   include BitkeyDefinitions
 
-  subject { Interactors::DestroyEffortSplitTimes.new(effort, split_time_ids) }
-  let!(:split_time_1) { create(:split_time, effort: effort, lap: 1, split: split_1, bitkey: in_bitkey, time_from_start: 0, stopped_here: false) }
-  let!(:split_time_2) { create(:split_time, effort: effort, lap: 1, split: split_2, bitkey: in_bitkey, time_from_start: 10_000, stopped_here: false) }
+  subject { described_class.new(effort, split_time_ids) }
+
+  before do
+    create(:split_time, effort: effort, lap: 1, split: split_1, bitkey: in_bitkey, time_from_start: 0, stopped_here: false)
+    create(:split_time, effort: effort, lap: 1, split: split_2, bitkey: in_bitkey, time_from_start: 10_000, stopped_here: false)
+    effort.reload
+  end
+
   let!(:split_time_3) { create(:split_time, effort: effort, lap: 1, split: split_2, bitkey: out_bitkey, time_from_start: 11_000, stopped_here: false) }
   let!(:split_time_4) { create(:split_time, effort: effort, lap: 1, split: split_3, bitkey: in_bitkey, time_from_start: 20_000, stopped_here: false) }
   let!(:split_time_5) { create(:split_time, effort: effort, lap: 1, split: split_3, bitkey: out_bitkey, time_from_start: 21_000, stopped_here: true) }
   let(:split_time_ids) { split_times.map { |st| st.id.to_s } }
 
   let(:effort) { create(:effort, event: event) }
-  let(:event) { create(:event, course: course) }
+  let(:event) { create(:event, course: course, event_group: create(:event_group, organization: course.organization)) }
   let(:course) { create(:course) }
   let(:split_1) { create(:split, :start, course: course) }
   let(:split_2) { create(:split, course: course) }
   let(:split_3) { create(:split, course: course) }
   let(:split_4) { create(:split, :finish, course: course) }
-
-  before { effort.reload }
 
   describe "#initialize" do
     context "when effort and split_time_ids arguments are provided" do
@@ -31,7 +34,8 @@ RSpec.describe Interactors::DestroyEffortSplitTimes do
     end
 
     context "when no effort is provided" do
-      subject { Interactors::DestroyEffortSplitTimes.new(nil, split_time_ids) }
+      subject { described_class.new(nil, split_time_ids) }
+
       let(:split_times) { [split_time_4, split_time_5] }
 
       it "raises an error" do
@@ -40,7 +44,7 @@ RSpec.describe Interactors::DestroyEffortSplitTimes do
     end
 
     context "when no split_time_ids argument is provided" do
-      subject { Interactors::DestroyEffortSplitTimes.new(effort, nil) }
+      subject { described_class.new(effort, nil) }
 
       it "raises an error" do
         expect { subject }.to raise_error(/split_time_ids argument was not provided/)
@@ -68,7 +72,7 @@ RSpec.describe Interactors::DestroyEffortSplitTimes do
         expect(effort.split_times.size).to eq(3)
         split_time_3.reload
         expect(split_time_3.stopped_here).to eq(true)
-        expect(response.resources).to match_array([split_time_3, split_time_4, split_time_5])
+        expect(response.resources).to contain_exactly(split_time_3, split_time_4, split_time_5)
       end
     end
 
@@ -82,7 +86,7 @@ RSpec.describe Interactors::DestroyEffortSplitTimes do
         expect(effort.split_times.size).to eq(3)
         split_time_5.reload
         expect(split_time_5.stopped_here).to eq(true)
-        expect(response.resources).to match_array([split_time_3, split_time_4])
+        expect(response.resources).to contain_exactly(split_time_3, split_time_4)
       end
     end
 
@@ -94,7 +98,7 @@ RSpec.describe Interactors::DestroyEffortSplitTimes do
         response = subject.perform!
         effort.reload
         expect(effort.split_times.size).to eq(5)
-        expect(response.resources).to match_array([])
+        expect(response.resources).to be_empty
       end
     end
   end

--- a/spec/services/interactors/match_raw_times_to_split_times_spec.rb
+++ b/spec/services/interactors/match_raw_times_to_split_times_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Interactors::MatchRawTimesToSplitTimes do
 
   let(:effort) { create(:effort, :with_bib_number, event: event) }
   let(:event) { create(:event, course: course, event_group: event_group, scheduled_start_time_local: "2018-02-10 06:00:00") }
-  let(:course) { create(:course) }
+  let(:course) { create(:course, organization: event_group.organization) }
   let(:event_group) { create(:event_group, available_live: true) }
   let(:split_1) { create(:split, :start, course: course) }
   let(:split_2) { create(:split, course: course) }

--- a/spec/services/interactors/match_time_records_to_split_times_spec.rb
+++ b/spec/services/interactors/match_time_records_to_split_times_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Interactors::MatchTimeRecordsToSplitTimes do
     end
 
     context "when the candidate pool contains a matching split_time belonging to an effort in a different event_group" do
-      let(:other_event_group) { create(:event_group) }
+      let(:other_event_group) { create(:event_group, organization: event.event_group.organization) }
       let(:other_event) do
         create(:event, event_group: other_event_group, course: event.course,
                        scheduled_start_time: event.scheduled_start_time)

--- a/spec/services/interactors/upsert_split_times_from_raw_time_row_spec.rb
+++ b/spec/services/interactors/upsert_split_times_from_raw_time_row_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Interactors::UpsertSplitTimesFromRawTimeRow do
 
   let(:effort) { create(:effort, :with_bib_number, event: event) }
   let(:event) { create(:event, course: course, event_group: event_group, scheduled_start_time_local: "2018-02-10 06:00:00") }
-  let(:course) { create(:course) }
+  let(:course) { create(:course, organization: event_group.organization) }
   let(:split_1) { create(:split, :start, course: course) }
   let(:split_2) { create(:split, course: course) }
   let(:split_3) { create(:split, course: course) }


### PR DESCRIPTION
## Summary

The hardening PR from #2235, written TDD-style (failing specs committed first). Two pieces:

**1. The validation.** `Event` now validates that its course belongs to its event group's organization. This closes every path that could mint new cross-organization relics — UI, API, imports, and `DuplicateEventGroup` (which copies events into a group in the same organization, so it passes naturally). The validation skips when course or event group is absent, leaving those to the presence validations.

**2. The nil-course guard (carried over from closed #2234).** `conform_changed_course` bails when the course is blank, so a nil `course_id` (e.g., an API `PATCH` with `course_id: null`) produces the `belongs_to` presence validation's 422 instead of an `ArgumentError` 500 from `ChangeEventCourse`.

## Deployment note

**Merge only after the staging data repair from #2235 is complete.** Production audited clean, so no production data blocks this — but the eight staging relics would fail validation on their next save. (Existing invalid rows don't break reads; they'd surface only when someone edits one.)

## Factory and spec fallout

The event factory previously built `course` and `event_group` independently, each minting its own organization — so every factory event was cross-organization by default. The factory now builds the course in the event group's organization (`course { association :course, organization: event_group&.organization }`), which fixed most of the suite automatically. Twelve spec files that explicitly paired independently-built courses and event groups now thread a single organization through their setup (a one-line change per site). Rubocop's whole-file CI check also swept the touched API controller specs (`response.parsed_body` conversions and the like).

## Testing

- New event specs: cross-organization course is invalid (build and persisted-change paths, with the change confirmed not to persist); same-organization is valid; factory events are consistent by construction; nil course on a persisted event is invalid rather than raising. Four behavior-differentiating examples verified to fail pre-change.
- Full affected sweep: all 93 non-system spec files referencing the event factory plus the plan-effort system spec — 1,762 examples, 0 failures.
- rubocop clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)